### PR TITLE
Fix mistaken url for the Sass home page.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,7 +67,7 @@ Hampton Catlin (@hcatlin). The extension and continuing evolution
 of the language has all been the result of years of work by Nathan
 Weizenbaum (@nex3) and Chris Eppstein (@chriseppstein). 
 
-For more information about Sass itself, please visit http://sass-lang.org
+For more information about Sass itself, please visit http://sass-lang.com
 
 Contribution Agreement
 ----------------------


### PR DESCRIPTION
The actual url for the Sass homepage is http://sass-lang.com, the .org is a camped domain.
