### PR TITLE
Fix bug in loop in Document::emit_css when size_t is unsigned.

### DIFF
--- a/document.cpp
+++ b/document.cpp
@@ -137,7 +137,7 @@ namespace Sass {
     if (!retval.empty()) {
       size_t newlines = 0;
       size_t i = retval.length();
-      while (i --> 0) {
+      while (i--) {
         if (retval[i] == '\n') {
           ++newlines;
           continue;


### PR DESCRIPTION
When size_t is unsigned on some platforms, loop in Document:emit_css is infinite, and get in out of range (i = 0 - 1).
This commit is fixed it.
