### PR TITLE
Implementing sass_free_folder_context() function

### DIFF
--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -39,7 +39,6 @@ extern "C" {
 
   void sass_free_folder_context(sass_folder_context* ctx)
   {
-    if (ctx->output_path) free(ctx->output_path);
     if (ctx->error_message) free(ctx->error_message);
 
     free(ctx);


### PR DESCRIPTION
Although `sass_interface.h` header contains the prototype of `void sass_free_folder_context(struct sass_folder_context *)` function, `sass_interface.cpp` hadn't implemented it. This had caused link errors, so I fixed it.

Thanks!
