### PR TITLE
Minor makefile patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all: $(OBJECTS)
 	ar rvs libsass.a $(OBJECTS)
 
 shared: $(OBJECTS)
-	$(CC) -shared -o libsass.so *.o
+	$(CC) -shared $(LDFLAGS) -o libsass.so $(OBJECTS)
 
 .cpp.o:
 	$(CC) $(CFLAGS) $< -o $@


### PR DESCRIPTION
Hey, I noticed in the Makefile `LDFLAGS` is declared but not used. Is this intentional? I'm putting together a libsass package for Fedora and adding it in there makes things easier (to override).
