### PR TITLE
Add installation targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,37 @@
-CC=g++
-CFLAGS=-c -Wall -O2 -fPIC
-LDFLAGS= -fPIC
-SOURCES = \
-	constants.cpp context.cpp functions.cpp document.cpp \
-	document_parser.cpp eval_apply.cpp node.cpp \
-	node_factory.cpp node_emitters.cpp prelexer.cpp \
-	sass_interface.cpp
+CC      = g++
+CFLAGS  = -Wall -O2 -fPIC
+LDFLAGS = -fPIC
+
+PREFIX  = /usr/local
+LIBDIR  = $(PREFIX)/lib
+
+SOURCES = constants.cpp context.cpp functions.cpp document.cpp \
+          document_parser.cpp eval_apply.cpp node.cpp \
+          node_factory.cpp node_emitters.cpp prelexer.cpp \
+          sass_interface.cpp
+
 OBJECTS = $(SOURCES:.cpp=.o)
 
-all: $(OBJECTS)
-	ar rvs libsass.a $(OBJECTS)
+static: libsass.a
+shared: libsass.so
 
-shared: $(OBJECTS)
-	$(CC) -shared $(LDFLAGS) -o libsass.so $(OBJECTS)
+libsass.a: $(OBJECTS)
+	ar rvs $@ $(OBJECTS)
+
+libsass.so: $(OBJECTS)
+	$(CC) -shared $(LDFLAGS) -o $@ $(OBJECTS)
 
 .cpp.o:
-	$(CC) $(CFLAGS) $< -o $@
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+install: libsass.a
+	install -Dpm0755 $< $(DESTDIR)$(LIBDIR)/$<
+
+install-shared: libsass.so
+	install -Dpm0755 $< $(DESTDIR)$(LIBDIR)/$<
 
 clean:
-	rm -rf *.o *.a *.so
+	rm -f $(OBJECTS) *.a *.so
+
+
+.PHONY: static shared install install-static clean


### PR DESCRIPTION
This adds targets for installing a static or shared library (static by default) as per #14.
