### PR TITLE
Improved Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ clean:
 	rm -f $(OBJECTS) *.a *.so
 
 
-.PHONY: static shared install install-static clean
+.PHONY: static shared install install-shared clean


### PR DESCRIPTION
Hey, sorry for the mail spam. This is a rebased version of my last 2 (closed) pull requests.
- Remove `-c` from `CFLAGS` and hard-code it into the recipe -- failing to include `-c` when overriding CFLAGS via the command-line shouldn't invoke the linker on object files
- Use real target names for library files instead of phony targets
- Add `install` and `install-shared` targets (closes #14)
- Use `$(OBJECTS)` instead of `*.o`
- Use `.PHONY` to properly mark phony targets
