### PR TITLE
Make source string const

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -56,7 +56,7 @@ namespace Sass {
     function_env(map<string, Function>()),
     extensions(multimap<Node, Node>()),
     pending_extensions(vector<pair<Node, Node> >()),
-    source_refs(vector<char*>()),
+    source_refs(vector<const char*>()),
     include_paths(vector<string>()),
     color_names_to_values(map<string, Node>()),
     color_values_to_names(map<Node, string>()),

--- a/context.hpp
+++ b/context.hpp
@@ -23,7 +23,7 @@ namespace Sass {
     map<string, Function> function_env;
     multimap<Node, Node> extensions;
     vector<pair<Node, Node> > pending_extensions;
-    vector<char*> source_refs; // all the source c-strings
+    vector<const char*> source_refs; // all the source c-strings
     vector<string> include_paths;
     map<string, Node> color_names_to_values;
     map<Node, string> color_values_to_names;

--- a/document.cpp
+++ b/document.cpp
@@ -86,7 +86,7 @@ namespace Sass {
     return doc;
   }
 
-  Document Document::make_from_source_chars(Context& ctx, char* src, string path, bool own_source)
+  Document Document::make_from_source_chars(Context& ctx, const char* src, string path, bool own_source)
   {
     Document doc(ctx);
     doc.path = path;
@@ -110,7 +110,7 @@ namespace Sass {
     doc.root = ctx.new_Node(Node::root, path, 1, 0);
     doc.lexed = Token::make();
     doc.own_source = false;
-    doc.source = const_cast<char*>(t.begin);
+    doc.source = t.begin;
     doc.end = t.end;
     doc.position = doc.source;
 

--- a/document.hpp
+++ b/document.hpp
@@ -29,7 +29,7 @@ namespace Sass {
     enum CSS_Style { nested, expanded, compact, compressed, echo };
     
     string path;
-    char* source;
+    const char* source;
     const char* position;
     const char* end;
     size_t line;
@@ -48,7 +48,7 @@ namespace Sass {
     ~Document();
 
     static Document make_from_file(Context& ctx, string path);
-    static Document make_from_source_chars(Context& ctx, char* src, string path = "", bool own_source = false);
+    static Document make_from_source_chars(Context& ctx, const char* src, string path = "", bool own_source = false);
     static Document make_from_token(Context& ctx, Token t, string path = "", size_t line_number = 1);
 
     template <prelexer mx>

--- a/sass_interface.h
+++ b/sass_interface.h
@@ -16,7 +16,7 @@ struct sass_options {
 };
 
 struct sass_context {
-  char* source_string;
+  const char* source_string;
   char* output_string;
   struct sass_options options;
   int error_status;


### PR DESCRIPTION
In the C interface, `sass_context->source_string` is declared as `char*` but gets `const_cast` in the library. Does `source_string` need to be writable? Would it make sense to change it to `const char*`?  It would help to avoid casting or copying when passing a `const char*` via bindings.
