### PR TITLE
Add support for sourcemaps (--debug-info in ruby). Fixess #33

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -53,7 +53,7 @@ namespace Sass {
     // }
   }
   
-  Context::Context(const char* paths_str, const char* img_path_str, bool sc)
+  Context::Context(const char* paths_str, const char* img_path_str, int sc)
   : global_env(Environment()),
     function_env(map<string, Function>()),
     extensions(multimap<Node, Node>()),

--- a/context.hpp
+++ b/context.hpp
@@ -33,10 +33,10 @@ namespace Sass {
     // string sass_path;
     // string css_path;
     bool has_extensions;
-    bool source_comments;
+    int source_comments;
 
     void collect_include_paths(const char* paths_str);
-    Context(const char* paths_str = 0, const char* img_path_str = 0, bool sc = false);
+    Context(const char* paths_str = 0, const char* img_path_str = 0, int sc = 0);
     ~Context();
 
     void register_function(Signature sig, Primitive ip);

--- a/node.cpp
+++ b/node.cpp
@@ -85,6 +85,14 @@ namespace Sass {
     }
   }
 
+  string Node::debug_info_path() const
+  {
+    char* c_abs_path = realpath( path().c_str(), NULL);
+    string abs_path(c_abs_path);
+    delete c_abs_path;
+    return abs_path;
+  }
+
   bool Node::operator==(Node rhs) const
   {
     Type t = type(), u = rhs.type();

--- a/node.hpp
+++ b/node.hpp
@@ -204,6 +204,7 @@ namespace Sass {
     bool& is_splat() const;
 
     string& path() const;
+    string debug_info_path() const;
     size_t line() const;
     size_t size() const;
     bool empty() const;
@@ -244,7 +245,7 @@ namespace Sass {
     bool operator>=(Node rhs) const;
 
     string to_string(Type inside_of = none, const string space = " ", const bool in_media_feature = false) const;
-    void emit_nested_css(stringstream& buf, size_t depth, bool at_toplevel = false, bool in_media_query = false, bool source_comments = false);
+    void emit_nested_css(stringstream& buf, size_t depth, bool at_toplevel = false, bool in_media_query = false, int source_comments = false);
     void emit_propset(stringstream& buf, size_t depth, const string& prefix, const bool compressed = false);
     void echo(stringstream& buf, size_t depth = 0);
     void emit_expanded_css(stringstream& buf, const string& prefix);

--- a/node_emitters.cpp
+++ b/node_emitters.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <sstream>
 #include "node.hpp"
+#include "sass_interface.h"
 
 using std::string;
 using std::stringstream;
@@ -394,7 +395,7 @@ namespace Sass {
     }
   }
 
-  void Node::emit_nested_css(stringstream& buf, size_t depth, bool at_toplevel, bool in_media_query, bool source_comments)
+  void Node::emit_nested_css(stringstream& buf, size_t depth, bool at_toplevel, bool in_media_query, int source_comments)
   {
     switch (type())
     {
@@ -413,7 +414,16 @@ namespace Sass {
         if (block.has_statements() || block.has_comments()) {
           if (source_comments) {
             buf << string(2*depth, ' ');
-            buf << "/* line " << sel_group.line() << ", " << sel_group.path() << " */" << endl;
+            switch (source_comments)
+            {
+              case SASS_SOURCE_COMMENTS_DEFAULT: {
+                buf << "/* line " << sel_group.line() << ", " << sel_group.path() << " */" << endl;
+              } break;
+              case SASS_SOURCE_COMMENTS_MAP: {
+                buf << "@media -sass-debug-info{filename{font-family:file:" << sel_group.debug_info_path() << "}line{font-family:\\00003" << sel_group.line() << "}}" << endl;
+              } break;
+              default: break;
+            }
           }
           buf << string(2*depth, ' ');
           buf << sel_group.to_string();

--- a/sass_interface.h
+++ b/sass_interface.h
@@ -9,6 +9,10 @@ extern "C" {
 #define SASS_STYLE_COMPACT    2
 #define SASS_STYLE_COMPRESSED 3
 
+#define SASS_SOURCE_COMMENTS_NONE 0
+#define SASS_SOURCE_COMMENTS_DEFAULT 1
+#define SASS_SOURCE_COMMENTS_MAP 2
+
 struct sass_options {
   int output_style;
   int source_comments; // really want a bool, but C doesn't have them


### PR DESCRIPTION
Honestly, i didn't study sourcemap specifications.
I opened generated css with --debug-info from ruby and it look's like it's almost same as -l option. Only format is different.

``` css
@media -sass-debug-info{filename{font-family:<absolute_filepath>}line{font-family:\00003<line>}}
```

``` csss
/* line <line>, <filename>*/
```

And... It works fine :)
