### PR TITLE
Reduce complexity by using strdup().

### DIFF
--- a/node.cpp
+++ b/node.cpp
@@ -297,10 +297,7 @@ namespace Sass {
       case numeric_dimension: {
         v.dimension.tag = SASS_DIMENSION;
         v.dimension.value = numeric_value();
-        const char* orig = string(unit().begin, unit().end - unit().begin).c_str();
-        char* copy = (char*) malloc(sizeof(char)*(strlen(orig)+1));
-        strcpy(copy, orig);
-        v.dimension.unit = copy;
+        v.dimension.unit = strdup(string(unit().begin, unit().end - unit().begin).c_str());
       } break;
       case numeric_color: {
         v.color.tag = SASS_COLOR;
@@ -322,10 +319,7 @@ namespace Sass {
       } break;
       default: { // should only be string-like things at this point
         v.string.tag = SASS_STRING;
-        const char* orig = to_string().c_str();
-        char* copy = (char*) malloc(sizeof(char)*(strlen(orig)+1));
-        strcpy(copy, orig);
-        v.string.value = copy;
+        v.string.value = strdup(to_string().c_str());
       } break;
     }
     return v;

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -60,9 +60,7 @@ extern "C" {
     // extend_selectors(doc.context.pending_extensions, doc.context.extensions, doc.context.new_Node);
     if (doc.context.has_extensions) extend(doc.root, doc.context.extensions, doc.context.new_Node);
     string output(doc.emit_css(static_cast<Document::CSS_Style>(style)));
-    char* c_output = (char*) malloc(output.size() + 1);
-    strcpy(c_output, output.c_str());
-    return c_output;
+    return strdup(output.c_str());
   }
 
   int sass_compile(sass_context* c_ctx)
@@ -85,22 +83,16 @@ extern "C" {
     catch (Error& e) {
       stringstream msg_stream;
       msg_stream << e.path << ":" << e.line << ": error: " << e.message << endl;
-      string msg(msg_stream.str());
-      char* msg_str = (char*) malloc(msg.size() + 1);
-      strcpy(msg_str, msg.c_str());
+      c_ctx->error_message = strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;
-      c_ctx->error_message = msg_str;
     }
     catch(bad_alloc& ba) {
       stringstream msg_stream;
       msg_stream << "Unable to allocate memory: " << ba.what() << endl;
-      string msg(msg_stream.str());
-      char* msg_str = (char*) malloc(msg.size() + 1);
-      strcpy(msg_str, msg.c_str());
+      c_ctx->error_message = strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;
-      c_ctx->error_message = msg_str;
     }
     // TO DO: CATCH EVERYTHING ELSE
     return 0;
@@ -127,22 +119,16 @@ extern "C" {
     catch (Error& e) {
       stringstream msg_stream;
       msg_stream << e.path << ":" << e.line << ": error: " << e.message << endl;
-      string msg(msg_stream.str());
-      char* msg_str = (char*) malloc(msg.size() + 1);
-      strcpy(msg_str, msg.c_str());
+      c_ctx->error_message = strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;
-      c_ctx->error_message = msg_str;
     }
     catch(bad_alloc& ba) {
       stringstream msg_stream;
       msg_stream << "Unable to allocate memory: " << ba.what() << endl;
-      string msg(msg_stream.str());
-      char* msg_str = (char*) malloc(msg.size() + 1);
-      strcpy(msg_str, msg.c_str());
+      c_ctx->error_message = strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;
-      c_ctx->error_message = msg_str;
     }
     catch(string& bad_path) {
       for (vector<string>::iterator path = cpp_ctx.include_paths.begin(); path < cpp_ctx.include_paths.end(); ++path) {
@@ -160,12 +146,9 @@ extern "C" {
       // couldn't find the specified file in the include paths; report an error
       stringstream msg_stream;
       msg_stream << "error reading file \"" << bad_path << "\"" << endl;
-      string msg(msg_stream.str());
-      char* msg_str = (char*) malloc(msg.size() + 1);
-      strcpy(msg_str, msg.c_str());
+      c_ctx->error_message = strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;
-      c_ctx->error_message = msg_str;
     }
     // TO DO: CATCH EVERYTHING ELSE
     return 0;

--- a/sass_values.cpp
+++ b/sass_values.cpp
@@ -60,9 +60,7 @@ union Sass_Value new_sass_c_dimension(double val, const char* unit)
 	union Sass_Value v;
 	v.dimension.tag = SASS_DIMENSION;
 	v.dimension.value = val;
-	char* copy = (char*) malloc(sizeof(char)*(strlen(unit)+1));
-	strcpy(copy, unit);
-	v.dimension.unit = copy;
+	v.dimension.unit = strdup(unit);
 	return v;
 }
 
@@ -81,9 +79,7 @@ union Sass_Value new_sass_c_string(const char* val)
 {
 	union Sass_Value v;
 	v.string.tag = SASS_STRING;
-	char* copy = (char*) malloc(sizeof(char)*(strlen(val)+1));
-	strcpy(copy, val);
-	v.string.value = copy;
+	v.string.value = strdup(val);
 	return v;
 }
 
@@ -100,9 +96,7 @@ union Sass_Value new_sass_c_error(const char* msg)
 {
 	union Sass_Value v;
 	v.error.tag = SASS_ERROR;
-	char* copy = (char*) malloc(sizeof(char)*(strlen(msg)+1));
-	strcpy(copy, msg);
-	v.error.message = copy;
+	v.error.message = strdup(msg);
 	return v;
 }
 


### PR DESCRIPTION
This patch simplifies a lot of code by using strdup() when appropriate. stdup() is POSIX and also exists on Windows so there shouldn't be any portability concerns.
