### PR TITLE
[eval_apply.cpp] Fix c_val_to_node when type is a list.

### DIFF
--- a/eval_apply.cpp
+++ b/eval_apply.cpp
@@ -1648,6 +1648,7 @@ namespace Sass {
       } break;
       case SASS_LIST: {
         node = ctx.new_Node(Node::list, path, line, v.list.length);
+        node.is_comma_separated() = v.list.separator == SASS_COMMA;
         for (size_t i = 0; i < v.list.length; ++i) {
           node << c_val_to_node(v.list.values[i], ctx, bt, path, line);
         }


### PR DESCRIPTION
v_val_to_node() was creating the list but then dropping it on the floor. This patch fixes the problem by moving the new node into the "node" variable which is what gets returned from the function.

-David
