### PR TITLE
[sass_values.cpp] Set the list length when making a new c_list.

### DIFF
--- a/sass_values.cpp
+++ b/sass_values.cpp
@@ -93,6 +93,7 @@ union Sass_Value new_sass_c_list(size_t len, enum Sass_Separator sep)
 	v.list.tag = SASS_LIST;
 	v.list.separator = sep;
 	v.list.values = (union Sass_Value*) malloc(sizeof(union Sass_Value)*len);
+	v.list.length = len;
 	return v;
 }
 


### PR DESCRIPTION
This confused me and I don't know if it's intended behavior or not:

```
union Sass_Value list = make_sass_list(my_length, sep);
for (int i=0; i<my_length; i++) {
    ...
}
```

That was populating the list but leaving the length not set inside the Sass_Value union. It seems that if we were passing in the length to make_sass_list() then that's probably the right place initialize the length in the union. It's probably unlikely that you'd want to pass in a length there but populate less than that (of course you're still free to do that).

-David
