### PR TITLE
[test_node_factory.cpp] Remove unused unordered_map include.

### DIFF
--- a/test_node_factory.cpp
+++ b/test_node_factory.cpp
@@ -1,8 +1,3 @@
-#if _MSC_VER >= 1600
-  #include <unordered_map>
-#else
-  #include <tr1/unordered_map>
-#endif
 #include <iostream>
 #include <string>
 #include <map>


### PR DESCRIPTION
It was causing problems when [compiling on OpenSolaris (no joke!)](http://www.cpantesters.org/cpan/report/4c2ebc04-d934-11e2-9caf-ce73a3ac3ce9).

I know it's "test" but due to the way Perl builds modules by default it was compiling this and failing. Since the code doesn't appear to actually use unordered_map, it seemed like the easiest thing to do was to just get rid of it.

-David
