### PR TITLE
Updating autogen.sh script.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,6 +1,3 @@
 #!/bin/sh
 set -ex
-aclocal -I m4
-autoheader
-automake --add-missing --copy --foreign
-autoconf
+autoreconf -vfi


### PR DESCRIPTION
Newer versions of autoconf don't come with automake and aclocal bundled, so use the equivalent commands from autoconf: autoreconf instead.  Info from this article:  

http://www.gnu.org/software/automake/manual/html_node/Upgrading.html
