### PR TITLE
Fix rounded colors NOT like ruby sass

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -206,12 +206,6 @@ namespace Sass {
     Color* hsla_impl(double h, double s, double l, double a, Context& ctx, const string& path, size_t line)
     {
       h = static_cast<double>(((static_cast<int>(h) % 360) + 360) % 360) / 360.0;
-      s = (s < 0)   ? 0 :
-          (s > 100) ? 100 :
-          s;
-      l = (l < 0)   ? 0 :
-          (l > 100) ? 100 :
-          l;
       s /= 100.0;
       l /= 100.0;
 
@@ -220,9 +214,9 @@ namespace Sass {
       else m2 = l+s-l*s;
       double m1 = l*2-m2;
       // round the results -- consider moving this into the Color constructor
-      double r = std::floor(h_to_rgb(m1, m2, h+1.0/3.0) * 255.0 + 0.5);
-      double g = std::floor(h_to_rgb(m1, m2, h) * 255.0 + 0.5);
-      double b = std::floor(h_to_rgb(m1, m2, h-1.0/3.0) * 255.0 + 0.5);
+      double r = (h_to_rgb(m1, m2, h+1.0/3.0) * 255.0);
+      double g = (h_to_rgb(m1, m2, h) * 255.0);
+      double b = (h_to_rgb(m1, m2, h-1.0/3.0) * 255.0);
 
       return new (ctx.mem) Color(path, line, r, g, b, a);
     }


### PR DESCRIPTION
As mentionned in hcatlin/libsass#179 , it's possible to merge only this commit to have a behaviour where lighten/darekn/saturate/desaturate are symetrics (=> their satuation/lightness can exceed 1..100 limits)
