### PR TITLE
Improve const-correctness in sass_interface.h

### DIFF
--- a/sass_interface.h
+++ b/sass_interface.h
@@ -18,8 +18,8 @@ extern "C" {
 struct sass_options {
   int output_style;
   int source_comments; // really want a bool, but C doesn't have them
-  char* include_paths;
-  char* image_path;
+  const char* include_paths;
+  const char* image_path;
 };
 
 struct sass_context {
@@ -34,7 +34,7 @@ struct sass_context {
 };
 
 struct sass_file_context {
-  char* input_path;
+  const char* input_path;
   char* output_string;
   struct sass_options options;
   int error_status;
@@ -45,8 +45,8 @@ struct sass_file_context {
 };
 
 struct sass_folder_context {
-  char* search_path;
-  char* output_path;
+  const char* search_path;
+  const char* output_path;
   struct sass_options options;
   int error_status;
   char* error_message;


### PR DESCRIPTION
This reduces the need for unnecessary casting/copying in bindings.
