### PR TITLE
Use Clang and GCC on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
 env:
-    - AUTOTOOLS=yes
-    - AUTOTOOLS=no
+  - AUTOTOOLS=yes
+  - AUTOTOOLS=no
+
 before_install:
   - git clone https://github.com/hcatlin/sass-spec.git
   - git clone https://github.com/hcatlin/sassc.git
   - export SASS_SPEC_PATH=$TRAVIS_BUILD_DIR/sass-spec
   - export SASS_SASSC_PATH=$TRAVIS_BUILD_DIR/sassc
   - export SASS_LIBSASS_PATH=$TRAVIS_BUILD_DIR
-script: ./travis.sh
 
+script: ./travis.sh


### PR DESCRIPTION
Switch language flag to C++. All Travis VMs have Ruby, so the spec test still run fine.
