### PR TITLE
Improve variable argument support

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -512,6 +512,7 @@ namespace Sass {
     string type() { return is_arglist_ ? "arglist" : "list"; }
     static string type_name() { return "list"; }
     bool is_invisible() { return !length(); }
+    Expression* value_at_index(size_t i);
     ATTACH_OPERATIONS();
   };
 
@@ -954,6 +955,11 @@ namespace Sass {
     }
     ATTACH_OPERATIONS();
   };
+
+  //////////////////////////////////////////////////////////////////////////////////////////
+  // Additional method on Lists to retrieve values directly or from an encompassed Argument.
+  //////////////////////////////////////////////////////////////////////////////////////////
+  inline Expression* List::value_at_index(size_t i) { return is_arglist_ ? ((Argument*)(*this)[i])->value() : (*this)[i]; }
 
   ////////////////////////////////////////////////////////////////////////
   // Argument lists -- in their own class to facilitate context-sensitive

--- a/bind.cpp
+++ b/bind.cpp
@@ -37,64 +37,73 @@ namespace Sass {
       Parameter* p = (*ps)[ip];
       Argument*  a = (*as)[ia];
 
-      if (a->is_rest_argument() && p->is_rest_parameter()) {
-        // rest param and rest arg -- just add one to the other
-        if (env->current_frame_has(p->name())) {
-          *static_cast<List*>(env->current_frame()[p->name()])
-                              += static_cast<List*>(a->value());
-        }
-        else {
-          env->current_frame()[p->name()] = a->value();
-        }
-        ++ia;
-        ++ip;
-      }
-      else if (p->is_rest_parameter()) {
-        List* arglist = 0;
-        if (!env->current_frame_has(p->name())) {
-          arglist = new (ctx.mem) List(p->path(),
-                                       p->line(),
-                                       0,
-                                       List::COMMA,
-                                       true);
+      // If the current parameter is the rest parameter, process and break the loop
+      if (p->is_rest_parameter()) {
+        if (a->is_rest_argument()) {
+          // rest param and rest arg -- just add one to the other
+          if (env->current_frame_has(p->name())) {
+            *static_cast<List*>(env->current_frame()[p->name()])
+            += static_cast<List*>(a->value());
+          }
+          else {
+            env->current_frame()[p->name()] = a->value();
+          }
+        } else {
+
+          // copy all remaining arguments into the rest parameter, preserving names
+          List* arglist = new (ctx.mem) List(p->path(),
+                                             p->line(),
+                                             0,
+                                             List::COMMA,
+                                             true);
           env->current_frame()[p->name()] = arglist;
+          while (ia < LA) {
+            a = (*as)[ia];
+            (*arglist) << new (ctx.mem) Argument(a->path(),
+                                                 a->line(),
+                                                 a->value(),
+                                                 a->name(),
+                                                 false);
+            ++ia;
+          }
         }
-        else {
-          arglist = static_cast<List*>(env->current_frame()[p->name()]);
-        }
-        *arglist << a->value(); // TODO: named args going into rest-param?
-        ++ia;
+        ++ip;
+        break;
       }
-      else if (a->is_rest_argument()) {
+
+      // If the current argument is the rest argument, extract a value for processing
+      if (a->is_rest_argument()) {
         // normal param and rest arg
-        if (env->current_frame_has(p->name())) {
-          stringstream msg;
-          msg << "parameter " << p->name()
-              << " provided more than once in call to " << callee;
-          error(msg.str(), a->path(), a->line());
-        }
         List* arglist = static_cast<List*>(a->value());
         // empty rest arg - treat all args as default values
         if (!arglist->length()) {
           break;
         }
-        // if it's the last param, move the whole arglist into it
-        if (ip == LP-1) {
-          env->current_frame()[p->name()] = arglist;
+        // otherwise move one of the rest args into the param, converting to argument if necessary
+        if (arglist->is_arglist()) {
+          a = static_cast<Argument*>((*arglist)[0]);
+        } else {
+          Expression* a_to_convert = (*arglist)[0];
+          a = new (ctx.mem) Argument(a_to_convert->path(), a_to_convert->line(), a_to_convert, "", false);
+        }
+        arglist->elements().erase(arglist->elements().begin());
+        if (!arglist->length() || (!arglist->is_arglist() && ip + 1 == LP)) {
           ++ia;
         }
-        // otherwise move one of the rest args into the param and loop
-        else {
-          env->current_frame()[p->name()] = (*arglist)[0];
-          arglist->elements().erase(arglist->elements().begin());
-        }
-        ++ip;
+      } else {
+        ++ia;
       }
-      else if (a->name().empty()) {
+
+      if (a->name().empty()) {
+        if (env->current_frame_has(p->name())) {
+          stringstream msg;
+          msg << "parameter " << p->name()
+          << " provided more than once in call to " << callee;
+          error(msg.str(), a->path(), a->line());
+        }
         // ordinal arg -- bind it to the next param
         env->current_frame()[p->name()] = a->value();
         ++ip;
-        ++ia;
       }
       else {
         // named arg -- bind it to the appropriately named param
@@ -116,7 +125,6 @@ namespace Sass {
           error(msg.str(), a->path(), a->line());
         }
         env->current_frame()[a->name()] = a->value();
-        ++ia;
       }
     }
 

--- a/functions.cpp
+++ b/functions.cpp
@@ -751,7 +751,8 @@ namespace Sass {
       List* arglist = ARG("$x2", List);
       Number* least = x1;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        Number* xi = dynamic_cast<Number*>((*arglist)[i]);
+        arglist->is_invisible();
+        Number* xi = dynamic_cast<Number*>(arglist->value_at_index(i));
         if (!xi) error("`" + string(sig) + "` only takes numeric arguments", path, line);
         if (lt(xi, least, ctx)) least = xi;
       }
@@ -765,7 +766,7 @@ namespace Sass {
       List* arglist = ARG("$x2", List);
       Number* greatest = x1;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        Number* xi = dynamic_cast<Number*>((*arglist)[i]);
+        Number* xi = dynamic_cast<Number*>(arglist->value_at_index(i));
         if (!xi) error("`" + string(sig) + "` only takes numeric arguments", path, line);
         if (lt(greatest, xi, ctx)) greatest = xi;
       }
@@ -796,7 +797,7 @@ namespace Sass {
       }
       if (l->empty()) error("argument `$list` of `" + string(sig) + "` must not be empty", path, line);
       if (n->value() < 1) error("argument `$n` of `" + string(sig) + "` must be greater than or equal to 1", path, line);
-      return (*l)[std::floor(n->value() - 1)];
+      return l->value_at_index(std::floor(n->value() - 1));
     }
 
     Signature index_sig = "index($list, $value)";
@@ -809,7 +810,7 @@ namespace Sass {
         *l << ARG("$list", Expression);
       }
       for (size_t i = 0, L = l->length(); i < L; ++i) {
-        if (eq((*l)[i], v, ctx)) return new (ctx.mem) Number(path, line, i+1);
+        if (eq(l->value_at_index(i), v, ctx)) return new (ctx.mem) Number(path, line, i+1);
       }
       return new (ctx.mem) Boolean(path, line, false);
     }
@@ -867,11 +868,15 @@ namespace Sass {
       List* arglist = new (ctx.mem) List(*ARG("$lists", List));
       size_t shortest = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        List* ith = dynamic_cast<List*>((*arglist)[i]);
+        List* ith = dynamic_cast<List*>(arglist->value_at_index(i));
         if (!ith) {
           ith = new (ctx.mem) List(path, line, 1);
-          *ith << (*arglist)[i];
-          (*arglist)[i] = ith;
+          *ith << arglist->value_at_index(i);
+          if (arglist->is_arglist()) {
+            ((Argument*)(*arglist)[i])->value(ith);
+          } else {
+            (*arglist)[i] = ith;
+          }
         }
         shortest = (i ? std::min(shortest, ith->length()) : ith->length());
       }
@@ -880,7 +885,7 @@ namespace Sass {
       for (size_t i = 0; i < shortest; ++i) {
         List* zipper = new (ctx.mem) List(path, line, L);
         for (size_t j = 0; j < L; ++j) {
-          *zipper << (*static_cast<List*>((*arglist)[j]))[i];
+          *zipper << (*static_cast<List*>(arglist->value_at_index(j)))[i];
         }
         *zippers << zipper;
       }
@@ -892,7 +897,7 @@ namespace Sass {
     {
       List* arglist = ARG("$values", List);
       if (arglist->length() == 1) {
-        Expression* the_arg = (*arglist)[0];
+        Expression* the_arg = arglist->value_at_index(0);
         arglist = dynamic_cast<List*>(the_arg);
         if (!arglist) {
           List* result = new (ctx.mem) List(path, line, 1, List::COMMA);
@@ -902,9 +907,9 @@ namespace Sass {
       }
       List* result = new (ctx.mem) List(path, line, 0, List::COMMA);
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        Boolean* ith = dynamic_cast<Boolean*>((*arglist)[i]);
+        Boolean* ith = dynamic_cast<Boolean*>(arglist->value_at_index(i));
         if (ith && ith->value() == false) continue;
-        *result << (*arglist)[i];
+        *result << arglist->value_at_index(i);
       }
       return result;
     }


### PR DESCRIPTION
Rework variable argument support to add support for named variables, improve error reporting, and fix crashes on edge cases like zero arguments passed into a chain of variable arguments.

To support named arguments, note that arglists have been upgraded to be lists of Arguments (with values matching the passed-in Expression) instead of being just lists of Expressions.  This has required changes to a number of functions which work with lists to cope with either ArgLists or Lists and their different wrapped types, adding a `value_at_index` method to lists to pull out the value if required.

(Corrects output to satisfy the libsass/composed-args test - to be upgraded in a forthcoming patch; also significantly improves the match for the libsass/var-args test, no regressions in other tests)
