### PR TITLE
Remove negative check of unsigned int

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -790,6 +790,7 @@ namespace Sass {
     {
       List* l = dynamic_cast<List*>(env["$list"]);
       Number* n = ARG("$n", Number);
+      if (n->value() == 0) error("argument `$n` of `" + string(sig) + "` must be non-zero", path, position);
       if (!l) {
         l = new (ctx.mem) List(path, position, 1);
         *l << ARG("$list", Expression);


### PR DESCRIPTION
I remember seeing that there was a reason that `index` was kept as an unsigned int, but since it is Clang complains about comparing it with a negative value.
