### PR TITLE
Fix default Makefile with clang on Travis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXX      = g++
+CXX     ?= g++
 CXXFLAGS = -Wall -O2 -fPIC
 LDFLAGS  = -fPIC
 


### PR DESCRIPTION
If you check the merge for #206 that's [built on Travis](https://travis-ci.org/hcatlin/libsass/jobs/15677895), you'll see that it doesn't actually use `clang++` with the default makefile (`AUTOTOOLS=no` and `CC=clang`).

That's because the `Makefile` unconditionally sets the `CXX` variable which is higher priority than the environment variable that Travis uses.
