### PR TITLE
Add gitattributes for line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 .sass-cache
 *.gem
 .svn/*
-.gitattributes
 
 # Configuration stuff
 


### PR DESCRIPTION
Not sure why the `.gitattributes` was ignored
