### PR TITLE
Fix EditorConfig Makefile selector

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,5 +10,6 @@ insert_final_newline = true
 indent_style = spaces
 indent_size = 2
 
-{Makefile, Makefile.am}
+[{Makefile, Makefile.am}]
 indent_style = tab
+indent_size = 4


### PR DESCRIPTION
My bad, since it is an INI format, the curly brace selector needs to wrapped in square brackets. Bumped the spacing for the tabs to 4, but that is a visual change only for supported editors.
