### PR TITLE
Convert Windows backslashes into forward slashes on Windows when retrieving cwd

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -281,7 +281,9 @@ namespace Sass {
     char wd[wd_len];
     string cwd = getcwd(wd, wd_len);
     if (cwd[cwd.length() - 1] != '/') cwd += '/';
+#ifdef _WIN32
     replace(begin(cwd), end(cwd), '\\', '/');    //convert Windows backslashes to URL forward slashes
+#endif
     return cwd;
   }
 


### PR DESCRIPTION
We've run into a problem on Windows where paths are not being processed correctly and invalid JSON is being returned when generating source maps. Backslashes returned by `getwcd` confuses the path parsing logic (for example `resolve_relative_path`).

The end result is invalid JSON because the paths contain backslashes:

```
{                                                                                                                          
  "version": 3,                                                                                                            
  "file": "",                                                                                                              
  "sources": ["../C:\temp\WindowsNodeSassJsonBug\App/Main.scss","../C:\temp\WindowsNodeSassJsonBug\App/_anotherfile.scss"],
  "names": [],                                                                                                             
  "mappings": "ACAA;EACC,OAAO"                                                                                             
}                                                                                                                          
```

This pull-request attempts to solve the problem at the source by modifying the return value of `getcwd`. I resorted to pre-processor directives to reduce the risk of affecting non-Windows builds since backslashes are valid characters in Linux paths.
