### PR TITLE
Fixes compilation issues with pull request #329

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -282,7 +282,7 @@ namespace Sass {
     string cwd = getcwd(wd, wd_len);
     if (cwd[cwd.length() - 1] != '/') cwd += '/';
 #ifdef _WIN32
-    replace(begin(cwd), end(cwd), '\\', '/');    //convert Windows backslashes to URL forward slashes
+    replace(cwd.begin(), cwd.end(), '\\', '/');    //convert Windows backslashes to URL forward slashes
 #endif
     return cwd;
   }


### PR DESCRIPTION
I was not able to compile the latest version due to an issue with pull request #329:

```
Building CSS-Sass
gcc -c -I"libsass" -s -O2 -DWIN32 -DWIN64 -DCONSERVATIVE  -DPERL_TEXTMODE_SCRIPTS \
  -DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -fno-strict-aliasing -mms-bitfields -s -O2 \
  -I"C:\strawberry\perl\64\5.14\perl\lib\CORE" -I"C:\strawberry\perl\64\5.14\c\include" \
  -o "libsass\context.o" "libsass\context.cpp"
libsass\context.cpp: In member function 'std::string Sass::Context::get_cwd()':
libsass\context.cpp:289:22: error: 'begin' was not declared in this scope
libsass\context.cpp:289:32: error: 'end' was not declared in this scope
error building dll file from 'libsass/context.cpp' at C:/STRAWBERRY/perl/64/5.14/perl/lib/ExtUtils/CBuilder/Platform/Windows.pm line 130.
```

The fix seems obvious as all other string instances use begin and end the same way.
