### PR TITLE
Treat `-moz-calc` and `-webkit-calc` properties the same as `calc`.

### DIFF
--- a/constants.cpp
+++ b/constants.cpp
@@ -54,19 +54,21 @@ namespace Sass {
     extern const char vendor_khtml_kwd[]    = "-khtml-";
 
     // css functions and keywords
-    extern const char charset_kwd[]    = "@charset";
-    extern const char media_kwd[]      = "@media";
-    extern const char keyframes_kwd[]  = "keyframes";
-    extern const char only_kwd[]       = "only";
-    extern const char rgb_kwd[]        = "rgb(";
-    extern const char url_kwd[]        = "url(";
-    extern const char image_url_kwd[]  = "image-url(";
-    extern const char important_kwd[]  = "important";
-    extern const char pseudo_not_kwd[] = ":not(";
-    extern const char even_kwd[]       = "even";
-    extern const char odd_kwd[]        = "odd";
-    extern const char progid_kwd[]     = "progid";
-    extern const char calc_kwd[]       = "calc(";
+    extern const char charset_kwd[]      = "@charset";
+    extern const char media_kwd[]        = "@media";
+    extern const char keyframes_kwd[]    = "keyframes";
+    extern const char only_kwd[]         = "only";
+    extern const char rgb_kwd[]          = "rgb(";
+    extern const char url_kwd[]          = "url(";
+    extern const char image_url_kwd[]    = "image-url(";
+    extern const char important_kwd[]    = "important";
+    extern const char pseudo_not_kwd[]   = ":not(";
+    extern const char even_kwd[]         = "even";
+    extern const char odd_kwd[]          = "odd";
+    extern const char progid_kwd[]       = "progid";
+    extern const char calc_kwd[]         = "calc(";
+    extern const char moz_calc_kwd[]     = "-moz-calc(";
+    extern const char webkit_calc_kwd[]  = "-webkit-calc(";
 
     // css attribute-matching operators
     extern const char tilde_equal[]  = "~=";

--- a/constants.hpp
+++ b/constants.hpp
@@ -67,6 +67,8 @@ namespace Sass {
     extern const char odd_kwd[];
     extern const char progid_kwd[];
     extern const char calc_kwd[];
+    extern const char moz_calc_kwd[];
+    extern const char webkit_calc_kwd[];
 
     // css attribute-matching operators
     extern const char tilde_equal[];

--- a/parser.cpp
+++ b/parser.cpp
@@ -916,7 +916,9 @@ namespace Sass {
       }
       return kwd_arg;
     }
-    else if (peek< exactly<calc_kwd> >()) {
+    else if (peek< exactly< calc_kwd > >() ||
+             peek< exactly< moz_calc_kwd > >() ||
+             peek< exactly< webkit_calc_kwd > >()) {
       return parse_calc_function();
     }
     else if (peek< functional_schema >()) {


### PR DESCRIPTION
Fixes #330.

```
$ cat issue_330.scss
.selector {
  height: -webkit-calc(100% - 40px);
  height: -moz-calc(100% - 40px);
  height: calc(100% - 40px);
}

$ sassc/bin/sassc issue_330.scss
.selector {
  height: -webkit-calc(100% - 40px);
  height: -moz-calc(100% - 40px);
  height: calc(100% - 40px); }
```
