### PR TITLE
implement NOT unary expression

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -580,7 +580,7 @@ namespace Sass {
   ////////////////////////////////////////////////////////////////////////////
   class Unary_Expression : public Expression {
   public:
-    enum Type { PLUS, MINUS };
+    enum Type { PLUS, MINUS, NOT };
   private:
     ADD_PROPERTY(Type, type);
     ADD_PROPERTY(Expression*, operand);

--- a/eval.cpp
+++ b/eval.cpp
@@ -237,7 +237,11 @@ namespace Sass {
   Expression* Eval::operator()(Unary_Expression* u)
   {
     Expression* operand = u->operand()->perform(this);
-    if (operand->concrete_type() == Expression::NUMBER) {
+    if (u->type() == Unary_Expression::NOT) {
+      Boolean* result = new (ctx.mem) Boolean(u->path(), u->position(), !*operand);
+      return result;
+    }
+    else if (operand->concrete_type() == Expression::NUMBER) {
       Number* result = new (ctx.mem) Number(*static_cast<Number*>(operand));
       result->value(u->type() == Unary_Expression::MINUS
                     ? -result->value()

--- a/parser.cpp
+++ b/parser.cpp
@@ -843,6 +843,10 @@ namespace Sass {
 
   Expression* Parser::parse_expression()
   {
+    if (lex< exactly<not_kwd> >()) {
+      return new (ctx.mem) Unary_Expression(path, source_position, Unary_Expression::NOT, parse_expression());
+    }
+
     Expression* term1 = parse_term();
     // if it's a singleton, return it directly; don't wrap it
     if (!(peek< exactly<'+'> >(position) ||


### PR DESCRIPTION
I'm not sure if this implementation is correct, the comment for Unary_Expression suggests this is not the correct expression:
// Arithmetic negation (logical negation is just an ordinary function call).

Please comment how else it should be implemented...

See also https://github.com/hcatlin/sass-spec/pull/14
