### PR TITLE
Allow trailing commas in lists. Fixes #359

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -760,6 +760,15 @@ namespace Sass {
 
     while (lex< exactly<','> >())
     {
+      if (//peek< exactly<'!'> >(position) ||
+          peek< exactly<';'> >(position) ||
+          peek< exactly<'}'> >(position) ||
+          peek< exactly<'{'> >(position) ||
+          peek< exactly<')'> >(position) ||
+          //peek< exactly<':'> >(position) ||
+          peek< exactly<ellipsis> >(position)) {
+        break;
+      }
       Expression* list = parse_space_list();
       (*comma_list) << list;
     }


### PR DESCRIPTION
More than one trailing comma is not allowed by sass, so only one trailing comma is permitted here.
