### PR TITLE
fixing `make install` (install -D) on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,12 @@ libsass.so: $(OBJECTS)
 	$(CXX) $(CXXFLAGS) -o $@ $+ $(LDFLAGS)
 
 install: libsass.a
-	install -Dpm0755 $< $(DESTDIR)$(LIBDIR)/$<
+	mkdir -p $(DESTDIR)$(LIBDIR)/
+	install -pm0755 $< $(DESTDIR)$(LIBDIR)/$<
 
 install-shared: libsass.so
-	install -Dpm0755 $< $(DESTDIR)$(LIBDIR)/$<
+	mkdir -p $(DESTDIR)$(LIBDIR)/
+	install -pm0755 $< $(DESTDIR)$(LIBDIR)/$<
 
 $(SASSC_BIN): libsass.a
 	cd $(SASS_SASSC_PATH) && make


### PR DESCRIPTION
`install -D` does not work on OSX, but since it only creates the target directories, it can easily be split out into a `mkdir -p …`.

```
install -Dpm0755 libsass.a /usr/local/lib/libsass.a
install: illegal option -- D
```
