### PR TITLE
include cstdlib for std::abs() for Emscripten

### DIFF
--- a/utf8_string.cpp
+++ b/utf8_string.cpp
@@ -2,6 +2,7 @@
 #define SASS_UTF8_STRING
 
 #include <string>
+#include <cstdlib>
 #include <cmath>
 
 namespace Sass {


### PR DESCRIPTION
While gcc compiled fine, emscripten did not. The following error was thrown:

```
/usr/local/bin/emscripten/emscripten/1.8.2/em++ -Wall -O2 -fPIC -c -o utf8_string.o utf8_string.cpp
utf8_string.cpp:111:16: error: call to 'abs' is ambiguous
      else if (std::abs(index) <= signed_len) {
               ^~~~~~~~
```

Either including `cstdlib` or changing `std::abs(index)` to `std::abs((float)index)` fixed the issue with Emscripten without breaking in gcc.
