### PR TITLE
Use double instead of long to avoid ambiguous error

### DIFF
--- a/utf8_string.cpp
+++ b/utf8_string.cpp
@@ -109,7 +109,7 @@ namespace Sass {
       else if (index == 0) {
         return 0;
       }
-      else if (std::abs((long)index) <= signed_len) {
+      else if (std::abs((double)index) <= signed_len) {
         // negative and within string length
         return index + signed_len;
       }


### PR DESCRIPTION
Fixes the issues of building libsass using glibc-2.11 in ubuntu Lucid x64 for heroku as mentioned here: https://github.com/sass/libsass/pull/395

cc @pornel
