### PR TITLE
eval is not available during expansion

### DIFF
--- a/contextualize.cpp
+++ b/contextualize.cpp
@@ -117,10 +117,10 @@ namespace Sass {
   { return s; }
 
   Selector* Contextualize::operator()(Attribute_Selector* s)
-  { 
+  {
     // the value might be interpolated; evaluate it
     String* v = s->value();
-    if (v) {
+    if (v && eval) {
       v = static_cast<String*>(v->perform(eval->with(env, backtrace)));
     }
     Attribute_Selector* ss = new (ctx.mem) Attribute_Selector(*s);


### PR DESCRIPTION
I've found a crasher: expansion of `&[foo="bar"]` would try to evaluate the attribute when `eval` was `null`.
