### PR TITLE
Use `make -j` to speed up Travis CI build.

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -8,7 +8,7 @@ if [ "x$AUTOTOOLS" == "xyes" ]; then
   autoreconf -i
   ./configure --enable-tests \
     --prefix=$TRAVIS_BUILD_DIR
-  make install
+  make install -j
   cp $TRAVIS_BUILD_DIR/lib/libsass.a $TRAVIS_BUILD_DIR
 fi
 

--- a/script/spec
+++ b/script/spec
@@ -4,4 +4,4 @@ script/bootstrap
 
 export SASS_LIBSASS_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
 
-make test_build
+make test_build -j


### PR DESCRIPTION
Example  https://travis-ci.org/XhmikosR/libsass/builds/27940640

Before:

```
Job     Duration        Finished                    Compiler    ENV
380.1   3 min 26 sec    about 16 hours ago          gcc         AUTOTOOLS=yes
380.2   2 min           about 16 hours ago          gcc         AUTOTOOLS=no
380.3   2 min 34 sec    about 16 hours ago          clang       AUTOTOOLS=yes
380.4   1 min 16 sec    about 16 hours ago          clang       AUTOTOOLS=no
```

After:

```
Job     Duration        Finished                    Compiler    ENV
1.1     1 min           less than a minute ago      gcc         AUTOTOOLS=yes
1.2     24 sec          2 minutes ago               gcc         AUTOTOOLS=no
1.3     1 min 24 sec    less than a minute ago      clang       AUTOTOOLS=yes
1.4     17 sec          2 minutes ago               clang       AUTOTOOLS=no
```
