### PR TITLE
Option: Map URL is now disableable (#357)

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -43,23 +43,24 @@ namespace Sass {
 
   Context::Context(Context::Data initializers)
   : mem(Memory_Manager<AST_Node>()),
-    source_c_str    (initializers.source_c_str()),
-    sources         (vector<const char*>()),
-    include_paths   (initializers.include_paths()),
-    queue           (vector<pair<string, const char*> >()),
-    style_sheets    (map<string, Block*>()),
-    source_map(File::base_name(initializers.output_path())),
-    c_functions     (vector<Sass_C_Function_Descriptor>()),
-    image_path      (initializers.image_path()),
-    source_comments (initializers.source_comments()),
-    source_maps     (initializers.source_maps()),
-    output_style    (initializers.output_style()),
-    source_map_file (initializers.source_map_file()),
-    names_to_colors (map<string, Color*>()),
-    colors_to_names (map<int, string>()),
-    precision       (initializers.precision()),
-    extensions(multimap<Compound_Selector, Complex_Selector*>()),
-    subset_map(Subset_Map<string, pair<Complex_Selector*, Compound_Selector*> >())
+    source_c_str         (initializers.source_c_str()),
+    sources              (vector<const char*>()),
+    include_paths        (initializers.include_paths()),
+    queue                (vector<pair<string, const char*> >()),
+    style_sheets         (map<string, Block*>()),
+    source_map           (File::base_name(initializers.output_path())),
+    c_functions          (vector<Sass_C_Function_Descriptor>()),
+    image_path           (initializers.image_path()),
+    source_comments      (initializers.source_comments()),
+    source_maps          (initializers.source_maps()),
+    output_style         (initializers.output_style()),
+    source_map_file      (initializers.source_map_file()),
+    omit_source_map_url  (initializers.omit_source_map_url()),
+    names_to_colors      (map<string, Color*>()),
+    colors_to_names      (map<int, string>()),
+    precision            (initializers.precision()),
+    extensions           (multimap<Compound_Selector, Complex_Selector*>()),
+    subset_map           (Subset_Map<string, pair<Complex_Selector*, Compound_Selector*> >())
   {
     cwd = get_cwd();
 
@@ -233,7 +234,7 @@ namespace Sass {
         Output_Compressed output_compressed(this);
         root->perform(&output_compressed);
         string output = output_compressed.get_buffer();
-        if (source_maps) output += format_source_mapping_url(source_map_file);
+        if (!omit_source_map_url) output += format_source_mapping_url(source_map_file);
         result = copy_c_str(output.c_str());
       } break;
 
@@ -241,7 +242,7 @@ namespace Sass {
         Output_Nested output_nested(source_comments, this);
         root->perform(&output_nested);
         string output = output_nested.get_buffer();
-        if (source_maps) output += "\n" + format_source_mapping_url(source_map_file);
+        if (!omit_source_map_url) output += "\n" + format_source_mapping_url(source_map_file);
         result = copy_c_str(output.c_str());
 
       } break;

--- a/context.hpp
+++ b/context.hpp
@@ -53,6 +53,7 @@ namespace Sass {
     bool         source_maps;
     Output_Style output_style;
     string       source_map_file;
+    bool         omit_source_map_url;
 
     map<string, Color*> names_to_colors;
     map<int, string>    colors_to_names;
@@ -71,6 +72,7 @@ namespace Sass {
       KWD_ARG(Data, bool,            source_maps);
       KWD_ARG(Data, Output_Style,    output_style);
       KWD_ARG(Data, string,          source_map_file);
+      KWD_ARG(Data, bool,            omit_source_map_url);
       KWD_ARG(Data, size_t,          precision);
     };
 

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -104,6 +104,7 @@ extern "C" {
                        .source_comments(c_ctx->options.source_comments == SASS_SOURCE_COMMENTS_DEFAULT)
                        .source_maps(source_maps)
                        .source_map_file(source_map_file)
+                       .omit_source_map_url(c_ctx->omit_source_map_url)
                        .image_path(c_ctx->options.image_path ?
                                    c_ctx->options.image_path :
                                    "")
@@ -166,6 +167,7 @@ extern "C" {
                        .source_comments(c_ctx->options.source_comments == SASS_SOURCE_COMMENTS_DEFAULT)
                        .source_maps(source_maps)
                        .source_map_file(source_map_file)
+                       .omit_source_map_url(c_ctx->omit_source_map_url)
                        .image_path(c_ctx->options.image_path ?
                                    c_ctx->options.image_path :
                                    "")

--- a/sass_interface.h
+++ b/sass_interface.h
@@ -1,7 +1,7 @@
 #define SASS_INTERFACE
 
 #include "sass.h"
-
+#include <stdbool.h>
 #include "sass2scss/sass2scss.h"
 
 #ifdef __cplusplus
@@ -32,6 +32,7 @@ struct sass_context {
   char* output_string;
   char* source_map_string;
   const char* source_map_file;
+  bool omit_source_map_url;
   struct sass_options options;
   int error_status;
   char* error_message;
@@ -46,6 +47,7 @@ struct sass_file_context {
   char* output_string;
   char* source_map_string;
   const char* source_map_file;
+  bool omit_source_map_url;
   struct sass_options options;
   int error_status;
   char* error_message;


### PR DESCRIPTION
Fixes #357.

Couple of notes:
- The option is reversed `omit_source_map_url` as opposed to `source_map_url` to make it a non-breaking change (for instance, the current state of `node-sass` is working just fine with this change. later they can provide a CLI switch and the code to back in `sass.js` and `binding.cpp` to make use of this feature).
- I used C99's `stdbool` in `sass_interface.h`. With GCC's `std=c99` and VC12 (devenv2013), its supported and compiled well on Win7 (don't know about the others compilers). I saw @akhleung's comment about lack of bool support in C. Let me know, if you guys have concerns regarding C99 (particularly `<stdbool.h>`), I will change it to `int`.
