### PR TITLE
Alter the invert function to accept numbers, for native CSS invert

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -423,16 +423,26 @@ namespace Sass {
                        position);
     }
 
-    Signature invert_sig = "invert($color)";
+    Signature invert_sig = "invert($value)";
     BUILT_IN(invert)
     {
-      Color* rgb_color = ARG("$color", Color);
-      return new (ctx.mem) Color(path,
-                                 position,
-                                 255 - rgb_color->r(),
-                                 255 - rgb_color->g(),
-                                 255 - rgb_color->b(),
-                                 rgb_color->a());
+      Expression* v = ARG("$value", Expression);
+      if (v->concrete_type() == Expression::NUMBER) {
+        To_String to_string;
+        String_Constant* str = new String_Constant(path,
+                                                   position,
+                                                   v->perform(&to_string));
+        return new (ctx.mem) String_Constant(path, position, "invert(" + str->value() + ")");
+      }
+      else {
+        Color* rgb_color = static_cast<Color*>(v);
+        return new (ctx.mem) Color(path,
+                                   position,
+                                   255 - rgb_color->r(),
+                                   255 - rgb_color->g(),
+                                   255 - rgb_color->b(),
+                                   rgb_color->a());
+      }
     }
 
     ////////////////////


### PR DESCRIPTION
This fixes a minor bug, where if you try and use "-webkit-filter: invert(100%);", the invert function will fail since it is expecting a colour. (See bug on Sassmeister here: https://gist.github.com/iamcarrico/8f11aacc54391db152a6)This is already changed in [Ruby Sass](https://github.com/sass/sass/blob/stable/lib/sass/script/functions.rb#L1311), and I did some alterations to allow invert to have numbers or colours. If a number is passed on, then it will return as a string with the number inside. 

Thoughts? My C++ is ... rusty. So there might be a better way. 
