### PR TITLE
Fixes to-upper and to-lower to skip utf8 code points

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -809,7 +809,9 @@ namespace Sass {
       string str = s->value();
 
       for (size_t i = 0, L = str.length(); i < L; ++i) {
-        str[i] = std::toupper(str[i]);
+        if (isascii(str[i])) {
+          str[i] = std::toupper(str[i]);
+        }
       }
 
       return new (ctx.mem) String_Constant(path, position, str);
@@ -822,7 +824,9 @@ namespace Sass {
       string str = s->value();
 
       for (size_t i = 0, L = str.length(); i < L; ++i) {
-        str[i] = std::tolower(str[i]);
+        if (isascii(str[i])) {
+          str[i] = std::tolower(str[i]);
+        }
       }
 
       return new (ctx.mem) String_Constant(path, position, str);


### PR DESCRIPTION
Tried the latest spec test suite today and encountered one error.

```
#   Failed test 'sass-spec t/sass-spec/spec/basic/48_case_conversion/input.scss'
#   at t\99_sass_specs.t line 68.
#          got: 'div {
#   bar: "BLAH";
#   bar: "BLAH";
#   bar: "BLAH";
#   bar: "1232178942";
#   bar: "├©├í├®├¡├│├║├╝├▒┬┐├®├á┼ñÃàÃé╔è╔▒╩¡╩¼Ð¬Êê¦ô";
#   bar: BLAH;
#   bar: BLAH;
#   bar: BLAH;
#   bar: "";
#   bar: "blah";
#   bar: "BLAH";
#   bar: "bLaH";
#   bar: "1232178942";
#   bar: "Ò©ÒíÒ®Ò¡Ò│Ò║Ò╝Ò▒Ô┐Ò®ÒáÕñþàþéÚÜÚ▒Û¡Û¼±¬‗ê²ô";
#   bar: blah;
#   bar: BLAH;
#   bar: bLaH;
#   bar: ""; }'
#     expected: 'div {
#   bar: "BLAH";
#   bar: "BLAH";
#   bar: "BLAH";
#   bar: "1232178942";
#   bar: "├©├í├®├¡├│├║├╝├▒┬┐├®├á┼ñÃàÃé╔è╔▒╩¡╩¼Ð¬Êê¦ô";
#   bar: BLAH;
#   bar: BLAH;
#   bar: BLAH;
#   bar: "";
#   bar: "blah";
#   bar: "blah";
#   bar: "blah";
#   bar: "1232178942";
#   bar: "├©├í├®├¡├│├║├╝├▒┬┐├®├á┼ñÃàÃé╔è╔▒╩¡╩¼Ð¬Êê¦ô";
#   bar: blah;
#   bar: blah;
#   bar: blah;
#   bar: ""; }'
```

The windows console is not utf8 aware, but you still should see that to-lower changed the unicode string. Fix was pretty obvious and now libsass seems to pass all spec tests again. I guess it was assumed that std::toupper and std::tolower would only work on ascii characters. I have no idea why this is not the case on my platform (Windows 7 and Strawberry Perl, which provides the compiler gcc version 4.6.3 (gcc-4.6.3 release with patches [build 20121012 by perlmingw.sf.net])).
