### PR TITLE
Issue 460: Update the extend operator to no longer filter non-placeholder selectors in the first pass of placeholder substitution

### DIFF
--- a/extend.cpp
+++ b/extend.cpp
@@ -51,9 +51,10 @@ namespace Sass {
       while (cplx) {
         Selector_Placeholder* sp = cplx->find_placeholder();
         if (!sp) {
-            // if there's no placeholder, we don't want to lose the selector, so append
-            // it to ng, so that it will get added to all_subbed. all_subbed becomes the
-            // new selector for this rule set.
+            // After the loop over this rule set's selectors completes, the selectors in
+            // all_subbed will become the new selectors for this rule set. If we get here, there's no
+            // placeholder selector in the current complex selector. We don't want to lose
+            // this selector, so append it to ng, so that it will get added to all_subbed.
             ng = new (ctx.mem) Selector_List(sg->path(), sg->position());
             *ng << cplx;
             break;


### PR DESCRIPTION
Fixes Issue #460

The first pass of placeholder substitution via the extend operator builds up an all_subbed list of selectors that were substituted. It then creates a selector out of the list and sets it as the selector for the passed in rule set. This ended up blowing away any non-substituted selectors for the rule set.

From issue #146, it sounds like there is a large set of changes intended for the extend operator. So, this fix tries to be surgical to fix the use case in issue 460 only. Our codebase relies on the pattern mentioned in #460 heavily.

There is also a pull request from michaek to update sass-spec to test for this case: sass/sass-spec#33. Once this change is merged, that test should now pass.
