### PR TITLE
Allow trailing commas in maps

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -783,6 +783,10 @@ namespace Sass {
 
     while (lex< exactly<','> >())
     {
+      // allow trailing commas - #495
+      if (peek< exactly<')'> >(position))
+      { break; }
+
       Expression* key = parse_list();
       // if it's not a map treat it like a list
       if (!(peek< exactly<':'> >(position)))


### PR DESCRIPTION
This PR allows trailing commas in maps. Fixes #495.
