### PR TITLE
Fixes build to report correctly to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,25 @@ script: ./script/cibuild
 
 before_install:
   - sudo pip install cpp-coveralls
+  # enable to debug coverage
+  - sudo pip install gcovr
+  - sudo apt-get install libjson-perl
+  - sudo apt-get install libjson-xs-perl
+  - sudo apt-get install libfile-slurp-perl
 
 install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  # gcc >= 4.7 is needed for -std=c++11
+  - ./script/install-compiler
   - gem install minitest
 
 after_success:
-  - coveralls --exclude sass-spec --exclude sassc --gcov-options '\-lp'
+  # exclude some directories from profiling (.libs is from autotools)
+  - export EXCLUDE_COVERAGE="--exclude sassc --exclude sass-spec --exclude .libs"
+  # debug via gcovr
+  - gcovr -r .
+  # debug via coveralls (dump result for futher analyzing)
+  - coveralls $EXCLUDE_COVERAGE --gcov-options '\-lp' --dump coveralls.json
+  # analyze the resulting json
+  - ./script/coveralls-debug
+  # generate and submit report to coveralls.io
+  - coveralls $EXCLUDE_COVERAGE --gcov-options '\-lp'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CXX      ?= g++
-CXXFLAGS = -std=c++11 -Wall -fPIC -O2
-LDFLAGS  = -fPIC
+CXXFLAGS = -std=c++11 -Wall -fPIC -O2 $(EXTRA_CFLAGS)
+LDFLAGS  = -fPIC $(EXTRA_LDFLAGS)
 
 ifneq (,$(findstring /cygdrive/,$(PATH)))
 	UNAME := Cygwin

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,10 @@
 ACLOCAL_AMFLAGS = -I m4
-AM_CXXFLAGS = -std=c++11 -Wall -fPIC -O2
+AM_CXXFLAGS = -std=c++11 -Wall -fPIC
 
-if COND_COVERAGE
-   AM_CXXFLAGS += --coverage --no-inline
+if ENABLE_COVERAGE
+  AM_CXXFLAGS += -O0 --coverage
+else
+  AM_CXXFLAGS += -O2
 endif
 
 pkgconfigdir = $(libdir)/pkgconfig
@@ -52,6 +54,10 @@ noinst_PROGRAMS = sass-tester
 sass_tester_SOURCES = $(SASS_SASSC_PATH)/sassc.c
 sass_tester_LDADD = libsass.la
 sass_tester_LDFLAGS = -no-install
+if ENABLE_COVERAGE
+sass_tester_LDFLAGS += -static
+nodist_EXTRA_sass_tester_SOURCES = non-existent-file-to-force-CXX-linking.cxx
+endif
 
 TESTS = \
 	$(SASS_SPEC_PATH)/spec/basic \

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,9 @@ Libsass
 
 by Aaron Leung ([@akhleung]) and Hampton Catlin ([@hcatlin])
 
-[![Build Status](https://travis-ci.org/sass/libsass.png?branch=master)](https://travis-ci.org/sass/libsass) [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=283068)](https://www.bountysource.com/trackers/283068-libsass?utm_source=283068&utm_medium=shield&utm_campaign=TRACKER_BADGE)
+[![Build Status](https://travis-ci.org/sass/libsass.png?branch=master)](https://travis-ci.org/sass/libsass)
+[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=283068)](https://www.bountysource.com/trackers/283068-libsass?utm_source=283068&utm_medium=shield&utm_campaign=TRACKER_BADGE)
+[![Coverage Status](https://img.shields.io/coveralls/sass/libsass.svg)](https://coveralls.io/r/sass/libsass?branch=feature%2Ftest-travis-ci-3)
 
 https://github.com/sass/libsass
 

--- a/configure.ac
+++ b/configure.ac
@@ -71,10 +71,26 @@ AM_CONDITIONAL(ENABLE_TESTS, test "x$enable_tests" = "xyes")
 
 AC_ARG_ENABLE([coverage],
   [AS_HELP_STRING([--enable-coverage],
-    [create coverage report for the test suite])],
-    [],
-    [enable_coverage=no])
-AM_CONDITIONAL([COND_COVERAGE],[test '!' "$enable_coverage" = no])
+    [enable coverage report for test suite])],
+    [enable_cov=$enableval],
+    [enable_cov=no])
 
+if test "x$enable_cov" = "xyes"; then
+    if test "x$enable_static" != "xyes"; then
+        AC_MSG_ERROR([Static libraries are required for --enable-coverage])
+    fi
+
+    AC_CHECK_PROG(GCOV, gcov, gcov)
+
+    # Remove all optimization flags from C[XX]FLAGS
+    changequote({,})
+    CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9]*//g'`
+    CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-O[0-9]*//g'`
+    changequote([,])
+
+    AC_SUBST(GCOV)
+fi
+
+AM_CONDITIONAL(ENABLE_COVERAGE, test "x$enable_cov" = "xyes")
 AC_CONFIG_FILES([Makefile support/libsass.pc])
 AC_OUTPUT

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,5 +6,5 @@ if [ ! -d "sass-spec" ]; then
   git clone https://github.com/sass/sass-spec.git
 fi
 if [ ! -d "sassc" ]; then
-  git clone https://github.com/sass/sassc.git
+  git clone -b feature/extra-env-variables https://github.com/mgreter/sassc.git
 fi

--- a/script/cibuild
+++ b/script/cibuild
@@ -4,12 +4,47 @@ set -e
 
 script/bootstrap
 
+# export this path right here (was in script/spec before)
+export SASS_LIBSASS_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
+
+# use some defaults if not running under travis ci
+if [ "x$TRAVIS_BUILD_DIR" == "x" ]; then export TRAVIS_BUILD_DIR=$(pwd)/build; fi
+if [ "x$SASS_SASSC_PATH" == "x" ]; then export SASS_SASSC_PATH=$(pwd)/sassc; fi
+if [ "x$SASS_SPEC_PATH" == "x" ]; then export SASS_SPEC_PATH=$(pwd)/sass-spec; fi
+
+if [ "x$CXX" == "xclang++" ]; then
+  COVERAGE="--enable-coverage"
+  export EXTRA_CFLAGS="-O0 --coverage"
+  export EXTRA_LDFLAGS="-O0 --coverage"
+else
+  COVERAGE="--enable-coverage"
+  export EXTRA_CFLAGS="-O0 --coverage"
+  export EXTRA_LDFLAGS="-O0 --coverage"
+fi
+
+export MAKE_OPTS="-j5 V=1"
+
 if [ "x$AUTOTOOLS" == "xyes" ]; then
+
+  echo -en 'travis_fold:start:configure\r'
   autoreconf -i
-  ./configure --enable-tests \
+  ./configure --enable-tests $COVERAGE \
+    --with-sassc-dir=$SASS_SASSC_PATH \
+    --with-sass-spec-dir=$SASS_SPEC_PATH \
     --prefix=$TRAVIS_BUILD_DIR
-  make -j5 install
-  cp $TRAVIS_BUILD_DIR/lib/libsass.a $TRAVIS_BUILD_DIR
+  echo -en 'travis_fold:end:configure\r'
+
+  make $MAKE_OPTS install
+
+  # sassc expects file to be in our root
+  echo "moving libsass.a in-place for sassc"
+  echo cp $TRAVIS_BUILD_DIR/lib/libsass.a $(pwd)
+  cp $TRAVIS_BUILD_DIR/lib/libsass.a $(pwd)
+
+else
+
+  make $MAKE_OPTS $SASS_SASSC_PATH/bin/sassc
+
 fi
 
 script/spec

--- a/script/coveralls-debug
+++ b/script/coveralls-debug
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use JSON;
+use File::Slurp;
+my $json = JSON->new;
+my $file = read_file('coveralls.json', { binmode => ':utf8' });
+my $rv = $json->decode($file);
+my $sources = $rv->{'source_files'};
+print STDERR join ", ", keys %{$rv}, "\n";
+foreach my $source (sort {
+	$a->{'name'} cmp $b->{'name'}
+} @{$sources})
+{
+	my $sum = 0;
+	my $undefs = 0;
+	my $coverages = $source->{'coverage'};
+	foreach my $coverage (@{$coverages})
+	{
+		if (defined $coverage)
+		{ $sum += $coverage }
+		else { $undefs ++; }
+	}
+	if ($sum > 0)
+	{
+		print STDERR $source->{'name'};
+		print STDERR " [sum: $sum]";
+		print STDERR " [undefs: $undefs]";
+		print STDERR "\n";
+	}
+}

--- a/script/install-compiler
+++ b/script/install-compiler
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ "x$CXX" = "xg++" ]; then
+  sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  sudo apt-get update -qq
+  sudo apt-get install -qq g++-4.8
+  sudo rm /usr/bin/cpp
+  sudo rm /usr/bin/gcc
+  sudo rm /usr/bin/c++
+  sudo rm /usr/bin/g++
+  sudo rm /usr/bin/gcov
+  sudo ln -s /usr/bin/cpp-4.8 /usr/bin/cpp
+  sudo ln -s /usr/bin/gcc-4.8 /usr/bin/gcc
+  sudo ln -s /usr/bin/c++-4.8 /usr/bin/c++
+  sudo ln -s /usr/bin/g++-4.8 /usr/bin/g++
+  sudo ln -s /usr/bin/gcov-4.8 /usr/bin/gcov
+fi

--- a/script/spec
+++ b/script/spec
@@ -2,6 +2,4 @@
 
 script/bootstrap
 
-export SASS_LIBSASS_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
-
-make -j5 test_build
+make $MAKE_OPTS test_build


### PR DESCRIPTION
Do _not_ merge this before https://github.com/sass/sassc/pull/70 is merged!
Do _not_ merge before I changed the official sassc repository reference back in `script/cibuild`!

This adds some major changes to the travis ci and build chain. Great care has been taken to not break any existing setups. Thanks to @QuLogic for his groundwork with the autotools build (from where do you have this `non-existent-file-to-force-CXX-linking.cxx` voodoo?).

I have tested it on a local branch and you may check out the [coverage results](https://coveralls.io/builds/1294127).

I have left in some debug stuff which can/should be disabled at some point (indicated by comments in `.travis.yml`). It doesn't seem to hurt much, so I decided to leave it in for now. Coverage reports are correctly generated and reported for all variations (autotools=[yes/no], cxx=[g++/clang++]).

This pull request is expected to break on travis-ci since the needed PR for sassc is not merged yet. @hcatlin maybe you could restart that task on travis ci once the sassc PR is merged!

Edit: decided to reference my local branch (which is the base for https://github.com/sass/sassc/pull/70) to have it passing on travis-ci. Will ammend this commit/branch as soon as the other PR is merged!
