### PR TITLE
Straightens out some sass_interface api issues

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -55,7 +55,6 @@ namespace Sass {
     image_path           (initializers.image_path()),
     output_path          (make_canonical_path(initializers.output_path())),
     source_comments      (initializers.source_comments()),
-    source_maps          (initializers.source_maps()),
     output_style         (initializers.output_style()),
     source_map_file      (make_canonical_path(initializers.source_map_file())),
     omit_source_map_url  (initializers.omit_source_map_url()),
@@ -270,7 +269,7 @@ namespace Sass {
 
   char* Context::generate_source_map()
   {
-    if (!source_maps) return 0;
+    if (source_map_file == "") return 0;
     char* result = 0;
     string map = source_map.generate_source_map();
     result = copy_c_str(map.c_str());

--- a/context.hpp
+++ b/context.hpp
@@ -50,11 +50,10 @@ namespace Sass {
 
     string       image_path; // for the image-url Sass function
     string       output_path; // for relative paths to the output
-    bool         source_comments;
-    bool         source_maps;
-    Output_Style output_style;
-    string       source_map_file;
-    bool         omit_source_map_url;
+    bool         source_comments; // for inline debug comments in css output
+    Output_Style output_style; // output style for the generated css code
+    string       source_map_file; // path to source map file (enables feature)
+    bool         omit_source_map_url; // disable source map comment in css output
 
     map<string, Color*> names_to_colors;
     map<int, string>    colors_to_names;
@@ -70,7 +69,6 @@ namespace Sass {
       KWD_ARG(Data, const char**,    include_paths_array);
       KWD_ARG(Data, vector<string>,  include_paths);
       KWD_ARG(Data, bool,            source_comments);
-      KWD_ARG(Data, bool,            source_maps);
       KWD_ARG(Data, Output_Style,    output_style);
       KWD_ARG(Data, string,          source_map_file);
       KWD_ARG(Data, bool,            omit_source_map_url);

--- a/sass.cpp
+++ b/sass.cpp
@@ -45,7 +45,8 @@ extern "C" {
                                                c_ctx->output_style)
 
                          .source_comments     (c_ctx->source_comments)
-                         .source_maps         (c_ctx->source_maps)
+                         .source_map_file     (c_ctx->source_map_file)
+                         .omit_source_map_url (c_ctx->omit_source_map_url)
 
                          .image_path          (c_ctx->image_path ?
                                                c_ctx->image_path :

--- a/sass.h
+++ b/sass.h
@@ -23,7 +23,8 @@ struct Sass_Context {
 
   int          output_style;
   bool         source_comments;
-  int          source_maps;
+  const char*  source_map_file;
+  bool         omit_source_map_url;
   const char*  image_path;
   const char*  output_path;
   const char*  include_paths_string;

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -83,17 +83,16 @@ extern "C" {
     *n = num;
   }
 
+  // helper for safe access to c_ctx
+  const char* safe_str (const char* str) {
+    return str == NULL ? "" : str;
+  }
+
   int sass_compile(sass_context* c_ctx)
   {
     using namespace Sass;
     try {
-      bool source_maps = false;
-      string source_map_file = "";
-      if (c_ctx->source_map_file && c_ctx->options.source_comments) {
-        source_maps = true;
-        source_map_file = c_ctx->source_map_file;
-      }
-      string input_path = c_ctx->input_path ? c_ctx->input_path : "";
+      string input_path = safe_str(c_ctx->input_path);
       int lastindex = input_path.find_last_of(".");
       string output_path;
       if (!c_ctx->output_path) {
@@ -108,13 +107,10 @@ extern "C" {
         Context::Data().source_c_str(c_ctx->source_string)
                        .output_path(output_path)
                        .output_style((Output_Style) c_ctx->options.output_style)
-                       .source_comments(!c_ctx->options.source_comments)
-                       .source_maps(source_maps)
-                       .source_map_file(source_map_file)
+                       .source_comments(c_ctx->options.source_comments)
+                       .source_map_file(safe_str(c_ctx->options.source_map_file))
                        .omit_source_map_url(c_ctx->options.omit_source_map_url)
-                       .image_path(c_ctx->options.image_path ?
-                                   c_ctx->options.image_path :
-                                   "")
+                       .image_path(safe_str(c_ctx->options.image_path))
                        .include_paths_c_str(c_ctx->options.include_paths)
                        .include_paths_array(0)
                        .include_paths(vector<string>())
@@ -184,13 +180,7 @@ extern "C" {
   {
     using namespace Sass;
     try {
-      bool source_maps = false;
-      string source_map_file = "";
-      if (c_ctx->source_map_file && c_ctx->options.source_comments) {
-        source_maps = true;
-        source_map_file = c_ctx->source_map_file;
-      }
-      string input_path = c_ctx->input_path ? c_ctx->input_path : "";
+      string input_path = safe_str(c_ctx->input_path);
       int lastindex = input_path.find_last_of(".");
       string output_path;
       if (!c_ctx->output_path) {
@@ -203,13 +193,10 @@ extern "C" {
         Context::Data().entry_point(input_path)
                        .output_path(output_path)
                        .output_style((Output_Style) c_ctx->options.output_style)
-                       .source_comments(!c_ctx->options.source_comments)
-                       .source_maps(source_maps)
-                       .source_map_file(source_map_file)
+                       .source_comments(c_ctx->options.source_comments)
+                       .source_map_file(safe_str(c_ctx->options.source_map_file))
                        .omit_source_map_url(c_ctx->options.omit_source_map_url)
-                       .image_path(c_ctx->options.image_path ?
-                                   c_ctx->options.image_path :
-                                   "")
+                       .image_path(safe_str(c_ctx->options.image_path))
                        .include_paths_c_str(c_ctx->options.include_paths)
                        .include_paths_array(0)
                        .include_paths(vector<string>())

--- a/sass_interface.h
+++ b/sass_interface.h
@@ -16,16 +16,24 @@ extern "C" {
 // Please ensure there are no null values.
 // Thar be dragons.
 struct sass_options {
-  // A value defined above in SASS_STYLE_* constants
+  // Output style for the generated css code
+  // A value from above SASS_STYLE_* constants
   int output_style;
   // If you want inline source comments
   bool source_comments;
-  // colon-separated list of paths (semicolon-separated if you're on Windows)
-  const char* include_paths;
-  const char* image_path;
-  // Positive integer
-  int precision;
+  // Path to source map file
+  // Enables the source map generating
+  // Used to create sourceMappingUrl
+  const char* source_map_file;
+  // Disable sourceMappingUrl in css output
   bool omit_source_map_url;
+  // Colon-separated list of paths
+  // Semicolon-separated on Windows
+  const char* include_paths;
+  // For the image-url Sass function
+  const char* image_path;
+  // Precision for outputting fractional numbers
+  int precision;
 };
 
 struct sass_context {
@@ -34,7 +42,6 @@ struct sass_context {
   const char* source_string;
   char* output_string;
   char* source_map_string;
-  const char* source_map_file;
   struct sass_options options;
   int error_status;
   char* error_message;
@@ -48,7 +55,6 @@ struct sass_file_context {
   const char* output_path;
   char* output_string;
   char* source_map_string;
-  const char* source_map_file;
   struct sass_options options;
   int error_status;
   char* error_message;

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,5 +6,5 @@ if [ ! -d "sass-spec" ]; then
   git clone https://github.com/sass/sass-spec.git
 fi
 if [ ! -d "sassc" ]; then
-  git clone -b feature/extra-env-variables https://github.com/mgreter/sassc.git
+  git clone https://github.com/sass/sassc.git
 fi


### PR DESCRIPTION
This has to be merged with https://github.com/sass/sassc/pull/72 to make travis ci happy again!

```
Moved `source_map_file` from context to options.
Fix for `omit_source_map_url` (propagate to cpp_ctx).
Removed superfluous `source_maps` from struct, generate
source maps when `source_map_file` string contains data.
```

With some of the latest patches the sass_interface API was changed. This created some issues for the perl bindings and the API is IMO currently not in a well defined state. My main concern is about the fallowing line that got added to sass_interface.cpp:

```
.source_comments(!c_ctx->options.source_comments)
```

We had some discission at https://github.com/sass/sassc/pull/69 and I decided to keep the option names for now, but straighten out the code logic. I guess the main issue was that source_map generating was linked to the source_comments option, which is IMO no longer needed as we can use source_map_file and omit_source_map_url for that.

But since `source_comments` was changed from int to bool, all bindings will need to update anyway. So IMO it would be a good time if we would want to change the names to make their use more intuitive.
- To create source maps you need to set `source_map_file` (adds sourceMappingUrl to css)
- To omit the sourceMappingUrl in the final css you can set `omit_source_map_url = true`
- Enable comments about original line numbers by setting `source_comments = true`

This only lacks the possibility to add the sourceMappingUrl without actually generating the source map. But I guess this should never be a real problem. If you implement the C bindings, make sure you initialize the structs accordingly to avoid segfaults:

```
struct sass_options options = { 0 };
```

Best regards
Marcel
