### PR TITLE
Implement the list_separator function

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -401,6 +401,7 @@ namespace Sass {
     register_function(ctx, append_sig, append, env);
     register_function(ctx, compact_sig, compact, env);
     register_function(ctx, zip_sig, zip, env);
+    register_function(ctx, list_separator_sig, list_separator, env);
     // Map Functions
     register_function(ctx, map_get_sig, map_get, env);
     register_function(ctx, map_merge_sig, map_merge, env);

--- a/functions.cpp
+++ b/functions.cpp
@@ -1151,6 +1151,19 @@ namespace Sass {
       return result;
     }
 
+    Signature list_separator_sig = "list_separator($list)";
+    BUILT_IN(list_separator)
+    {
+      List* l = dynamic_cast<List*>(env["$list"]);
+      if (!l) {
+        l = new (ctx.mem) List(path, position, 1);
+        *l << ARG("$list", Expression);
+      }
+      return new (ctx.mem) String_Constant(path,
+                                           position,
+                                           l->separator() == List::COMMA ? "comma" : "space");
+    }
+
     /////////////////
     // MAP FUNCTIONS
     /////////////////

--- a/functions.hpp
+++ b/functions.hpp
@@ -84,6 +84,7 @@ namespace Sass {
     extern Signature append_sig;
     extern Signature zip_sig;
     extern Signature compact_sig;
+    extern Signature list_separator_sig;
     extern Signature type_of_sig;
     extern Signature unit_sig;
     extern Signature unitless_sig;
@@ -152,6 +153,7 @@ namespace Sass {
     BUILT_IN(append);
     BUILT_IN(zip);
     BUILT_IN(compact);
+    BUILT_IN(list_separator);
     BUILT_IN(type_of);
     BUILT_IN(unit);
     BUILT_IN(unitless);


### PR DESCRIPTION
This PR implements the list_separator function as defined here: http://sass-lang.com/documentation/Sass/Script/Functions.html#list_separator-instance_method.

Fixes #506. Specs added https://github.com/sass/sass-spec/pull/55.
