### PR TITLE
Don't error on css variable syntax

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -745,6 +745,9 @@ namespace Sass {
     else if (lex< sequence< optional< exactly<'*'> >, identifier > >()) {
       prop = new (ctx.mem) String_Constant(path, source_position, lexed);
     }
+    else if (lex< custom_property_name >()) {
+      prop = new (ctx.mem) String_Constant(path, source_position, lexed);
+    }
     else {
       error("invalid property name");
     }

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -166,6 +166,11 @@ namespace Sass {
                                                 backslash_something > > >(src);
     }
 
+    // Match CSS css variables.
+    const char* custom_property_name(const char* src) {
+      return sequence< exactly<'-'>, exactly<'-'>, identifier >(src);
+    }
+
     // Match interpolant schemas
     const char* identifier_schema(const char* src) {
       // follows this pattern: (x*ix*)+ ... well, not quite

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -320,6 +320,8 @@ namespace Sass {
 
     const char* backslash_something(const char* src);
 
+    // Match CSS css variables.
+    const char* custom_property_name(const char* src);
     // Match a CSS identifier.
     const char* identifier(const char* src);
     // Match selector names.


### PR DESCRIPTION
This PR prevents libsass from barfing when it encounters the custom property syntax (css variables).

Fixes sass/libsass#453. Spec added https://github.com/sass/sass-spec/pull/56.
