### PR TITLE
Interface: Treat source string as Indented Sass

### DIFF
--- a/context.hpp
+++ b/context.hpp
@@ -54,6 +54,7 @@ namespace Sass {
     Output_Style output_style; // output style for the generated css code
     string       source_map_file; // path to source map file (enables feature)
     bool         omit_source_map_url; // disable source map comment in css output
+    bool         is_indented_syntax_src; // treat source string as sass
 
     map<string, Color*> names_to_colors;
     map<int, string>    colors_to_names;
@@ -72,6 +73,7 @@ namespace Sass {
       KWD_ARG(Data, Output_Style,    output_style);
       KWD_ARG(Data, string,          source_map_file);
       KWD_ARG(Data, bool,            omit_source_map_url);
+      KWD_ARG(Data, bool,            is_indented_syntax_src);
       KWD_ARG(Data, size_t,          precision);
     };
 

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -107,6 +107,7 @@ extern "C" {
         Context::Data().source_c_str(c_ctx->source_string)
                        .output_path(output_path)
                        .output_style((Output_Style) c_ctx->options.output_style)
+                       .is_indented_syntax_src(c_ctx->options.is_indented_syntax_src)
                        .source_comments(c_ctx->options.source_comments)
                        .source_map_file(safe_str(c_ctx->options.source_map_file))
                        .omit_source_map_url(c_ctx->options.omit_source_map_url)

--- a/sass_interface.h
+++ b/sass_interface.h
@@ -27,6 +27,8 @@ struct sass_options {
   const char* source_map_file;
   // Disable sourceMappingUrl in css output
   bool omit_source_map_url;
+  // Treat source_string as sass (as opposed to scss)
+  bool is_indented_syntax_src;
   // Colon-separated list of paths
   // Semicolon-separated on Windows
   const char* include_paths;


### PR DESCRIPTION
Fixes #488.

/cc @hcatlin 
