### PR TITLE
Fix parsing bug with maps with map and lists as key and value

### DIFF
--- a/parser.hpp
+++ b/parser.hpp
@@ -203,6 +203,7 @@ namespace Sass {
     Attribute_Selector* parse_attribute_selector();
     Block* parse_block();
     Declaration* parse_declaration();
+    Expression* parse_map_value();
     Expression* parse_map();
     Expression* parse_list();
     Expression* parse_comma_list();

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -166,6 +166,16 @@ namespace Sass {
                                                 backslash_something > > >(src);
     }
 
+    const char* map_key(const char* src) {
+      return sequence< spaces_and_comments,
+                       one_plus< sequence< exactly<'('>, spaces_and_comments > >,
+                       one_plus< alternatives< identifier, string_constant, variable, spaces > >,
+                       spaces_and_comments,
+                       zero_plus< exactly<')'> >,
+                       spaces_and_comments,
+                       exactly<':'> >(src);
+    }
+
     // Match CSS css variables.
     const char* custom_property_name(const char* src) {
       return sequence< exactly<'-'>, exactly<'-'>, identifier >(src);

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -320,6 +320,8 @@ namespace Sass {
 
     const char* backslash_something(const char* src);
 
+    const char* map_key(const char* src);
+
     // Match CSS css variables.
     const char* custom_property_name(const char* src);
     // Match a CSS identifier.


### PR DESCRIPTION
This pull request makes the parsing of maps much more robust and more inline with the flexibility of the ruby equivalent. IMHO this is must-have for 3.0 since the current implement errors with maps or comma separated lists as values.

Fixes #509.

Specs added https://github.com/sass/sass-spec/pull/83.
