### PR TITLE
Don't output null values in compress output

### DIFF
--- a/output_compressed.cpp
+++ b/output_compressed.cpp
@@ -239,6 +239,11 @@ namespace Sass {
     }
   }
 
+  void Output_Compressed::operator()(Null* n)
+  {
+    // noop
+  }
+
   void Output_Compressed::operator()(Argument* a)
   {
     if (!a->name().empty()) {

--- a/output_compressed.hpp
+++ b/output_compressed.hpp
@@ -63,6 +63,7 @@ namespace Sass {
     // virtual void operator()(String_Constant* x);
     // virtual void operator()(Media_Query*);
     virtual void operator()(Media_Query_Expression*);
+    virtual void operator()(Null*);
     // // parameters and arguments
     // virtual void operator()(Parameter*);
     // virtual void operator()(Parameters*);


### PR DESCRIPTION
This PR stop `null` being outputting in compressed output.

Fixes https://github.com/sass/libsass/issues/487. Specs added https://github.com/sass/sass-spec/pull/84

As it stands I don't see a what to really test this against sass-spec other than to say it doesn't introduce regressions.
