### PR TITLE
Make index() sas 3.3 compatible

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -1064,7 +1064,7 @@ namespace Sass {
       for (size_t i = 0, L = l->length(); i < L; ++i) {
         if (eq(l->value_at_index(i), v, ctx)) return new (ctx.mem) Number(path, position, i+1);
       }
-      return new (ctx.mem) Boolean(path, position, false);
+      return new (ctx.mem) Null(path, position);
     }
 
     Signature join_sig = "join($list1, $list2, $separator: auto)";


### PR DESCRIPTION
This PR makes `index()` compatible with ruby sass 3.3.0 by returning null rather than `false` if the index doesn't exists.

Fixes https://github.com/sass/libsass/issues/512. Spec added https://github.com/sass/sass-spec/pull/62, https://github.com/sass/sass-spec/pull/85, https://github.com/sass/sass-spec/pull/86
