### PR TITLE
Remove trailing ; in compressed output

### DIFF
--- a/output_compressed.cpp
+++ b/output_compressed.cpp
@@ -58,6 +58,8 @@ namespace Sass {
           stm->perform(this);
         }
       }
+      size_t l = buffer.length();
+      buffer.erase(l-1);
       append_singleline_part_to_buffer("}");
     }
 


### PR DESCRIPTION
This PR remove trailing ; in compressed output.

Fixes https://github.com/sass/libsass/issues/377.

Spec not added because it requires compressed mode output.
