### PR TITLE
Don't output declarations with null values

### DIFF
--- a/inspect.cpp
+++ b/inspect.cpp
@@ -78,6 +78,7 @@ namespace Sass {
 
   void Inspect::operator()(Declaration* dec)
   {
+    if (dec->value()->concrete_type() == Expression::NULL_VAL) return;
     if (ctx) ctx->source_map.add_mapping(dec->property());
     dec->property()->perform(this);
     append_to_buffer(": ");


### PR DESCRIPTION
This PR stops libsass outputting declarations where the value is null. 

Fixes #113. Specs added https://github.com/sass/sass-spec/pull/87.

---

~~This conceptually feels like the right way to solve this issue, but it might not the most correct. Specs pass so I assume nothing is broken.~~ Turns out compressed output is already doing this the same way.
