### PR TITLE
Allow map keys to be numbers

### DIFF
--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -169,7 +169,7 @@ namespace Sass {
     const char* map_key(const char* src) {
       return sequence< spaces_and_comments,
                        one_plus< sequence< exactly<'('>, spaces_and_comments > >,
-                       one_plus< alternatives< identifier, string_constant, variable, spaces > >,
+                       one_plus< alternatives< identifier, alnums, string_constant, variable, spaces > >,
                        spaces_and_comments,
                        zero_plus< exactly<')'> >,
                        spaces_and_comments,


### PR DESCRIPTION
Fixes #534. Specs added https://github.com/sass/sass-spec/pull/89.
