### PR TITLE
Exports quote and unquote functions for C bindings

### DIFF
--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -6,6 +6,7 @@
 
 #include "sass_interface.h"
 #include "context.hpp"
+#include "inspect.hpp"
 
 #ifndef SASS_ERROR_HANDLING
 #include "error_handling.hpp"
@@ -264,6 +265,14 @@ extern "C" {
   int sass_compile_folder(sass_folder_context* c_ctx)
   {
     return 1;
+  }
+
+  const char* quote (const char *str, const char quotemark) {
+    return Sass::quote(str, quotemark).c_str();
+  }
+
+  const char* unquote (const char *str) {
+    return Sass::unquote(str).c_str();
   }
 
 }

--- a/sass_interface.h
+++ b/sass_interface.h
@@ -88,6 +88,9 @@ int sass_compile            (struct sass_context* ctx);
 int sass_compile_file       (struct sass_file_context* ctx);
 int sass_compile_folder     (struct sass_folder_context* ctx);
 
+const char* quote     (const char *str, const char quotemark);
+const char* unquote   (const char *str);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Needed to exchange strings with registered custom functions.

Libsass passes strings in quoted form inclusive quotemarks to the C bindings. I guess this is also how it is handled internally (I see a lot of unquote stuff going on in functions.cpp). IMO it would have been better to unquote on reading and quote on output if needed. Probably too late now. So this should be handy for all C Bindings if they have to consume or return strings in custom functions.
