### PR TITLE
lexer: allow variables to be any valid CSS identifier

### DIFF
--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -479,7 +479,7 @@ namespace Sass {
 
     // Match SCSS variable names.
     const char* variable(const char* src) {
-      return sequence<exactly<'$'>, name>(src);
+      return sequence<exactly<'$'>, identifier>(src);
     }
 
     // Match Sass boolean keywords.


### PR DESCRIPTION
Previously, variables were required to be a "name" token--alphanumeric,
`-`, or `_` only. Allow variable names to be any valid identifier for
consistency with mixin/function names and Ruby Sass.

Satisfies tests introduced by sass/sass-spec#94.

Fixes #553.
