### PR TITLE
Add generic support for destructuring assignment in @each

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -475,11 +475,11 @@ namespace Sass {
   // The Sass `@each` control directive.
   //////////////////////////////////////
   class Each : public Has_Block {
-    ADD_PROPERTY(string, variable);
+    ADD_PROPERTY(vector<string>, variables);
     ADD_PROPERTY(Expression*, list);
   public:
-    Each(string path, Position position, string var, Expression* lst, Block* b)
-    : Has_Block(path, position, b), variable_(var), list_(lst)
+    Each(string path, Position position, vector<string> vars, Expression* lst, Block* b)
+    : Has_Block(path, position, b), variables_(vars), list_(lst)
     { }
     ATTACH_OPERATIONS();
   };

--- a/ast_factory.hpp
+++ b/ast_factory.hpp
@@ -26,7 +26,7 @@ namespace Sass {
     Comment* new_Comment(string p, size_t l, String* txt);
     If* new_If(string p, size_t l, Expression* pred, Block* con, Block* alt = 0);
     For* new_For(string p, size_t l, string var, Expression* lo, Expression* hi, Block* b, bool inc);
-    Each* new_Each(string p, size_t l, string var, Expression* lst, Block* b);
+    Each* new_Each(string p, size_t l, vector<string> vars, Expression* lst, Block* b);
     While* new_While(string p, size_t l, Expression* pred, Block* b);
     Extension* new_Extension(string p, size_t l, Selector* s);
     Definition<MIXIN>* new_Mixin_Definition(string p, size_t l, string n, Parameters* params, Block* b);

--- a/expand.cpp
+++ b/expand.cpp
@@ -211,10 +211,14 @@ namespace Sass {
 
   Statement* Expand::operator()(Each* e)
   {
-    string variable(e->variable());
+    vector<string> variables(e->variables());
     Expression* expr = e->list()->perform(eval->with(env, backtrace));
     List* list = 0;
-    if (expr->concrete_type() != Expression::LIST) {
+    Map* map = 0;
+    if (expr->concrete_type() == Expression::MAP) {
+      map = static_cast<Map*>(expr);
+    }
+    else if (expr->concrete_type() != Expression::LIST) {
       list = new (ctx.mem) List(expr->path(), expr->position(), 1, List::COMMA);
       *list << expr;
     }
@@ -222,13 +226,31 @@ namespace Sass {
       list = static_cast<List*>(expr);
     }
     Env new_env;
-    new_env[variable] = 0;
+    for (size_t i = 0, L = variables.size(); i < L; ++i) new_env[variables[i]] = 0;
     new_env.link(env);
     env = &new_env;
     Block* body = e->block();
-    for (size_t i = 0, L = list->length(); i < L; ++i) {
-      (*env)[variable] = (*list)[i]->perform(eval->with(env, backtrace));
-      append_block(body);
+
+    if (map) {
+      for (auto key : map->keys()) {
+        (*env)[variables[0]] = key->perform(eval->with(env, backtrace));
+        (*env)[variables[1]] = map->at(key)->perform(eval->with(env, backtrace));
+        append_block(body);
+      }
+    }
+    else {
+      for (size_t i = 0, L = list->length(); i < L; ++i) {
+        List* variable = static_cast<List*>(list->value_at_index(i));
+        for (size_t j = 0, K = variables.size(); j < K; ++j) {
+          if (j < variable->length()) {
+            (*env)[variables[j]] = (*variable)[j]->perform(eval->with(env, backtrace));
+          }
+          else {
+            (*env)[variables[j]] = new (ctx.mem) Null(expr->path(), expr->position());
+          }
+        }
+        append_block(body);
+      }
     }
     env = new_env.parent();
     return 0;

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -162,7 +162,11 @@ namespace Sass {
   void Inspect::operator()(Each* loop)
   {
     append_to_buffer("@each ");
-    append_to_buffer(loop->variable());
+    append_to_buffer(loop->variables()[0]);
+    for (size_t i = 1, L = loop->variables().size(); i < L; ++i) {
+      append_to_buffer(", ");
+      append_to_buffer(loop->variables()[i]);
+    }
     append_to_buffer(" in ");
     loop->list()->perform(this);
     loop->block()->perform(this);

--- a/parser.cpp
+++ b/parser.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <iostream>
+#include <vector>
 #include "parser.hpp"
 #include "file.hpp"
 #include "inspect.hpp"
@@ -1454,7 +1455,12 @@ namespace Sass {
     lex < each_directive >();
     Position each_source_position = source_position;
     if (!lex< variable >()) error("@each directive requires an iteration variable");
-    string var(Util::normalize_underscores(lexed));
+    vector<string> vars;
+    vars.push_back(Util::normalize_underscores(lexed));
+    while (peek< exactly<','> >() && lex< exactly<','> >()) {
+      if (!lex< variable >()) error("@each directive requires an iteration variable");
+      vars.push_back(Util::normalize_underscores(lexed));
+    }
     if (!lex< in >()) error("expected 'in' keyword in @each directive");
     Expression* list = parse_list();
     list->is_delayed(false);
@@ -1466,7 +1472,7 @@ namespace Sass {
     }
     if (!peek< exactly<'{'> >()) error("expected '{' after the upper bound in @each directive");
     Block* body = parse_block();
-    return new (ctx.mem) Each(path, each_source_position, var, list, body);
+    return new (ctx.mem) Each(path, each_source_position, vars, list, body);
   }
 
   While* Parser::parse_while_directive()


### PR DESCRIPTION
This PR adds generic support for destructuring assignment in @each.

Fixes #492. Specs added https://github.com/sass/sass-spec/pull/54, https://github.com/sass/sass-spec/pull/96.
#### TODO
- [ ] confirm if eval needs to be updated as well (looks like dead code to me)

/cc @ericam 
