### PR TITLE
Fixes regression with custom precision (#364)

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -63,7 +63,8 @@ namespace Sass {
     names_to_colors         (map<string, Color*>()),
     colors_to_names         (map<int, string>()),
     precision               (initializers.precision()),
-    subset_map              (Subset_Map<string, pair<Complex_Selector*, Compound_Selector*> >())
+    subset_map              (Subset_Map<string, pair<Complex_Selector*, Compound_Selector*> >()),
+    _skip_source_map_update (initializers._skip_source_map_update())
   {
     cwd = get_cwd();
 

--- a/context.hpp
+++ b/context.hpp
@@ -60,6 +60,7 @@ namespace Sass {
     map<int, string>    colors_to_names;
 
     size_t precision; // precision for outputting fractional numbers
+    bool _skip_source_map_update; // status flag to skip source map updates
 
     KWD_ARG_SET(Data) {
       KWD_ARG(Data, const char*,     source_c_str);
@@ -75,6 +76,7 @@ namespace Sass {
       KWD_ARG(Data, bool,            omit_source_map_url);
       KWD_ARG(Data, bool,            is_indented_syntax_src);
       KWD_ARG(Data, size_t,          precision);
+      KWD_ARG(Data, bool,            _skip_source_map_update);
     };
 
     Context(Data);

--- a/eval.cpp
+++ b/eval.cpp
@@ -500,7 +500,9 @@ namespace Sass {
   Expression* Eval::operator()(String_Schema* s)
   {
     string acc;
-    To_String to_string(0);
+    ctx._skip_source_map_update = true;
+    To_String to_string(&ctx);
+    ctx._skip_source_map_update = false;
     for (size_t i = 0, L = s->length(); i < L; ++i) {
       string chunk((*s)[i]->perform(this)->perform(&to_string));
       if (((s->quote_mark() && is_quoted(chunk)) || !s->quote_mark()) && (*s)[i]->is_interpolant()) { // some redundancy in that test

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -627,7 +627,8 @@ namespace Sass {
   void Inspect::append_to_buffer(const string& text)
   {
     buffer += text;
-    if (ctx) ctx->source_map.update_column(text);
+    if (ctx && !ctx->_skip_source_map_update)
+      ctx->source_map.update_column(text);
   }
 
 }

--- a/output_compressed.cpp
+++ b/output_compressed.cpp
@@ -363,7 +363,8 @@ namespace Sass {
   void Output_Compressed::append_singleline_part_to_buffer(const string& text)
   {
     buffer += text;
-    if (ctx) ctx->source_map.update_column(text);
+    if (ctx && !ctx->_skip_source_map_update)
+      ctx->source_map.update_column(text);
   }
 
 }

--- a/output_nested.cpp
+++ b/output_nested.cpp
@@ -262,7 +262,8 @@ namespace Sass {
   void Output_Nested::append_to_buffer(const string& text)
   {
     buffer += text;
-    if (ctx) ctx->source_map.update_column(text);
+    if (ctx && !ctx->_skip_source_map_update)
+      ctx->source_map.update_column(text);
   }
 
 }


### PR DESCRIPTION
I do not know what the [original commit](https://github.com/nsams/libsass/commit/e231c6c995e97ba6a8eb42ff484f4ef8c24e96b1) that introduced this regression is doing. This approach is pretty hackish, but IMO not much more than the previous "fix". I've added another `bool` to context to let string eval have it its own way. Not really pretty but works!

I guess this is better than nothing and if I did break the other fix, it will probably come up soon again :)
If other committers agree, this can be merged. If there are no objections, I will merge it in soon!
