### PR TITLE
Fix compressed output of media queries

### DIFF
--- a/output_compressed.cpp
+++ b/output_compressed.cpp
@@ -122,9 +122,7 @@ namespace Sass {
       // JMA - not hoisted, just output in order
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement* stm = (*b)[i];
-        if (!stm->is_hoistable()) {
-          stm->perform(this);
-        }
+        stm->perform(this);
       }
     }
 


### PR DESCRIPTION
This PR fixes the output of `@media` blocks which broke in the 3.0.0 release. This PR simply makes the compressed output mimic the behaviour of nested output which doesn't suffer from this bug.

See: https://github.com/sass/libsass/blob/master/output_nested.cpp#L189-L192

Fixes https://github.com/sass/libsass/issues/566.

No spec was added because this requires compressed output. A naive test of this fix can be performed locally by running.

``` bash
$ cd SASS_LIBSASS_PATH
$ make
$ cd SASS_SASSC_PATH
$ make
$ echo "@media screen and (min-width: 400px) {body {background-color: purple;}}" | sassc/bin/sassc -t compressed -s
// @media screen and (min-width: 400px){body{background-color:purple}}
```
