### PR TITLE
Remove the non-standard compact function

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -410,7 +410,6 @@ namespace Sass {
     register_function(ctx, index_sig, index, env);
     register_function(ctx, join_sig, join, env);
     register_function(ctx, append_sig, append, env);
-    register_function(ctx, compact_sig, compact, env);
     register_function(ctx, zip_sig, zip, env);
     register_function(ctx, list_separator_sig, list_separator, env);
     // Map Functions

--- a/functions.cpp
+++ b/functions.cpp
@@ -1164,30 +1164,6 @@ namespace Sass {
       return zippers;
     }
 
-    Signature compact_sig = "compact($values...)";
-    BUILT_IN(compact)
-    {
-      List* arglist = ARG("$values", List);
-      List::Separator sep = List::COMMA;
-      if (arglist->length() == 1) {
-        Expression* the_arg = arglist->value_at_index(0);
-        arglist = dynamic_cast<List*>(the_arg);
-        if (!arglist) {
-          List* result = new (ctx.mem) List(path, position, 1, List::COMMA);
-          *result << the_arg;
-          return result;
-        }
-        sep = arglist->separator();
-      }
-      List* result = new (ctx.mem) List(path, position, 0, sep);
-      for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        Boolean* ith = dynamic_cast<Boolean*>(arglist->value_at_index(i));
-        if (ith && ith->value() == false) continue;
-        *result << arglist->value_at_index(i);
-      }
-      return result;
-    }
-
     Signature list_separator_sig = "list_separator($list)";
     BUILT_IN(list_separator)
     {

--- a/functions.hpp
+++ b/functions.hpp
@@ -83,7 +83,6 @@ namespace Sass {
     extern Signature join_sig;
     extern Signature append_sig;
     extern Signature zip_sig;
-    extern Signature compact_sig;
     extern Signature list_separator_sig;
     extern Signature type_of_sig;
     extern Signature unit_sig;
@@ -154,7 +153,6 @@ namespace Sass {
     BUILT_IN(join);
     BUILT_IN(append);
     BUILT_IN(zip);
-    BUILT_IN(compact);
     BUILT_IN(list_separator);
     BUILT_IN(type_of);
     BUILT_IN(unit);


### PR DESCRIPTION
This PR removes the non-standard compact function. 

Fixes https://github.com/sass/libsass/issues/585.