### PR TITLE
Radically simply the map parser logic

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -760,34 +760,15 @@ namespace Sass {
 
   Expression* Parser::parse_map()
   {
-    if (!(peek< map_key >(position)))
-    { return parse_list(); }
-
-    lex< exactly<'('> >();
-
-    // empty maps so treat it like an empty list
-    if (peek< exactly<')'> >(position))
-    {
-      lex< exactly<')'> >();
-      return new (ctx.mem) List(path, source_position, 0);
-    }
-
     Expression* key = parse_list();
 
     // it's not a map so return the lexed value as a list value
-    if (!lex< exactly<':'> >())
-    {
-      if (!lex< exactly<')'> >()) error("unclosed parenthesis");
-      return key;
-    }
+    if (!peek< exactly<':'> >())
+    { return key; }
 
-    Expression* value;
-    if (peek< map_key >(position))
-    {
-      value = parse_map();
-    } else {
-      value = parse_space_list();
-    }
+    lex< exactly<':'> >();
+
+    Expression* value = parse_space_list();
 
     Map* map = new (ctx.mem) Map(path, source_position, 1);
     (*map) << make_pair(key, value);
@@ -803,18 +784,10 @@ namespace Sass {
       if (!(lex< exactly<':'> >()))
       { error("invalid syntax"); }
 
-      Expression* value;
-      if (peek< map_key >(position))
-      {
-        value = parse_map();
-      } else {
-        value = parse_space_list();
-      }
+      Expression* value = parse_space_list();
 
       (*map) << make_pair(key, value);
     }
-
-    if (!lex< exactly<')'> >()) error("unclosed parenthesis 3");
 
     return map;
   }
@@ -848,7 +821,7 @@ namespace Sass {
           peek< exactly<'}'> >(position) ||
           peek< exactly<'{'> >(position) ||
           peek< exactly<')'> >(position) ||
-          //peek< exactly<':'> >(position) ||
+          peek< exactly<':'> >(position) ||
           peek< exactly<ellipsis> >(position)) {
         break;
       }
@@ -861,9 +834,7 @@ namespace Sass {
 
   Expression* Parser::parse_space_list()
   {
-    Expression* disj1;
-    if (peek< map_key >(position)) disj1 = parse_map();
-    else disj1 = parse_disjunction();
+    Expression* disj1 = parse_disjunction();
     // if it's a singleton, return it directly; don't wrap it
     if (//peek< exactly<'!'> >(position) ||
         peek< exactly<';'> >(position) ||
@@ -992,7 +963,7 @@ namespace Sass {
   Expression* Parser::parse_factor()
   {
     if (lex< exactly<'('> >()) {
-      Expression* value = parse_list();
+      Expression* value = parse_map();
       if (!lex< exactly<')'> >()) error("unclosed parenthesis");
       value->is_delayed(false);
       // make sure wrapped lists and division expressions are non-delayed within parentheses

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -166,16 +166,6 @@ namespace Sass {
                                                 backslash_something > > >(src);
     }
 
-    const char* map_key(const char* src) {
-      return sequence< spaces_and_comments,
-                       one_plus< sequence< exactly<'('>, spaces_and_comments > >,
-                       one_plus< alternatives< identifier, alnums, string_constant, variable, spaces, exactly<','> > >,
-                       spaces_and_comments,
-                       zero_plus< exactly<')'> >,
-                       spaces_and_comments,
-                       exactly<':'> >(src);
-    }
-
     // Match CSS css variables.
     const char* custom_property_name(const char* src) {
       return sequence< exactly<'-'>, exactly<'-'>, identifier >(src);

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -320,8 +320,6 @@ namespace Sass {
 
     const char* backslash_something(const char* src);
 
-    const char* map_key(const char* src);
-
     // Match CSS css variables.
     const char* custom_property_name(const char* src);
     // Match a CSS identifier.


### PR DESCRIPTION
This PR radically simplifies the maps parser logic. I've removed the prelexer hack I added to get 3.0 out the door with useful maps. The prelexer hack imposed limitations on what could be in a map key subsequently making #555, #574 impossible. It also changed the parser token resolution flow which meant https://github.com/sass/libsass/issues/575 wasn't possible.

Fixes #575. Specs added https://github.com/sass/sass-spec/commit/eaad1c6bd63961c3892465dcefd61d94fe89c2f9, https://github.com/sass/sass-spec/pull/110.
