### PR TITLE
Fix problem compiling warn and debug statements in sass2css

### DIFF
--- a/sass2scss.cpp
+++ b/sass2scss.cpp
@@ -559,7 +559,10 @@ namespace Sass
 				}
 
 			}
-
+			// terminate warn and debug statements immediately
+			else if (sass.substr(pos_left, 5) == "@warn" || sass.substr(pos_left, 6) == "@debug") {
+				sass = indent + sass.substr(pos_left);
+			}
 			// replace some specific sass shorthand directives (if not fallowed by a white space character)
 			else if (sass.substr(pos_left, 1) == "=" && sass.find_first_of(SASS2SCSS_FIND_WHITESPACE, pos_left) != pos_left + 1)
 			{ sass = indent + "@mixin " + sass.substr(pos_left + 1); }


### PR DESCRIPTION
See https://github.com/sass/libsass/issues/599

Source code:

```
@function str-replace($string, $old, $new: "", $case-sensitive: true)
    @if $string
        @warn "One of the 3 arguments is not a string"
        @return $string

    @return $string
```

Before patch:

```
@function str-replace($string, $old, $new: "", $case-sensitive: true) {
    @if $string {
        @warn "One of the 3 arguments is not a string" {}
        @return $string; }

    @return $string; }
```

After patch:

```
@function str-replace($string, $old, $new: "", $case-sensitive: true) {
    @if $string {
        @warn "One of the 3 arguments is not a string";
        @return $string; }

    @return $string; }
```
