### PR TITLE
Allow \ in identifiers

### DIFF
--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -288,7 +288,8 @@ namespace Sass {
     const char* name(const char* src) {
       return one_plus< alternatives< alnum,
                                      exactly<'-'>,
-                                     exactly<'_'> > >(src);
+                                     exactly<'_'>,
+                                     exactly<'\\'> > >(src);
     }
 
     const char* warn(const char* src) {


### PR DESCRIPTION
This PR fixes the incorrect treatment of `\` in identifiers.

Fixes https://github.com/sass/libsass/issues/602. Specs added https://github.com/sass/sass-spec/pull/116.
