### PR TITLE
Don't error when blocks terminated by ;

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -609,7 +609,7 @@ namespace Sass {
           Comment* comment  = new (ctx.mem) Comment(path, source_position, contents);
           (*block) << comment;
         }
-        if (lex< exactly<'}'> >()) break;
+        if (lex< sequence< exactly<'}'>, zero_plus< exactly<';'> > > >()) break;
       }
       if (lex< block_comment >()) {
         String*  contents = parse_interpolated_chunk(lexed);


### PR DESCRIPTION
This PR fixes the erroneous handling of unexpected (but valid) semi-colons terminating a block.

Fixed https://github.com/sass/libsass/issues/595. Specs added https://github.com/sass/sass-spec/pull/112, https://github.com/sass/sass-spec/pull/117.
