### PR TITLE
install newly required header in autotools build system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ libsass_la_SOURCES = \
 
 libsass_la_LDFLAGS = -no-undefined -version-info 0:0:0
 
-include_HEADERS = sass_interface.h sass.h
+include_HEADERS = sass2scss.h sass_interface.h sass.h
 
 if ENABLE_TESTS
 


### PR DESCRIPTION
sass_interface.h #includes sass2scss.h so we need to have the
latter header wherever we have the former one.
