### PR TITLE
Add basic support for feature queries

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -340,6 +340,19 @@ namespace Sass {
     ATTACH_OPERATIONS();
   };
 
+  ///////////////////
+  // Feature queries.
+  ///////////////////
+  class Feature_Block : public Has_Block {
+    ADD_PROPERTY(Feature_Queries*, feature_queries);
+  public:
+    Feature_Block(string path, Position position, Feature_Queries* fqs, Block* b)
+    : Has_Block(path, position, b), feature_queries_(fqs)
+    { }
+    bool is_hoistable() { return true; }
+    ATTACH_OPERATIONS();
+  };
+
   ///////////////////////////////////////////////////////////////////////
   // At-rules -- arbitrary directives beginning with "@" that may have an
   // optional statement block.
@@ -1324,6 +1337,50 @@ namespace Sass {
     Media_Query_Expression(string path, Position position,
                            Expression* f, Expression* v, bool i = false)
     : Expression(path, position), feature_(f), value_(v), is_interpolated_(i)
+    { }
+    ATTACH_OPERATIONS();
+  };
+
+  ///////////////////
+  // Feature queries.
+  ///////////////////
+  class Feature_Queries : public Expression, public Vectorized<Feature_Query*> {
+  public:
+    Feature_Queries(string path, Position position, size_t s = 0)
+    : Expression(path, position), Vectorized<Feature_Query*>(s)
+    { }
+    ATTACH_OPERATIONS();
+  };
+
+  /////////////////
+  // Feature query.
+  /////////////////
+  class Feature_Query : public Expression, public Vectorized<Feature_Query_Condition*> {
+    ADD_PROPERTY(bool, is_negated);
+  public:
+    Feature_Query(string path, Position position, size_t s = 0, bool n = false)
+    : Expression(path, position), Vectorized<Feature_Query_Condition*>(s),
+      is_negated_(false)
+    { }
+    ATTACH_OPERATIONS();
+  };
+
+  ////////////////////////////////////////////////////////
+  // Feature expressions (for use inside feature queries).
+  ////////////////////////////////////////////////////////
+  class Feature_Query_Condition : public Expression {
+  public:
+    enum Operand { NONE, AND, OR };
+  private:
+    ADD_PROPERTY(Expression*, feature);
+    ADD_PROPERTY(Expression*, value);
+    ADD_PROPERTY(Operand, operand);
+    ADD_PROPERTY(bool, is_negated);
+  public:
+    Feature_Query_Condition(string path, Position position,
+                           Expression* f, Expression* v,
+                           Operand o = NONE, bool n = false, bool i = false)
+    : Expression(path, position), feature_(f), value_(v), operand_(o), is_negated_(n)
     { }
     ATTACH_OPERATIONS();
   };

--- a/ast_factory.hpp
+++ b/ast_factory.hpp
@@ -16,6 +16,7 @@ namespace Sass {
     Block* new_Block(string p, size_t l, size_t s = 0, bool r = false);
     Ruleset* new_Ruleset(string p, size_t l, Selector* s, Block* b);
     Propset* new_Propset(string p, size_t l, String* pf, Block* b);
+    Feature_Query* new_Feature_Query(string p, size_t l, Feature_Queries* f, Block* b);
     Media_Query* new_Media_Query(string p, size_t l, List* q, Block* b);
     At_Rule* new_At_Rule(string p, size_t l, string kwd, Selector* sel, Block* b);
     Declaration* new_Declaration(string p, size_t l, String* prop, List* vals);
@@ -63,6 +64,7 @@ namespace Sass {
     String_Constant* new_String_Constant(string p, size_t l, string val);
     String_Constant* new_String_Constant(string p, size_t l, const char* beg);
     String_Constant* new_String_Constant(string p, size_t l, const char* beg, const char* end);
+    Feature_Query_Condition* new_Feature_Query_Condition(string p, size_t l, String* f, Expression* v);
     Media_Expression* new_Media_Expression(string p, size_t l, String* f, Expression* v);
     // parameters and arguments
     Parameter* new_Parameter(string p, size_t l, string n, Expression* def = 0, bool rest = false);

--- a/ast_fwd_decl.hpp
+++ b/ast_fwd_decl.hpp
@@ -10,6 +10,7 @@ namespace Sass {
   class Ruleset;
   class Propset;
   class Media_Block;
+  class Feature_Block;
   class At_Rule;
   class Declaration;
   class Assignment;
@@ -44,6 +45,9 @@ namespace Sass {
   class String_Constant;
   class Media_Query;
   class Media_Query_Expression;
+  class Feature_Queries;
+  class Feature_Query;
+  class Feature_Query_Condition;
   class Null;
   // parameters and arguments
   class Parameter;

--- a/constants.cpp
+++ b/constants.cpp
@@ -57,6 +57,7 @@ namespace Sass {
     // css functions and keywords
     extern const char charset_kwd[]      = "@charset";
     extern const char media_kwd[]        = "@media";
+    extern const char supports_kwd[]     = "@supports";
     extern const char keyframes_kwd[]    = "keyframes";
     extern const char only_kwd[]         = "only";
     extern const char rgb_kwd[]          = "rgb(";

--- a/constants.hpp
+++ b/constants.hpp
@@ -57,6 +57,7 @@ namespace Sass {
     // css functions and keywords
     extern const char charset_kwd[];
     extern const char media_kwd[];
+    extern const char supports_kwd[];
     extern const char keyframes_kwd[];
     extern const char only_kwd[];
     extern const char rgb_kwd[];

--- a/eval.cpp
+++ b/eval.cpp
@@ -559,6 +559,41 @@ namespace Sass {
     return s;
   }
 
+  Expression* Eval::operator()(Feature_Queries* f)
+  {
+    Feature_Queries* ff = new (ctx.mem) Feature_Queries(f->path(),
+                                                        f->position(),
+                                                        f->length());
+    for (size_t i = 0, L = f->length(); i < L; ++i) {
+      *ff << static_cast<Feature_Query*>((*f)[i]->perform(this));
+    }
+    return ff;
+  }
+
+  Expression* Eval::operator()(Feature_Query* q)
+  {
+    Feature_Query* qq = new (ctx.mem) Feature_Query(q->path(),
+                                                    q->position(),
+                                                    q->length(),
+                                                    q->is_negated());
+    for (size_t i = 0, L = q->length(); i < L; ++i) {
+      *qq << static_cast<Feature_Query_Condition*>((*q)[i]->perform(this));
+    }
+    return qq;
+  }
+
+  Expression* Eval::operator()(Feature_Query_Condition* c)
+  {
+    Expression* feature = c->feature()->perform(this);
+    Expression* value = c->value()->perform(this);
+    return new (ctx.mem) Feature_Query_Condition(c->path(),
+                                                 c->position(),
+                                                 feature,
+                                                 value,
+                                                 c->operand(),
+                                                 c->is_negated());
+  }
+
   Expression* Eval::operator()(Media_Query* q)
   {
     String* t = q->media_type();

--- a/eval.hpp
+++ b/eval.hpp
@@ -63,6 +63,9 @@ namespace Sass {
     Expression* operator()(String_Constant*);
     Expression* operator()(Media_Query*);
     Expression* operator()(Media_Query_Expression*);
+    Expression* operator()(Feature_Queries*);
+    Expression* operator()(Feature_Query*);
+    Expression* operator()(Feature_Query_Condition*);
     Expression* operator()(Null*);
     Expression* operator()(Argument*);
     Expression* operator()(Arguments*);

--- a/expand.cpp
+++ b/expand.cpp
@@ -88,6 +88,16 @@ namespace Sass {
     return 0;
   }
 
+  Statement* Expand::operator()(Feature_Block* f)
+  {
+    Expression* feature_queries = f->feature_queries()->perform(eval->with(env, backtrace));
+    Feature_Block* ff = new (ctx.mem) Feature_Block(f->path(),
+                                                    f->position(),
+                                                    static_cast<Feature_Queries*>(feature_queries),
+                                                    f->block()->perform(this)->block());
+    return ff;
+  }
+
   Statement* Expand::operator()(Media_Block* m)
   {
     Expression* media_queries = m->media_queries()->perform(eval->with(env, backtrace));

--- a/expand.hpp
+++ b/expand.hpp
@@ -48,6 +48,7 @@ namespace Sass {
     Statement* operator()(Ruleset*);
     Statement* operator()(Propset*);
     Statement* operator()(Media_Block*);
+    Statement* operator()(Feature_Block*);
     Statement* operator()(At_Rule*);
     Statement* operator()(Declaration*);
     Statement* operator()(Assignment*);

--- a/extend.cpp
+++ b/extend.cpp
@@ -1937,6 +1937,11 @@ namespace Sass {
     pRuleset->block()->perform(this);
   }
 
+  void Extend::operator()(Feature_Block* pFeatureBlock)
+  {
+    pFeatureBlock->block()->perform(this);
+  }
+
   void Extend::operator()(Media_Block* pMediaBlock)
   {
     if (pMediaBlock->selector()) {

--- a/extend.hpp
+++ b/extend.hpp
@@ -39,6 +39,7 @@ namespace Sass {
 
     void operator()(Block*);
     void operator()(Ruleset*);
+    void operator()(Feature_Block*);
     void operator()(Media_Block*);
     void operator()(At_Rule*);
 

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -61,6 +61,14 @@ namespace Sass {
     media_block->block()->perform(this);
   }
 
+  void Inspect::operator()(Feature_Block* feature_block)
+  {
+    if (ctx) ctx->source_map.add_mapping(feature_block);
+    append_to_buffer("@supports ");
+    feature_block->feature_queries()->perform(this);
+    feature_block->block()->perform(this);
+  }
+
   void Inspect::operator()(At_Rule* at_rule)
   {
     append_to_buffer(at_rule->keyword());
@@ -394,6 +402,43 @@ namespace Sass {
   void Inspect::operator()(String_Constant* s)
   {
     append_to_buffer(s->needs_unquoting() ? unquote(s->value()) : s->value());
+  }
+
+  void Inspect::operator()(Feature_Queries* fq)
+  {
+    size_t i = 0;
+    (*fq)[i++]->perform(this);
+    for (size_t L = fq->length(); i < L; ++i) {
+      (*fq)[i]->perform(this);
+    }
+  }
+
+  void Inspect::operator()(Feature_Query* fq)
+  {
+    size_t i = 0;
+    (*fq)[i++]->perform(this);
+    for (size_t L = fq->length(); i < L; ++i) {
+      if (fq->is_negated()) append_to_buffer("not ");
+      (*fq)[i]->perform(this);
+    }
+  }
+
+  void Inspect::operator()(Feature_Query_Condition* fqc)
+  {
+    if (fqc->operand() == Feature_Query_Condition::AND)
+      append_to_buffer(" and ");
+    else if (fqc->operand() == Feature_Query_Condition::OR)
+      append_to_buffer(" or ");
+
+    if (fqc->is_negated()) append_to_buffer("not ");
+
+    append_to_buffer("(");
+    fqc->feature()->perform(this);
+    if (fqc->value()) {
+      append_to_buffer(": ");
+      fqc->value()->perform(this);
+    }
+    append_to_buffer(")");
   }
 
   void Inspect::operator()(Media_Query* mq)

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -40,6 +40,7 @@ namespace Sass {
     virtual void operator()(Block*);
     virtual void operator()(Ruleset*);
     virtual void operator()(Propset*);
+    virtual void operator()(Feature_Block*);
     virtual void operator()(Media_Block*);
     virtual void operator()(At_Rule*);
     virtual void operator()(Declaration*);
@@ -70,6 +71,9 @@ namespace Sass {
     virtual void operator()(Boolean*);
     virtual void operator()(String_Schema*);
     virtual void operator()(String_Constant*);
+    virtual void operator()(Feature_Queries*);
+    virtual void operator()(Feature_Query*);
+    virtual void operator()(Feature_Query_Condition*);
     virtual void operator()(Media_Query*);
     virtual void operator()(Media_Query_Expression*);
     virtual void operator()(Null*);

--- a/operation.hpp
+++ b/operation.hpp
@@ -17,6 +17,7 @@ namespace Sass {
     virtual T operator()(Block* x)                  = 0;
     virtual T operator()(Ruleset* x)                = 0;
     virtual T operator()(Propset* x)                = 0;
+    virtual T operator()(Feature_Block* x)          = 0;
     virtual T operator()(Media_Block* x)            = 0;
     virtual T operator()(At_Rule* x)                = 0;
     virtual T operator()(Declaration* x)            = 0;
@@ -48,6 +49,9 @@ namespace Sass {
     virtual T operator()(Boolean* x)                = 0;
     virtual T operator()(String_Schema* x)          = 0;
     virtual T operator()(String_Constant* x)        = 0;
+    virtual T operator()(Feature_Queries* x)        = 0;
+    virtual T operator()(Feature_Query* x)          = 0;
+    virtual T operator()(Feature_Query_Condition* x)= 0;
     virtual T operator()(Media_Query* x)            = 0;
     virtual T operator()(Media_Query_Expression* x) = 0;
     virtual T operator()(Null* x)                   = 0;
@@ -82,6 +86,7 @@ namespace Sass {
     virtual T operator()(Block* x)                  { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Ruleset* x)                { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Propset* x)                { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Feature_Block* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Block* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(At_Rule* x)                { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Declaration* x)            { return static_cast<D*>(this)->fallback(x); }
@@ -113,6 +118,9 @@ namespace Sass {
     virtual T operator()(Boolean* x)                { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(String_Schema* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(String_Constant* x)        { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Feature_Queries* x)        { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Feature_Query* x)          { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Feature_Query_Condition* x){ return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Query* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Query_Expression* x) { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Null* x)                   { return static_cast<D*>(this)->fallback(x); }

--- a/parser.hpp
+++ b/parser.hpp
@@ -232,6 +232,13 @@ namespace Sass {
     List* parse_media_queries();
     Media_Query* parse_media_query();
     Media_Query_Expression* parse_media_expression();
+    Feature_Block* parse_feature_block();
+    Feature_Queries* parse_feature_queries();
+    Feature_Query* parse_feature_query();
+    Feature_Query_Condition* parse_supports_negation();
+    Feature_Query_Condition* parse_supports_conjunction();
+    Feature_Query_Condition* parse_supports_disjunction();
+    Feature_Query_Condition* parse_supports_declaration_condition();
     At_Rule* parse_at_rule();
     Warning* parse_warning();
 

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -207,6 +207,10 @@ namespace Sass {
       return exactly<media_kwd>(src);
     }
 
+    const char* supports(const char* src) {
+      return exactly<supports_kwd>(src);
+    }
+
     const char* keyframes(const char* src) {
       return sequence< exactly<'@'>, optional< vendor_prefix >, exactly< keyframes_kwd > >(src);
     }

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -338,6 +338,7 @@ namespace Sass {
     const char* at_keyword(const char* src);
     const char* import(const char* src);
     const char* media(const char* src);
+    const char* supports(const char* src);
     const char* keyframes(const char* src);
     const char* keyf(const char* src);
     const char* mixin(const char* src);

--- a/util.hpp
+++ b/util.hpp
@@ -14,6 +14,7 @@ namespace Sass {
     bool containsAnyPrintableStatements(Block* b);
     
     bool isPrintable(Ruleset* r);
+    bool isPrintable(Feature_Block* r);
     bool isPrintable(Media_Block* r);
     bool isPrintable(Block* b);
 


### PR DESCRIPTION
This PR implements basic support for `@supports` feature queries. There are almost certainly cases that aren't yet covered but it gets the basic job done.

Fixes https://github.com/sass/libsass/issues/261. Specs added https://github.com/sass/sass-spec/commit/e73cbf3e8580a2e17c1ec82cf2529ad759ce2200.
