### PR TITLE
Hoist selectors in feature queries

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -345,9 +345,10 @@ namespace Sass {
   ///////////////////
   class Feature_Block : public Has_Block {
     ADD_PROPERTY(Feature_Queries*, feature_queries);
+    ADD_PROPERTY(Selector*, selector);
   public:
     Feature_Block(string path, Position position, Feature_Queries* fqs, Block* b)
-    : Has_Block(path, position, b), feature_queries_(fqs)
+    : Has_Block(path, position, b), feature_queries_(fqs), selector_(0)
     { }
     bool is_hoistable() { return true; }
     ATTACH_OPERATIONS();

--- a/expand.cpp
+++ b/expand.cpp
@@ -95,6 +95,7 @@ namespace Sass {
                                                     f->position(),
                                                     static_cast<Feature_Queries*>(feature_queries),
                                                     f->block()->perform(this)->block());
+    ff->selector(selector_stack.back());
     return ff;
   }
 

--- a/extend.cpp
+++ b/extend.cpp
@@ -1939,6 +1939,10 @@ namespace Sass {
 
   void Extend::operator()(Feature_Block* pFeatureBlock)
   {
+    if (pFeatureBlock->selector()) {
+      extendObjectWithSelectorAndBlock(pFeatureBlock, ctx, subset_map);
+    }
+
     pFeatureBlock->block()->perform(this);
   }
 

--- a/output_nested.hpp
+++ b/output_nested.hpp
@@ -43,6 +43,7 @@ namespace Sass {
     virtual void operator()(Block*);
     virtual void operator()(Ruleset*);
     // virtual void operator()(Propset*);
+    virtual void operator()(Feature_Block*);
     virtual void operator()(Media_Block*);
     virtual void operator()(At_Rule*);
     // virtual void operator()(Declaration*);

--- a/util.cpp
+++ b/util.cpp
@@ -55,12 +55,13 @@ namespace Sass {
 
       Block* b = f->block();
 
-      bool hasSelectors = false;
+      bool hasSelectors = f->selector() && static_cast<Selector_List*>(f->selector())->length() > 0;
+
       bool hasDeclarations = false;
       bool hasPrintableChildBlocks = false;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement* stm = (*b)[i];
-        if (!stm->is_hoistable() && !hasSelectors) {
+        if (!stm->is_hoistable() && f->selector() != NULL && !hasSelectors) {
           // If a statement isn't hoistable, the selectors apply to it. If there are no selectors (a selector list of length 0),
           // then those statements aren't considered printable. That means there was a placeholder that was removed. If the selector
           // is NULL, then that means there was never a wrapping selector and it is printable (think of a top level media block with


### PR DESCRIPTION
Following on from https://github.com/sass/libsass/pull/612. This PR gives selectors in feature queries the same hoisting semantics as media queries.

Fixes https://github.com/sass/libsass/issues/617. Specs added https://github.com/sass/sass-spec/pull/124, https://github.com/sass/sass-spec/pull/125.
