### PR TITLE
[BUGFIX] Add fix for source-maps (Fix-Up PR #591)

### DIFF
--- a/cencode.c
+++ b/cencode.c
@@ -7,8 +7,6 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include "b64/cencode.h"
 
-const int CHARS_PER_LINE = 72;
-
 void base64_init_encodestate(base64_encodestate* state_in)
 {
 	state_in->step = step_A;
@@ -73,11 +71,6 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			*codechar++ = base64_encode_value(result);
 
 			++(state_in->stepcount);
-			if (state_in->stepcount == CHARS_PER_LINE/4)
-			{
-				*codechar++ = '\n';
-				state_in->stepcount = 0;
-			}
 		}
 	}
 	/* control should not reach here */

--- a/context.cpp
+++ b/context.cpp
@@ -269,13 +269,14 @@ namespace Sass {
     return result;
   }
 
-  string Context::format_source_mapping_url(const string& file) const
+  string Context::format_source_mapping_url(const string& file)
   {
     string url = resolve_relative_path(file, output_path, cwd);
     if (source_map_embed) {
-      base64::encoder E;
-      istringstream is( sources[0] );
+      string map = source_map.generate_source_map(*this);
+      istringstream is( map );
       ostringstream buffer;
+      base64::encoder E;
       E.encode(is, buffer);
       url = "data:text/css;base64," + buffer.str();
       url.erase(url.size() - 1);

--- a/context.hpp
+++ b/context.hpp
@@ -113,7 +113,7 @@ namespace Sass {
 
   private:
     void add_source(const string &load_path, const string &abs_path, const char* contents);
-    string format_source_mapping_url(const string& file) const;
+    string format_source_mapping_url(const string& file);
     string get_cwd();
 
     string cwd;

--- a/source_map.cpp
+++ b/source_map.cpp
@@ -38,7 +38,7 @@ namespace Sass {
 
     JsonNode *json_contents = json_mkarray();
     if (include_sources) {
-      for (size_t i = 1; i < source_index.size(); ++i) {
+      for (size_t i = 0; i < source_index.size(); ++i) {
         const char *content = sources[source_index[i]];
         JsonNode *json_content = json_mkstring(content);
         json_append_element(json_contents, json_content);


### PR DESCRIPTION
This fixes some bugs which I unfortunately just discovered now (https://github.com/sass/libsass/pull/591)!
- Remove line-breaks in Base64 encoded string
- Actually embed the source-map json in data-url
- Include original source in sources array

IMO the last one will probably cause some test fails for node sass! /cc @am11, @andrew 
The sources array should contain the initial source too, as there is no other way to get it otherwise. 
IMO I've just added a fix for that, so node sass tests pass. After some re-thinking I came to the conclusion that it has to be the way as this PR implements it!

Best regards
