### PR TITLE
Output leading zeros on numbers as seen in input (Fixes #550)

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -992,13 +992,15 @@ namespace Sass {
   ////////////////////////////////////////////////
   class Number : public Expression {
     ADD_PROPERTY(double, value);
+    ADD_PROPERTY(bool, zero);
     vector<string> numerator_units_;
     vector<string> denominator_units_;
     size_t hash_;
   public:
-    Number(string path, Position position, double val, string u = "")
+    Number(string path, Position position, double val, string u = "", bool zero = true)
     : Expression(path, position),
       value_(val),
+      zero_(zero),
       numerator_units_(vector<string>()),
       denominator_units_(vector<string>()),
       hash_(0)
@@ -1006,6 +1008,7 @@ namespace Sass {
       if (!u.empty()) numerator_units_.push_back(u);
       concrete_type(NUMBER);
     }
+    bool            zero()              { return zero_; }
     vector<string>& numerator_units()   { return numerator_units_; }
     vector<string>& denominator_units() { return denominator_units_; }
     string type() { return "number"; }

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -333,6 +333,10 @@ namespace Sass {
     if (n->numerator_units().size() > 1 || n->denominator_units().size() > 0) {
       error(d + n->unit() + " is not a valid CSS value", n->path(), n->position());
     }
+    if (!n->zero()) {
+      if (d.substr(0, 3) == "-0.") d.erase(1, 1);
+      if (d.substr(0, 2) == "0.") d.erase(0, 1);
+    }
     append_to_buffer(d == "-0" ? "0" : d);
     append_to_buffer(n->unit());
   }


### PR DESCRIPTION
This fixes #550 and some other related issues!

To do this I had to add a status bool to `Number` to preserve the state that we have parsed!
Turned out to be trickier than anticipated, but it should now be in line with ruby sass!

I initially implemented that status flag on all number representations down to the C interface, but decided to drop it for now as it would mean a small change in the API and I [added this a local branch](https://github.com/mgreter/libsass/tree/issue/550-c-interface) for now.
