### PR TITLE
Correctly handle nested feature queries

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -344,10 +344,10 @@ namespace Sass {
   // Feature queries.
   ///////////////////
   class Feature_Block : public Has_Block {
-    ADD_PROPERTY(Feature_Queries*, feature_queries);
+    ADD_PROPERTY(Feature_Query*, feature_queries);
     ADD_PROPERTY(Selector*, selector);
   public:
-    Feature_Block(string path, Position position, Feature_Queries* fqs, Block* b)
+    Feature_Block(string path, Position position, Feature_Query* fqs, Block* b)
     : Has_Block(path, position, b), feature_queries_(fqs), selector_(0)
     { }
     bool is_hoistable() { return true; }
@@ -1345,23 +1345,10 @@ namespace Sass {
   ///////////////////
   // Feature queries.
   ///////////////////
-  class Feature_Queries : public Expression, public Vectorized<Feature_Query*> {
-  public:
-    Feature_Queries(string path, Position position, size_t s = 0)
-    : Expression(path, position), Vectorized<Feature_Query*>(s)
-    { }
-    ATTACH_OPERATIONS();
-  };
-
-  /////////////////
-  // Feature query.
-  /////////////////
   class Feature_Query : public Expression, public Vectorized<Feature_Query_Condition*> {
-    ADD_PROPERTY(bool, is_negated);
   public:
-    Feature_Query(string path, Position position, size_t s = 0, bool n = false)
-    : Expression(path, position), Vectorized<Feature_Query_Condition*>(s),
-      is_negated_(false)
+    Feature_Query(string path, Position position, size_t s = 0)
+    : Expression(path, position), Vectorized<Feature_Query_Condition*>(s)
     { }
     ATTACH_OPERATIONS();
   };
@@ -1369,19 +1356,19 @@ namespace Sass {
   ////////////////////////////////////////////////////////
   // Feature expressions (for use inside feature queries).
   ////////////////////////////////////////////////////////
-  class Feature_Query_Condition : public Expression {
+  class Feature_Query_Condition : public Expression, public Vectorized<Feature_Query_Condition*> {
   public:
-    enum Operand { NONE, AND, OR };
+    enum Operand { NONE, AND, OR, NOT };
   private:
-    ADD_PROPERTY(Expression*, feature);
+    ADD_PROPERTY(String*, feature);
     ADD_PROPERTY(Expression*, value);
     ADD_PROPERTY(Operand, operand);
-    ADD_PROPERTY(bool, is_negated);
+    ADD_PROPERTY(bool, is_root);
   public:
-    Feature_Query_Condition(string path, Position position,
-                           Expression* f, Expression* v,
-                           Operand o = NONE, bool n = false, bool i = false)
-    : Expression(path, position), feature_(f), value_(v), operand_(o), is_negated_(n)
+    Feature_Query_Condition(string path, Position position, size_t s = 0, String* f = 0,
+                            Expression* v = 0, Operand o = NONE, bool r = false)
+    : Expression(path, position), Vectorized<Feature_Query_Condition*>(s),
+      feature_(f), value_(v), operand_(o), is_root_(r)
     { }
     ATTACH_OPERATIONS();
   };

--- a/ast_factory.hpp
+++ b/ast_factory.hpp
@@ -16,7 +16,7 @@ namespace Sass {
     Block* new_Block(string p, size_t l, size_t s = 0, bool r = false);
     Ruleset* new_Ruleset(string p, size_t l, Selector* s, Block* b);
     Propset* new_Propset(string p, size_t l, String* pf, Block* b);
-    Feature_Query* new_Feature_Query(string p, size_t l, Feature_Queries* f, Block* b);
+    Feature_Query* new_Feature_Query(string p, size_t l, Feature_Query* f, Block* b);
     Media_Query* new_Media_Query(string p, size_t l, List* q, Block* b);
     At_Rule* new_At_Rule(string p, size_t l, string kwd, Selector* sel, Block* b);
     Declaration* new_Declaration(string p, size_t l, String* prop, List* vals);

--- a/ast_fwd_decl.hpp
+++ b/ast_fwd_decl.hpp
@@ -45,7 +45,6 @@ namespace Sass {
   class String_Constant;
   class Media_Query;
   class Media_Query_Expression;
-  class Feature_Queries;
   class Feature_Query;
   class Feature_Query_Condition;
   class Null;

--- a/eval.cpp
+++ b/eval.cpp
@@ -559,23 +559,11 @@ namespace Sass {
     return s;
   }
 
-  Expression* Eval::operator()(Feature_Queries* f)
-  {
-    Feature_Queries* ff = new (ctx.mem) Feature_Queries(f->path(),
-                                                        f->position(),
-                                                        f->length());
-    for (size_t i = 0, L = f->length(); i < L; ++i) {
-      *ff << static_cast<Feature_Query*>((*f)[i]->perform(this));
-    }
-    return ff;
-  }
-
   Expression* Eval::operator()(Feature_Query* q)
   {
     Feature_Query* qq = new (ctx.mem) Feature_Query(q->path(),
                                                     q->position(),
-                                                    q->length(),
-                                                    q->is_negated());
+                                                    q->length());
     for (size_t i = 0, L = q->length(); i < L; ++i) {
       *qq << static_cast<Feature_Query_Condition*>((*q)[i]->perform(this));
     }
@@ -584,14 +572,20 @@ namespace Sass {
 
   Expression* Eval::operator()(Feature_Query_Condition* c)
   {
-    Expression* feature = c->feature()->perform(this);
-    Expression* value = c->value()->perform(this);
-    return new (ctx.mem) Feature_Query_Condition(c->path(),
+    String* feature = c->feature();
+    Expression* value = c->value();
+    value = (value ? value->perform(this) : 0);
+    Feature_Query_Condition* cc = new (ctx.mem) Feature_Query_Condition(c->path(),
                                                  c->position(),
+                                                 c->length(),
                                                  feature,
                                                  value,
                                                  c->operand(),
-                                                 c->is_negated());
+                                                 c->is_root());
+    for (size_t i = 0, L = c->length(); i < L; ++i) {
+      *cc << static_cast<Feature_Query_Condition*>((*c)[i]->perform(this));
+    }
+    return cc;
   }
 
   Expression* Eval::operator()(Media_Query* q)

--- a/eval.hpp
+++ b/eval.hpp
@@ -63,7 +63,6 @@ namespace Sass {
     Expression* operator()(String_Constant*);
     Expression* operator()(Media_Query*);
     Expression* operator()(Media_Query_Expression*);
-    Expression* operator()(Feature_Queries*);
     Expression* operator()(Feature_Query*);
     Expression* operator()(Feature_Query_Condition*);
     Expression* operator()(Null*);

--- a/expand.cpp
+++ b/expand.cpp
@@ -93,7 +93,7 @@ namespace Sass {
     Expression* feature_queries = f->feature_queries()->perform(eval->with(env, backtrace));
     Feature_Block* ff = new (ctx.mem) Feature_Block(f->path(),
                                                     f->position(),
-                                                    static_cast<Feature_Queries*>(feature_queries),
+                                                    static_cast<Feature_Query*>(feature_queries),
                                                     f->block()->perform(this)->block());
     ff->selector(selector_stack.back());
     return ff;

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -71,7 +71,6 @@ namespace Sass {
     virtual void operator()(Boolean*);
     virtual void operator()(String_Schema*);
     virtual void operator()(String_Constant*);
-    virtual void operator()(Feature_Queries*);
     virtual void operator()(Feature_Query*);
     virtual void operator()(Feature_Query_Condition*);
     virtual void operator()(Media_Query*);

--- a/operation.hpp
+++ b/operation.hpp
@@ -49,7 +49,6 @@ namespace Sass {
     virtual T operator()(Boolean* x)                = 0;
     virtual T operator()(String_Schema* x)          = 0;
     virtual T operator()(String_Constant* x)        = 0;
-    virtual T operator()(Feature_Queries* x)        = 0;
     virtual T operator()(Feature_Query* x)          = 0;
     virtual T operator()(Feature_Query_Condition* x)= 0;
     virtual T operator()(Media_Query* x)            = 0;
@@ -118,7 +117,6 @@ namespace Sass {
     virtual T operator()(Boolean* x)                { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(String_Schema* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(String_Constant* x)        { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Feature_Queries* x)        { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Feature_Query* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Feature_Query_Condition* x){ return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Query* x)            { return static_cast<D*>(this)->fallback(x); }

--- a/output_nested.cpp
+++ b/output_nested.cpp
@@ -126,7 +126,7 @@ namespace Sass {
 
   void Output_Nested::operator()(Feature_Block* f)
   {
-    Feature_Queries*  q = f->feature_queries();
+    Feature_Query* q    = f->feature_queries();
     Block* b            = f->block();
 
     // Filter out feature blocks that aren't printable (process its children though)

--- a/parser.hpp
+++ b/parser.hpp
@@ -233,12 +233,13 @@ namespace Sass {
     Media_Query* parse_media_query();
     Media_Query_Expression* parse_media_expression();
     Feature_Block* parse_feature_block();
-    Feature_Queries* parse_feature_queries();
-    Feature_Query* parse_feature_query();
+    Feature_Query* parse_feature_queries();
+    Feature_Query_Condition* parse_feature_query();
+    Feature_Query_Condition* parse_feature_query_in_parens();
     Feature_Query_Condition* parse_supports_negation();
     Feature_Query_Condition* parse_supports_conjunction();
     Feature_Query_Condition* parse_supports_disjunction();
-    Feature_Query_Condition* parse_supports_declaration_condition();
+    Feature_Query_Condition* parse_supports_declaration();
     At_Rule* parse_at_rule();
     Warning* parse_warning();
 


### PR DESCRIPTION
This PR fixes the incorrectly output produced for nested feature query conditions i.e. 

``` css
@supports ((foo: bar) or (foo: bar) or (foo: bar)) and (foo: bar) { }
```

Fixes https://github.com/sass/libsass/issues/614. Specs added https://github.com/sass/sass-spec/pull/122.
