### PR TITLE
Implement Sass::Util::isAscii() since isascii() is not present on some systems.

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -907,7 +907,7 @@ namespace Sass {
       string str = s->value();
 
       for (size_t i = 0, L = str.length(); i < L; ++i) {
-        if (isascii(str[i])) {
+        if (Sass::Util::isAscii(str[i])) {
           str[i] = std::toupper(str[i]);
         }
       }
@@ -922,7 +922,7 @@ namespace Sass {
       string str = s->value();
 
       for (size_t i = 0, L = str.length(); i < L; ++i) {
-        if (isascii(str[i])) {
+        if (Sass::Util::isAscii(str[i])) {
           str[i] = std::tolower(str[i]);
         }
       }

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include "constants.hpp"
 #include "prelexer.hpp"
+#include "util.hpp"
 
 
 namespace Sass {
@@ -24,10 +25,10 @@ namespace Sass {
 
     // Match a single character satisfying the ctype predicates.
     const char* space(const char* src) { return std::isspace(*src) ? src+1 : 0; }
-    const char* alpha(const char* src) { return std::isalpha(*src) || !isascii(*src) ? src+1 : 0; }
+    const char* alpha(const char* src) { return std::isalpha(*src) || !Sass::Util::isAscii(*src) ? src+1 : 0; }
     const char* digit(const char* src) { return std::isdigit(*src) ? src+1 : 0; }
     const char* xdigit(const char* src) { return std::isxdigit(*src) ? src+1 : 0; }
-    const char* alnum(const char* src) { return std::isalnum(*src) || !isascii(*src) ? src+1 : 0; }
+    const char* alnum(const char* src) { return std::isalnum(*src) || !Sass::Util::isAscii(*src) ? src+1 : 0; }
     const char* punct(const char* src) { return std::ispunct(*src) ? src+1 : 0; }
     // Match multiple ctype characters.
     const char* spaces(const char* src) { return one_plus<space>(src); }

--- a/util.cpp
+++ b/util.cpp
@@ -158,5 +158,9 @@ namespace Sass {
        return false;
      }
 
+     bool isAscii(int ch) {
+         return ch >= 0 && ch < 128;
+     }
+
   }
 }

--- a/util.hpp
+++ b/util.hpp
@@ -17,6 +17,7 @@ namespace Sass {
     bool isPrintable(Feature_Block* r);
     bool isPrintable(Media_Block* r);
     bool isPrintable(Block* b);
+    bool isAscii(int ch);
 
   }
 }


### PR DESCRIPTION
isascii() is deprecated according to the manpages http://linux.die.net/man/3/isascii.
See also: http://msdn.microsoft.com/en-us/library/ms235417.aspx

Currently libsass fails to compile on a windows machine running cygwin. Using __isascii() fixes this.

This compiles on linux with gcc 4.8.3, clang 3.5.0-r1 and glibc 2.19-r1.
