### PR TITLE
Fix bug with map key caching

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -1302,9 +1302,9 @@ namespace Sass {
       }
     }
 
-    virtual size_t hash() const
+    virtual size_t hash()
     {
-      if (hash_ == 0) std::hash<string>()(unquoted_);
+      if (hash_ == 0) hash_ = std::hash<string>()(unquoted_);
       return hash_;
     }
 


### PR DESCRIPTION
This PR fixes a bug which meant hashes for string keys in maps weren't be cached. This was causing massive performance issue.

```
➜  test  ./test.sh
Libsass 3.0.2

real    0m0.942s
user    0m0.914s
sys 0m0.017s

Libsass 3.0.2 with patch

real    0m0.230s
user    0m0.213s
sys 0m0.015s

Ruby sass 3.4.6

real    0m1.241s
user    0m1.179s
sys 0m0.060s
```

**Summary**

```
Libsass 3.0.2 - 1.3 faster ruby 
Libsass 3.0.2 with patch - 5.4x faster ruby
```
