### PR TITLE
Add support for numbers as map keys

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -980,10 +980,32 @@ namespace Sass {
   private:
     ADD_PROPERTY(Type, type);
     ADD_PROPERTY(string, value);
+    size_t hash_;
   public:
     Textual(string path, Position position, Type t, string val)
-    : Expression(path, position, true), type_(t), value_(val)
+    : Expression(path, position, true), type_(t), value_(val),
+      hash_(0)
     { }
+
+    virtual bool operator==(Expression& rhs) const
+    {
+      try
+      {
+        Textual& e = dynamic_cast<Textual&>(rhs);
+        return e && value() == e.value() && type() == e.type();
+      }
+      catch (std::bad_cast&)
+      {
+        return false;
+      }
+    }
+
+    virtual size_t hash()
+    {
+      if (hash_ == 0) hash_ = std::hash<string>()(value_) ^ std::hash<int>()(type_);
+      return hash_;
+    }
+
     ATTACH_OPERATIONS();
   };
 


### PR DESCRIPTION
This PR allows number to be map keys. This was originally thought to have been fixed by https://github.com/sass/libsass/pull/596 but it wasn't.

Fixes https://github.com/sass/libsass/issues/534. Spec added https://github.com/sass/sass-spec/commit/6ec734b37cb50927846264176d631d9084913672, https://github.com/sass/sass-spec/pull/138.
