### PR TITLE
Fix error for some selectors with interpolants

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1660,6 +1660,7 @@ namespace Sass {
 
     while ((q = peek< identifier >(p))                             ||
            (q = peek< hyphens_and_identifier >(p))                 ||
+           (q = peek< hyphens_and_name >(p))                       ||
            (q = peek< type_selector >(p))                          ||
            (q = peek< id_name >(p))                                ||
            (q = peek< class_name >(p))                             ||

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -319,6 +319,9 @@ namespace Sass {
     const char* hyphens_and_identifier(const char* src) {
       return sequence< zero_plus< exactly< '-' > >, identifier >(src);
     }
+    const char* hyphens_and_name(const char* src) {
+      return sequence< zero_plus< exactly< '-' > >, name >(src);
+    }
     const char* universal(const char* src) {
       return sequence< optional<namespace_prefix>, exactly<'*'> >(src);
     }

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -373,6 +373,7 @@ namespace Sass {
     const char* namespace_prefix(const char* src);
     const char* type_selector(const char* src);
     const char* hyphens_and_identifier(const char* src);
+    const char* hyphens_and_name(const char* src);
     const char* universal(const char* src);
     // Match CSS id names.
     const char* id_name(const char* src);


### PR DESCRIPTION
This PR fixes an error caused by some selectors with interpolants.

Fixes https://github.com/sass/libsass/issues/641. Specs added sass/sass-spec#135, https://github.com/sass/sass-spec/pull/139.
