### PR TITLE
Revert/not expression

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -771,7 +771,7 @@ namespace Sass {
   ////////////////////////////////////////////////////////////////////////////
   class Unary_Expression : public Expression {
   public:
-    enum Type { PLUS, MINUS, NOT };
+    enum Type { PLUS, MINUS };
   private:
     ADD_PROPERTY(Type, type);
     ADD_PROPERTY(Expression*, operand);

--- a/eval.cpp
+++ b/eval.cpp
@@ -301,12 +301,7 @@ namespace Sass {
   Expression* Eval::operator()(Unary_Expression* u)
   {
     Expression* operand = u->operand()->perform(this);
-    if (u->type() == Unary_Expression::NOT) {
-      Boolean* result = new (ctx.mem) Boolean(*static_cast<Boolean*>(operand));
-      result->value(!result->value());
-      return result;
-    }
-    else if (operand->concrete_type() == Expression::NUMBER) {
+    if (operand->concrete_type() == Expression::NUMBER) {
       Number* result = new (ctx.mem) Number(*static_cast<Number*>(operand));
       result->value(u->type() == Unary_Expression::MINUS
                     ? -result->value()

--- a/parser.cpp
+++ b/parser.cpp
@@ -1072,9 +1072,6 @@ namespace Sass {
     else if (lex< sequence< exactly<'-'>, spaces_and_comments, negate< number> > >()) {
       return new (ctx.mem) Unary_Expression(path, source_position, Unary_Expression::MINUS, parse_factor());
     }
-    else if (lex< sequence< not_op, spaces_and_comments > >()) {
-      return new (ctx.mem) Unary_Expression(path, source_position, Unary_Expression::NOT, parse_factor());
-    }
     else {
       return parse_value();
     }


### PR DESCRIPTION
This PR reverts implementing `not` expression (https://github.com/sass/libsass/pull/658) because it broke untested behaviour.
