### PR TITLE
Normalize decimals in IE keyword args

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1046,6 +1046,7 @@ namespace Sass {
       lex< exactly<'='> >();
       *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);
       if (lex< variable >()) *kwd_arg << new (ctx.mem) Variable(path, source_position, Util::normalize_underscores(lexed));
+      else if (lex< number >()) *kwd_arg << new (ctx.mem) Textual(path, source_position, Textual::NUMBER, Util::normalize_decimals(lexed));
       else {
         lex< alternatives< identifier_schema, identifier, number, hex > >();
         *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);

--- a/util.cpp
+++ b/util.cpp
@@ -14,6 +14,13 @@ namespace Sass {
       return normalized;
     }
 
+    string normalize_decimals(const string& str) {
+      string prefix = "0";
+      string normalized = str;
+
+      return normalized[0] == '.' ? normalized.insert(0, prefix) : normalized;
+    }
+
     bool isPrintable(Ruleset* r) {
       if (r == NULL) {
         return false;

--- a/util.hpp
+++ b/util.hpp
@@ -10,6 +10,7 @@ namespace Sass {
   namespace Util {
 
     std::string normalize_underscores(const std::string& str);
+    std::string normalize_decimals(const std::string& str);
 
     bool containsAnyPrintableStatements(Block* b);
 


### PR DESCRIPTION
This PR normalizes decimal arguments in IE keyword args.

Fixes https://github.com/sass/libsass/issues/623. Specs added https://github.com/sass/sass-spec/pull/144.
