### PR TITLE
Implement the random() function

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -432,6 +432,7 @@ namespace Sass {
     register_function(ctx, abs_sig, abs, env);
     register_function(ctx, min_sig, min, env);
     register_function(ctx, max_sig, max, env);
+    register_function(ctx, random_sig, random, env);
     // List Functions
     register_function(ctx, length_sig, length, env);
     register_function(ctx, nth_sig, nth, env);

--- a/functions.hpp
+++ b/functions.hpp
@@ -75,6 +75,7 @@ namespace Sass {
     extern Signature abs_sig;
     extern Signature min_sig;
     extern Signature max_sig;
+    extern Signature random_sig;
     extern Signature length_sig;
     extern Signature nth_sig;
     extern Signature index_sig;
@@ -147,6 +148,7 @@ namespace Sass {
     BUILT_IN(abs);
     BUILT_IN(min);
     BUILT_IN(max);
+    BUILT_IN(random);
     BUILT_IN(length);
     BUILT_IN(nth);
     BUILT_IN(index);


### PR DESCRIPTION
This PR implements the `random` function introduced in Ruby sass 3.3.

Fixes https://github.com/sass/libsass/issues/657. Specs added https://github.com/sass/sass-spec/pull/151.
