### PR TITLE
Implement the unique-id() function

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -465,6 +465,8 @@ namespace Sass {
     register_function(ctx, if_sig, sass_if, env);
     // Path Functions
     register_function(ctx, image_url_sig, image_url, env);
+    // Misc Functions
+    register_function(ctx, unique_id_sig, unique_id, env);
   }
 
   void register_c_functions(Context& ctx, Env* env, Sass_C_Function_List descrs)

--- a/functions.cpp
+++ b/functions.cpp
@@ -10,6 +10,7 @@
 #include "util.hpp"
 #include "utf8_string.hpp"
 #include "utf8.h"
+#include <random>
 
 #include <cstdlib>
 #include <cmath>
@@ -1447,6 +1448,21 @@ namespace Sass {
       string full_path(quote(ctx.image_path + "/" + unquote(ipath->value()), '"'));
       if (!only_path) full_path = "url(" + full_path + ")";
       return new (ctx.mem) String_Constant(path, position, full_path);
+    }
+
+    /////////////////
+    // MAP FUNCTIONS
+    /////////////////
+
+    Signature unique_id_sig = "unique-id()";
+    BUILT_IN(unique_id)
+    {
+      std::stringstream ss;
+      random_device rd;
+      mt19937 gen(rd());
+      uniform_real_distribution<> dis(0, 4294967296); // 16^8
+      ss << "u" << setfill('0') << setw(8) << std::hex << (long)dis(gen);
+      return new (ctx.mem) String_Constant(path, position, ss.str());
     }
 
   }

--- a/functions.hpp
+++ b/functions.hpp
@@ -103,6 +103,7 @@ namespace Sass {
     extern Signature map_has_key_sig;
     extern Signature keywords_sig;
     extern Signature set_nth_sig;
+    extern Signature unique_id_sig;
 
     BUILT_IN(rgb);
     BUILT_IN(rgba_4);
@@ -174,6 +175,7 @@ namespace Sass {
     BUILT_IN(map_has_key);
     BUILT_IN(keywords);
     BUILT_IN(set_nth);
+    BUILT_IN(unique_id);
 
   }
 }

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -1,6 +1,7 @@
 #include <cctype>
 #include <cstddef>
 #include <iostream>
+#include <iomanip>
 #include "constants.hpp"
 #include "prelexer.hpp"
 #include "util.hpp"


### PR DESCRIPTION
This PR implements the `unique-id` function introduced in Ruby sass 3.3 by returning a random unique CSS identifier. The implementation is pretty much an exact copy of the Ruby sass implementation https://github.com/sass/sass/commit/f3be0f40b7c5072635b2d6dab772f2c29e8d629a.

This implementation is slightly different to the Ruby implement which

> Returns a unique CSS identifier within the scope of a single CSS file.

I'm not sure the scoping serves any particular benefit but maybe @chriseppstein knows better?

Fixes https://github.com/sass/libsass/issues/636. Specs added https://github.com/sass/sass-spec/pull/150.
