### PR TITLE
Add a way to set functions in the Sass_C_Function_List

### DIFF
--- a/sass_functions.cpp
+++ b/sass_functions.cpp
@@ -32,6 +32,10 @@ extern "C" {
     return cb;
   }
 
+  void* sass_set_function(Sass_C_Function_List* list, Sass_C_Function_Callback cb, int pos) {
+	return *list[pos] = cb;
+  }
+
   const char* sass_function_get_signature(Sass_C_Function_Callback fn) { return fn->signature; }
   Sass_C_Function sass_function_get_function(Sass_C_Function_Callback fn) { return fn->function; }
   void* sass_function_get_cookie(Sass_C_Function_Callback fn) { return fn->cookie; }

--- a/sass_functions.h
+++ b/sass_functions.h
@@ -62,6 +62,7 @@ typedef union Sass_Value*(*Sass_C_Function) (union Sass_Value*, void *cookie);
 // Creators for sass function list and function descriptors
 Sass_C_Function_List sass_make_function_list (size_t length);
 Sass_C_Function_Callback sass_make_function (const char* signature, Sass_C_Function fn, void* cookie);
+void* sass_set_function(Sass_C_Function_List* list, Sass_C_Function_Callback cb, int pos);
 
 // Getters for custom function descriptors
 const char* sass_function_get_signature (Sass_C_Function_Callback fn);


### PR DESCRIPTION
This convenience method makes it easier to interface with the Sass_C_Function_List.  By adding a function the implementing language doesn't have to figure out how index the List struct and add individual functions to the pointer array.

I used this to successfully execute Go code as a custom c_function, so awesome!
