### PR TITLE
Don't parse static values in declarations

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -810,8 +810,12 @@ namespace Sass {
     }
     if (!lex< exactly<':'> >()) error("property \"" + string(lexed) + "\" must be followed by a ':'");
     if (peek< exactly<';'> >()) error("style declaration must contain a value");
-    Expression* list = parse_list();
-    return new (ctx.mem) Declaration(path, prop->position(), prop, list/*, lex<important>()*/);
+    if (peek< static_value >()) {
+      return new (ctx.mem) Declaration(path, prop->position(), prop, parse_static_value()/*, lex<important>()*/);
+    }
+    else {
+      return new (ctx.mem) Declaration(path, prop->position(), prop, parse_list()/*, lex<important>()*/);
+    }
   }
 
   Expression* Parser::parse_map()
@@ -1199,6 +1203,17 @@ namespace Sass {
       }
     }
     return schema;
+  }
+
+  String_Constant* Parser::parse_static_value()
+  {
+    lex< static_value >();
+    Token str(lexed);
+    --str.end;
+    --position;
+    String_Constant* str_node = new (ctx.mem) String_Constant(path, source_position, str);
+    str_node->is_delayed(true);
+    return str_node;
   }
 
   String* Parser::parse_string()

--- a/parser.hpp
+++ b/parser.hpp
@@ -222,6 +222,7 @@ namespace Sass {
     Function_Call_Schema* parse_function_call_schema();
     String* parse_interpolated_chunk(Token);
     String* parse_string();
+    String_Constant* parse_static_value();
     String* parse_ie_stuff();
     String_Schema* parse_value_schema();
     String* parse_identifier_schema();

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -617,5 +617,33 @@ namespace Sass {
       }
       return pos;
     }
+
+    const char* static_string(const char* src) {
+      const char* pos = src;
+      const char * s = string_constant(pos);
+      Token t(pos, s);
+      const unsigned int p = count_interval< interpolant >(t.begin, t.end);
+      return (p == 0) ? t.end : 0;
+    }
+
+    const char* static_component(const char* src) {
+      return alternatives< identifier,
+                           static_string,
+                           hex,
+                           sequence< alternatives< exactly<'+'>, exactly<'-'> >, number >,
+                           sequence< exactly<'!'>, exactly<important_kwd> >
+                          >(src);
+    }
+
+    const char* static_value(const char* src) {
+      return sequence< static_component,
+                       zero_plus < sequence<
+                                   alternatives< spaces, exactly<'/'> >,
+                                   optional_spaces,
+                                   static_component
+                       > >,
+                       alternatives< exactly<';'>, exactly<'}'> >
+                      >(src);
+    }
   }
 }

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -454,6 +454,11 @@ namespace Sass {
     const char* folder(const char* src);
     const char* folders(const char* src);
 
+
+    const char* static_string(const char* src);
+    const char* static_component(const char* src);
+    const char* static_value(const char* src);
+
     // Utility functions for finding and counting characters in a string.
     template<char c>
     const char* find_first(const char* src) {


### PR DESCRIPTION
Ruby sass has some smarts around determining whether a declarations value needs to be parsed i.e. if it has function calls for interpolants. If the value looks static it's left untouched.

This behaviour was previously mentioned in https://github.com/sass/libsass/pull/658#issuecomment-63612597.

With this change we can finally address the `not` problem (#368) by re-applying 4e6ac82e588a72fa60c7ab65f1ec17ea68bd2876.
