### PR TITLE
Add support for the not expression

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -771,7 +771,7 @@ namespace Sass {
   ////////////////////////////////////////////////////////////////////////////
   class Unary_Expression : public Expression {
   public:
-    enum Type { PLUS, MINUS };
+    enum Type { PLUS, MINUS, NOT };
   private:
     ADD_PROPERTY(Type, type);
     ADD_PROPERTY(Expression*, operand);

--- a/eval.cpp
+++ b/eval.cpp
@@ -301,7 +301,12 @@ namespace Sass {
   Expression* Eval::operator()(Unary_Expression* u)
   {
     Expression* operand = u->operand()->perform(this);
-    if (operand->concrete_type() == Expression::NUMBER) {
+    if (u->type() == Unary_Expression::NOT) {
+      Boolean* result = new (ctx.mem) Boolean(*static_cast<Boolean*>(operand));
+      result->value(!result->value());
+      return result;
+    }
+    else if (operand->concrete_type() == Expression::NUMBER) {
       Number* result = new (ctx.mem) Number(*static_cast<Number*>(operand));
       result->value(u->type() == Unary_Expression::MINUS
                     ? -result->value()

--- a/parser.cpp
+++ b/parser.cpp
@@ -1076,6 +1076,9 @@ namespace Sass {
     else if (lex< sequence< exactly<'-'>, spaces_and_comments, negate< number> > >()) {
       return new (ctx.mem) Unary_Expression(path, source_position, Unary_Expression::MINUS, parse_factor());
     }
+    else if (lex< sequence< not_op, spaces_and_comments > >()) {
+      return new (ctx.mem) Unary_Expression(path, source_position, Unary_Expression::NOT, parse_factor());
+    }
     else {
       return parse_value();
     }


### PR DESCRIPTION
This PR adds support for the not expression. Now that we're correctly not parsing static declaration values (https://github.com/sass/libsass/pull/679) my previous implementation (https://github.com/sass/libsass/pull/658) is now viable.

Fixes #368. Fixes #660. Specs added sass/sass-spec#14, https://github.com/sass/sass-spec/pull/95, https://github.com/sass/sass-spec/pull/143.

/cc @nsams 
