### PR TITLE
Fix special IE property parsing

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1037,25 +1037,11 @@ namespace Sass {
       }
       return value;
     }
-    else if (peek< ie_stuff >()) {
-      return parse_ie_stuff();
+    else if (peek< ie_property >()) {
+      return parse_ie_property();
     }
     else if (peek< ie_keyword_arg >()) {
-      String_Schema* kwd_arg = new (ctx.mem) String_Schema(path, source_position, 3);
-      if (lex< variable >()) *kwd_arg << new (ctx.mem) Variable(path, source_position, Util::normalize_underscores(lexed));
-      else {
-        lex< alternatives< identifier_schema, identifier > >();
-        *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);
-      }
-      lex< exactly<'='> >();
-      *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);
-      if (lex< variable >()) *kwd_arg << new (ctx.mem) Variable(path, source_position, Util::normalize_underscores(lexed));
-      else if (lex< number >()) *kwd_arg << new (ctx.mem) Textual(path, source_position, Textual::NUMBER, Util::normalize_decimals(lexed));
-      else {
-        lex< alternatives< identifier_schema, identifier, number, hex > >();
-        *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);
-      }
-      return kwd_arg;
+      return parse_ie_keyword_arg();
     }
     else if (peek< exactly< calc_kwd > >() ||
              peek< exactly< moz_calc_kwd > >() ||
@@ -1263,12 +1249,10 @@ namespace Sass {
     // return schema;
   }
 
-  String* Parser::parse_ie_stuff()
+  String* Parser::parse_ie_property()
   {
-    lex< ie_stuff >();
+    lex< ie_property >();
     Token str(lexed);
-    --str.end;
-    --position;
     const char* i = str.begin;
     // see if there any interpolants
     const char* p = find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(str.begin, str.end);
@@ -1304,6 +1288,25 @@ namespace Sass {
       }
     }
     return schema;
+  }
+
+  String* Parser::parse_ie_keyword_arg()
+  {
+    String_Schema* kwd_arg = new (ctx.mem) String_Schema(path, source_position, 3);
+    if (lex< variable >()) *kwd_arg << new (ctx.mem) Variable(path, source_position, Util::normalize_underscores(lexed));
+    else {
+      lex< alternatives< identifier_schema, identifier > >();
+      *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);
+    }
+    lex< exactly<'='> >();
+    *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);
+    if (lex< variable >()) *kwd_arg << new (ctx.mem) Variable(path, source_position, Util::normalize_underscores(lexed));
+    else if (lex< number >()) *kwd_arg << new (ctx.mem) Textual(path, source_position, Textual::NUMBER, Util::normalize_decimals(lexed));
+    else {
+      lex< alternatives< identifier_schema, identifier, number, hex > >();
+      *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);
+    }
+    return kwd_arg;
   }
 
   String_Schema* Parser::parse_value_schema()

--- a/parser.hpp
+++ b/parser.hpp
@@ -223,7 +223,8 @@ namespace Sass {
     String* parse_interpolated_chunk(Token);
     String* parse_string();
     String_Constant* parse_static_value();
-    String* parse_ie_stuff();
+    String* parse_ie_property();
+    String* parse_ie_keyword_arg();
     String_Schema* parse_value_schema();
     String* parse_identifier_schema();
     String_Schema* parse_url_schema();

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -384,6 +384,11 @@ namespace Sass {
       ptrdiff_t len = p - src;
       return (len != 4 && len != 7) ? 0 : p;
     }
+    const char* hexa(const char* src) {
+      const char* p = sequence< exactly<'#'>, one_plus<xdigit> >(src);
+      ptrdiff_t len = p - src;
+      return (len != 4 && len != 7 && len != 9) ? 0 : p;
+    }
 
     const char* rgb_prefix(const char* src) {
       return exactly<rgb_kwd>(src);
@@ -519,14 +524,47 @@ namespace Sass {
 
     // match specific IE syntax
     const char* ie_progid(const char* src) {
-      return sequence < exactly<progid_kwd>, exactly<':'>, alternatives< identifier_schema, identifier >, one_plus< sequence< exactly<'.'>, alternatives< identifier_schema, identifier > > > >(src);
+      return sequence <
+        exactly<progid_kwd>,
+        exactly<':'>,
+        alternatives< identifier_schema, identifier >,
+        zero_plus< sequence<
+          exactly<'.'>,
+          alternatives< identifier_schema, identifier >
+        > >,
+        zero_plus < sequence<
+          exactly<'('>,
+          spaces_and_comments,
+          optional < sequence<
+            alternatives< variable, identifier_schema, identifier >,
+            spaces_and_comments,
+            exactly<'='>,
+            spaces_and_comments,
+            alternatives< variable, identifier_schema, identifier, string_constant, number, hexa >,
+            zero_plus< sequence<
+              spaces_and_comments,
+              exactly<','>,
+              spaces_and_comments,
+              sequence<
+                alternatives< variable, identifier_schema, identifier >,
+                spaces_and_comments,
+                exactly<'='>,
+                spaces_and_comments,
+                alternatives< variable, identifier_schema, identifier, string_constant, number, hexa >
+              >
+            > >
+          > >,
+          spaces_and_comments,
+          exactly<')'>,
+          spaces_and_comments
+        > >
+      >(src);
     }
     const char* ie_expression(const char* src) {
-      return exactly<expression_kwd>(src);
+      return sequence < exactly<expression_kwd>, delimited_by< '(', ')', true> >(src);
     }
-    // match any IE syntax
-    const char* ie_stuff(const char* src) {
-      return sequence< alternatives < ie_expression, ie_progid >, delimited_by<'(', ';', true> >(src);
+    const char* ie_property(const char* src) {
+      return alternatives < ie_expression, ie_progid >(src);
     }
 
     // const char* ie_args(const char* src) {
@@ -535,7 +573,7 @@ namespace Sass {
     // }
 
     const char* ie_keyword_arg(const char* src) {
-      return sequence< alternatives< variable, identifier_schema, identifier >, spaces_and_comments, exactly<'='>, spaces_and_comments, alternatives< variable, identifier_schema, identifier, number, hex > >(src);
+      return sequence< alternatives< variable, identifier_schema, identifier >, spaces_and_comments, exactly<'='>, spaces_and_comments, alternatives< variable, identifier_schema, identifier, string_constant, number, hexa > >(src);
     }
 
     // Path matching functions.

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -392,6 +392,7 @@ namespace Sass {
     const char* percentage(const char* src);
     const char* dimension(const char* src);
     const char* hex(const char* src);
+    const char* hexa(const char* src);
     const char* rgb_prefix(const char* src);
     // Match CSS uri specifiers.
     const char* uri_prefix(const char* src);
@@ -443,8 +444,9 @@ namespace Sass {
     const char* lte_op(const char* src);
 
     // IE stuff
-    const char* ie_stuff(const char* src);
-    const char* ie_args(const char* src);
+    const char* ie_progid(const char* src);
+    const char* ie_expression(const char* src);
+    const char* ie_property(const char* src);
     const char* ie_keyword_arg(const char* src);
 
     // match urls


### PR DESCRIPTION
Fixes issue #683 - Parsing issues with IE specific property syntax.

The whole ie specific property is parsed as a whole (as it was before), but now it should do it with a proper "parsing tree". This is IMO not a 100% proper fix, since all tokens should be parsed and emmitted as such, so they would ie. generate source-map entries. But this is a nice start, since it now recognizes the tokens as such, it just doesn't create an "AST tree".

@xzyfer What do you think?
