### PR TITLE
Make Sass_Values const in API function calls

### DIFF
--- a/sass_functions.h
+++ b/sass_functions.h
@@ -63,7 +63,7 @@ struct Sass_C_Function_Descriptor;
 typedef struct Sass_C_Function_Descriptor* (*Sass_C_Function_List);
 typedef struct Sass_C_Function_Descriptor (*Sass_C_Function_Callback);
 // Typedef defining custom function prototype and its return value type
-typedef union Sass_Value*(*Sass_C_Function) (union Sass_Value*, void* cookie);
+typedef union Sass_Value*(*Sass_C_Function) (const union Sass_Value*, void* cookie);
 
 
 // Creators for sass function list and function descriptors

--- a/sass_values.cpp
+++ b/sass_values.cpp
@@ -86,65 +86,65 @@ extern "C" {
   };
 
   // Return the sass tag for a generic sass value
-  enum Sass_Tag sass_value_get_tag(union Sass_Value* v) { return v->unknown.tag; }
+  enum Sass_Tag sass_value_get_tag(const union Sass_Value* v) { return v->unknown.tag; }
 
   // Check value for specified type
-  bool sass_value_is_null(union Sass_Value* v) { return v->unknown.tag == SASS_NULL; }
-  bool sass_value_is_number(union Sass_Value* v) { return v->unknown.tag == SASS_NUMBER; }
-  bool sass_value_is_string(union Sass_Value* v) { return v->unknown.tag == SASS_STRING; }
-  bool sass_value_is_boolean(union Sass_Value* v) { return v->unknown.tag == SASS_BOOLEAN; }
-  bool sass_value_is_color(union Sass_Value* v) { return v->unknown.tag == SASS_COLOR; }
-  bool sass_value_is_list(union Sass_Value* v) { return v->unknown.tag == SASS_LIST; }
-  bool sass_value_is_map(union Sass_Value* v) { return v->unknown.tag == SASS_MAP; }
-  bool sass_value_is_error(union Sass_Value* v) { return v->unknown.tag == SASS_ERROR; }
-  bool sass_value_is_warning(union Sass_Value* v) { return v->unknown.tag == SASS_WARNING; }
+  bool sass_value_is_null(const union Sass_Value* v) { return v->unknown.tag == SASS_NULL; }
+  bool sass_value_is_number(const union Sass_Value* v) { return v->unknown.tag == SASS_NUMBER; }
+  bool sass_value_is_string(const union Sass_Value* v) { return v->unknown.tag == SASS_STRING; }
+  bool sass_value_is_boolean(const union Sass_Value* v) { return v->unknown.tag == SASS_BOOLEAN; }
+  bool sass_value_is_color(const union Sass_Value* v) { return v->unknown.tag == SASS_COLOR; }
+  bool sass_value_is_list(const union Sass_Value* v) { return v->unknown.tag == SASS_LIST; }
+  bool sass_value_is_map(const union Sass_Value* v) { return v->unknown.tag == SASS_MAP; }
+  bool sass_value_is_error(const union Sass_Value* v) { return v->unknown.tag == SASS_ERROR; }
+  bool sass_value_is_warning(const union Sass_Value* v) { return v->unknown.tag == SASS_WARNING; }
 
   // Getters and setters for Sass_Number
-  double sass_number_get_value(union Sass_Value* v) { return v->number.value; }
+  double sass_number_get_value(const union Sass_Value* v) { return v->number.value; }
   void sass_number_set_value(union Sass_Value* v, double value) { v->number.value = value; }
-  const char* sass_number_get_unit(union Sass_Value* v) { return v->number.unit; }
+  const char* sass_number_get_unit(const union Sass_Value* v) { return v->number.unit; }
   void sass_number_set_unit(union Sass_Value* v, char* unit) { v->number.unit = unit; }
 
   // Getters and setters for Sass_String
-  const char* sass_string_get_value(union Sass_Value* v) { return v->string.value; }
+  const char* sass_string_get_value(const union Sass_Value* v) { return v->string.value; }
   void sass_string_set_value(union Sass_Value* v, char* value) { v->string.value = value; }
 
   // Getters and setters for Sass_Boolean
-  bool sass_boolean_get_value(union Sass_Value* v) { return v->boolean.value; }
+  bool sass_boolean_get_value(const union Sass_Value* v) { return v->boolean.value; }
   void sass_boolean_set_value(union Sass_Value* v, bool value) { v->boolean.value = value; }
 
   // Getters and setters for Sass_Color
-  double sass_color_get_r(union Sass_Value* v) { return v->color.r; }
+  double sass_color_get_r(const union Sass_Value* v) { return v->color.r; }
   void sass_color_set_r(union Sass_Value* v, double r) { v->color.r = r; }
-  double sass_color_get_g(union Sass_Value* v) { return v->color.g; }
+  double sass_color_get_g(const union Sass_Value* v) { return v->color.g; }
   void sass_color_set_g(union Sass_Value* v, double g) { v->color.g = g; }
-  double sass_color_get_b(union Sass_Value* v) { return v->color.b; }
+  double sass_color_get_b(const union Sass_Value* v) { return v->color.b; }
   void sass_color_set_b(union Sass_Value* v, double b) { v->color.b = b; }
-  double sass_color_get_a(union Sass_Value* v) { return v->color.a; }
+  double sass_color_get_a(const union Sass_Value* v) { return v->color.a; }
   void sass_color_set_a(union Sass_Value* v, double a) { v->color.a = a; }
 
   // Getters and setters for Sass_List
-  size_t sass_list_get_length(union Sass_Value* v) { return v->list.length; }
-  enum Sass_Separator sass_list_get_separator(union Sass_Value* v) { return v->list.separator; }
+  size_t sass_list_get_length(const union Sass_Value* v) { return v->list.length; }
+  enum Sass_Separator sass_list_get_separator(const union Sass_Value* v) { return v->list.separator; }
   void sass_list_set_separator(union Sass_Value* v, enum Sass_Separator separator) { v->list.separator = separator; }
   // Getters and setters for Sass_List values
-  union Sass_Value* sass_list_get_value(union Sass_Value* v, size_t i) { return v->list.values[i]; }
+  union Sass_Value* sass_list_get_value(const union Sass_Value* v, size_t i) { return v->list.values[i]; }
   void sass_list_set_value(union Sass_Value* v, size_t i, union Sass_Value* value) { v->list.values[i] = value; }
 
   // Getters and setters for Sass_Map
-  size_t sass_map_get_length(union Sass_Value* v) { return v->map.length; }
+  size_t sass_map_get_length(const union Sass_Value* v) { return v->map.length; }
   // Getters and setters for Sass_List keys and values
-  union Sass_Value* sass_map_get_key(union Sass_Value* v, size_t i) { return v->map.pairs[i].key; }
-  union Sass_Value* sass_map_get_value(union Sass_Value* v, size_t i) { return v->map.pairs[i].value; }
+  union Sass_Value* sass_map_get_key(const union Sass_Value* v, size_t i) { return v->map.pairs[i].key; }
+  union Sass_Value* sass_map_get_value(const union Sass_Value* v, size_t i) { return v->map.pairs[i].value; }
   void sass_map_set_key(union Sass_Value* v, size_t i, union Sass_Value* key) { v->map.pairs[i].key = key; }
   void sass_map_set_value(union Sass_Value* v, size_t i, union Sass_Value* val) { v->map.pairs[i].value = val; }
 
   // Getters and setters for Sass_Error
-  char* sass_error_get_message(union Sass_Value* v) { return v->error.message; };
+  char* sass_error_get_message(const union Sass_Value* v) { return v->error.message; };
   void sass_error_set_message(union Sass_Value* v, char* msg) { v->error.message = msg; };
 
   // Getters and setters for Sass_Warning
-  char* sass_warning_get_message(union Sass_Value* v) { return v->warning.message; };
+  char* sass_warning_get_message(const union Sass_Value* v) { return v->warning.message; };
   void sass_warning_set_message(union Sass_Value* v, char* msg) { v->warning.message = msg; };
 
   // Creator functions for all value types
@@ -282,6 +282,55 @@ extern "C" {
     }
 
     free(val);
+
+    }
+
+  // Make a deep cloned copy of the given sass value
+  union Sass_Value* sass_clone_value (const union Sass_Value* val)
+  {
+
+    size_t i;
+    if (val == 0) return 0;
+    switch(val->unknown.tag) {
+        case SASS_NULL: {
+                return sass_make_null();
+        }   break;
+        case SASS_BOOLEAN: {
+                return sass_make_boolean(val->boolean.value);
+        }   break;
+        case SASS_NUMBER: {
+                return sass_make_number(val->number.value, val->number.unit);
+        }   break;
+        case SASS_COLOR: {
+                return sass_make_color(val->color.r, val->color.g, val->color.b, val->color.a);
+        }   break;
+        case SASS_STRING: {
+                return sass_make_string(val->string.value);
+        }   break;
+        case SASS_LIST: {
+                union Sass_Value* list = sass_make_list(val->list.length, val->list.separator);
+                for (i = 0; i < list->list.length; i++) {
+                    list->list.values[i] = sass_clone_value(val->list.values[i]);
+                }
+                return list;
+        }   break;
+        case SASS_MAP: {
+                union Sass_Value* map = sass_make_map(val->map.length);
+                for (i = 0; i < val->map.length; i++) {
+                    map->map.pairs[i].key = sass_clone_value(val->map.pairs[i].key);
+                    map->map.pairs[i].value = sass_clone_value(val->map.pairs[i].value);
+                }
+                return map;
+        }   break;
+        case SASS_ERROR: {
+                return sass_make_error(val->error.message);
+        }   break;
+        case SASS_WARNING: {
+                return sass_make_warning(val->warning.message);
+        }   break;
+    }
+
+    return 0;
 
   }
 

--- a/sass_values.h
+++ b/sass_values.h
@@ -33,67 +33,67 @@ enum Sass_Separator {
 
 // Return the sass tag for a generic sass value
 // Check is needed before accessing specific values!
-enum Sass_Tag sass_value_get_tag (union Sass_Value* v);
+enum Sass_Tag sass_value_get_tag (const union Sass_Value* v);
 
 // Check value to be of a specific type
 // Can also be used before accessing properties!
-bool sass_value_is_null (union Sass_Value* v);
-bool sass_value_is_number (union Sass_Value* v);
-bool sass_value_is_string (union Sass_Value* v);
-bool sass_value_is_boolean (union Sass_Value* v);
-bool sass_value_is_color (union Sass_Value* v);
-bool sass_value_is_list (union Sass_Value* v);
-bool sass_value_is_map (union Sass_Value* v);
-bool sass_value_is_error (union Sass_Value* v);
-bool sass_value_is_warning (union Sass_Value* v);
+bool sass_value_is_null (const union Sass_Value* v);
+bool sass_value_is_number (const union Sass_Value* v);
+bool sass_value_is_string (const union Sass_Value* v);
+bool sass_value_is_boolean (const union Sass_Value* v);
+bool sass_value_is_color (const union Sass_Value* v);
+bool sass_value_is_list (const union Sass_Value* v);
+bool sass_value_is_map (const union Sass_Value* v);
+bool sass_value_is_error (const union Sass_Value* v);
+bool sass_value_is_warning (const union Sass_Value* v);
 
 // Getters and setters for Sass_Number
-double sass_number_get_value (union Sass_Value* v);
+double sass_number_get_value (const union Sass_Value* v);
 void sass_number_set_value (union Sass_Value* v, double value);
-const char* sass_number_get_unit (union Sass_Value* v);
+const char* sass_number_get_unit (const union Sass_Value* v);
 void sass_number_set_unit (union Sass_Value* v, char* unit);
 
 // Getters and setters for Sass_String
-const char* sass_string_get_value (union Sass_Value* v);
+const char* sass_string_get_value (const union Sass_Value* v);
 void sass_string_set_value (union Sass_Value* v, char* value);
 
 // Getters and setters for Sass_Boolean
-bool sass_boolean_get_value (union Sass_Value* v);
+bool sass_boolean_get_value (const union Sass_Value* v);
 void sass_boolean_set_value (union Sass_Value* v, bool value);
 
 // Getters and setters for Sass_Color
-double sass_color_get_r (union Sass_Value* v);
+double sass_color_get_r (const union Sass_Value* v);
 void sass_color_set_r (union Sass_Value* v, double r);
-double sass_color_get_g (union Sass_Value* v);
+double sass_color_get_g (const union Sass_Value* v);
 void sass_color_set_g (union Sass_Value* v, double g);
-double sass_color_get_b (union Sass_Value* v);
+double sass_color_get_b (const union Sass_Value* v);
 void sass_color_set_b (union Sass_Value* v, double b);
-double sass_color_get_a (union Sass_Value* v);
+double sass_color_get_a (const union Sass_Value* v);
 void sass_color_set_a (union Sass_Value* v, double a);
 
 // Getter for the number of items in list
-size_t sass_list_get_length (union Sass_Value* v);
+size_t sass_list_get_length (const union Sass_Value* v);
 // Getters and setters for Sass_List
-enum Sass_Separator sass_list_get_separator (union Sass_Value* v);
+enum Sass_Separator sass_list_get_separator (const union Sass_Value* v);
 void sass_list_set_separator (union Sass_Value* v, enum Sass_Separator value);
 // Getters and setters for Sass_List values
-union Sass_Value* sass_list_get_value (union Sass_Value* v, size_t i);
+union Sass_Value* sass_list_get_value (const union Sass_Value* v, size_t i);
 void sass_list_set_value (union Sass_Value* v, size_t i, union Sass_Value* value);
 
 // Getter for the number of items in map
-size_t sass_map_get_length (union Sass_Value* v);
+size_t sass_map_get_length (const union Sass_Value* v);
 // Getters and setters for Sass_List keys and values
-union Sass_Value* sass_map_get_key (union Sass_Value* v, size_t i);
+union Sass_Value* sass_map_get_key (const union Sass_Value* v, size_t i);
 void sass_map_set_key (union Sass_Value* v, size_t i, union Sass_Value*);
-union Sass_Value* sass_map_get_value (union Sass_Value* v, size_t i);
+union Sass_Value* sass_map_get_value (const union Sass_Value* v, size_t i);
 void sass_map_set_value (union Sass_Value* v, size_t i, union Sass_Value*);
 
 // Getters and setters for Sass_Error
-char* sass_error_get_message (union Sass_Value* v);
+char* sass_error_get_message (const union Sass_Value* v);
 void sass_error_set_message (union Sass_Value* v, char* msg);
 
 // Getters and setters for Sass_Warning
-char* sass_warning_get_message (union Sass_Value* v);
+char* sass_warning_get_message (const union Sass_Value* v);
 void sass_warning_set_message (union Sass_Value* v, char* msg);
 
 // Creator functions for all value types


### PR DESCRIPTION
This is in reference to https://github.com/sass/libsass/issues/689

I'm not 100% sure if this really is the right way to "solve" this issue, but it should at least improve the situation slightly. Compiler will now issue a warning if someone tries to return the same value in custom functions ... if warnings are enabled. Any opinions on this? I'm just not sure what the best way is to tell implementors where a copy is needed and where it is not!?
