### PR TITLE
Implement API to fetch compiled version

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,13 +1,21 @@
 ACLOCAL_AMFLAGS = -I m4
+
+AM_LDFLAGS = -lstdc++ -lm
 AM_CFLAGS = -Wall -fPIC
 AM_CXXFLAGS = -Wall -fPIC
+AM_CFLAGS += -DLIBSASS_VERSION="\"$(LIBSASS_VERSION)\""
+AM_CXXFLAGS += -DLIBSASS_VERSION="\"$(LIBSASS_VERSION)\""
+
+AM_CXXFLAGS += -std=c++0x
 
 if ENABLE_COVERAGE
   AM_CFLAGS += -O0 --coverage
   AM_CXXFLAGS += -O0 --coverage
+  AM_LDFLAGS += -O0 --coverage -lgcov
 else
   AM_CFLAGS += -O2
   AM_CXXFLAGS += -O2
+  AM_LDFLAGS += -O2
 endif
 
 pkgconfigdir = $(libdir)/pkgconfig
@@ -52,25 +60,25 @@ libsass_la_SOURCES = \
 	utf8_string.cpp \
 	util.cpp
 
-libsass_la_CXXFLAGS = $(AM_CXXFLAGS) -std=c++0x
-libsass_la_LDFLAGS = -no-undefined -version-info 0:9:0
-
-if ENABLE_COVERAGE
-libsass_la_LDFLAGS += -lgcov
-endif
+libsass_la_CFLAGS = $(AM_CFLAGS)
+libsass_la_CXXFLAGS = $(AM_CXXFLAGS)
+libsass_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined -version-info 0:9:0
 
 include_HEADERS = sass2scss.h sass_context.h sass_functions.h sass_values.h sass.h
 
 if ENABLE_TESTS
 
-noinst_PROGRAMS = sass-tester
+noinst_PROGRAMS = sassc_bin
 
-sass_tester_SOURCES = $(SASS_SASSC_PATH)/sassc.c
-sass_tester_LDADD = libsass.la
-sass_tester_LDFLAGS = -no-install
+sassc_bin_SOURCES = $(SASS_SASSC_PATH)/sassc.c
+sassc_bin_LDADD = libsass.la
+sassc_bin_CFLAGS = $(AM_CFLAGS)
+sassc_bin_CXXFLAGS = $(AM_CXXFLAGS)
+sassc_bin_LDFLAGS = $(AM_LDFLAGS) -no-install
+
 if ENABLE_COVERAGE
-sass_tester_LDFLAGS += -lgcov
-nodist_EXTRA_sass_tester_SOURCES = non-existent-file-to-force-CXX-linking.cxx
+nodist_EXTRA_sassc_bin_SOURCES = non-existent-file-to-force-CXX-linking.cxx
+nodist_EXTRA_libsass_la_SOURCES = non-existent-file-to-force-CXX-linking.cxx
 endif
 
 TESTS = \

--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,6 @@ if test "x$enable_tests" = "xyes"; then
   AC_PROG_CC
   AC_PROG_AWK
   AC_PATH_PROG(RUBY, [ruby])
-
   AC_ARG_WITH(sassc-dir,
               AS_HELP_STRING([--with-sassc-dir=<dir>], [specify directory of sassc sources for testing (default: sassc)]),
               [sassc_dir="$withval"], [sassc_dir="sassc"])
@@ -89,5 +88,31 @@ if test "x$enable_cov" = "xyes"; then
 fi
 
 AM_CONDITIONAL(ENABLE_COVERAGE, test "x$enable_cov" = "xyes")
+
+AC_ARG_VAR(LIBSASS_VERSION, libsass version)
+if test "x$LIBSASS_VERSION" = "x"; then
+  AC_CHECK_PROG(GIT, git, git)
+  if test "x$GIT" = "x"; then
+    AC_MSG_ERROR([Unable to find git binary to query version.
+You can solve this by setting LIBSASS_VERSION:
+# export LIBSASS_VERSION="x.y.z"
+])
+  else
+    AC_CHECK_FILE(.git/config, [], [
+    AC_MSG_ERROR([Unable to find .git directory to query version.
+You can solve this by setting LIBSASS_VERSION:
+# export LIBSASS_VERSION="x.y.z"
+])
+    ])
+    LIBSASS_VERSION=`$GIT describe --abbrev=4 --dirty --always --tags`
+  fi
+  if test "x$LIBSASS_VERSION" = "x"; then
+    AC_MSG_ERROR([LIBSASS_VERSION not defined.
+You can solve this by setting LIBSASS_VERSION:
+# export LIBSASS_VERSION="x.y.z"
+])
+  fi
+fi
+
 AC_CONFIG_FILES([Makefile support/libsass.pc])
 AC_OUTPUT

--- a/sass.cpp
+++ b/sass.cpp
@@ -25,4 +25,9 @@ extern "C" {
     return cstr;
   }
 
+  // Get compiled libsass version
+  const char* libsass_version() {
+    return LIBSASS_VERSION;
+  }
+
 }

--- a/sass.h
+++ b/sass.h
@@ -6,6 +6,10 @@
 #include "sass_values.h"
 #include "sass_functions.h"
 
+#ifndef LIBSASS_VERSION
+#define LIBSASS_VERSION "[NA]"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -23,6 +27,8 @@ enum Sass_Output_Style {
 char* sass_string_quote (const char *str, const char quotemark);
 char* sass_string_unquote (const char *str);
 
+// Get compiled libsass version
+const char* libsass_version();
 
 #ifdef __cplusplus
 }

--- a/sass2scss.cpp
+++ b/sass2scss.cpp
@@ -823,4 +823,9 @@ extern "C"
 		return Sass::sass2scss(sass, options);
 	}
 
+	// Get compiled sass2scss version
+	const char* sass2scss_version() {
+		return SASS2SCSS_VERSION;
+	}
+
 }

--- a/sass2scss.h
+++ b/sass2scss.h
@@ -6,8 +6,8 @@
 #include <sstream>
 #include <iostream>
 
-#ifndef VERSION
-#define VERSION "[NA]"
+#ifndef SASS2SCSS_VERSION
+#define SASS2SCSS_VERSION "1.0.3"
 #endif
 
 // using std::string
@@ -16,10 +16,6 @@ using namespace std;
 // add namespace for c++
 namespace Sass
 {
-
-	// define version from arguments
-	// compile with g++ -DVERSION="\"vX.X.X\""
-	const string SASS2SCSS_VERSION = VERSION;
 
 	// pretty print options
 	const int SASS2SCSS_PRETTIFY_0 = 0;
@@ -86,6 +82,9 @@ extern "C" {
 
 	// available to c and c++ code
 	char* sass2scss (const char* sass, const int options);
+
+	// Get compiled sass2scss version
+	const char* sass2scss_version();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Updated the build system to fetch version automatically via git.
The variable is than exposed through `libsass_version` function.
Implementors like `sassc` can use this to query the compiled version!
With this we can then fix https://github.com/sass/sassc/issues/66
