### PR TITLE
Fix colours as map keys

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1127,7 +1127,8 @@ namespace Sass {
 
     if (lex< identifier >()) {
       String_Constant* str = new (ctx.mem) String_Constant(path, source_position, lexed);
-      str->is_delayed(true);
+      // Dont' delay this string if it is a name color. Fixes #652.
+      str->is_delayed(ctx.names_to_colors.count(lexed) == 0);
       return str;
     }
 


### PR DESCRIPTION
This PR fixes the treatment of colours when used as map keys. 

The current problem is named colours like purple are treated as identifiers meaning they're not evaluated and coerced into colours. This causes issues when doing operations that expect a colour like `map-get($map, purple)`. In this case the argument `purple` is treated as a colours but the map key `purple` is a string which causes the lookup to (correctly) fail.

Fixes #652. Specs added https://github.com/sass/sass-spec/pull/156.
