### PR TITLE
Implement feature-exists()

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -460,6 +460,7 @@ namespace Sass {
     register_function(ctx, global_variable_exists_sig, global_variable_exists, env);
     register_function(ctx, function_exists_sig, function_exists, env);
     register_function(ctx, mixin_exists_sig, mixin_exists, env);
+    register_function(ctx, feature_exists_sig, feature_exists, env);
     register_function(ctx, call_sig, call, env);
     // Boolean Functions
     register_function(ctx, not_sig, sass_not, env);

--- a/functions.cpp
+++ b/functions.cpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <iostream>
 #include <random>
+#include <set>
 
 #define ARG(argname, argtype) get_arg<argtype>(argname, env, sig, path, position, backtrace)
 #define ARGR(argname, argtype, lo, hi) get_arg_r(argname, env, sig, path, position, lo, hi, backtrace)
@@ -113,6 +114,9 @@ namespace Sass {
     // generally only used to seed a PRNG such as mt19937.
     static random_device rd;
     static mt19937 rand(rd());
+
+    // features
+    static set<string> features;
 
     ////////////////
     // RGB FUNCTIONS
@@ -1420,6 +1424,19 @@ namespace Sass {
       }
       else {
         return new (ctx.mem) Boolean(path, position, false);
+      }
+    }
+
+    Signature feature_exists_sig = "feature-exists($name)";
+    BUILT_IN(feature_exists)
+    {
+      string s = unquote(ARG("$name", String_Constant)->value());
+
+      if(features.find(s) == features.end()) {
+        return new (ctx.mem) Boolean(path, position, false);
+      }
+      else {
+        return new (ctx.mem) Boolean(path, position, true);
       }
     }
 

--- a/functions.hpp
+++ b/functions.hpp
@@ -92,6 +92,7 @@ namespace Sass {
     extern Signature global_variable_exists_sig;
     extern Signature function_exists_sig;
     extern Signature mixin_exists_sig;
+    extern Signature feature_exists_sig;
     extern Signature call_sig;
     extern Signature not_sig;
     extern Signature if_sig;
@@ -165,6 +166,7 @@ namespace Sass {
     BUILT_IN(global_variable_exists);
     BUILT_IN(function_exists);
     BUILT_IN(mixin_exists);
+    BUILT_IN(feature_exists);
     BUILT_IN(call);
     BUILT_IN(sass_not);
     BUILT_IN(sass_if);


### PR DESCRIPTION
This PR implement `feature-exists()`. Ruby sass has 4 defined features, all of which are unsupported by Libsass at the moment.

Fixes https://github.com/sass/libsass/issues/702. Specs added https://github.com/sass/sass-spec/pull/161.
