### PR TITLE
Implement @error function

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -442,6 +442,18 @@ namespace Sass {
     ATTACH_OPERATIONS();
   };
 
+  ///////////////////////////////
+  // The Sass `@error` directive.
+  ///////////////////////////////
+  class Error : public Statement {
+    ADD_PROPERTY(Expression*, message);
+  public:
+    Error(string path, Position position, Expression* msg)
+    : Statement(path, position), message_(msg)
+    { }
+    ATTACH_OPERATIONS();
+  };
+
   ///////////////////////////////////////////
   // CSS comments. These may be interpolated.
   ///////////////////////////////////////////

--- a/ast_factory.hpp
+++ b/ast_factory.hpp
@@ -24,6 +24,7 @@ namespace Sass {
     Import<Function_Call*>* new_CSS_Import(string p, size_t l, Function_Call* loc);
     Import<String*>* new_SASS_Import(string p, size_t l, String* loc);
     Warning* new_Warning(string p, size_t l, Expression* msg);
+    Error* new_Error(string p, size_t l, Expression* msg);
     Comment* new_Comment(string p, size_t l, String* txt);
     If* new_If(string p, size_t l, Expression* pred, Block* con, Block* alt = 0);
     For* new_For(string p, size_t l, string var, Expression* lo, Expression* hi, Block* b, bool inc);

--- a/ast_fwd_decl.hpp
+++ b/ast_fwd_decl.hpp
@@ -17,6 +17,7 @@ namespace Sass {
   class Import;
   class Import_Stub;
   class Warning;
+  class Error;
   class Comment;
   class If;
   class For;

--- a/constants.cpp
+++ b/constants.cpp
@@ -26,6 +26,7 @@ namespace Sass {
     extern const char in_kwd[]            = "in";
     extern const char while_kwd[]         = "@while";
     extern const char warn_kwd[]          = "@warn";
+    extern const char error_kwd[]         = "@error";
     extern const char default_kwd[]       = "default";
     extern const char global_kwd[]        = "global";
     extern const char null_kwd[]          = "null";

--- a/constants.hpp
+++ b/constants.hpp
@@ -26,6 +26,7 @@ namespace Sass {
     extern const char in_kwd[];
     extern const char while_kwd[];
     extern const char warn_kwd[];
+    extern const char error_kwd[];
     extern const char default_kwd[];
     extern const char global_kwd[];
     extern const char null_kwd[];

--- a/error_handling.cpp
+++ b/error_handling.cpp
@@ -7,12 +7,12 @@
 
 namespace Sass {
 
-  Error::Error(Type type, string path, Position position, string message)
+  Sass_Error::Sass_Error(Type type, string path, Position position, string message)
   : type(type), path(path), position(position), message(message)
   { }
 
   void error(string msg, string path, Position position)
-  { throw Error(Error::syntax, path, position, msg); }
+  { throw Sass_Error(Sass_Error::syntax, path, position, msg); }
 
   void error(string msg, string path, Position position, Backtrace* bt)
   {
@@ -22,7 +22,7 @@ namespace Sass {
     Backtrace top(bt, path, position, "");
     msg += top.to_string();
 
-    throw Error(Error::syntax, path, position, msg);
+    throw Sass_Error(Sass_Error::syntax, path, position, msg);
   }
 
 }

--- a/error_handling.hpp
+++ b/error_handling.hpp
@@ -10,7 +10,7 @@ namespace Sass {
 
   struct Backtrace;
 
-  struct Error {
+  struct Sass_Error {
     enum Type { read, write, syntax, evaluation };
 
     Type type;
@@ -18,7 +18,7 @@ namespace Sass {
     Position position;
     string message;
 
-    Error(Type type, string path, Position position, string message);
+    Sass_Error(Type type, string path, Position position, string message);
 
   };
 

--- a/eval.hpp
+++ b/eval.hpp
@@ -46,6 +46,7 @@ namespace Sass {
     Expression* operator()(While*);
     Expression* operator()(Return*);
     Expression* operator()(Warning*);
+    Expression* operator()(Error*);
 
     Expression* operator()(List*);
     Expression* operator()(Map*);

--- a/expand.cpp
+++ b/expand.cpp
@@ -174,6 +174,13 @@ namespace Sass {
     return 0;
   }
 
+  Statement* Expand::operator()(Error* e)
+  {
+    // eval handles this too, because errors may occur in functions
+    e->perform(eval->with(env, backtrace));
+    return 0;
+  }
+
   Statement* Expand::operator()(Comment* c)
   {
     // TODO: eval the text, once we're parsing/storing it as a String_Schema

--- a/expand.hpp
+++ b/expand.hpp
@@ -55,6 +55,7 @@ namespace Sass {
     Statement* operator()(Import*);
     Statement* operator()(Import_Stub*);
     Statement* operator()(Warning*);
+    Statement* operator()(Error*);
     Statement* operator()(Comment*);
     Statement* operator()(If*);
     Statement* operator()(For*);

--- a/functions.cpp
+++ b/functions.cpp
@@ -47,8 +47,11 @@ namespace Sass {
   Definition* make_c_function(Signature sig, Sass_C_Function f, void* cookie, Context& ctx)
   {
     Parser sig_parser = Parser::from_c_str(sig, ctx, "[c function]");
-    // allow to overload generic callback and @warn with custom functions
-    sig_parser.lex< alternatives < identifier, exactly <'*'>, exactly<Constants::warn_kwd> > >();
+    // allow to overload generic callback plus @warn and @error with custom functions
+    sig_parser.lex < alternatives < identifier, exactly <'*'>,
+                                    exactly < Constants::warn_kwd >,
+                                    exactly < Constants::error_kwd >
+                   >              >();
     string name(Util::normalize_underscores(sig_parser.lexed));
     Parameters* params = sig_parser.parse_parameters();
     return new (ctx.mem) Definition("[c function]",

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -138,6 +138,14 @@ namespace Sass {
     append_to_buffer(";");
   }
 
+  void Inspect::operator()(Error* error)
+  {
+    if (ctx) ctx->source_map.add_mapping(error);
+    append_to_buffer("@error ");
+    error->message()->perform(this);
+    append_to_buffer(";");
+  }
+
   void Inspect::operator()(Comment* comment)
   {
     comment->text()->perform(this);

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -48,6 +48,7 @@ namespace Sass {
     virtual void operator()(Import*);
     virtual void operator()(Import_Stub*);
     virtual void operator()(Warning*);
+    virtual void operator()(Error*);
     virtual void operator()(Comment*);
     virtual void operator()(If*);
     virtual void operator()(For*);

--- a/operation.hpp
+++ b/operation.hpp
@@ -25,6 +25,7 @@ namespace Sass {
     virtual T operator()(Import* x)                 = 0;
     virtual T operator()(Import_Stub* x)            = 0;
     virtual T operator()(Warning* x)                = 0;
+    virtual T operator()(Error* x)                  = 0;
     virtual T operator()(Comment* x)                = 0;
     virtual T operator()(If* x)                     = 0;
     virtual T operator()(For* x)                    = 0;
@@ -93,6 +94,7 @@ namespace Sass {
     virtual T operator()(Import* x)                 { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Import_Stub* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Warning* x)                { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Error* x)                  { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Comment* x)                { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(If* x)                     { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(For* x)                    { return static_cast<D*>(this)->fallback(x); }

--- a/output_compressed.hpp
+++ b/output_compressed.hpp
@@ -38,6 +38,7 @@ namespace Sass {
     virtual void operator()(Import*);
     // virtual void operator()(Import_Stub*);
     // virtual void operator()(Warning*);
+    // virtual void operator()(Error*);
     virtual void operator()(Comment*);
     // virtual void operator()(If*);
     // virtual void operator()(For*);

--- a/output_nested.hpp
+++ b/output_nested.hpp
@@ -51,6 +51,7 @@ namespace Sass {
     virtual void operator()(Import*);
     // virtual void operator()(Import_Stub*);
     // virtual void operator()(Warning*);
+    // virtual void operator()(Error*);
     // virtual void operator()(Comment*);
     // virtual void operator()(If*);
     // virtual void operator()(For*);

--- a/parser.cpp
+++ b/parser.cpp
@@ -96,6 +96,10 @@ namespace Sass {
         (*root) << parse_warning();
         if (!lex< exactly<';'> >()) error("top-level @warn directive must be terminated by ';'");
       }
+      else if (peek< err >()) {
+        (*root) << parse_error();
+        if (!lex< exactly<';'> >()) error("top-level @error directive must be terminated by ';'");
+      }
       // ignore the @charset directive for now
       else if (lex< exactly< charset_kwd > >()) {
         lex< string_constant >();
@@ -707,6 +711,10 @@ namespace Sass {
         (*block) << parse_warning();
         semicolon = true;
       }
+      else if (peek< err >()) {
+        (*block) << parse_error();
+        semicolon = true;
+      }
       else if (stack.back() == function_def) {
         error("only variable declarations and control directives are allowed inside functions");
       }
@@ -1092,7 +1100,7 @@ namespace Sass {
         *args << arg;
         return result;
       }
-      catch (Error&) {
+      catch (Sass_Error&) {
         // back up so we can try again
         position = here;
         source_position = here_p;
@@ -1722,6 +1730,12 @@ namespace Sass {
     return new (ctx.mem) Warning(path, source_position, parse_list());
   }
 
+  Error* Parser::parse_error()
+  {
+    lex< err >();
+    return new (ctx.mem) Error(path, source_position, parse_list());
+  }
+
   Selector_Lookahead Parser::lookahead_for_selector(const char* start)
   {
     const char* p = start ? start : position;
@@ -1939,7 +1953,7 @@ namespace Sass {
 
   void Parser::error(string msg, Position pos)
   {
-    throw Error(Error::syntax, path, pos.line ? pos : source_position, msg);
+    throw Sass_Error(Sass_Error::syntax, path, pos.line ? pos : source_position, msg);
   }
 
 }

--- a/parser.hpp
+++ b/parser.hpp
@@ -246,6 +246,7 @@ namespace Sass {
     Feature_Query_Condition* parse_supports_declaration();
     At_Rule* parse_at_rule();
     Warning* parse_warning();
+    Error* parse_error();
 
     Selector_Lookahead lookahead_for_selector(const char* start = 0);
     Selector_Lookahead lookahead_for_extension_target(const char* start = 0);

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -302,6 +302,10 @@ namespace Sass {
       return exactly<warn_kwd>(src);
     }
 
+    const char* err(const char* src) {
+      return exactly<error_kwd>(src);
+    }
+
     const char* directive(const char* src) {
       return sequence< exactly<'@'>, identifier >(src);
     }

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -363,6 +363,7 @@ namespace Sass {
     const char* while_directive(const char* src);
 
     const char* warn(const char* src);
+    const char* err(const char* src);
 
     const char* directive(const char* src);
     const char* at_keyword(const char* src);

--- a/sass2scss.cpp
+++ b/sass2scss.cpp
@@ -562,8 +562,11 @@ namespace Sass
 			}
 
 			// terminate warn and debug statements immediately
-			else if (sass.substr(pos_left, 5) == "@warn" || sass.substr(pos_left, 6) == "@debug")
-			{ sass = indent + sass.substr(pos_left); }
+			else if (
+				sass.substr(pos_left, 5) == "@warn" ||
+				sass.substr(pos_left, 6) == "@debug" ||
+				sass.substr(pos_left, 6) == "@error"
+			) { sass = indent + sass.substr(pos_left); }
 			// replace some specific sass shorthand directives (if not fallowed by a white space character)
 			else if (sass.substr(pos_left, 1) == "=" && sass.find_first_of(SASS2SCSS_FIND_WHITESPACE, pos_left) != pos_left + 1)
 			{ sass = indent + "@mixin " + sass.substr(pos_left + 1); }

--- a/sass_context.cpp
+++ b/sass_context.cpp
@@ -206,7 +206,7 @@ extern "C" {
     try {
      throw;
     }
-    catch (Error& e) {
+    catch (Sass_Error& e) {
       stringstream msg_stream;
       JsonNode* json_err = json_mkobject();
       json_append_member(json_err, "status", json_mknumber(1));

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -138,7 +138,7 @@ extern "C" {
 
       copy_strings(cpp_ctx.get_included_files(1), &c_ctx->included_files, 1);
     }
-    catch (Error& e) {
+    catch (Sass_Error& e) {
       stringstream msg_stream;
       msg_stream << e.path << ":" << e.position.line << ": " << e.message << endl;
       c_ctx->error_message = strdup(msg_stream.str().c_str());
@@ -225,7 +225,7 @@ extern "C" {
 
       copy_strings(cpp_ctx.get_included_files(), &c_ctx->included_files);
     }
-    catch (Error& e) {
+    catch (Sass_Error& e) {
       stringstream msg_stream;
       msg_stream << e.path << ":" << e.position.line << ": " << e.message << endl;
       c_ctx->error_message = strdup(msg_stream.str().c_str());

--- a/sass_values.h
+++ b/sass_values.h
@@ -21,7 +21,8 @@ enum Sass_Tag {
   SASS_LIST,
   SASS_MAP,
   SASS_NULL,
-  SASS_ERROR
+  SASS_ERROR,
+  SASS_WARNING
 };
 
 // Tags for denoting Sass list separators
@@ -44,6 +45,7 @@ bool sass_value_is_color (union Sass_Value* v);
 bool sass_value_is_list (union Sass_Value* v);
 bool sass_value_is_map (union Sass_Value* v);
 bool sass_value_is_error (union Sass_Value* v);
+bool sass_value_is_warning (union Sass_Value* v);
 
 // Getters and setters for Sass_Number
 double sass_number_get_value (union Sass_Value* v);
@@ -90,6 +92,10 @@ void sass_map_set_value (union Sass_Value* v, size_t i, union Sass_Value*);
 char* sass_error_get_message (union Sass_Value* v);
 void sass_error_set_message (union Sass_Value* v, char* msg);
 
+// Getters and setters for Sass_Warning
+char* sass_warning_get_message (union Sass_Value* v);
+void sass_warning_set_message (union Sass_Value* v, char* msg);
+
 // Creator functions for all value types
 union Sass_Value* sass_make_null    (void);
 union Sass_Value* sass_make_boolean (bool val);
@@ -99,6 +105,7 @@ union Sass_Value* sass_make_color   (double r, double g, double b, double a);
 union Sass_Value* sass_make_list    (size_t len, enum Sass_Separator sep);
 union Sass_Value* sass_make_map     (size_t len);
 union Sass_Value* sass_make_error   (const char* msg);
+union Sass_Value* sass_make_warning (const char* msg);
 
 // Generic destructor function for all types
 // Will release memory of all associated Sass_Values


### PR DESCRIPTION
In reference to https://github.com/sass/sass-spec/issues/136 and https://github.com/sass/libsass/issues/704

I first tried to duplicate all `Warning` related code, but ran into the issue that `Error`, `error` and `SASS_ERROR` are already taken by other parts. Therefore I decided to "hack" `Warning` to add a `is_fatal` flag to indicate these kind of Errors internally. I guess this does make sense, although the namings are already a bit confusing and this PR does not help to reduce that.

This is not complete as this should also be added to the C Interface (related to #711). But I'm not sure if we should split this into error and warning (would IMO feel a bit more natural) or introduce the "concept of fatal warnings" also to the C-API. Unfortunately we already and only have `Sass_Error`, so to not break anything we would need to add "non fatal errors". Which leads back to probably just split it into `Errors` and `Warnings` at the C-API level.
