### PR TITLE
Implement emitting utf8 charset when seen in output

### DIFF
--- a/output_compressed.hpp
+++ b/output_compressed.hpp
@@ -16,6 +16,7 @@ namespace Sass {
     string buffer;
     string rendered_imports;
     Context* ctx;
+    bool seen_utf8;
 
     void fallback_impl(AST_Node* n);
 
@@ -25,7 +26,10 @@ namespace Sass {
     Output_Compressed(Context* ctx = 0);
     virtual ~Output_Compressed();
 
-    string get_buffer() { return rendered_imports + buffer; }
+    string get_buffer() {
+      return (seen_utf8 ? "@charset \"UTF-8\";\n" : "")
+             + rendered_imports + buffer;
+    }
 
     // statements
     virtual void operator()(Block*);

--- a/output_nested.hpp
+++ b/output_nested.hpp
@@ -21,6 +21,7 @@ namespace Sass {
     size_t indentation;
     bool source_comments;
     Context* ctx;
+    bool seen_utf8;
     void indent();
 
     void fallback_impl(AST_Node* n);
@@ -33,10 +34,11 @@ namespace Sass {
     virtual ~Output_Nested();
 
     string get_buffer() {
-        if (!rendered_imports.empty() && !buffer.empty()) {
-            rendered_imports += "\n";
-        }
-        return rendered_imports + buffer;
+      if (!rendered_imports.empty() && !buffer.empty()) {
+        rendered_imports += "\n";
+      }
+      return (seen_utf8 ? "@charset \"UTF-8\";\n" : "")
+             + rendered_imports + buffer;
     }
 
     // statements


### PR DESCRIPTION
https://github.com/sass/libsass/issues/629: "when we run into utf-8 characters, we throw in the charset"

There are some unknowns and open things here:
- Does ruby sass support other encodings than utf-8
- We don't, so anything else is out of perspective here!
- [x] ~~IMO this should be configurable via a context option~~ -> optional
- [x] ~~Code needs some re-factoring (use less copy paste)~~ -> todo #734
- [x] Needs to update spec/basic/48_case_conversion -> https://github.com/sass/sass-spec/pull/178
