### PR TITLE
Error if a user defined function uses a reserved name

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -215,6 +215,8 @@ namespace Sass {
     string which_str(lexed);
     if (!lex< identifier >()) error("invalid name in " + which_str + " definition");
     string name(Util::normalize_underscores(lexed));
+    if (which_type == Definition::FUNCTION && (name == "and" || name == "or" || name == "not"))
+    { error("Invalid function name \"" + name + "\"."); }
     Position source_position_of_def = source_position;
     Parameters* params = parse_parameters();
     if (!peek< exactly<'{'> >()) error("body for " + which_str + " " + name + " must begin with a '{'");


### PR DESCRIPTION
This PR implements reserved function names as implemented in Ruby Sass 3.3.9.

Fixes #713. Specs added https://github.com/sass/sass-spec/pull/167.
