### PR TITLE
Error when trying to string concatenate with null

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -982,6 +982,8 @@ namespace Sass {
       case Binary_Expression::DIV: sep = "/"; break;
       default:                         break;
     }
+    if (ltype == Expression::NULL_VAL) error("invalid null operation: \"null plus "+quote(unquote(rstr), '"')+"\".", lhs->path(), lhs->position());
+    if (rtype == Expression::NULL_VAL) error("invalid null operation: \""+quote(unquote(lstr), '"')+" plus null\".", lhs->path(), lhs->position());
     char q = '\0';
     if (lstr[0] == '"' || lstr[0] == '\'') q = lstr[0];
     else if (rstr[0] == '"' || rstr[0] == '\'') q = rstr[0];


### PR DESCRIPTION
This PR brings the string concatenation behaviour in line with Ruby Sass by throwing an error when one of the strings involved is `null`.

Fixes https://github.com/sass/libsass/issues/698. Spec added https://github.com/sass/sass-spec/pull/168.
