### PR TITLE
Parse selector identifiers prefixed with an ampersand correctly

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -490,7 +490,7 @@ namespace Sass {
         return seq;
       }
     }
-    if (sawsomething && lex< sequence< negate< functional >, alternatives< hyphens_and_identifier, universal, string_constant, dimension, percentage, number > > >()) {
+    if (sawsomething && lex< sequence< negate< functional >, alternatives< identifier_fragment, universal, string_constant, dimension, percentage, number > > >()) {
       // saw an ampersand, then allow type selectors with arbitrary number of hyphens at the beginning
       (*seq) << new (ctx.mem) Type_Selector(path, source_position, lexed);
     } else if (lex< sequence< negate< functional >, alternatives< type_selector, universal, string_constant, dimension, percentage, number > > >()) {
@@ -1776,6 +1776,8 @@ namespace Sass {
            (q = peek< sequence< optional<sign>,
                                 digits > >(p))                     ||
            (q = peek< number >(p))                                 ||
+           (q = peek< sequence< exactly<'&'>,
+                                identifier_fragment > >(p))        ||
            (q = peek< exactly<'&'> >(p))                           ||
            (q = peek< exactly<'%'> >(p))                           ||
            (q = peek< alternatives<exact_match,
@@ -1832,6 +1834,8 @@ namespace Sass {
            (q = peek< sequence< optional<sign>,
                                 digits > >(p))                     ||
            (q = peek< number >(p))                                 ||
+           (q = peek< sequence< exactly<'&'>,
+                                identifier_fragment > >(p))        ||
            (q = peek< exactly<'&'> >(p))                           ||
            (q = peek< exactly<'%'> >(p))                           ||
            (q = peek< alternatives<exact_match,

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -157,6 +157,13 @@ namespace Sass {
                                                 backslash_something > > >(src);
     }
 
+    const char* identifier_fragment(const char* src) {
+      return one_plus< alternatives< alnum,
+                                     exactly<'-'>,
+                                     exactly<'_'>,
+                                     backslash_something > >(src);
+    }
+
     // Match CSS selectors.
     const char* sel_ident(const char* src) {
       return sequence< optional< alternatives< exactly<'-'>, exactly<'|'> > >,

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -324,6 +324,7 @@ namespace Sass {
     const char* custom_property_name(const char* src);
     // Match a CSS identifier.
     const char* identifier(const char* src);
+    const char* identifier_fragment(const char* src);
     // Match selector names.
     const char* sel_ident(const char* src);
     // Match interpolant schemas


### PR DESCRIPTION
This PR fixes a bug in parsing BEM style selector identifiers.

Fixes https://github.com/sass/libsass/issues/738. Specs added https://github.com/sass/sass-spec/pull/186.
