### PR TITLE
Better support for parsing complex ie function values

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1315,7 +1315,7 @@ namespace Sass {
     }
     lex< exactly<'='> >();
     *kwd_arg << new (ctx.mem) String_Constant(path, source_position, lexed);
-    if (lex< variable >()) *kwd_arg << new (ctx.mem) Variable(path, source_position, Util::normalize_underscores(lexed));
+    if (peek< variable >()) *kwd_arg << parse_list();
     else if (lex< number >()) *kwd_arg << new (ctx.mem) Textual(path, source_position, Textual::NUMBER, Util::normalize_decimals(lexed));
     else {
       lex< alternatives< identifier_schema, identifier, number, hex > >();


### PR DESCRIPTION
This PR adds better support for parsing complex ie function values. If a value looks to be more than a simple variable or number we parse it with all of sass' abilities as we would any other declaration value.

Fixes https://github.com/sass/libsass/issues/549. Specs added  sass/sass-spec#104, https://github.com/sass/sass-spec/pull/188.
