### PR TITLE
Fix for source-map issues

### DIFF
--- a/inspect.cpp
+++ b/inspect.cpp
@@ -714,8 +714,6 @@ namespace Sass {
   void Inspect::append_to_buffer(const string& text)
   {
     buffer += text;
-    if (ctx && !ctx->_skip_source_map_update)
-      ctx->source_map.update_column(text);
   }
 
 }

--- a/output_compressed.cpp
+++ b/output_compressed.cpp
@@ -27,6 +27,8 @@ namespace Sass {
       seen_utf8 = true;
     }
     buffer += text;
+    if (ctx && !ctx->_skip_source_map_update)
+      ctx->source_map.update_column(text);
   }
 
   void Output_Compressed::operator()(Import* imp)
@@ -224,6 +226,8 @@ namespace Sass {
         seen_utf8 = true;
       }
       buffer += text;
+      if (ctx && !ctx->_skip_source_map_update)
+       ctx->source_map.update_column(text);
     }
   }
 
@@ -382,6 +386,8 @@ namespace Sass {
   void Output_Compressed::append_singleline_part_to_buffer(const string& text)
   {
     buffer += text;
+    if (ctx && !ctx->_skip_source_map_update)
+      ctx->source_map.update_column(text);
     for(const char& chr : text) {
       // abort clause
       if (seen_utf8) break;
@@ -390,8 +396,6 @@ namespace Sass {
       // singleton
       seen_utf8 = true;
     }
-    if (ctx && !ctx->_skip_source_map_update)
-      ctx->source_map.update_column(text);
   }
 
 }

--- a/output_nested.cpp
+++ b/output_nested.cpp
@@ -30,6 +30,8 @@ namespace Sass {
       seen_utf8 = true;
     }
     buffer += text;
+    if (ctx && !ctx->_skip_source_map_update)
+      ctx->source_map.update_column(text);
   }
 
   void Output_Nested::operator()(Import* imp)
@@ -347,6 +349,8 @@ namespace Sass {
   void Output_Nested::append_to_buffer(const string& text)
   {
     buffer += text;
+    if (ctx && !ctx->_skip_source_map_update)
+      ctx->source_map.update_column(text);
     for(const char& chr : text) {
       // abort clause
       if (seen_utf8) break;
@@ -355,8 +359,6 @@ namespace Sass {
       // singleton
       seen_utf8 = true;
     }
-    if (ctx && !ctx->_skip_source_map_update)
-      ctx->source_map.update_column(text);
   }
 
 }


### PR DESCRIPTION
https://github.com/sass/libsass/issues/720

This should hopefully fix the regression I have introduced recently.
We should probably be save to remove `_skip_source_map_update` too.
But I want to wait for that until we have some basic tests for source-maps.
Anyway, this commit makes a lot of sense from a logical coding standpoint!
