### PR TITLE
Fix boolean coersion in unary not operator

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -346,7 +346,7 @@ namespace Sass {
   {
     Expression* operand = u->operand()->perform(this);
     if (u->type() == Unary_Expression::NOT) {
-      Boolean* result = new (ctx.mem) Boolean(*static_cast<Boolean*>(operand));
+      Boolean* result = new (ctx.mem) Boolean(u->path(), u->position(), (bool)*operand);
       result->value(!result->value());
       return result;
     }


### PR DESCRIPTION
This PR fixes the coercion of non-boolean expression in `if not` operations.

Fixes https://github.com/sass/libsass/issues/748. Spec added https://github.com/sass/sass-spec/pull/170, https://github.com/sass/sass-spec/pull/193.
