### PR TITLE
Implement raw css imports

### DIFF
--- a/file.cpp
+++ b/file.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <fstream>
 #include <cctype>
+#include <vector>
 #include <algorithm>
 #include <sys/stat.h>
 #include "file.hpp"
@@ -202,34 +203,38 @@ namespace Sass {
       // (4) given + extension
       char* contents = 0;
       real_path = path;
-      // if the file isn't found with the given filename ...
+      vector<string> exts(3);
+      exts[0] = ".scss";
+      exts[1] = ".sass";
+      exts[2] = ".css";
+
+      // if the file isn't found with the given filename (1)
       if (!(contents = read_file(real_path))) {
         string dir(dir_name(path));
         string base(base_name(path));
-        string _base("_" + base);
-        real_path = dir + _base;
-        // if the file isn't found with '_' + filename ...
-        if (!(contents = read_file(real_path))) {
-          string _base_scss(_base + ".scss");
-          real_path = dir + _base_scss;
-          // if the file isn't found with '_' + filename + ".scss" ...
-          if (!(contents = read_file(real_path))) {
-            string _base_sass(_base + ".sass");
-            real_path = dir + _base_sass;
-            // if the file isn't found with '_' + filename + ".sass" ...
-            if (!(contents = read_file(real_path))) {
-              string base_scss(base + ".scss");
-              real_path = dir + base_scss;
-              // if the file isn't found with filename + ".scss" ...
-              if (!(contents = read_file(real_path))) {
-                string base_sass(base + ".sass");
-                real_path = dir + base_sass;
-                // if the file isn't found with filename + ".sass" ...
-                if (!(contents = read_file(real_path))) {
-                  // default back to scss version
-                  real_path = dir + base_scss;
-                }
-              }
+        real_path = dir + base;
+        // (2) underscore + given
+        string test_path(dir + "_" + base);
+        if ((contents = read_file(test_path))) {
+          real_path = test_path;
+        }
+        // (3) underscore + given + extension
+        if (!contents) {
+          for(auto ext : exts) {
+            test_path = dir + "_" + base + ext;
+            if ((contents = read_file(test_path))) {
+              real_path = test_path;
+              break;
+            }
+          }
+        }
+        // (4) given + extension
+        if (!contents) {
+          for(auto ext : exts) {
+            test_path = dir + base + ext;
+            if ((contents = read_file(test_path))) {
+              real_path = test_path;
+              break;
             }
           }
         }


### PR DESCRIPTION
Also refactors the lookup code for better readability!

This is an attempt to fix one of our longer standing issues -> https://github.com/sass/libsass/issues/318
I tried to read all related issues on ruby sass to make this compatible!
This PR allows to import a `file.css` with the following syntax:

```
@import "file";
```

This will try to resolve the partial as normal, but will also look for `.css` files.
Previously this would produces an error if no file could be found.

The old behaviour is still active:
```
@import "file.css";
```

Will result in:
```
@import url(file.css);
```

So this should IMO be pretty much backward compatible!
If this is not acceptable by default I suggest to make this configurable!

@hcatlin what do you think?