### PR TITLE
str-slice with $end-at should never return a value

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -923,7 +923,9 @@ namespace Sass {
         size_t start = UTF_8::offset_at_position(str, UTF_8::normalize_index(n->value(), UTF_8::code_point_count(str)));
         size_t end = UTF_8::offset_at_position(str, UTF_8::normalize_index(m->value(), UTF_8::code_point_count(str)));
 
-        if(start == end) {
+        // `str-slice` should always return an empty string when $end-at == 0
+        // `normalize_index` normalizes 1 -> 0 so we need to check the original value
+        if(start == end && m->value() > 0) {
           newstr = str.substr(start, 1);
         } else if(end > start) {
           newstr = str.substr(start, end - start + UTF_8::code_point_size_at_offset(str, end));


### PR DESCRIPTION
This PR fixes an edge case with `str-slice` where `$start-at == 1` and `$end-at == 0` cause by they're normalisation.

Generally speaking `str-slice` should never return a value when `$start-at > $end-at > 0`. Our input validation is aware of this, but due to normalisation the case `$start-at == 1` and `$end-at == 0` gets normalised to `$start-at == 0` and `$end-at == 0`. 

Essentially we need to enforce `$start-at > $end-at > 0` pre-normalisation. 

Fixes https://github.com/sass/libsass/issues/760. Specs added https://github.com/sass/sass-spec/pull/194.
