### PR TITLE
Guarded assignments should override null values

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -55,7 +55,8 @@ namespace Sass {
   {
     string var(a->variable());
     if (env->has(var)) {
-      if(!a->is_guarded()) (*env)[var] = a->value()->perform(this);
+      Expression* v = static_cast<Expression*>((*env)[var]);
+      if (!a->is_guarded() || v->concrete_type() == Expression::NULL_VAL) (*env)[var] = a->value()->perform(this);
     }
     else {
       env->current_frame()[var] = a->value()->perform(this);

--- a/expand.cpp
+++ b/expand.cpp
@@ -144,7 +144,8 @@ namespace Sass {
   {
     string var(a->variable());
     if (env->has(var)) {
-      if(!a->is_guarded()) (*env)[var] = a->value()->perform(eval->with(env, backtrace));
+      Expression* v = static_cast<Expression*>((*env)[var]);
+      if (!a->is_guarded() || v->concrete_type() == Expression::NULL_VAL) (*env)[var] = a->value()->perform(eval->with(env, backtrace));
     }
     else {
       env->current_frame()[var] = a->value()->perform(eval->with(env, backtrace));


### PR DESCRIPTION
This PR allows guarded assignments to override `null` values.

Fixes https://github.com/sass/libsass/issues/740. Spec added https://github.com/sass/sass-spec/pull/197.
