### PR TITLE
Improved parsing of - in declaration values

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1019,13 +1019,14 @@ namespace Sass {
     Expression* term1 = parse_term();
     // if it's a singleton, return it directly; don't wrap it
     if (!(peek< exactly<'+'> >(position) ||
-          peek< sequence< negate< number >, exactly<'-'> > >(position)) ||
+          (peek< no_spaces >(position) && peek< sequence< negate< digits >, exactly<'-'> > >(position)) ||
+          (peek< sequence< negate< digits >, exactly<'-'>, negate< digits > > >(position))) ||
           peek< identifier >(position))
     { return term1; }
 
     vector<Expression*> operands;
     vector<Binary_Expression::Type> operators;
-    while (lex< exactly<'+'> >() || lex< sequence< negate< number >, exactly<'-'> > >()) {
+    while (lex< exactly<'+'> >() || lex< sequence< negate< digits >, exactly<'-'> > >()) {
       operators.push_back(lexed == "+" ? Binary_Expression::ADD : Binary_Expression::SUB);
       operands.push_back(parse_term());
     }


### PR DESCRIPTION
This PR improves the parsing of the minus operator addressing more use-cases.

Fixes https://github.com/sass/libsass/issues/733. Specs added https://github.com/sass/sass-spec/pull/176, https://github.com/sass/sass-spec/pull/198.

I'm going to leave this until 3.1.0 is stable because there's a chance this introduces subtle regressions not covered by our spec suite.