### PR TITLE
Don't output empty blocks

### DIFF
--- a/expand.cpp
+++ b/expand.cpp
@@ -133,10 +133,14 @@ namespace Sass {
   {
     String* old_p = d->property();
     String* new_p = static_cast<String*>(old_p->perform(eval->with(env, backtrace)));
+    Expression* value = d->value()->perform(eval->with(env, backtrace));
+
+    if (value->is_invisible() && !d->is_important()) return 0;
+
     return new (ctx.mem) Declaration(d->path(),
                                      d->position(),
                                      new_p,
-                                     d->value()->perform(eval->with(env, backtrace)),
+                                     value,
                                      d->is_important());
   }
 


### PR DESCRIPTION
This PR replicates the Ruby sass behaviour of removing declarations with SassScript values that evaluated to `null`. This by proxy means blocks made up of only these values aren't outputted.

Fixes https://github.com/sass/libsass/issues/659. Specs added https://github.com/sass/sass-spec/pull/199.
