### PR TITLE
Hydrate division operands when it makes sense

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -326,6 +326,8 @@ namespace Sass {
     Binary_Expression::Type op_type = b->type();
     // don't eval delayed expressions (the '/' when used as a separator)
     if (op_type == Binary_Expression::DIV && b->is_delayed()) return b;
+    // if one of the operands is a '/' then make sure it's evaluated
+    if (typeid(*b->left()) == typeid(Binary_Expression)) b->left()->is_delayed(false);
     // the logical connectives need to short-circuit
     Expression* lhs = b->left()->perform(this);
     switch (op_type) {


### PR DESCRIPTION
This PR addresses some issue with number comparisons, specifically cases involving divisions. Currently `1/2` becomes a delayed node, because of this it's evaluated in cases like `1/2 == 0.5` resulting in a `false` comparison.

Fixes https://github.com/sass/libsass/issues/590. Specs added sass/sass-spec#137, https://github.com/sass/sass-spec/pull/200.
