### PR TITLE
Fully evaluation nested binary operations

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -558,6 +558,10 @@ namespace Sass {
     // backtrace = here.parent;
     // env = old_env;
     result->position(c->position());
+    do {
+      result->is_delayed(result->concrete_type() == Expression::STRING);
+      result = result->perform(this);
+    } while (result->concrete_type() == Expression::NONE);
     return result;
   }
 

--- a/eval.cpp
+++ b/eval.cpp
@@ -326,10 +326,11 @@ namespace Sass {
     Binary_Expression::Type op_type = b->type();
     // don't eval delayed expressions (the '/' when used as a separator)
     if (op_type == Binary_Expression::DIV && b->is_delayed()) return b;
-    // if one of the operands is a '/' then make sure it's evaluated
-    if (typeid(*b->left()) == typeid(Binary_Expression)) b->left()->is_delayed(false);
     // the logical connectives need to short-circuit
     Expression* lhs = b->left()->perform(this);
+    lhs->is_delayed(false);
+    while (typeid(*lhs) == typeid(Binary_Expression)) lhs = lhs->perform(this);
+
     switch (op_type) {
       case Binary_Expression::AND:
         return *lhs ? b->right()->perform(this) : lhs;
@@ -344,6 +345,8 @@ namespace Sass {
     }
     // not a logical connective, so go ahead and eval the rhs
     Expression* rhs = b->right()->perform(this);
+    rhs->is_delayed(false);
+    while (typeid(*rhs) == typeid(Binary_Expression)) rhs = rhs->perform(this);
 
     // see if it's a relational expression
     switch(op_type) {


### PR DESCRIPTION
This PR request is an evolution of https://github.com/sass/libsass/pull/770 which cover many more cases where division operations aren't correct evaluated.

Address parts of https://github.com/sass/libsass/issues/629. Specs added https://github.com/sass/sass-spec/pull/201.

I'm going to leave this until 3.1.0 is stable because there's a chance this introduces subtle regressions not covered by our spec suite.