### PR TITLE
Improve parsing of static values

### DIFF
--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -684,7 +684,7 @@ namespace Sass {
       return alternatives< identifier,
                            static_string,
                            hex,
-                           sequence< alternatives< exactly<'+'>, exactly<'-'> >, number >,
+                           number,
                            sequence< exactly<'!'>, exactly<important_kwd> >
                           >(src);
     }
@@ -692,8 +692,11 @@ namespace Sass {
     const char* static_value(const char* src) {
       return sequence< static_component,
                        zero_plus < sequence<
-                                   alternatives< spaces, exactly<'/'> >,
-                                   optional_spaces,
+                                   alternatives<
+                                     sequence< optional_spaces, exactly<'/'>, optional_spaces >,
+                                     sequence< optional_spaces, exactly<','>, optional_spaces >,
+                                     spaces
+                                   >,
                                    static_component
                        > >,
                        alternatives< exactly<';'>, exactly<'}'> >


### PR DESCRIPTION
This PR is an evolution of https://github.com/sass/libsass/pull/679 which makes the static value look ahead more faithful to the Ruby sass version.

As a bonus this makes the follow tests pass:
- https://github.com/sass/sass-spec/blob/master/spec/libsass-todo-tests/15_arithmetic_and_lists
- https://github.com/sass/sass-spec/blob/master/spec/libsass-todo-tests/at-stuff

However upon further investigation the second spec is out of date and incorrect in 3.3+.
