### PR TITLE
(DO NOT MERGE) 694 unquoting problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ libsass/*
 *.a
 a.out
 libsass.js
+TAGS
 
 bin/*
 .deps/

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ SOURCES = \
 	output_nested.cpp \
 	parser.cpp \
 	prelexer.cpp \
+	quote.cpp \
 	remove_placeholders.cpp \
 	sass.cpp \
 	sass_util.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,7 @@ libsass_la_SOURCES = \
 	output_nested.cpp output_nested.hpp \
 	parser.cpp parser.hpp \
 	prelexer.cpp prelexer.hpp \
+	quote.cpp quote.hpp \
 	remove_placeholders.cpp remove_placeholders.hpp \
 	sass.cpp sass.h \
 	sass_util.cpp sass_util.hpp \

--- a/ast.hpp
+++ b/ast.hpp
@@ -43,6 +43,8 @@
 #include "environment.hpp"
 #endif
 
+#include "quote.hpp"
+
 #include "sass.h"
 #include "sass_values.h"
 #include "sass_functions.h"

--- a/catch/parser/.gitignore
+++ b/catch/parser/.gitignore
@@ -1,0 +1,2 @@
+test-all
+pin

--- a/catch/parser/Makefile
+++ b/catch/parser/Makefile
@@ -1,0 +1,36 @@
+# source files under test in this dir
+TESTOBJECT=../../lib/libsass.a
+
+CXX      ?= g++
+CXXFLAGS ?= -Wall -gdwarf-4
+LDFLAGS  ?= -Wall -gdwarf-4
+
+CXXFLAGS += -std=c++0x
+LDFLAGS  += -std=c++0x
+
+CXXFLAGS += -I `node -e "require('catch')"`
+
+MAIN = main.cpp
+
+all: pin test-all
+
+PINSOURCES = next_unescaped_interpolant.cpp $(MAIN) 
+PINOBJECTS = $(PINSOURCES:.cpp=.o) $(TESTOBJECT)
+
+ALLSOURCES = $(PINSOURCES)
+
+test: $(TESTOBJECT)
+
+$(TESTOBJECT): 
+	$(MAKE) -C ../.. static
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+pin: $(PINOBJECTS)
+	$(CXX) $(LDFLAGS) -o $@ $(PINOBJECTS)
+
+test-all: $(TESTOBJECT)
+	$(CXX) $(LDFLAGS) -o $@ $(PINOBJECTS)
+
+.PHONY: all debug clean test

--- a/catch/parser/main.cpp
+++ b/catch/parser/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch/single_include/catch.hpp"

--- a/catch/parser/next_unescaped_interpolant.cpp
+++ b/catch/parser/next_unescaped_interpolant.cpp
@@ -1,0 +1,136 @@
+#include <exception>
+
+#include "catch/single_include/catch.hpp"
+#include "../../parser.hpp"
+
+
+TEST_CASE( "tests run", "[meta]" ) {
+  REQUIRE( 1 == 1 );
+}
+
+TEST_CASE( "create a parser", "[parser]" ) {
+  Sass::Context::Data initializers;
+  initializers.source_c_str("")
+    .output_path("")
+    .output_style((Sass::Output_Style) Sass::NESTED)
+    .source_map_file("")
+    .source_map_embed("")
+    .source_map_contents("")
+    .image_path("")
+    .include_paths_c_str("")
+    .include_paths_array(0)
+    .include_paths(vector<string>())
+    .precision(5)
+    .importer(0); 
+
+  Sass::Context ctx(initializers);
+  Sass::Position pos;
+  Sass::Parser p(ctx, "", pos);
+}
+
+TEST_CASE( "next_unescaped_interpolant (no interpolant)", "[parser][unit]" ) {
+  const char * t = "no interpolant here";
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+}
+
+TEST_CASE( "next_unescaped_interpolant (one interpolant)", "[parser][unit]" ) {
+  //                0         1         2
+  //                012345678901234567890123
+  const char * t = "one #{interpolant} here";
+
+  REQUIRE( (t+4) ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t+5, t+strlen(t)) );
+}
+
+TEST_CASE( "next_unescaped_interpolant (two interpolants)", "[parser][unit]" ) {
+  //                0         1         2        3
+  //                0123456789012345678901234578901234567
+  const char * t = "two #{interpolants} #{in} this string";
+
+  REQUIRE( (t+4) ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+
+  REQUIRE( (t+20) ==
+           Sass::Parser::next_unescaped_interpolant(t+5, t+strlen(t)) );
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t+21, t+strlen(t)) );
+}
+
+TEST_CASE( "next_unescaped_interpolant (escaped interpolant)", "[parser][unit]" ) {
+  //                0         1         2        3         4
+  //                01234567890123456789012 34578901234567890123456789
+  const char * t = "two #{interpolants}, 1 \\#{escaped} #{in} this string";
+
+  REQUIRE( (t+4) ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+
+  REQUIRE( (t+35) ==
+           Sass::Parser::next_unescaped_interpolant(t+5, t+strlen(t)) );
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t+37, t+strlen(t)) );
+}
+
+TEST_CASE( "next_unescaped_interpolant (string-initial interpolant)", "[parser][unit]" ) {
+  //                0         1         2        3         4
+  //                01234567890123456789012 34578901234567890123456789
+  const char * t = "#{interpolant}";
+
+  REQUIRE( (t) ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t+1, t+strlen(t)) );
+}
+
+TEST_CASE( "next_unescaped_interpolant (string-final interpolant)", "[parser][unit]" ) {
+  //                0         1         2        3         4
+  //                01234567890123456789012 34578901234567890123456789
+  const char * t = "ends with #{interpolant}";
+
+  REQUIRE( (t+10) ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t+11, t+strlen(t)) );
+}
+
+TEST_CASE( "next_unescaped_interpolant (string-initial escaped interpolant)", "[parser][unit]" ) {
+  //                 0         1         2        3         4
+  //                 01234567890123456789012 34578901234567890123456789
+  const char * t = "\\#{ignore-me} #{interpolant}";
+
+  REQUIRE( (t+14) ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t+15, t+strlen(t)) );
+}
+
+
+TEST_CASE( "next_unescaped_interpolant (string-final escaped interpolant)", "[parser][unit]" ) {
+  //                 0         1         2        3         4
+  //                 01234567890123456789012 34578901234567890123456789
+  const char * t = "#{find-me} \\#{ignore-me}";
+
+  REQUIRE( t ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t+1, t+strlen(t)) );
+}
+
+TEST_CASE( "next_unescaped_interpolant (escaped interpolant alone in string)", "[parser][unit]" ) {
+  //                 0         1         2        3         4
+  //                 01234567890123456789012 34578901234567890123456789
+  const char * t = "\\#{ignore-me}";
+
+  REQUIRE( NULL ==
+           Sass::Parser::next_unescaped_interpolant(t, t+strlen(t)) );
+}

--- a/catch/quote/Makefile
+++ b/catch/quote/Makefile
@@ -1,0 +1,27 @@
+# source files under test in this dir
+TESTSOURCE=../../quote.cpp
+TESTOBJECT=quote.o
+
+CXX      ?= g++
+CXXFLAGS ?= -Wall -gdwarf-4
+LDFLAGS  ?= -Wall -gdwarf-4
+
+CXXFLAGS += -I `node -e "require('catch')"`
+
+MAIN = main.cpp
+
+all: pin
+
+PINSOURCES = pin.cpp $(MAIN) 
+PINOBJECTS = $(PINSOURCES:.cpp=.o) $(TESTOBJECT)
+
+$(TESTOBJECT): $(TESTSOURCE)
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+pin: $(PINOBJECTS)
+	$(CXX) $(LDFLAGS) -o $@ $(PINOBJECTS)
+
+.PHONY: all debug clean

--- a/catch/quote/main.cpp
+++ b/catch/quote/main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch/single_include/catch.hpp"

--- a/catch/quote/pin.cpp
+++ b/catch/quote/pin.cpp
@@ -66,14 +66,16 @@ TEST_CASE( "unquote handles string-initial escaped quote", "[unquote]" ) {
 }
 
 TEST_CASE( "unquote throws on string-initial unescaped quote", "[unquote][ill-formed][bug]" ) {
-  REQUIRE_THROWS( Sass::unquote("''Hello,\\' I said.'") );
-  REQUIRE_THROWS( Sass::unquote("\"\"Hello,\\\" I said.\"") );
+  REQUIRE( std::string("'Hello,' I said.") ==
+           Sass::unquote("''Hello,\\' I said.'") );
+  REQUIRE( std::string("\"Hello,\" I said.") ==
+           Sass::unquote("\"\"Hello,\\\" I said.\"") );
 }
 
 TEST_CASE( "unquote eats previous char on string-final unescaped quote", "[unquote][ill-formed][bug]" ) {
-  REQUIRE( std::string("I said, 'Hello'") ==
+  REQUIRE( std::string("I said, 'Hello.'") ==
            Sass::unquote("'I said, \\'Hello.''") );
-  REQUIRE( std::string("I said, \"Hello\"") ==
+  REQUIRE( std::string("I said, \"Hello.\"") ==
            Sass::unquote("\"I said, \\\"Hello.\"\"") );
 }
 

--- a/catch/quote/pin.cpp
+++ b/catch/quote/pin.cpp
@@ -1,0 +1,137 @@
+#include <exception>
+
+#include "catch/single_include/catch.hpp"
+#include "../../quote.hpp"
+
+TEST_CASE( "tests run", "[meta]" ) {
+  REQUIRE( 1 == 1 );
+}
+
+TEST_CASE( "unquote empty", "[unquote]" ) {
+  REQUIRE( std::string("") == Sass::unquote("") );
+}
+
+TEST_CASE( "unquote one quote", "[unquote][ill-formed]" ) {
+  REQUIRE( std::string("") == Sass::unquote("\"") );
+  REQUIRE( std::string("") == Sass::unquote("\'") );
+}
+
+TEST_CASE( "only quoted one side (doublequote)", "[unquote][ill-formed][doublequote]" ) {
+  REQUIRE( std::string("\"foo") == Sass::unquote("\"foo") );
+  REQUIRE( std::string("foo\"") == Sass::unquote("foo\"") );
+}
+
+TEST_CASE( "only quoted one side (singlequote)", "[unquote][ill-formed][singlequote]" ) {
+  REQUIRE( std::string("'foo") == Sass::unquote("'foo") );
+  REQUIRE( std::string("foo'") == Sass::unquote("foo'") );
+}
+
+TEST_CASE( "mismatched quotes", "[unquote][ill-formed]" ) {
+  REQUIRE( std::string("'foo\"") == Sass::unquote("'foo\"") );
+  REQUIRE( std::string("\"foo'") == Sass::unquote("\"foo'") );
+}
+
+TEST_CASE( "valid unquote (doublequote)", "[unquote][doublequote]" ) {
+  REQUIRE( std::string("foo") == Sass::unquote("\"foo\"") );
+  REQUIRE( std::string("f'o'o") == Sass::unquote("\"f'o'o\"") );  
+}
+
+TEST_CASE( "valid unquote (singlequote)", "[unquote][singlequote]" ) {
+  REQUIRE( std::string("foo") == Sass::unquote("'foo'") );
+  REQUIRE( std::string("f\"o\"o") == Sass::unquote("'f\"o\"o'") );
+}
+
+TEST_CASE( "valid unquote (doublequotes)(escaped quotes)", "[unquote][doublequote]" ) {
+  REQUIRE( std::string("I said, \"Hello,\" to them.") ==
+           Sass::unquote("\"I said, \\\"Hello,\\\" to them.\"") );
+}
+
+TEST_CASE( "valid unquote (singlequote)(escaped quotes)", "[unquote][singlequote]" ) {
+  REQUIRE( std::string("I said, 'Hello,' to them.") ==
+           Sass::unquote("\'I said, \\'Hello,\\' to them.'") );
+}
+
+TEST_CASE( "unquote handles string-final escaped quote", "[unquote]" ) {
+  REQUIRE( std::string("I said, 'Hello.'") ==
+           Sass::unquote("'I said, \\'Hello.\\''") );
+  REQUIRE( std::string("I said, \"Hello.\"") ==
+           Sass::unquote("\"I said, \\\"Hello.\\\"\"") );
+}
+
+TEST_CASE( "unquote handles string-initial escaped quote", "[unquote]" ) {
+  REQUIRE( std::string("'Hello,' I said.") ==
+           Sass::unquote("'\\'Hello,\\' I said.'") );
+  REQUIRE( std::string("\"Hello,\" I said.") ==
+           Sass::unquote("\"\\\"Hello,\\\" I said.\"") );
+}
+
+TEST_CASE( "unquote throws on string-initial unescaped quote", "[unquote][ill-formed][bug]" ) {
+  REQUIRE_THROWS( Sass::unquote("''Hello,\\' I said.'") );
+  REQUIRE_THROWS( Sass::unquote("\"\"Hello,\\\" I said.\"") );
+}
+
+TEST_CASE( "unquote eats previous char on string-final unescaped quote", "[unquote][ill-formed][bug]" ) {
+  REQUIRE( std::string("I said, 'Hello'") ==
+           Sass::unquote("'I said, \\'Hello.''") );
+  REQUIRE( std::string("I said, \"Hello\"") ==
+           Sass::unquote("\"I said, \\\"Hello.\"\"") );
+}
+
+TEST_CASE( "unquote only honors backslash before quote char", "[unquote][bug]" ) {
+  REQUIRE( std::string("quoted ' ignored \\\\ end") ==
+           Sass::unquote("'quoted \\' ignored \\\\ end'") );
+  REQUIRE( std::string("quoted \" ignored \\\\ end") ==
+           Sass::unquote("\"quoted \\\" ignored \\\\ end\"") );
+}
+
+/// test quote
+
+TEST_CASE( "quote empty string returns pair of quotes", "[quote]" ) {
+  REQUIRE( std::string("''") == Sass::quote("", '\'') );
+  REQUIRE( std::string("\"\"") == Sass::quote("", '"') );
+}
+
+TEST_CASE( "any char can be quote char", "[quote]" ) {
+  // arguably bug
+  REQUIRE( std::string("ZZ") == Sass::quote("", 'Z') );
+}
+
+TEST_CASE( "quote non-empty with NUL is no-op", "[quote]" ) {
+  REQUIRE( std::string("'") == Sass::quote("'", '\0') );
+  REQUIRE( std::string("Z") == Sass::quote("Z", '\0') );
+  REQUIRE( std::string("\"") == Sass::quote("\"", '\0') );
+}
+
+TEST_CASE( "quote empty with NUL is weird", "[quote][corner-case]") {
+  std::string sTwoNULs;
+
+  sTwoNULs.push_back('\0');
+  sTwoNULs.push_back('\0');
+  
+  REQUIRE( sTwoNULs == Sass::quote("", '\0') );
+  REQUIRE( std::string("") != Sass::quote("", '\0') );
+}
+
+TEST_CASE( "quote quoted string is no-op", "[quote]") {
+  REQUIRE( std::string("\"foo\"") == Sass::quote("\"foo\"", '"') );
+  REQUIRE( std::string("\"foo\"") == Sass::quote("\"foo\"", '\'') );
+
+  REQUIRE( std::string("'foo'") == Sass::quote("'foo'", '"') );
+  REQUIRE( std::string("'foo'") == Sass::quote("'foo'", '\'') );
+}
+
+TEST_CASE( "only leading quote is checked", "[quote][ill-formed][edge-case]") {
+  REQUIRE( std::string("\"foo\\\"\"") == Sass::quote("foo\"", '"') );
+  REQUIRE( std::string("'foo\"'") == Sass::quote("foo\"", '\'') );
+
+  REQUIRE( std::string("\"foo'\"") == Sass::quote("foo'", '"') );
+  REQUIRE( std::string("'foo\\''") == Sass::quote("foo'", '\'') );
+}
+
+TEST_CASE( "backslash is not quoted", "[quote][edge-case]") {
+  REQUIRE( std::string("\"foo\\\\\"\"") == Sass::quote("foo\\\"", '"') );
+  REQUIRE( std::string("'foo\\\"'") == Sass::quote("foo\\\"", '\'') );
+
+  REQUIRE( std::string("\"foo\\'\"") == Sass::quote("foo\\'", '"') );
+  REQUIRE( std::string("'foo\\\\''") == Sass::quote("foo\\'", '\'') );
+}

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -1,6 +1,7 @@
 #include "inspect.hpp"
 #include "ast.hpp"
 #include "context.hpp"
+#include "quote.hpp"
 #include <cmath>
 #include <iostream>
 #include <iomanip>
@@ -683,41 +684,6 @@ namespace Sass {
 
   void Inspect::indent()
   { append_to_buffer(string(2*indentation, ' ')); }
-
-  string unquote(const string& s)
-  {
-    if (s.empty()) return "";
-    if (s.length() == 1) {
-      if (s[0] == '"' || s[0] == '\'') return "";
-    }
-    char q;
-    if      (*s.begin() == '"'  && *s.rbegin() == '"')  q = '"';
-    else if (*s.begin() == '\'' && *s.rbegin() == '\'') q = '\'';
-    else                                                return s;
-    string t;
-    t.reserve(s.length()-2);
-    for (size_t i = 1, L = s.length()-1; i < L; ++i) {
-      // if we see a quote, we need to remove the preceding backslash from t
-      if (s[i-1] == '\\' && s[i] == q) t.erase(t.length()-1);
-      t.push_back(s[i]);
-    }
-    return t;
-  }
-
-  string quote(const string& s, char q)
-  {
-    if (s.empty()) return string(2, q);
-    if (!q || s[0] == '"' || s[0] == '\'') return s;
-    string t;
-    t.reserve(s.length()+2);
-    t.push_back(q);
-    for (size_t i = 0, L = s.length(); i < L; ++i) {
-      if (s[i] == q) t.push_back('\\');
-      t.push_back(s[i]);
-    }
-    t.push_back(q);
-    return t;
-  }
 
   void Inspect::append_to_buffer(const string& text)
   {

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -101,8 +101,5 @@ namespace Sass {
     void fallback(U x) { fallback_impl(reinterpret_cast<AST_Node*>(x)); }
   };
 
-  string unquote(const string&);
-  string quote(const string&, char);
-
 }
 #endif

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "libsass",
+  "version": "3.1.0-beta19",
+  "description": "Libsass",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "make test",
+    "qt": "ruby sass-spec/sass-spec.rb -c sassc/bin/sassc -s sass-spec/spec"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sass/libsass.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sass/libsass/issues"
+  },
+  "homepage": "https://github.com/sass/libsass",
+  "devDependencies": {
+    "catch": "^1.0.48"
+  }
+}

--- a/parser.cpp
+++ b/parser.cpp
@@ -1204,7 +1204,13 @@ namespace Sass {
   }
 
   const char* Parser::next_unescaped_interpolant(const char* b, const char* e) {
-    return find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(b, e);
+    const char * p = find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(b, e);
+
+    if (p > b && p[-1] == '\\') {
+      return next_unescaped_interpolant(p+1, e);
+    }
+
+    return p;
   }
 
   const char* Parser::next_interpolant(const char* b, const char* e) {

--- a/parser.cpp
+++ b/parser.cpp
@@ -397,14 +397,13 @@ namespace Sass {
     String_Schema* schema = new (ctx.mem) String_Schema(path, source_position);
 
     while (i < end_of_selector) {
-      p = find_first_in_interval< exactly<hash_lbrace> >(i, end_of_selector);
+      p = next_interpolant(i, end_of_selector);
       if (p) {
         // accumulate the preceding segment if there is one
         if (i < p) (*schema) << new (ctx.mem) String_Constant(path, source_position, Token(i, p));
         // find the end of the interpolant and parse it
-        const char* j = find_first_in_interval< exactly<rbrace> >(p, end_of_selector);
-        Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, path, source_position).parse_list();
-        interp_node->is_interpolant(true);
+        const char* j = end_interpolant(p, end_of_selector);
+        Expression* interp_node = parse_interpolant(Token(p+2, j));
         (*schema) << interp_node;
         i = j + 1;
       }
@@ -1204,13 +1203,36 @@ namespace Sass {
     return 0;
   }
 
+  const char* Parser::next_unescaped_interpolant(const char* b, const char* e) {
+    return find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(b, e);
+  }
+
+  const char* Parser::next_interpolant(const char* b, const char* e) {
+    return find_first_in_interval< exactly<hash_lbrace> >(b, e);
+  }
+
+  const char* Parser::end_interpolant(const char* b, const char * e) {
+    return find_first_in_interval< exactly<rbrace> >(b, e); // find the closing brace
+  }
+
+  String_Constant* Parser::make_string_constant(Token chunk, bool unq = false) {
+    return new (ctx.mem) String_Constant(path, source_position, chunk, unq);
+  }
+
+  Expression* Parser::parse_interpolant(Token chunk) {
+    Expression * interp_node = Parser::from_token(chunk, ctx, path, source_position).parse_list();
+    interp_node->is_interpolant(true);
+    return interp_node;
+  }
+
   String* Parser::parse_interpolated_chunk(Token chunk)
   {
     const char* i = chunk.begin;
-    // see if there any interpolants
-    const char* p = find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(chunk.begin, chunk.end);
+
+    const char* p = next_unescaped_interpolant(chunk.begin, chunk.end);
     if (!p) {
-      String_Constant* str_node = new (ctx.mem) String_Constant(path, source_position, chunk, dequote);
+      // if no interpolants
+      String_Constant* str_node = make_string_constant(chunk, dequote);
       str_node->is_delayed(true);
       return str_node;
     }
@@ -1218,17 +1240,18 @@ namespace Sass {
     String_Schema* schema = new (ctx.mem) String_Schema(path, source_position);
     schema->quote_mark(*chunk.begin);
     while (i < chunk.end) {
-      p = find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(i, chunk.end);
+      p = next_unescaped_interpolant(i, chunk.end);
       if (p) {
         if (i < p) {
-          (*schema) << new (ctx.mem) String_Constant(path, source_position, Token(i, p)); // accumulate the preceding segment if it's nonempty
+          // accumulate the preceding segment if it's nonempty
+          (*schema) << make_string_constant(Token(i, p));
         }
-        const char* j = find_first_in_interval< exactly<rbrace> >(p, chunk.end); // find the closing brace
+
+        const char* j = end_interpolant(p, chunk.end);
+
         if (j) {
           // parse the interpolant and accumulate it
-          Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, path, source_position).parse_list();
-          interp_node->is_interpolant(true);
-          (*schema) << interp_node;
+          (*schema) << parse_interpolant(Token(p+2, j));
           i = j+1;
         }
         else {
@@ -1236,8 +1259,12 @@ namespace Sass {
           error("unterminated interpolant inside string constant " + chunk.to_string());
         }
       }
-      else { // no interpolants left; add the last segment if nonempty
-        if (i < chunk.end) (*schema) << new (ctx.mem) String_Constant(path, source_position, Token(i, chunk.end));
+      else { 
+        // no interpolants left
+        if (i < chunk.end) {
+          // add the last segment if nonempty
+          (*schema) << make_string_constant(Token(i, chunk.end));
+        }
         break;
       }
     }
@@ -1304,7 +1331,7 @@ namespace Sass {
     Token str(lexed);
     const char* i = str.begin;
     // see if there any interpolants
-    const char* p = find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(str.begin, str.end);
+    const char* p = next_unescaped_interpolant(str.begin, str.end);
     if (!p) {
       String_Constant* str_node = new (ctx.mem) String_Constant(path, source_position, str);
       str_node->is_delayed(true);
@@ -1313,16 +1340,15 @@ namespace Sass {
 
     String_Schema* schema = new (ctx.mem) String_Schema(path, source_position);
     while (i < str.end) {
-      p = find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(i, str.end);
+      p = next_unescaped_interpolant(i, str.end);
       if (p) {
         if (i < p) {
           (*schema) << new (ctx.mem) String_Constant(path, source_position, Token(i, p)); // accumulate the preceding segment if it's nonempty
         }
-        const char* j = find_first_in_interval< exactly<rbrace> >(p, str.end); // find the closing brace
+        const char* j = end_interpolant(p, str.end); // find the closing brace
         if (j) {
           // parse the interpolant and accumulate it
-          Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, path, source_position).parse_list();
-          interp_node->is_interpolant(true);
+          Expression* interp_node = parse_interpolant(Token(p+2, j));
           (*schema) << interp_node;
           i = j+1;
         }
@@ -1364,9 +1390,8 @@ namespace Sass {
     size_t num_items = 0;
     while (position < end) {
       if (lex< interpolant >()) {
-        Token insides(Token(lexed.begin + 2, lexed.end - 1));
-        Expression* interp_node = Parser::from_token(insides, ctx, path, source_position).parse_list();
-        interp_node->is_interpolant(true);
+        Token insides(lexed.begin + 2, lexed.end - 1);
+        Expression* interp_node = parse_interpolant(insides);
         (*schema) << interp_node;
       }
       else if (lex< exactly<'%'> >()) {
@@ -1413,9 +1438,8 @@ namespace Sass {
         ++position;
       }
       else if (lex< interpolant >()) {
-        Token insides(Token(lexed.begin + 2, lexed.end - 1));
-        Expression* interp_node = Parser::from_token(insides, ctx, path, source_position).parse_list();
-        interp_node->is_interpolant(true);
+        Token insides(lexed.begin + 2, lexed.end - 1);
+        Expression* interp_node = parse_interpolant(insides);
         (*schema) << interp_node;
       }
       else if (lex< sequence< identifier, exactly<':'> > >()) {
@@ -1437,23 +1461,22 @@ namespace Sass {
     Token id(lexed);
     const char* i = id.begin;
     // see if there any interpolants
-    const char* p = find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(id.begin, id.end);
+    const char* p = next_unescaped_interpolant(id.begin, id.end);
     if (!p) {
       return new (ctx.mem) String_Constant(path, source_position, id);
     }
 
     String_Schema* schema = new (ctx.mem) String_Schema(path, source_position);
     while (i < id.end) {
-      p = find_first_in_interval< sequence< negate< exactly<'\\'> >, exactly<hash_lbrace> > >(i, id.end);
+      p = next_unescaped_interpolant(i, id.end);
       if (p) {
         if (i < p) {
           (*schema) << new (ctx.mem) String_Constant(path, source_position, Token(i, p)); // accumulate the preceding segment if it's nonempty
         }
-        const char* j = find_first_in_interval< exactly<rbrace> >(p, id.end); // find the closing brace
+        const char* j = end_interpolant(p, id.end); // find the closing brace
         if (j) {
           // parse the interpolant and accumulate it
-          Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, path, source_position).parse_list();
-          interp_node->is_interpolant(true);
+          Expression* interp_node = parse_interpolant(Token(p+2, j));
           (*schema) << interp_node;
           schema->has_interpolants(true);
           i = j+1;

--- a/parser.hpp
+++ b/parser.hpp
@@ -258,6 +258,13 @@ namespace Sass {
 
     void throw_syntax_error(string message, size_t ln = 0);
     void throw_read_error(string message, size_t ln = 0);
+
+    static const char* next_unescaped_interpolant(const char* b, const char* e);
+    static const char* next_interpolant(const char* b, const char* e);    
+    static const char* end_interpolant(const char* b, const char* e);
+
+    String_Constant * make_string_constant(Token chunk, bool unq);
+    Expression* parse_interpolant(Token);
   };
 
   size_t check_bom_chars(const char* src, const char *end, const unsigned char* bom, size_t len);

--- a/quote.cpp
+++ b/quote.cpp
@@ -16,8 +16,11 @@ namespace Sass {
     string t;
     t.reserve(s.length()-2);
     for (size_t i = 1, L = s.length()-1; i < L; ++i) {
-      // if we see a quote, we need to remove the preceding backslash from t
-      if (s[i-1] == '\\' && s[i] == q) t.erase(t.length()-1);
+      // if we see a backslash, we remove it because it quotes
+      // the following character
+      if (s[i] == '\\') {
+        ++i;
+      }
       t.push_back(s[i]);
     }
     return t;
@@ -31,7 +34,7 @@ namespace Sass {
     t.reserve(s.length()+2);
     t.push_back(q);
     for (size_t i = 0, L = s.length(); i < L; ++i) {
-      if (s[i] == q) t.push_back('\\');
+      if (s[i] == q || s[i] == '\\') t.push_back('\\');
       t.push_back(s[i]);
     }
     t.push_back(q);

--- a/quote.cpp
+++ b/quote.cpp
@@ -1,0 +1,41 @@
+#include <string>
+
+namespace Sass {
+  using namespace std;
+
+  string unquote(const string& s)
+  {
+    if (s.empty()) return "";
+    if (s.length() == 1) {
+      if (s[0] == '"' || s[0] == '\'') return "";
+    }
+    char q;
+    if      (*s.begin() == '"'  && *s.rbegin() == '"')  q = '"';
+    else if (*s.begin() == '\'' && *s.rbegin() == '\'') q = '\'';
+    else                                                return s;
+    string t;
+    t.reserve(s.length()-2);
+    for (size_t i = 1, L = s.length()-1; i < L; ++i) {
+      // if we see a quote, we need to remove the preceding backslash from t
+      if (s[i-1] == '\\' && s[i] == q) t.erase(t.length()-1);
+      t.push_back(s[i]);
+    }
+    return t;
+  }
+
+  string quote(const string& s, char q)
+  {
+    if (s.empty()) return string(2, q);
+    if (!q || s[0] == '"' || s[0] == '\'') return s;
+    string t;
+    t.reserve(s.length()+2);
+    t.push_back(q);
+    for (size_t i = 0, L = s.length(); i < L; ++i) {
+      if (s[i] == q) t.push_back('\\');
+      t.push_back(s[i]);
+    }
+    t.push_back(q);
+    return t;
+  }
+
+}

--- a/quote.hpp
+++ b/quote.hpp
@@ -1,0 +1,14 @@
+#ifndef SASS_QUOTE
+#define SASS_QUOTE
+
+#include <string>
+
+namespace Sass {
+  using namespace std;
+
+  string unquote(const string&);
+  string quote(const string&, char);
+
+}
+
+#endif

--- a/sass.cpp
+++ b/sass.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 
 #include "sass.h"
-#include "inspect.hpp"
+#include "quote.hpp"
 
 extern "C" {
   using namespace std;


### PR DESCRIPTION
This is a reference PR, not finished yet, and not intended for merging.

I am trying to approach the problems in #694 (interpolation of quoted strings differs from Ruby) by writing some systematic unit tests to cover the `Sass::unquote()` and `Sass:quote()` function.  To write these unit tests, I am using the C++ unit test framework `catch` as a module pulled from `npm`, so I have added a `package.json` -- this file is purely temporary and will not be included in the final PR, but is included for the moment if anyone is interested in playing with catch and/or reproducing my results.

So far I have done the following:

1. factor out `Sass::quote` and `Sass::unquote` into a separate file for testing
2. add unit tests to cover the branches in `Sass::unquote`.

I see at least two problems so far.  One is an underread of allocated memory when a quoted string ~~contains~~ begins with an unescaped quote -- i.e., when calling `Sass::unquote("\"\"Hello\"")`.  When the argument is `""Hello"` then unquote treats it as a quoted string, but then calls `t.erase(t.length()-1)` when `t.length()` is zero.  This is what triggers the exception (`basic_string`) thrown in case # 694.

The second problem is slightly subtler: When unquoting a string, backslash is not treated as a special character.  This causes two problems: one is that backslashes are not unescaped correctly -- `Sass::unquote("'\\\\'")` yields two backslashes, but should only yield one.  The second problem is that unescaped quotes inside strings are not detected; `Sass::unquote` just assumes that the character preceding a quote in a quoted string **is** a backslash, resulting in erroneous unquoting: `Sass::unquote("'foo \'bar' baz'")` yields `foo 'ba' baz` because `unquote` assumes that the `r` before the `'` is a backslash and deletes it.

