### PR TITLE
Make linefeed/indent configurable

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -58,6 +58,8 @@ namespace Sass {
     style_sheets            (map<string, Block*>()),
     source_map              (resolve_relative_path(initializers.output_path(), initializers.source_map_file(), get_cwd())),
     c_functions             (vector<Sass_C_Function_Callback>()),
+    indent                  (initializers.indent()),
+    linefeed                (initializers.linefeed()),
     image_path              (initializers.image_path()),
     input_path              (make_canonical_path(initializers.input_path())),
     output_path             (make_canonical_path(initializers.output_path())),

--- a/context.cpp
+++ b/context.cpp
@@ -246,7 +246,7 @@ namespace Sass {
         root->perform(&output_nested);
         string output = output_nested.get_buffer();
         if (source_map_file != "" && !omit_source_map_url) {
-          output += "\n" + format_source_mapping_url(source_map_file);
+          output += linefeed + format_source_mapping_url(source_map_file);
         }
         result = copy_c_str(output.c_str());
 

--- a/context.hpp
+++ b/context.hpp
@@ -70,6 +70,8 @@ namespace Sass {
     SourceMap source_map;
     vector<Sass_C_Function_Callback> c_functions;
 
+    string       indent;
+    string       linefeed;
     string       image_path; // for the image-url Sass function
     string       input_path; // for relative paths in src-map
     string       output_path; // for relative paths to the output
@@ -97,6 +99,8 @@ namespace Sass {
       KWD_ARG(Data, string,          input_path);
       KWD_ARG(Data, string,          output_path);
       KWD_ARG(Data, string,          image_path);
+      KWD_ARG(Data, string,          indent);
+      KWD_ARG(Data, string,          linefeed);
       KWD_ARG(Data, const char*,     include_paths_c_str);
       KWD_ARG(Data, const char**,    include_paths_array);
       KWD_ARG(Data, vector<string>,  include_paths);

--- a/context.hpp
+++ b/context.hpp
@@ -70,8 +70,8 @@ namespace Sass {
     SourceMap source_map;
     vector<Sass_C_Function_Callback> c_functions;
 
-    string       indent;
-    string       linefeed;
+    string       indent; // String to be used for indentation
+    string       linefeed; // String to be used for line feeds
     string       image_path; // for the image-url Sass function
     string       input_path; // for relative paths in src-map
     string       output_path; // for relative paths to the output

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -15,15 +15,15 @@ namespace Sass {
   void Inspect::operator()(Block* block)
   {
     if (!block->is_root()) {
-      append_to_buffer(" {\n");
+      append_to_buffer(" {" + ctx->linefeed);
       ++indentation;
     }
     for (size_t i = 0, L = block->length(); i < L; ++i) {
       indent();
       (*block)[i]->perform(this);
       // extra newline at the end of top-level statements
-      if (block->is_root()) append_to_buffer("\n");
-      append_to_buffer("\n");
+      if (block->is_root()) append_to_buffer(ctx->linefeed);
+      append_to_buffer(ctx->linefeed);
     }
     if (!block->is_root()) {
       --indentation;
@@ -113,7 +113,7 @@ namespace Sass {
       import->urls().front()->perform(this);
       append_to_buffer(";");
       for (size_t i = 1, S = import->urls().size(); i < S; ++i) {
-        append_to_buffer("\n");
+        append_to_buffer(ctx->linefeed);
         if (ctx) ctx->source_map.add_mapping(import);
         append_to_buffer("@import ");
         import->urls()[i]->perform(this);
@@ -165,7 +165,7 @@ namespace Sass {
     cond->predicate()->perform(this);
     cond->consequent()->perform(this);
     if (cond->alternative()) {
-      append_to_buffer("\n");
+      append_to_buffer(ctx->linefeed);
       indent();
       append_to_buffer("else");
       cond->alternative()->perform(this);

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -682,7 +682,12 @@ namespace Sass {
   { }
 
   void Inspect::indent()
-  { append_to_buffer(string(2*indentation, ' ')); }
+  {
+    string indent = "";
+    for (size_t i = 0; i < indentation; i++)
+      indent += ctx->indent;
+    append_to_buffer(indent);
+  }
 
   string unquote(const string& s)
   {

--- a/output_nested.cpp
+++ b/output_nested.cpp
@@ -39,7 +39,7 @@ namespace Sass {
     Inspect insp(ctx);
     imp->perform(&insp);
     if (!rendered_imports.empty()) {
-      rendered_imports += "\n";
+      rendered_imports += ctx->linefeed;
     }
     rendered_imports += insp.get_buffer();
   }
@@ -50,7 +50,7 @@ namespace Sass {
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       size_t old_len = buffer.length();
       (*b)[i]->perform(this);
-      if (i < L-1 && old_len < buffer.length()) append_to_buffer("\n");
+      if (i < L-1 && old_len < buffer.length()) append_to_buffer(ctx->linefeed);
     }
   }
 
@@ -84,7 +84,7 @@ namespace Sass {
         indent();
       }
       s->perform(this);
-      append_to_buffer(" {\n");
+      append_to_buffer(" {" + ctx->linefeed);
       ++indentation;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement* stm = (*b)[i];
@@ -113,13 +113,13 @@ namespace Sass {
         if (!stm->is_hoistable() && bPrintExpression) {
           if (!stm->block()) indent();
           stm->perform(this);
-          append_to_buffer("\n");
+          append_to_buffer(ctx->linefeed);
         }
       }
       --indentation;
       buffer.erase(buffer.length()-1);
       if (ctx) ctx->source_map.remove_line();
-      append_to_buffer(" }\n");
+      append_to_buffer(" }" + ctx->linefeed);
     }
 
     if (b->has_hoistable()) {
@@ -155,7 +155,7 @@ namespace Sass {
     ctx->source_map.add_mapping(f);
     append_to_buffer("@supports ");
     q->perform(this);
-    append_to_buffer(" {\n");
+    append_to_buffer(" {" + ctx->linefeed);
 
     Selector* e = f->selector();
     if (e && b->has_non_hoistable()) {
@@ -163,7 +163,7 @@ namespace Sass {
       ++indentation;
       indent();
       e->perform(this);
-      append_to_buffer(" {\n");
+      append_to_buffer(" {" + ctx->linefeed);
 
       ++indentation;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
@@ -171,14 +171,14 @@ namespace Sass {
         if (!stm->is_hoistable()) {
           if (!stm->block()) indent();
           stm->perform(this);
-          append_to_buffer("\n");
+          append_to_buffer(ctx->linefeed);
         }
       }
       --indentation;
 
       buffer.erase(buffer.length()-1);
       if (ctx) ctx->source_map.remove_line();
-      append_to_buffer(" }\n");
+      append_to_buffer(" }" + ctx->linefeed);
       --indentation;
 
       ++indentation;
@@ -201,14 +201,14 @@ namespace Sass {
           if (!stm->block()) indent();
         }
         stm->perform(this);
-        if (!stm->is_hoistable()) append_to_buffer("\n");
+        if (!stm->is_hoistable()) append_to_buffer(ctx->linefeed);
       }
       --indentation;
     }
 
     buffer.erase(buffer.length()-1);
     if (ctx) ctx->source_map.remove_line();
-    append_to_buffer(" }\n");
+    append_to_buffer(" }" + ctx->linefeed);
   }
 
   void Output_Nested::operator()(Media_Block* m)
@@ -231,7 +231,7 @@ namespace Sass {
     ctx->source_map.add_mapping(m);
     append_to_buffer("@media ");
     q->perform(this);
-    append_to_buffer(" {\n");
+    append_to_buffer(" {" + ctx->linefeed);
 
     Selector* e = m->selector();
     if (e && b->has_non_hoistable()) {
@@ -239,7 +239,7 @@ namespace Sass {
       ++indentation;
       indent();
       e->perform(this);
-      append_to_buffer(" {\n");
+      append_to_buffer(" {" + ctx->linefeed);
 
       ++indentation;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
@@ -247,14 +247,14 @@ namespace Sass {
         if (!stm->is_hoistable()) {
           if (!stm->block()) indent();
           stm->perform(this);
-          append_to_buffer("\n");
+          append_to_buffer(ctx->linefeed);
         }
       }
       --indentation;
 
       buffer.erase(buffer.length()-1);
       if (ctx) ctx->source_map.remove_line();
-      append_to_buffer(" }\n");
+      append_to_buffer(" }" + ctx->linefeed);
       --indentation;
 
       ++indentation;
@@ -277,14 +277,14 @@ namespace Sass {
           if (!stm->block()) indent();
         }
         stm->perform(this);
-        if (!stm->is_hoistable()) append_to_buffer("\n");
+        if (!stm->is_hoistable()) append_to_buffer(ctx->linefeed);
       }
       --indentation;
     }
 
     buffer.erase(buffer.length()-1);
     if (ctx) ctx->source_map.remove_line();
-    append_to_buffer(" }\n");
+    append_to_buffer(" }" + ctx->linefeed);
   }
 
   void Output_Nested::operator()(At_Rule* a)
@@ -311,7 +311,7 @@ namespace Sass {
       return;
     }
 
-    append_to_buffer(" {\n");
+    append_to_buffer(" {" + ctx->linefeed);
     ++indentation;
     decls = true;
     for (size_t i = 0, L = b->length(); i < L; ++i) {
@@ -319,7 +319,7 @@ namespace Sass {
       if (!stm->is_hoistable()) {
         if (!stm->block()) indent();
         stm->perform(this);
-        append_to_buffer("\n");
+        append_to_buffer(ctx->linefeed);
       }
     }
     --indentation;
@@ -329,7 +329,7 @@ namespace Sass {
       Statement* stm = (*b)[i];
       if (stm->is_hoistable()) {
         stm->perform(this);
-        append_to_buffer("\n");
+        append_to_buffer(ctx->linefeed);
       }
     }
     if (decls) --indentation;
@@ -340,7 +340,7 @@ namespace Sass {
       buffer.erase(buffer.length()-1);
       if (ctx) ctx->source_map.remove_line();
     }
-    append_to_buffer(" }\n");
+    append_to_buffer(" }" + ctx->linefeed);
   }
 
   void Output_Nested::indent()

--- a/output_nested.cpp
+++ b/output_nested.cpp
@@ -344,7 +344,12 @@ namespace Sass {
   }
 
   void Output_Nested::indent()
-  { append_to_buffer(string(2*indentation, ' ')); }
+  {
+    string indent = "";
+    for (size_t i = 0; i < indentation; i++)
+      indent += ctx->indent;
+    append_to_buffer(indent);
+  }
 
   void Output_Nested::append_to_buffer(const string& text)
   {

--- a/sass_context.cpp
+++ b/sass_context.cpp
@@ -69,6 +69,11 @@ extern "C" {
     char* output_path;
 
     // For the image-url Sass function
+    const char* indent;
+    // For the image-url Sass function
+    const char* linefeed;
+
+    // For the image-url Sass function
     char* image_path;
 
     // Colon-separated list of paths
@@ -325,7 +330,9 @@ extern "C" {
              .importer(c_ctx->importer)
              .include_paths_array(include_paths)
              .include_paths(vector<string>())
-             .precision(c_ctx->precision ? c_ctx->precision : 5);
+             .precision(c_ctx->precision ? c_ctx->precision : 5)
+             .linefeed(c_ctx->linefeed ? c_ctx->linefeed : "\n")
+             .indent(c_ctx->indent ? c_ctx->indent : "  ");
 
       // create new c++ Context
       Context* cpp_ctx = new Context(cpp_opt);
@@ -665,6 +672,8 @@ extern "C" {
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, is_indented_syntax_src);
   IMPLEMENT_SASS_OPTION_ACCESSOR(Sass_C_Function_List, c_functions);
   IMPLEMENT_SASS_OPTION_ACCESSOR(Sass_C_Import_Callback, importer);
+  IMPLEMENT_SASS_OPTION_ACCESSOR(const char*, indent);
+  IMPLEMENT_SASS_OPTION_ACCESSOR(const char*, linefeed);
   IMPLEMENT_SASS_OPTION_STRING_ACCESSOR(const char*, input_path);
   IMPLEMENT_SASS_OPTION_STRING_ACCESSOR(const char*, output_path);
   IMPLEMENT_SASS_OPTION_STRING_ACCESSOR(const char*, image_path);

--- a/sass_context.cpp
+++ b/sass_context.cpp
@@ -68,9 +68,9 @@ extern "C" {
     // information in source-maps etc.
     char* output_path;
 
-    // For the image-url Sass function
+    // String to be used for indentation
     const char* indent;
-    // For the image-url Sass function
+    // String to be used to for line feeds
     const char* linefeed;
 
     // For the image-url Sass function

--- a/sass_context.h
+++ b/sass_context.h
@@ -66,6 +66,8 @@ ADDAPI bool ADDCALL sass_option_get_source_map_embed (struct Sass_Options* optio
 ADDAPI bool ADDCALL sass_option_get_source_map_contents (struct Sass_Options* options);
 ADDAPI bool ADDCALL sass_option_get_omit_source_map_url (struct Sass_Options* options);
 ADDAPI bool ADDCALL sass_option_get_is_indented_syntax_src (struct Sass_Options* options);
+ADDAPI const char* ADDCALL sass_option_get_indent (struct Sass_Options* options);
+ADDAPI const char* ADDCALL sass_option_get_linefeed (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_input_path (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_output_path (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_image_path (struct Sass_Options* options);
@@ -82,6 +84,8 @@ ADDAPI void ADDCALL sass_option_set_source_map_embed (struct Sass_Options* optio
 ADDAPI void ADDCALL sass_option_set_source_map_contents (struct Sass_Options* options, bool source_map_contents);
 ADDAPI void ADDCALL sass_option_set_omit_source_map_url (struct Sass_Options* options, bool omit_source_map_url);
 ADDAPI void ADDCALL sass_option_set_is_indented_syntax_src (struct Sass_Options* options, bool is_indented_syntax_src);
+ADDAPI void ADDCALL sass_option_set_indent (struct Sass_Options* options, const char* indent);
+ADDAPI void ADDCALL sass_option_set_linefeed (struct Sass_Options* options, const char* linefeed);
 ADDAPI void ADDCALL sass_option_set_input_path (struct Sass_Options* options, const char* input_path);
 ADDAPI void ADDCALL sass_option_set_output_path (struct Sass_Options* options, const char* output_path);
 ADDAPI void ADDCALL sass_option_set_image_path (struct Sass_Options* options, const char* image_path);

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -122,6 +122,8 @@ extern "C" {
                        .include_paths_array(0)
                        .include_paths(vector<string>())
                        .precision(c_ctx->options.precision ? c_ctx->options.precision : 5)
+                       .indent(c_ctx->options.indent ? c_ctx->options.indent : "  ")
+                       .linefeed(c_ctx->options.linefeed ? c_ctx->options.linefeed : "\n")
                        .importer(0)
       );
       if (c_ctx->c_functions) {

--- a/sass_interface.h
+++ b/sass_interface.h
@@ -35,10 +35,10 @@ struct sass_options {
   const char* include_paths;
   // For the image-url Sass function
   const char* image_path;
-  // String to be used to indicate new lines
-  const char* linefeed;
   // String to be used for indentation
   const char* indent;
+  // String to be used to for line feeds
+  const char* linefeed;
   // Precision for outputting fractional numbers
   int precision;
 };

--- a/sass_interface.h
+++ b/sass_interface.h
@@ -35,6 +35,10 @@ struct sass_options {
   const char* include_paths;
   // For the image-url Sass function
   const char* image_path;
+  // String to be used to indicate new lines
+  const char* linefeed;
+  // String to be used for indentation
+  const char* indent;
   // Precision for outputting fractional numbers
   int precision;
 };


### PR DESCRIPTION
Added the necessary options to the context and tried to implement the output for newlines and indentations accordingly. In reference to https://github.com/sass/libsass/issues/248 and https://github.com/sass/libsass/issues/752. Please note that you need to provide `const char*` for these options (libsass will not make a copy, since we expect implementers to pass static strings, or strings that the implementor will free after the context gets out of scope)!