### PR TITLE
Add improved source-mapping implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ SOURCES = \
 	output_compressed.cpp \
 	output_nested.cpp \
 	parser.cpp \
+	position.cpp \
 	prelexer.cpp \
 	remove_placeholders.cpp \
 	sass.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,8 @@ lib_LTLIBRARIES = libsass.la
 libsass_la_SOURCES = \
 	ast_fwd_decl.hpp ast_def_macros.hpp \
 	kwd_arg_macros.hpp memory_manager.hpp \
-	position.hpp operation.hpp \
+	position.cpp position.hpp \
+	operation.hpp \
 	subset_map.hpp mapping.hpp \
 	color_names.hpp backtrace.hpp \
 	cencode.c b64/cencode.h b64/encode.h \

--- a/backtrace.hpp
+++ b/backtrace.hpp
@@ -16,15 +16,13 @@ namespace Sass {
 
   struct Backtrace {
 
-    Backtrace* parent;
-    string     path;
-    Position   position;
-    string     caller;
+    Backtrace*  parent;
+    ParserState pstate;
+    string      caller;
 
-    Backtrace(Backtrace* prn, string pth, Position position, string c)
+    Backtrace(Backtrace* prn, ParserState pstate, string c)
     : parent(prn),
-      path(pth),
-      position(position),
+      pstate(pstate),
       caller(c)
     { }
 
@@ -40,14 +38,14 @@ namespace Sass {
       while (this_point->parent) {
 
         // make path relative to the current directory
-        string rel_path(Sass::File::resolve_relative_path(this_point->path, cwd, cwd));
+        string rel_path(Sass::File::resolve_relative_path(this_point->pstate.path, cwd, cwd));
 
         if (warning) {
           ss << endl
              << "\t"
              << (++i == 0 ? "on" : "from")
              << " line "
-             << this_point->position.line
+             << this_point->pstate.line
              << " of "
              << rel_path;
         } else {
@@ -55,7 +53,7 @@ namespace Sass {
              << "\t"
              << rel_path
              << ":"
-             << this_point->position.line
+             << this_point->pstate.line
              << this_point->parent->caller;
         }
 

--- a/bind.cpp
+++ b/bind.cpp
@@ -32,7 +32,7 @@ namespace Sass {
         stringstream msg;
         msg << callee << " only takes " << LP << " arguments; "
             << "given " << LA;
-        error(msg.str(), as->path(), as->position());
+        error(msg.str(), as->pstate());
       }
       Parameter* p = (*ps)[ip];
       Argument*  a = (*as)[ia];
@@ -51,16 +51,14 @@ namespace Sass {
         } else {
 
           // copy all remaining arguments into the rest parameter, preserving names
-          List* arglist = new (ctx.mem) List(p->path(),
-                                             p->position(),
+          List* arglist = new (ctx.mem) List(p->pstate(),
                                              0,
                                              List::COMMA,
                                              true);
           env->current_frame()[p->name()] = arglist;
           while (ia < LA) {
             a = (*as)[ia];
-            (*arglist) << new (ctx.mem) Argument(a->path(),
-                                                 a->position(),
+            (*arglist) << new (ctx.mem) Argument(a->pstate(),
                                                  a->value(),
                                                  a->name(),
                                                  false);
@@ -84,7 +82,7 @@ namespace Sass {
           a = static_cast<Argument*>((*arglist)[0]);
         } else {
           Expression* a_to_convert = (*arglist)[0];
-          a = new (ctx.mem) Argument(a_to_convert->path(), a_to_convert->position(), a_to_convert, "", false);
+          a = new (ctx.mem) Argument(a_to_convert->pstate(), a_to_convert, "", false);
         }
         arglist->elements().erase(arglist->elements().begin());
         if (!arglist->length() || (!arglist->is_arglist() && ip + 1 == LP)) {
@@ -99,7 +97,7 @@ namespace Sass {
           if (!param_map.count(name)) {
             stringstream msg;
             msg << callee << " has no parameter named " << name;
-            error(msg.str(), a->path(), a->position());
+            error(msg.str(), a->pstate());
           }
           env->current_frame()[name] = argmap->at(key);
         }
@@ -114,7 +112,7 @@ namespace Sass {
           stringstream msg;
           msg << "parameter " << p->name()
           << " provided more than once in call to " << callee;
-          error(msg.str(), a->path(), a->position());
+          error(msg.str(), a->pstate());
         }
         // ordinal arg -- bind it to the next param
         env->current_frame()[p->name()] = a->value();
@@ -125,19 +123,19 @@ namespace Sass {
         if (!param_map.count(a->name())) {
           stringstream msg;
           msg << callee << " has no parameter named " << a->name();
-          error(msg.str(), a->path(), a->position());
+          error(msg.str(), a->pstate());
         }
         if (param_map[a->name()]->is_rest_parameter()) {
           stringstream msg;
           msg << "argument " << a->name() << " of " << callee
               << "cannot be used as named argument";
-          error(msg.str(), a->path(), a->position());
+          error(msg.str(), a->pstate());
         }
         if (env->current_frame_has(a->name())) {
           stringstream msg;
           msg << "parameter " << p->name()
               << "provided more than once in call to " << callee;
-          error(msg.str(), a->path(), a->position());
+          error(msg.str(), a->pstate());
         }
         env->current_frame()[a->name()] = a->value();
       }
@@ -154,8 +152,7 @@ namespace Sass {
       // cerr << "********" << endl;
       if (!env->current_frame_has(leftover->name())) {
         if (leftover->is_rest_parameter()) {
-          env->current_frame()[leftover->name()] = new (ctx.mem) List(leftover->path(),
-                                                                      leftover->position(),
+          env->current_frame()[leftover->name()] = new (ctx.mem) List(leftover->pstate(),
                                                                       0,
                                                                       List::COMMA,
                                                                       true);
@@ -175,7 +172,7 @@ namespace Sass {
           stringstream msg;
           msg << "required parameter " << leftover->name()
               << " is missing in call to " << callee;
-          error(msg.str(), as->path(), as->position());
+          error(msg.str(), as->pstate());
         }
       }
     }

--- a/context.cpp
+++ b/context.cpp
@@ -113,7 +113,7 @@ namespace Sass {
     size_t i = 0;
     while (color_names[i]) {
       string name(color_names[i]);
-      Color* value = new (mem) Color("[COLOR TABLE]", Position(),
+      Color* value = new (mem) Color(ParserState("[COLOR TABLE]"),
                                      color_values[i*4],
                                      color_values[i*4+1],
                                      color_values[i*4+2],
@@ -266,7 +266,7 @@ namespace Sass {
         0, 0
       );
       import_stack.push_back(import);
-      Parser p(Parser::from_c_str(queue[i].source, *this, queue[i].abs_path, Position(1 + i, 1, 1)));
+      Parser p(Parser::from_c_str(queue[i].source, *this, ParserState(queue[i].abs_path, i)));
       Block* ast = p.parse();
       sass_delete_import(import_stack.back());
       import_stack.pop_back();
@@ -275,7 +275,7 @@ namespace Sass {
     }
     if (root == 0) return 0;
     Env tge;
-    Backtrace backtrace(0, "", Position(), "");
+    Backtrace backtrace(0, ParserState("", 0), "");
     register_built_in_functions(*this, &tge);
     for (size_t i = 0, S = c_functions.size(); i < S; ++i) {
       register_c_function(*this, &tge, c_functions[i]);
@@ -383,8 +383,7 @@ namespace Sass {
 
   void register_overload_stub(Context& ctx, string name, Env* env)
   {
-    Definition* stub = new (ctx.mem) Definition("[built-in function]",
-                                            Position(),
+    Definition* stub = new (ctx.mem) Definition(ParserState("[built-in function]"),
                                             0,
                                             name,
                                             0,

--- a/contextualize.cpp
+++ b/contextualize.cpp
@@ -31,7 +31,7 @@ namespace Sass {
     To_String to_string;
     string result_str(s->contents()->perform(eval->with(env, backtrace))->perform(&to_string));
     result_str += '{'; // the parser looks for a brace to end the selector
-    Selector* result_sel = Parser::from_c_str(result_str.c_str(), ctx, s->path(), s->position()).parse_selector_group();
+    Selector* result_sel = Parser::from_c_str(result_str.c_str(), ctx, s->pstate()).parse_selector_group();
     return result_sel->perform(this);
   }
 
@@ -40,7 +40,7 @@ namespace Sass {
     Selector_List* p = static_cast<Selector_List*>(parent);
     Selector_List* ss = 0;
     if (p) {
-      ss = new (ctx.mem) Selector_List(s->path(), s->position(), p->length() * s->length());
+      ss = new (ctx.mem) Selector_List(s->pstate(), p->length() * s->length());
       for (size_t i = 0, L = p->length(); i < L; ++i) {
         for (size_t j = 0, L = s->length(); j < L; ++j) {
           parent = (*p)[i];
@@ -50,7 +50,7 @@ namespace Sass {
       }
     }
     else {
-      ss = new (ctx.mem) Selector_List(s->path(), s->position(), s->length());
+      ss = new (ctx.mem) Selector_List(s->pstate(), s->length());
       for (size_t j = 0, L = s->length(); j < L; ++j) {
         Complex_Selector* comb = static_cast<Complex_Selector*>((*s)[j]->perform(this));
         if (comb) *ss << comb;
@@ -93,7 +93,7 @@ namespace Sass {
     if (placeholder && extender && s->perform(&to_string) == placeholder->perform(&to_string)) {
       return extender;
     }
-    Compound_Selector* ss = new (ctx.mem) Compound_Selector(s->path(), s->position(), s->length());
+    Compound_Selector* ss = new (ctx.mem) Compound_Selector(s->pstate(), s->length());
     for (size_t i = 0, L = s->length(); i < L; ++i) {
       Simple_Selector* simp = static_cast<Simple_Selector*>((*s)[i]->perform(this));
       if (simp) *ss << simp;
@@ -105,8 +105,7 @@ namespace Sass {
   {
     Selector* old_parent = parent;
     parent = 0;
-    Wrapped_Selector* neg = new (ctx.mem) Wrapped_Selector(s->path(),
-                                                           s->position(),
+    Wrapped_Selector* neg = new (ctx.mem) Wrapped_Selector(s->pstate(),
                                                            s->name(),
                                                            s->selector()->perform(this));
     parent = old_parent;

--- a/error_handling.cpp
+++ b/error_handling.cpp
@@ -7,22 +7,22 @@
 
 namespace Sass {
 
-  Sass_Error::Sass_Error(Type type, string path, Position position, string message)
-  : type(type), path(path), position(position), message(message)
+  Sass_Error::Sass_Error(Type type, ParserState pstate, string message)
+  : type(type), pstate(pstate), message(message)
   { }
 
-  void error(string msg, string path, Position position)
-  { throw Sass_Error(Sass_Error::syntax, path, position, msg); }
+  void error(string msg, ParserState pstate)
+  { throw Sass_Error(Sass_Error::syntax, pstate, msg); }
 
-  void error(string msg, string path, Position position, Backtrace* bt)
+  void error(string msg, ParserState pstate, Backtrace* bt)
   {
-    if (!path.empty() && Prelexer::string_constant(path.c_str()))
-      path = path.substr(1, path.size() - 1);
+    if (!pstate.path.empty() && Prelexer::string_constant(pstate.path.c_str()))
+      pstate.path = pstate.path.substr(1, pstate.path.size() - 1);
 
-    Backtrace top(bt, path, position, "");
+    Backtrace top(bt, pstate, "");
     msg += top.to_string();
 
-    throw Sass_Error(Sass_Error::syntax, path, position, msg);
+    throw Sass_Error(Sass_Error::syntax, pstate, msg);
   }
 
 }

--- a/error_handling.hpp
+++ b/error_handling.hpp
@@ -15,14 +15,14 @@ namespace Sass {
 
     Type type;
     string path;
-    Position position;
+    ParserState pstate;
     string message;
 
-    Sass_Error(Type type, string path, Position position, string message);
+    Sass_Error(Type type, ParserState pstate, string message);
 
   };
 
-  void error(string msg, string path, Position position);
-  void error(string msg, string path, Position position, Backtrace* bt);
+  void error(string msg, ParserState pstate);
+  void error(string msg, ParserState pstate, Backtrace* bt);
 
 }

--- a/eval.hpp
+++ b/eval.hpp
@@ -73,7 +73,7 @@ namespace Sass {
     Expression* fallback(U x) { return fallback_impl(x); }
   };
 
-  Expression* cval_to_astnode(Sass_Value* v, Context& ctx, Backtrace* backtrace, string path = "", Position position = Position());
+  Expression* cval_to_astnode(Sass_Value* v, Context& ctx, Backtrace* backtrace, ParserState pstate = ParserState("[AST]"));
 
   bool eq(Expression*, Expression*, Context&);
   bool lt(Expression*, Expression*, Context&);

--- a/expand.cpp
+++ b/expand.cpp
@@ -32,7 +32,7 @@ namespace Sass {
     Env new_env;
     new_env.link(*env);
     env = &new_env;
-    Block* bb = new (ctx.mem) Block(b->path(), b->position(), b->length(), b->is_root());
+    Block* bb = new (ctx.mem) Block(b->pstate(), b->length(), b->is_root());
     block_stack.push_back(bb);
     append_block(b);
     block_stack.pop_back();
@@ -43,13 +43,39 @@ namespace Sass {
   Statement* Expand::operator()(Ruleset* r)
   {
     To_String to_string;
-    // if (selector_stack.back()) cerr << "expanding " << selector_stack.back()->perform(&to_string) << " and " << r->selector()->perform(&to_string) << endl;
-    Selector* sel_ctx = r->selector()->perform(contextualize->with(selector_stack.back(), env, backtrace));
-    // re-parse in order to restructure parent nodes correctly
-    sel_ctx = Parser::from_c_str((sel_ctx->perform(&to_string) + ";").c_str(), ctx, r->selector()->path(), r->selector()->position()).parse_selector_group();
+
+    Contextualize* contextual = contextualize->with(selector_stack.back(), env, backtrace);
+    Selector* sel_ctx = r->selector()->perform(contextual);
+
+    Inspect isp(0);
+    sel_ctx->perform(&isp);
+    string str = isp.get_buffer();
+    str += ";";
+
+    Parser p(ctx, ParserState("[REPARSE]", 0));
+    p.source   = str.c_str();
+    p.position = str.c_str();
+    p.end      = str.c_str() + strlen(str.c_str());
+    Selector_List* sel_lst = p.parse_selector_group();
+    sel_lst->pstate(isp.source_map.remap(sel_lst->pstate()));
+
+    for(size_t i = 0; i < sel_lst->length(); i++) {
+
+      Complex_Selector* pIter = (*sel_lst)[i];
+      while (pIter) {
+        Compound_Selector* pHead = pIter->head();
+        pIter->pstate(isp.source_map.remap(pIter->pstate()));
+        if (pHead) {
+          pHead->pstate(isp.source_map.remap(pHead->pstate()));
+          (*pHead)[0]->pstate(isp.source_map.remap((*pHead)[0]->pstate()));
+        }
+        pIter = pIter->tail();
+      }
+    }
+    sel_ctx = sel_lst;
+
     selector_stack.push_back(sel_ctx);
-    Ruleset* rr = new (ctx.mem) Ruleset(r->path(),
-                                        r->position(),
+    Ruleset* rr = new (ctx.mem) Ruleset(r->pstate(),
                                         sel_ctx,
                                         r->block()->perform(this)->block());
     selector_stack.pop_back();
@@ -66,10 +92,10 @@ namespace Sass {
       Statement* stm = (*expanded_block)[i];
       if (typeid(*stm) == typeid(Declaration)) {
         Declaration* dec = static_cast<Declaration*>(stm);
-        String_Schema* combined_prop = new (ctx.mem) String_Schema(p->path(), p->position());
+        String_Schema* combined_prop = new (ctx.mem) String_Schema(p->pstate());
         if (!property_stack.empty()) {
           *combined_prop << property_stack.back()
-                         << new (ctx.mem) String_Constant(p->path(), p->position(), "-")
+                         << new (ctx.mem) String_Constant(p->pstate(), "-")
                          << dec->property(); // TODO: eval the prop into a string constant
         }
         else {
@@ -79,7 +105,7 @@ namespace Sass {
         *current_block << dec;
       }
       else {
-        error("contents of namespaced properties must result in style declarations only", stm->path(), stm->position(), backtrace);
+        error("contents of namespaced properties must result in style declarations only", stm->pstate(), backtrace);
       }
     }
 
@@ -91,8 +117,7 @@ namespace Sass {
   Statement* Expand::operator()(Feature_Block* f)
   {
     Expression* feature_queries = f->feature_queries()->perform(eval->with(env, backtrace));
-    Feature_Block* ff = new (ctx.mem) Feature_Block(f->path(),
-                                                    f->position(),
+    Feature_Block* ff = new (ctx.mem) Feature_Block(f->pstate(),
                                                     static_cast<Feature_Query*>(feature_queries),
                                                     f->block()->perform(this)->block());
     ff->selector(selector_stack.back());
@@ -103,9 +128,8 @@ namespace Sass {
   {
     To_String to_string;
     Expression* mq = m->media_queries()->perform(eval->with(env, backtrace));
-    mq = Parser::from_c_str(mq->perform(&to_string).c_str(), ctx, mq->path(), mq->position()).parse_media_queries();
-    Media_Block* mm = new (ctx.mem) Media_Block(m->path(),
-                                                m->position(),
+    mq = Parser::from_c_str(mq->perform(&to_string).c_str(), ctx, mq->pstate()).parse_media_queries();
+    Media_Block* mm = new (ctx.mem) Media_Block(m->pstate(),
                                                 static_cast<List*>(mq),
                                                 m->block()->perform(this)->block(),
                                                 selector_stack.back());
@@ -121,8 +145,7 @@ namespace Sass {
     if (as) as = as->perform(contextualize->with(0, env, backtrace));
     else if (av) av = av->perform(eval->with(env, backtrace));
     Block* bb = ab ? ab->perform(this)->block() : 0;
-    At_Rule* aa = new (ctx.mem) At_Rule(a->path(),
-                                        a->position(),
+    At_Rule* aa = new (ctx.mem) At_Rule(a->pstate(),
                                         a->keyword(),
                                         as,
                                         bb);
@@ -139,8 +162,7 @@ namespace Sass {
 
     if (value->is_invisible() && !d->is_important()) return 0;
 
-    return new (ctx.mem) Declaration(d->path(),
-                                     d->position(),
+    return new (ctx.mem) Declaration(d->pstate(),
                                      new_p,
                                      value,
                                      d->is_important());
@@ -161,7 +183,7 @@ namespace Sass {
 
   Statement* Expand::operator()(Import* imp)
   {
-    Import* result = new (ctx.mem) Import(imp->path(), imp->position());
+    Import* result = new (ctx.mem) Import(imp->pstate());
     for ( size_t i = 0, S = imp->urls().size(); i < S; ++i) {
       result->urls().push_back(imp->urls()[i]->perform(eval->with(env, backtrace)));
     }
@@ -198,7 +220,7 @@ namespace Sass {
   Statement* Expand::operator()(Comment* c)
   {
     // TODO: eval the text, once we're parsing/storing it as a String_Schema
-    return new (ctx.mem) Comment(c->path(), c->position(), static_cast<String*>(c->text()->perform(eval->with(env, backtrace))));
+    return new (ctx.mem) Comment(c->pstate(), static_cast<String*>(c->text()->perform(eval->with(env, backtrace))));
   }
 
   Statement* Expand::operator()(If* i)
@@ -218,16 +240,16 @@ namespace Sass {
     string variable(f->variable());
     Expression* low = f->lower_bound()->perform(eval->with(env, backtrace));
     if (low->concrete_type() != Expression::NUMBER) {
-      error("lower bound of `@for` directive must be numeric", low->path(), low->position(), backtrace);
+      error("lower bound of `@for` directive must be numeric", low->pstate(), backtrace);
     }
     Expression* high = f->upper_bound()->perform(eval->with(env, backtrace));
     if (high->concrete_type() != Expression::NUMBER) {
-      error("upper bound of `@for` directive must be numeric", high->path(), high->position(), backtrace);
+      error("upper bound of `@for` directive must be numeric", high->pstate(), backtrace);
     }
     double start = static_cast<Number*>(low)->value();
     double end = static_cast<Number*>(high)->value();
     Env new_env;
-    new_env[variable] = new (ctx.mem) Number(low->path(), low->position(), start);
+    new_env[variable] = new (ctx.mem) Number(low->pstate(), start);
     new_env.link(env);
     env = &new_env;
     Block* body = f->block();
@@ -235,14 +257,14 @@ namespace Sass {
       if (f->is_inclusive()) ++end;
       for (double i = start;
            i < end;
-           (*env)[variable] = new (ctx.mem) Number(low->path(), low->position(), ++i)) {
+           (*env)[variable] = new (ctx.mem) Number(low->pstate(), ++i)) {
         append_block(body);
       }
     } else {
       if (f->is_inclusive()) --end;
       for (double i = start;
            i > end;
-           (*env)[variable] = new (ctx.mem) Number(low->path(), low->position(), --i)) {
+           (*env)[variable] = new (ctx.mem) Number(low->pstate(), --i)) {
         append_block(body);
       }
     }
@@ -260,7 +282,7 @@ namespace Sass {
       map = static_cast<Map*>(expr);
     }
     else if (expr->concrete_type() != Expression::LIST) {
-      list = new (ctx.mem) List(expr->path(), expr->position(), 1, List::COMMA);
+      list = new (ctx.mem) List(expr->pstate(), 1, List::COMMA);
       *list << expr;
     }
     else {
@@ -278,7 +300,7 @@ namespace Sass {
         Expression* v = map->at(key)->perform(eval->with(env, backtrace));
 
         if (variables.size() == 1) {
-          List* variable = new (ctx.mem) List(map->path(), map->position(), 2, List::SPACE);
+          List* variable = new (ctx.mem) List(map->pstate(), 2, List::SPACE);
           *variable << k;
           *variable << v;
           (*env)[variables[0]] = variable;
@@ -293,7 +315,7 @@ namespace Sass {
       for (size_t i = 0, L = list->length(); i < L; ++i) {
         List* variable = 0;
         if ((*list)[i]->concrete_type() != Expression::LIST  || variables.size() == 1) {
-          variable = new (ctx.mem) List((*list)[i]->path(), (*list)[i]->position(), 1, List::COMMA);
+          variable = new (ctx.mem) List((*list)[i]->pstate(), 1, List::COMMA);
           *variable << (*list)[i];
         }
         else {
@@ -304,7 +326,7 @@ namespace Sass {
             (*env)[variables[j]] = (*variable)[j]->perform(eval->with(env, backtrace));
           }
           else {
-            (*env)[variables[j]] = new (ctx.mem) Null(expr->path(), expr->position());
+            (*env)[variables[j]] = new (ctx.mem) Null(expr->pstate());
           }
         }
         append_block(body);
@@ -326,7 +348,7 @@ namespace Sass {
 
   Statement* Expand::operator()(Return* r)
   {
-    error("@return may only be used within a function", r->path(), r->position(), backtrace);
+    error("@return may only be used within a function", r->pstate(), backtrace);
     return 0;
   }
 
@@ -337,11 +359,11 @@ namespace Sass {
     if (!extender) return 0;
     Selector_List* extendee = static_cast<Selector_List*>(e->selector()->perform(contextualize->with(0, env, backtrace)));
     if (extendee->length() != 1) {
-      error("selector groups may not be extended", extendee->path(), extendee->position(), backtrace);
+      error("selector groups may not be extended", extendee->pstate(), backtrace);
     }
     Complex_Selector* c = (*extendee)[0];
     if (!c->head() || c->tail()) {
-      error("nested selectors may not be extended", c->path(), c->position(), backtrace);
+      error("nested selectors may not be extended", c->pstate(), backtrace);
     }
     Compound_Selector* s = c->head();
 
@@ -372,23 +394,22 @@ namespace Sass {
   {
     string full_name(c->name() + "[m]");
     if (!env->has(full_name)) {
-      error("no mixin named " + c->name(), c->path(), c->position(), backtrace);
+      error("no mixin named " + c->name(), c->pstate(), backtrace);
     }
     Definition* def = static_cast<Definition*>((*env)[full_name]);
     Block* body = def->block();
     Parameters* params = def->parameters();
     Arguments* args = static_cast<Arguments*>(c->arguments()
                                                ->perform(eval->with(env, backtrace)));
-    Backtrace here(backtrace, c->path(), c->position(), ", in mixin `" + c->name() + "`");
+    Backtrace here(backtrace, c->pstate(), ", in mixin `" + c->name() + "`");
     backtrace = &here;
     Env new_env;
     new_env.link(def->environment());
     if (c->block()) {
       // represent mixin content blocks as thunks/closures
-      Definition* thunk = new (ctx.mem) Definition(c->path(),
-                                                   c->position(),
+      Definition* thunk = new (ctx.mem) Definition(c->pstate(),
                                                    "@content",
-                                                   new (ctx.mem) Parameters(c->path(), c->position()),
+                                                   new (ctx.mem) Parameters(c->pstate()),
                                                    c->block(),
                                                    Definition::MIXIN);
       thunk->environment(env);
@@ -407,18 +428,17 @@ namespace Sass {
   {
     // convert @content directives into mixin calls to the underlying thunk
     if (!env->has("@content[m]")) return 0;
-    Mixin_Call* call = new (ctx.mem) Mixin_Call(c->path(),
-                                                c->position(),
+    Mixin_Call* call = new (ctx.mem) Mixin_Call(c->pstate(),
                                                 "@content",
-                                                new (ctx.mem) Arguments(c->path(), c->position()));
+                                                new (ctx.mem) Arguments(c->pstate()));
     return call->perform(this);
   }
 
   inline Statement* Expand::fallback_impl(AST_Node* n)
   {
-    error("unknown internal error; please contact the LibSass maintainers", n->path(), n->position(), backtrace);
-    String_Constant* msg = new (ctx.mem) String_Constant("", Position(), string("`Expand` doesn't handle ") + typeid(*n).name());
-    return new (ctx.mem) Warning("", Position(), msg);
+    error("unknown internal error; please contact the LibSass maintainers", n->pstate(), backtrace);
+    String_Constant* msg = new (ctx.mem) String_Constant(ParserState("[WARN]"), string("`Expand` doesn't handle ") + typeid(*n).name());
+    return new (ctx.mem) Warning(ParserState("[WARN]"), msg);
   }
 
   inline void Expand::append_block(Block* b)

--- a/extend.cpp
+++ b/extend.cpp
@@ -240,11 +240,11 @@ namespace Sass {
   static bool parentSuperselector(Complex_Selector* pOne, Complex_Selector* pTwo, Context& ctx) {
     // TODO: figure out a better way to create a Complex_Selector from scratch
     // TODO: There's got to be a better way. This got ugly quick...
-    Position noPosition;
-    Type_Selector fakeParent("", noPosition, "temp");
-    Compound_Selector fakeHead("", noPosition, 1 /*size*/);
+    Position noPosition(-1, -1, -1);
+    Type_Selector fakeParent(ParserState("[FAKE]"), "temp");
+    Compound_Selector fakeHead(ParserState("[FAKE]"), 1 /*size*/);
     fakeHead.elements().push_back(&fakeParent);
-    Complex_Selector fakeParentContainer("", noPosition, Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
+    Complex_Selector fakeParentContainer(ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
 
     pOne->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
     pTwo->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
@@ -602,11 +602,11 @@ namespace Sass {
   static bool parentSuperselector(const Node& one, const Node& two, Context& ctx) {
     // TODO: figure out a better way to create a Complex_Selector from scratch
     // TODO: There's got to be a better way. This got ugly quick...
-    Position noPosition;
-    Type_Selector fakeParent("", noPosition, "temp");
-    Compound_Selector fakeHead("", noPosition, 1 /*size*/);
+    Position noPosition(-1, -1, -1);
+    Type_Selector fakeParent(ParserState("[FAKE]"), "temp");
+    Compound_Selector fakeHead(ParserState("[FAKE]"), 1 /*size*/);
     fakeHead.elements().push_back(&fakeParent);
-    Complex_Selector fakeParentContainer("", noPosition, Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
+    Complex_Selector fakeParentContainer(ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
 
     Complex_Selector* pOneWithFakeParent = nodeToComplexSelector(one, ctx);
     pOneWithFakeParent->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
@@ -1521,7 +1521,7 @@ namespace Sass {
 //      DEBUG_EXEC(EXTEND_COMPOUND, printComplexSelector(&seq, "SEQ: "))
 
 
-      Compound_Selector* pSels = new (ctx.mem) Compound_Selector(pSelector->path(), pSelector->position());
+      Compound_Selector* pSels = new (ctx.mem) Compound_Selector(pSelector->pstate());
       for (vector<ExtensionPair>::iterator groupIter = group.begin(), groupIterEnd = group.end(); groupIter != groupIterEnd; groupIter++) {
         ExtensionPair& pair = *groupIter;
         Compound_Selector* pCompound = pair.second;
@@ -1553,7 +1553,7 @@ namespace Sass {
       Compound_Selector* pUnifiedSelector = NULL;
 
       if (!pInnermostCompoundSelector) {
-        pInnermostCompoundSelector = new (ctx.mem) Compound_Selector(pSelector->path(), pSelector->position());
+        pInnermostCompoundSelector = new (ctx.mem) Compound_Selector(pSelector->pstate());
       }
 
       pUnifiedSelector = pInnermostCompoundSelector->unify_with(pSelectorWithoutExtendSelectors, ctx);
@@ -1579,7 +1579,7 @@ namespace Sass {
       // complex is that Complex_Selector contains a combinator, but in ruby combinators have already been filtered
       // out and aren't operated on.
       Complex_Selector* pNewSelector = pExtComplexSelector->cloneFully(ctx);
-      Complex_Selector* pNewInnerMost = new (ctx.mem) Complex_Selector(pSelector->path(), pSelector->position(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, NULL);
+      Complex_Selector* pNewInnerMost = new (ctx.mem) Complex_Selector(pSelector->pstate(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, NULL);
       Complex_Selector::Combinator combinator = pNewSelector->clear_innermost();
       pNewSelector->set_innermost(pNewInnerMost, combinator);
 
@@ -1810,7 +1810,7 @@ namespace Sass {
 
     To_String to_string;
 
-    Selector_List* pNewSelectors = new (ctx.mem) Selector_List(pSelectorList->path(), pSelectorList->position(), pSelectorList->length());
+    Selector_List* pNewSelectors = new (ctx.mem) Selector_List(pSelectorList->pstate(), pSelectorList->length());
 
     extendedSomething = false;
 
@@ -1904,12 +1904,12 @@ namespace Sass {
       // re-parse in order to restructure expanded placeholder nodes correctly.
       //
       // TODO: I don't know if this is needed, but it was in the original C++ implementation, so I kept it. Try running the tests without re-parsing.
+      // this probably messes up source-maps
       pObject->selector(
         Parser::from_c_str(
           (pNewSelectorList->perform(&to_string) + ";").c_str(),
           ctx,
-          pNewSelectorList->path(),
-          pNewSelectorList->position()
+          pNewSelectorList->pstate()
         ).parse_selector_group()
       );
     } else {

--- a/functions.hpp
+++ b/functions.hpp
@@ -13,7 +13,7 @@
 #include "sass_functions.h"
 
 #define BUILT_IN(name) Expression*\
-name(Env& env, Env& d_env, Context& ctx, Signature sig, const string& path, Position position, Backtrace* backtrace)
+name(Env& env, Env& d_env, Context& ctx, Signature sig, ParserState pstate, Backtrace* backtrace)
 
 namespace Sass {
   struct Context;
@@ -23,7 +23,7 @@ namespace Sass {
   class Definition;
   typedef Environment<AST_Node*> Env;
   typedef const char* Signature;
-  typedef Expression* (*Native_Function)(Env&, Env&, Context&, Signature, const string&, Position, Backtrace*);
+  typedef Expression* (*Native_Function)(Env&, Env&, Context&, Signature, ParserState, Backtrace*);
 
   Definition* make_native_function(Signature, Native_Function, Context&);
   Definition* make_c_function(Signature sig, Sass_C_Function f, void* cookie, Context& ctx);

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -3,8 +3,16 @@
 
 #include <string>
 
+#ifndef SASS_SOURCE_MAP
+#include "source_map.hpp"
+#endif
+
 #ifndef SASS_OPERATION
 #include "operation.hpp"
+#endif
+
+#ifndef SASS_POSITION
+#include "position.hpp"
 #endif
 
 // #ifndef SASS_TO_STRING
@@ -23,14 +31,18 @@ namespace Sass {
     string buffer;
     size_t indentation;
     Context* ctx;
-    void indent();
 
     void fallback_impl(AST_Node* n);
 
+  public:
+    void append_indent_to_buffer();
     void append_to_buffer(const string& text);
+    void append_to_buffer(const string& text, AST_Node* node);
+    void append_to_buffer(const string& text, AST_Node* node, const string& tail);
 
   public:
 
+    SourceMap source_map;
     Inspect(Context* ctx = 0);
     virtual ~Inspect();
 

--- a/output.hpp
+++ b/output.hpp
@@ -1,0 +1,96 @@
+#define SASS_OUTPUT
+
+#ifndef SASS_OPERATION
+#include "operation.hpp"
+#endif
+
+#ifndef SASS_CONTEXT
+#include "context.hpp"
+#endif
+
+#ifndef SASS_UTIL
+#include "util.hpp"
+#endif
+
+#include <string>
+#include <vector>
+
+namespace Sass {
+  using namespace std;
+  struct Context;
+
+  template<typename T>
+  class Output : public Operation_CRTP<void, T> {
+    // import class-specific methods and override as desired
+    using Operation_CRTP<void, T>::operator();
+
+  protected:
+    Context* ctx;
+    string buffer;
+    vector<Import*> top_imports;
+    vector<Comment*> top_comments;
+    bool seen_utf8;
+    virtual void fallback_impl(AST_Node* n) = 0;
+
+  public:
+    Output(Context* ctx = 0)
+    : ctx(ctx),
+      buffer(""),
+      top_imports(0),
+      top_comments(0),
+      seen_utf8(false)
+    { }
+    virtual ~Output() { };
+
+    string get_buffer(void)
+    {
+      Inspect comments(ctx);
+      size_t size_com = top_comments.size();
+      for (size_t i = 0; i < size_com; i++) {
+        top_comments[i]->perform(&comments);
+        comments.append_to_buffer(ctx->linefeed);
+      }
+
+      Inspect imports(ctx);
+      size_t size_imp = top_imports.size();
+      for (size_t i = 0; i < size_imp; i++) {
+        top_imports[i]->perform(&imports);
+        imports.append_to_buffer(ctx->linefeed);
+      }
+
+      return comments.get_buffer()
+           + imports.get_buffer()
+           + buffer;
+    }
+
+    // append some text or token to the buffer
+    // it is the main function for source-mapping
+    void append_to_buffer(const string& data)
+    {
+      // search for unicode char
+      for(const char& chr : data) {
+        // abort clause
+        if (seen_utf8) break;
+        // skip all normal ascii chars
+        if (chr >= 0) continue;
+        // prepend charset to buffer
+        buffer = "@charset \"UTF-8\";\n" + buffer;
+        // singleton
+        seen_utf8 = true;
+      }
+      // add to buffer
+      buffer += data;
+      // account for data in source-maps
+      ctx->source_map.update_column(data);
+    }
+
+    void append_to_buffer(const string& data, AST_Node* node)
+    {
+      ctx->source_map.add_open_mapping(node);
+      append_to_buffer(data);
+      ctx->source_map.add_close_mapping(node);
+    }
+
+  };
+
+}

--- a/output_compressed.hpp
+++ b/output_compressed.hpp
@@ -1,21 +1,20 @@
 #include <string>
 
-#ifndef SASS_OPERATION
-#include "operation.hpp"
+#ifndef SASS_OUTPUT
+#include "output.hpp"
 #endif
 
 namespace Sass {
   using namespace std;
-
   struct Context;
 
-  class Output_Compressed : public Operation_CRTP<void, Output_Compressed> {
+  class Output_Compressed : public Output<Output_Compressed> {
     // import all the class-specific methods and override as desired
-    using Operation_CRTP<void, Output_Compressed>::operator();
+    // using Operation_CRTP<void, Output_Compressed>::operator();
 
-    string buffer;
-    string rendered_imports;
-    Context* ctx;
+    // string buffer;
+    // string rendered_imports;
+    // Context* ctx;
     bool seen_utf8;
 
     void fallback_impl(AST_Node* n);
@@ -25,11 +24,6 @@ namespace Sass {
   public:
     Output_Compressed(Context* ctx = 0);
     virtual ~Output_Compressed();
-
-    string get_buffer() {
-      return (seen_utf8 ? "@charset \"UTF-8\";\n" : "")
-             + rendered_imports + buffer;
-    }
 
     // statements
     virtual void operator()(Block*);

--- a/output_nested.hpp
+++ b/output_nested.hpp
@@ -1,44 +1,30 @@
 #include <string>
 
-#ifndef SASS_OPERATION
-#include "operation.hpp"
+#ifndef SASS_OUTPUT
+#include "output.hpp"
 #endif
-
-// #ifndef SASS_TO_STRING
-// #include "to_string.hpp"
-// #endif
 
 namespace Sass {
   using namespace std;
   struct Context;
 
-  class Output_Nested : public Operation_CRTP<void, Output_Nested> {
-    // import all the class-specific methods and override as desired
-    using Operation_CRTP<void, Output_Nested>::operator();
+  class Output_Nested : public Output<Output_Nested> {
 
-    string buffer;
-    string rendered_imports;
     size_t indentation;
     bool source_comments;
-    Context* ctx;
-    bool seen_utf8;
     void indent();
 
     void fallback_impl(AST_Node* n);
-
-    void append_to_buffer(const string& text);
 
   public:
 
     Output_Nested(bool source_comments = false, Context* ctx = 0);
     virtual ~Output_Nested();
 
-    string get_buffer() {
-      if (!rendered_imports.empty() && !buffer.empty()) {
-        rendered_imports += "\n";
-      }
-      return (seen_utf8 ? "@charset \"UTF-8\";\n" : "")
-             + rendered_imports + buffer;
+    string get_buffer()
+    {
+      // call parent method for result
+      return Output<Output_Nested>::get_buffer();
     }
 
     // statements
@@ -55,7 +41,7 @@ namespace Sass {
     // virtual void operator()(Warning*);
     // virtual void operator()(Error*);
     // virtual void operator()(Debug*);
-    // virtual void operator()(Comment*);
+    virtual void operator()(Comment*);
     // virtual void operator()(If*);
     // virtual void operator()(For*);
     // virtual void operator()(Each*);

--- a/position.cpp
+++ b/position.cpp
@@ -1,0 +1,107 @@
+#include "position.hpp"
+
+namespace Sass {
+
+  using namespace std;
+
+  Offset::Offset(const size_t line, const size_t column)
+  : line(line), column(column) { }
+
+  // increase offset by given string (mostly called by lexer)
+  // increase line counter and count columns on the last line
+  Offset Offset::inc(const char* begin, const char* end) const
+  {
+    Offset offset(line, column);
+    while (begin < end && *begin) {
+      if (*begin == '\n') {
+        ++ offset.line;
+        offset.column = 0;
+      } else {
+        ++ offset.column;
+      }
+      ++begin;
+    }
+    return offset;
+  }
+
+  bool Offset::operator== (const Offset &pos) const
+  {
+    return line == pos.line && column == pos.column;
+  }
+
+  bool Offset::operator!= (const Offset &pos) const
+  {
+    return line != pos.line || column != pos.column;
+  }
+
+  const Offset Offset::operator+ (const Offset &off) const
+  {
+    return Offset(line + off.line, off.line > 0 ? off.column : off.column + column);
+  }
+
+  Position::Position(const size_t file)
+  : Offset(0, 0), file(file) { }
+
+  Position::Position(const size_t line, const size_t column)
+  : Offset(line, column), file(-1) { }
+
+  Position::Position(const size_t file, const size_t line, const size_t column)
+  : Offset(line, column), file(file) { }
+
+
+  ParserState::ParserState(string path)
+  : Position(-1, 0, 0), path(path), offset(0, 0) { }
+
+  ParserState::ParserState(string path, const size_t file)
+  : Position(file, 0, 0), path(path), offset(0, 0) { }
+
+  ParserState::ParserState(string path, Position position, Offset offset)
+  : Position(position), path(path), offset(offset) { }
+
+
+  Position Position::inc(const char* begin, const char* end) const
+  {
+    Position pos(file, line, column);
+    while (begin < end && *begin) {
+      if (*begin == '\n') {
+        ++ pos.line;
+        pos.column = 0;
+      } else {
+        ++ pos.column;
+      }
+      ++begin;
+    }
+    return pos;
+  }
+
+  bool Position::operator== (const Position &pos) const
+  {
+    return file == pos.file && line == pos.line && column == pos.column;
+  }
+
+  bool Position::operator!= (const Position &pos) const
+  {
+    return file == pos.file || line != pos.line || column != pos.column;
+  }
+
+  const Position Position::operator+ (const Offset &off) const
+  {
+    return Position(file, line + off.line, off.line > 0 ? off.column : off.column + column);
+  }
+
+  std::ostream& operator<<(std::ostream& strm, const Offset& off)
+  {
+    if (off.line == string::npos) strm << "-1:"; else strm << off.line << ":";
+    if (off.column == string::npos) strm << "-1"; else strm << off.column;
+    return strm;
+  }
+
+  std::ostream& operator<<(std::ostream& strm, const Position& pos)
+  {
+    if (pos.file != string::npos) strm << pos.file << ":";
+    if (pos.line == string::npos) strm << "-1:"; else strm << pos.line << ":";
+    if (pos.column == string::npos) strm << "-1"; else strm << pos.column;
+    return strm;
+  }
+
+}

--- a/position.hpp
+++ b/position.hpp
@@ -1,22 +1,78 @@
+#ifndef SASS_POSITION
 #define SASS_POSITION
 
+#include <string>
 #include <cstdlib>
+#include <iostream>
 
 namespace Sass {
 
-  struct Position {
-    size_t file;
-    size_t line;
-    size_t column;
+  using namespace std;
 
-    Position()
-    : file(0), line(0), column(0) { }
+  class Offset {
 
-    Position(const size_t file, const size_t line, const size_t column)
-    : file(file), line(line), column(column) { }
+    public: // c-tor
+      Offset(const size_t line, const size_t column);
 
-    Position(const size_t line, const size_t column)
-    : file(0), line(line), column(column) { }
+      // return new position, incremented by the given string
+      Offset inc(const char* begin, const char* end) const;
+
+    public: // overload operators for position
+      bool operator== (const Offset &pos) const;
+      bool operator!= (const Offset &pos) const;
+      const Offset operator+ (const Offset &off) const;
+
+    public: // overload output stream operator
+      friend ostream& operator<<(ostream& strm, const Offset& off);
+
+    public:
+      Offset off() { return *this; };
+
+    public:
+      size_t line;
+      size_t column;
+
+  };
+
+  class Position : public Offset {
+
+    public: // c-tor
+      Position(const size_t file); // line(0), column(0)
+      Position(const size_t line, const size_t column); // file(-1)
+      Position(const size_t file, const size_t line, const size_t column);
+
+    public: // overload operators for position
+      bool operator== (const Position &pos) const;
+      bool operator!= (const Position &pos) const;
+      const Position operator+ (const Offset &off) const;
+      // return new position, incremented by the given string
+      Position inc(const char* begin, const char* end) const;
+
+    public: // overload output stream operator
+      friend ostream& operator<<(ostream& strm, const Position& pos);
+
+    public:
+      size_t file;
+
+  };
+
+  class ParserState : public Position{
+
+    public:
+      ParserState(string path);
+      ParserState(string path, const size_t file);
+      ParserState(string path, Position position, Offset offset);
+
+    public:
+      Offset off() { return *this; };
+      Position pos() { return *this; };
+
+    public:
+      string path;
+      Offset offset;
+
   };
 
 }
+
+#endif

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -657,7 +657,7 @@ namespace Sass {
     const char* static_string(const char* src) {
       const char* pos = src;
       const char * s = string_constant(pos);
-      Token t(pos, s);
+      Token t(pos, s, Position(0, 0));
       const unsigned int p = count_interval< interpolant >(t.begin, t.end);
       return (p == 0) ? t.end : 0;
     }

--- a/remove_placeholders.cpp
+++ b/remove_placeholders.cpp
@@ -17,7 +17,7 @@ namespace Sass {
         Selector_List* sl = static_cast<Selector_List*>(r->selector());
 
         if (sl) {
-            Selector_List* new_sl = new (ctx.mem) Selector_List(sl->path(), sl->position());
+            Selector_List* new_sl = new (ctx.mem) Selector_List(sl->pstate());
 
             for (size_t i = 0, L = sl->length(); i < L; ++i) {
                 if (!(*sl)[i]->has_placeholder()) {

--- a/sass_functions.cpp
+++ b/sass_functions.cpp
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #endif
 
+#include <cstring>
 #include "context.hpp"
 #include "sass_functions.h"
 

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -142,7 +142,7 @@ extern "C" {
     }
     catch (Sass_Error& e) {
       stringstream msg_stream;
-      msg_stream << e.path << ":" << e.position.line << ": " << e.message << endl;
+      msg_stream << e.pstate.path << ":" << e.pstate.line << ": " << e.message << endl;
       c_ctx->error_message = strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;
@@ -229,7 +229,7 @@ extern "C" {
     }
     catch (Sass_Error& e) {
       stringstream msg_stream;
-      msg_stream << e.path << ":" << e.position.line << ": " << e.message << endl;
+      msg_stream << e.path << ":" << e.pstate.line << ": " << e.message << endl;
       c_ctx->error_message = strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;

--- a/sass_values.cpp
+++ b/sass_values.cpp
@@ -164,7 +164,7 @@ extern "C" {
     if (v == 0) return 0;
     v->number.tag = SASS_NUMBER;
     v->number.value = val;
-    v->number.unit = strdup(unit);
+    v->number.unit = unit ? strdup(unit) : 0;
     if (v->number.unit == 0) { free(v); return 0; }
     return v;
   }
@@ -186,7 +186,7 @@ extern "C" {
     Sass_Value* v = (Sass_Value*) calloc(1, sizeof(Sass_Value));
     if (v == 0) return 0;
     v->string.tag = SASS_STRING;
-    v->string.value = strdup(val);
+    v->string.value = val ? strdup(val) : 0;
     if (v->string.value == 0) { free(v); return 0; }
     return v;
   }
@@ -227,7 +227,7 @@ extern "C" {
     Sass_Value* v = (Sass_Value*) calloc(1, sizeof(Sass_Value));
     if (v == 0) return 0;
     v->error.tag = SASS_ERROR;
-    v->error.message = strdup(msg);
+    v->error.message = msg ? strdup(msg) : 0;
     if (v->error.message == 0) { free(v); return 0; }
     return v;
   }
@@ -237,7 +237,7 @@ extern "C" {
     Sass_Value* v = (Sass_Value*) calloc(1, sizeof(Sass_Value));
     if (v == 0) return 0;
     v->warning.tag = SASS_WARNING;
-    v->warning.message = strdup(msg);
+    v->warning.message = msg ? strdup(msg) : 0;
     if (v->warning.message == 0) { free(v); return 0; }
     return v;
   }

--- a/source_map.hpp
+++ b/source_map.hpp
@@ -2,12 +2,10 @@
 
 #include <vector>
 
+#include "ast_fwd_decl.hpp"
+
 #ifndef SASS_MAPPING
 #include "mapping.hpp"
-#endif
-
-#ifndef SASS_AST
-#include "ast.hpp"
 #endif
 
 #ifndef SASSS_BASE64VLQ
@@ -25,13 +23,16 @@ namespace Sass {
 
   public:
     vector<size_t> source_index;
+    SourceMap();
     SourceMap(const string& file);
 
     void remove_line();
     void update_column(const string& str);
-    void add_mapping(AST_Node* node);
+    void add_open_mapping(AST_Node* node);
+    void add_close_mapping(AST_Node* node);
 
     string generate_source_map(Context &ctx);
+    ParserState remap(const ParserState& pstate);
 
   private:
 

--- a/token.hpp
+++ b/token.hpp
@@ -1,5 +1,6 @@
 #define SASS_TOKEN
 
+#include "position.hpp"
 #include <cstring>
 #include <string>
 #include <sstream>
@@ -8,14 +9,19 @@ namespace Sass {
   using namespace std;
 
   // Token type for representing lexed chunks of text
-  struct Token {
-
+  class Token {
+  public:
     const char* begin;
     const char* end;
+    Position before;
+    Position after;
 
-    Token()                             : begin(0), end(0)             { }
-    Token(const char* s)                : begin(s), end(s + strlen(s)) { }
-    Token(const char* b, const char* e) : begin(b), end(e)             { }
+    Token()
+    : begin(0), end(0), before(0), after(0) { }
+    Token(const char* b, const char* e, const Position pos)
+    : begin(b), end(e), before(pos), after(pos.inc(b, e)) { }
+    Token(const char* s, const Position pos)
+    : begin(s), end(s + strlen(s)), before(pos), after(pos.inc(s, s + strlen(s))) { }
 
     size_t length()    const { return end - begin; }
     string to_string() const { return string(begin, end - begin); }

--- a/util.cpp
+++ b/util.cpp
@@ -47,7 +47,7 @@ namespace Sass {
       bool hasSelectors = static_cast<Selector_List*>(r->selector())->length() > 0;
 
       if (!hasSelectors) {
-      	return false;
+        return false;
       }
 
       bool hasDeclarations = false;
@@ -55,16 +55,16 @@ namespace Sass {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement* stm = (*b)[i];
         if (dynamic_cast<Has_Block*>(stm)) {
-        	Block* pChildBlock = ((Has_Block*)stm)->block();
+          Block* pChildBlock = ((Has_Block*)stm)->block();
           if (isPrintable(pChildBlock)) {
             hasPrintableChildBlocks = true;
           }
         } else {
-        	hasDeclarations = true;
+          hasDeclarations = true;
         }
 
         if (hasDeclarations || hasPrintableChildBlocks) {
-        	return true;
+          return true;
         }
       }
 
@@ -122,7 +122,7 @@ namespace Sass {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement* stm = (*b)[i];
         if (!stm->is_hoistable() && m->selector() != NULL && !hasSelectors) {
-        	// If a statement isn't hoistable, the selectors apply to it. If there are no selectors (a selector list of length 0),
+          // If a statement isn't hoistable, the selectors apply to it. If there are no selectors (a selector list of length 0),
           // then those statements aren't considered printable. That means there was a placeholder that was removed. If the selector
           // is NULL, then that means there was never a wrapping selector and it is printable (think of a top level media block with
           // a declaration in it).
@@ -131,55 +131,73 @@ namespace Sass {
           hasDeclarations = true;
         }
         else if (dynamic_cast<Has_Block*>(stm)) {
-        	Block* pChildBlock = ((Has_Block*)stm)->block();
+          Block* pChildBlock = ((Has_Block*)stm)->block();
           if (isPrintable(pChildBlock)) {
             hasPrintableChildBlocks = true;
           }
         }
 
-				if (hasDeclarations || hasPrintableChildBlocks) {
-        	return true;
+        if (hasDeclarations || hasPrintableChildBlocks) {
+          return true;
         }
       }
 
       return false;
     }
 
-     bool isPrintable(Block* b) {
-       if (b == NULL) {
-         return false;
-       }
+    bool isPrintable(Block* b) {
+      if (b == NULL) {
+        return false;
+      }
 
-       for (size_t i = 0, L = b->length(); i < L; ++i) {
-         Statement* stm = (*b)[i];
-         if (typeid(*stm) == typeid(Declaration) || typeid(*stm) == typeid(At_Rule)) {
-           return true;
-         }
-         else if (typeid(*stm) == typeid(Ruleset)) {
-           Ruleset* r = (Ruleset*) stm;
-           if (isPrintable(r)) {
-             return true;
-           }
-         }
-         else if (typeid(*stm) == typeid(Feature_Block)) {
-           Feature_Block* f = (Feature_Block*) stm;
-           if (isPrintable(f)) {
-             return true;
-           }
-         }
-         else if (typeid(*stm) == typeid(Media_Block)) {
-           Media_Block* m = (Media_Block*) stm;
-           if (isPrintable(m)) {
-             return true;
-           }
-         }
-         else if (dynamic_cast<Has_Block*>(stm) && isPrintable(((Has_Block*)stm)->block())) {
-           return true;
-         }
-       }
+      for (size_t i = 0, L = b->length(); i < L; ++i) {
+        Statement* stm = (*b)[i];
+        if (typeid(*stm) == typeid(Declaration) || typeid(*stm) == typeid(At_Rule)) {
+          return true;
+        }
+        else if (typeid(*stm) == typeid(Ruleset)) {
+          Ruleset* r = (Ruleset*) stm;
+          if (isPrintable(r)) {
+            return true;
+          }
+        }
+        else if (typeid(*stm) == typeid(Feature_Block)) {
+          Feature_Block* f = (Feature_Block*) stm;
+          if (isPrintable(f)) {
+            return true;
+          }
+        }
+        else if (typeid(*stm) == typeid(Media_Block)) {
+          Media_Block* m = (Media_Block*) stm;
+          if (isPrintable(m)) {
+            return true;
+          }
+        }
+        else if (dynamic_cast<Has_Block*>(stm) && isPrintable(((Has_Block*)stm)->block())) {
+          return true;
+        }
+      }
 
-       return false;
-     }
+      return false;
+    }
+
+    string vecJoin(const vector<string>& vec, const string& sep)
+    {
+      switch (vec.size())
+      {
+        case 0:
+            return string("");
+        case 1:
+            return vec[0];
+        default:
+            std::ostringstream os;
+            os << vec[0];
+            for (size_t i = 1; i < vec.size(); i++) {
+              os << sep << vec[i];
+            }
+            return os.str();
+      }
+    }
 
      bool isAscii(int ch) {
          return ch >= 0 && ch < 128;

--- a/util.hpp
+++ b/util.hpp
@@ -8,11 +8,13 @@
 #include <string>
 namespace Sass {
   namespace Util {
+    using namespace std;
 
-    std::string normalize_underscores(const std::string& str);
-    std::string normalize_decimals(const std::string& str);
-    std::string normalize_sixtuplet(const std::string& col);
+    string normalize_underscores(const string& str);
+    string normalize_decimals(const string& str);
+    string normalize_sixtuplet(const string& col);
 
+    string vecJoin(const vector<string>& vec, const string& sep);
     bool containsAnyPrintableStatements(Block* b);
 
     bool isPrintable(Ruleset* r);

--- a/win/libsass.filters
+++ b/win/libsass.filters
@@ -78,6 +78,9 @@
     <ClCompile Include="..\parser.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\position.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\prelexer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -178,6 +178,7 @@
     <ClCompile Include="..\output_compressed.cpp" />
     <ClCompile Include="..\output_nested.cpp" />
     <ClCompile Include="..\parser.cpp" />
+    <ClCompile Include="..\position.cpp" />
     <ClCompile Include="..\prelexer.cpp" />
     <ClCompile Include="..\remove_placeholders.cpp" />
     <ClCompile Include="..\sass.cpp" />


### PR DESCRIPTION
This PR is the successor of #603 and #786. IMO this is already better than the current implementation, so I dare anyone to try it out. IMO we could include this "as is" in the next version to get this moving in the right direction, since the current implementation does not really work anyway IMHO. The whole feature is very complex, so I cannot give any guarantee that it will work for all mappings. But IMHO the current state of this PR is satisfactory and we could move on from that! 