### PR TITLE
Fix bug with options not being copied correctly

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ Libsass
 by Aaron Leung ([@akhleung]) and Hampton Catlin ([@hcatlin])
 
 [![Linux CI](https://travis-ci.org/sass/libsass.png?branch=master)](https://travis-ci.org/sass/libsass)
-[![Windows CI](https://ci.appveyor.com/api/projects/status/s88o0u5qra2ng4vy/branch/master?svg=true)](https://ci.appveyor.com/project/sass/libsass/branch/master)
+[![Windows CI](https://ci.appveyor.com/api/projects/status/github/sass/libsass?svg=true)](https://ci.appveyor.com/project/sass/libsass/branch/master)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=283068)](https://www.bountysource.com/trackers/283068-libsass?utm_source=283068&utm_medium=shield&utm_campaign=TRACKER_BADGE)
 [![Coverage Status](https://img.shields.io/coveralls/sass/libsass.svg)](https://coveralls.io/r/sass/libsass?branch=feature%2Ftest-travis-ci-3)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ cache:
   - C:\Ruby21-x64\bin
 
 install:
-  - git clone https://github.com/mgreter/sassc.git --branch feature/build-dll-win-mingw
+  - git clone https://github.com/sass/sassc.git
   - git clone https://github.com/sass/sass-spec.git
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - set SASS_LIBSASS_PATH=..


### PR DESCRIPTION
This is one part of a fix for https://github.com/sass/sassc/issues/88
Sassc related PR: https://github.com/sass/sassc/pull/89
Also adds more assertions for invalid context options!