### PR TITLE
Properly hydrate numbers after operations in variable assignments

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -591,11 +591,8 @@ namespace Sass {
     // behave according to as ruby sass (add leading zero)
     if (value->concrete_type() == Expression::NUMBER) {
       Number* n = static_cast<Number*>(value);
-      value = new (ctx.mem) Number(n->path(),
-                                   n->position(),
-                                   n->value(),
-                                   n->unit(),
-                                   true);
+      value = new (ctx.mem) Number(*n);
+      static_cast<Number*>(value)->zero(true);
     }
     else if (value->concrete_type() == Expression::STRING) {
       String_Constant* s = static_cast<String_Constant*>(value);
@@ -946,7 +943,7 @@ namespace Sass {
     string r_unit(tmp.unit());
     if (l_unit != r_unit && !l_unit.empty() && !r_unit.empty() &&
         (op == Binary_Expression::ADD || op == Binary_Expression::SUB)) {
-      error("cannot add or subtract numbers with incompatible units", l->path(), l->position());
+      error("Incompatible units: '"+r_unit+"' and '"+l_unit+"'.", l->path(), l->position());
     }
     Number* v = new (ctx.mem) Number(*l);
     v->position(b->position());

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -368,8 +368,12 @@ namespace Sass {
       d.resize(d.length()-1);
     }
     if (d[d.length()-1] == '.') d.resize(d.length()-1);
-    if (n->numerator_units().size() > 1 || n->denominator_units().size() > 0) {
-      error(d + n->unit() + " is not a valid CSS value", n->path(), n->position());
+    if (n->numerator_units().size() > 1 ||
+        n->denominator_units().size() > 0 ||
+        (n->numerator_units().size() && n->numerator_units()[0].find_first_of('/') != string::npos) ||
+        (n->numerator_units().size() && n->numerator_units()[0].find_first_of('*') != string::npos)
+    ) {
+      error(d + n->unit() + " isn't a valid CSS value.", n->path(), n->position());
     }
     if (!n->zero()) {
       if (d.substr(0, 3) == "-0.") d.erase(1, 1);


### PR DESCRIPTION
This PR fixes an issue where a number variable's units would be mangled after a binary operation i.e. `*`, `/`.

I've also updated the number validity check and error message to be more inline with Ruby sass.

Fixes https://github.com/sass/libsass/issues/783. Specs added https://github.com/sass/sass-spec/pull/216.