### PR TITLE
Correct handling of escaped interpolation \#{}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ libsass/*
 *.a
 a.out
 libsass.js
+TAGS
 
 bin/*
 .deps/

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -700,41 +700,6 @@ namespace Sass {
     append_to_buffer(indent);
   }
 
-  string unquote(const string& s)
-  {
-    if (s.empty()) return "";
-    if (s.length() == 1) {
-      if (s[0] == '"' || s[0] == '\'') return "";
-    }
-    char q;
-    if      (*s.begin() == '"'  && *s.rbegin() == '"')  q = '"';
-    else if (*s.begin() == '\'' && *s.rbegin() == '\'') q = '\'';
-    else                                                return s;
-    string t;
-    t.reserve(s.length()-2);
-    for (size_t i = 1, L = s.length()-1; i < L; ++i) {
-      // if we see a quote, we need to remove the preceding backslash from t
-      if (s[i-1] == '\\' && s[i] == q) t.erase(t.length()-1);
-      t.push_back(s[i]);
-    }
-    return t;
-  }
-
-  string quote(const string& s, char q)
-  {
-    if (s.empty()) return string(2, q);
-    if (!q || s[0] == '"' || s[0] == '\'') return s;
-    string t;
-    t.reserve(s.length()+2);
-    t.push_back(q);
-    for (size_t i = 0, L = s.length(); i < L; ++i) {
-      if (s[i] == q) t.push_back('\\');
-      t.push_back(s[i]);
-    }
-    t.push_back(q);
-    return t;
-  }
-
   void Inspect::append_to_buffer(const string& text)
   {
     buffer += text;

--- a/parser.hpp
+++ b/parser.hpp
@@ -258,6 +258,13 @@ namespace Sass {
 
     void throw_syntax_error(string message, size_t ln = 0);
     void throw_read_error(string message, size_t ln = 0);
+
+    static const char* next_unescaped_interpolant(const char* b, const char* e);
+    static const char* next_interpolant(const char* b, const char* e);    
+    static const char* end_interpolant(const char* b, const char* e);
+
+    String_Constant * make_string_constant(Token chunk, bool unq);
+    Expression* parse_interpolant(Token);
   };
 
   size_t check_bom_chars(const char* src, const char *end, const unsigned char* bom, size_t len);

--- a/util.cpp
+++ b/util.cpp
@@ -186,4 +186,46 @@ namespace Sass {
      }
 
   }
+  // end Sass::Util namespace
+
+  string unquote(const string& s)
+  {
+    if (s.empty()) return "";
+    if (s.length() == 1) {
+      if (s[0] == '"' || s[0] == '\'') return "";
+    }
+
+    // quoted string begins and ends with single or double quote
+    if ((*s.begin() != '"' && *s.begin() != '\'') ||
+        (*s.begin() != *s.rbegin())) {
+      return s;
+    }
+
+    string t;
+    t.reserve(s.length()-2);
+    for (size_t i = 1, L = s.length()-1; i < L; ++i) {
+      // if we see a backslash, we remove it because it quotes
+      // the following character
+      if (s[i] == '\\') {
+        ++i;
+      }
+      t.push_back(s[i]);
+    }
+    return t;
+  }
+
+  string quote(const string& s, char q)
+  {
+    if (s.empty()) return string(2, q);
+    if (!q || s[0] == '"' || s[0] == '\'') return s;
+    string t;
+    t.reserve(s.length()+2);
+    t.push_back(q);
+    for (size_t i = 0, L = s.length(); i < L; ++i) {
+      if (s[i] == q || s[i] == '\\') t.push_back('\\');
+      t.push_back(s[i]);
+    }
+    t.push_back(q);
+    return t;
+  }
 }


### PR DESCRIPTION
- partial merge of change to inspect.cpp
- initial set of catch unit tests
- add quote to Makefile.am
- remaining tests to cover quote
- escape backslash
- fix pin tests
- add more tests of current behavior
- factor out interpolant fns
- correct implementation of next_unescaped_interpolant
- unit tests for next_unescaped_interpolant
- ignore Emacs TAGS files