### PR TITLE
[3.2] Implement @at-root

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -1492,18 +1492,30 @@ namespace Sass {
     { }
     bool exclude(string str)
     {
-      bool with = feature() && unquote(static_cast<String_Constant*>(feature())->value()).compare("with") == 0;
-      string v = value() ? unquote(static_cast<String_Constant*>(value())->value()) : "rule";
+      To_String to_string;
+      bool with = feature() && unquote(feature()->perform(&to_string)).compare("with") == 0;
+      List* l = static_cast<List*>(value());
+      string v;
 
       if (with)
       {
-        if (v.compare("all") == 0) return false;
-        return (v != str);
+        if (!l || !l->length()) return str.compare("rule");
+        for (size_t i = 0, L = l->length(); i < L; ++i)
+        {
+          v = unquote((*l)[i]->perform(&to_string));
+          if (v.compare("all") == 0 || v == str) return false;
+        }
+        return true;
       }
       else
       {
-        if (v.compare("all") == 0) return true;
-        return (v == str);
+        if (!l || !l->length()) return str.compare("rule") == 0;
+        for (size_t i = 0, L = l->length(); i < L; ++i)
+        {
+          v = unquote((*l)[i]->perform(&to_string));
+          if (v.compare("all") == 0 || v == str) return true;
+        }
+        return false;
       }
     }
     ATTACH_OPERATIONS();

--- a/ast.hpp
+++ b/ast.hpp
@@ -389,8 +389,9 @@ namespace Sass {
   public:
     Feature_Block(ParserState pstate, Feature_Query* fqs, Block* b)
     : Has_Block(pstate, b), feature_queries_(fqs), selector_(0)
-    { }
+    { statement_type(FEATURE); }
     bool is_hoistable() { return true; }
+    bool bubbles() { return true; }
     ATTACH_OPERATIONS();
   };
 
@@ -406,6 +407,7 @@ namespace Sass {
     At_Rule(ParserState pstate, string kwd, Selector* sel = 0, Block* b = 0)
     : Has_Block(pstate, b), keyword_(kwd), selector_(sel), value_(0) // set value manually if needed
     { statement_type(DIRECTIVE); }
+    bool bubbles() { return true; }
     bool is_keyframes() { return keyword_.compare("keyframes"); }
     ATTACH_OPERATIONS();
   };
@@ -1523,9 +1525,17 @@ namespace Sass {
       {
         return expression()->exclude(static_cast<At_Rule*>(s)->keyword().erase(0, 1));
       }
+      if (s->statement_type() == Statement::MEDIA)
+      {
+        return expression()->exclude("media");
+      }
       if (s->statement_type() == Statement::RULESET)
       {
         return expression()->exclude("rule");
+      }
+      if (s->statement_type() == Statement::FEATURE)
+      {
+        return expression()->exclude("supports");
       }
       if (static_cast<At_Rule*>(s)->is_keyframes())
       {

--- a/ast.hpp
+++ b/ast.hpp
@@ -346,7 +346,7 @@ namespace Sass {
   /////////////////
   class Bubble : public Statement {
     ADD_PROPERTY(Statement*, node);
-    ADD_PROPERTY(Statement*, group_end);
+    ADD_PROPERTY(bool, group_end);
   public:
     Bubble(ParserState pstate, Statement* n, Statement* g = 0, size_t t = 0)
     : Statement(pstate, Statement::BUBBLE, t), node_(n), group_end_(g)

--- a/ast_factory.hpp
+++ b/ast_factory.hpp
@@ -17,6 +17,7 @@ namespace Sass {
     Propset* new_Propset(string p, size_t l, String* pf, Block* b);
     Feature_Query* new_Feature_Query(string p, size_t l, Feature_Query* f, Block* b);
     Media_Query* new_Media_Query(string p, size_t l, List* q, Block* b);
+    At_Root_Block* new_At_Root_Block(string p, size_t l, Selector* sel, Block* b);
     At_Rule* new_At_Rule(string p, size_t l, string kwd, Selector* sel, Block* b);
     Declaration* new_Declaration(string p, size_t l, String* prop, List* vals);
     Assignment* new_Assignment(string p, size_t l, string var, Expression* val, bool guarded = false);

--- a/ast_fwd_decl.hpp
+++ b/ast_fwd_decl.hpp
@@ -16,6 +16,7 @@ namespace Sass {
   class Media_Block;
   class Feature_Block;
   class At_Rule;
+  class At_Root_Block;
   class Declaration;
   class Assignment;
   class Import;
@@ -53,6 +54,7 @@ namespace Sass {
   class Media_Query_Expression;
   class Feature_Query;
   class Feature_Query_Condition;
+  class At_Root_Expression;
   class Null;
   // parameters and arguments
   class Parameter;

--- a/constants.cpp
+++ b/constants.cpp
@@ -8,6 +8,7 @@ namespace Sass {
     extern const char image_path_var[] = "$[image path]";
 
     // sass keywords
+    extern const char at_root_kwd[]       = "@at-root";
     extern const char import_kwd[]        = "@import";
     extern const char mixin_kwd[]         = "@mixin";
     extern const char function_kwd[]      = "@function";
@@ -32,6 +33,10 @@ namespace Sass {
     extern const char global_kwd[]        = "global";
     extern const char null_kwd[]          = "null";
     extern const char optional_kwd[]      = "optional";
+    extern const char with_kwd[]          = "with";
+    extern const char without_kwd[]       = "without";
+    extern const char all_kwd[]           = "all";
+    extern const char rule_kwd[]          = "rule";
 
     // css standard units
     extern const char em_kwd[]   = "em";

--- a/constants.hpp
+++ b/constants.hpp
@@ -9,6 +9,7 @@ namespace Sass {
     extern const char image_path_var[];
 
     // sass keywords
+    extern const char at_root_kwd[];
     extern const char import_kwd[];
     extern const char mixin_kwd[];
     extern const char function_kwd[];
@@ -33,6 +34,10 @@ namespace Sass {
     extern const char global_kwd[];
     extern const char null_kwd[];
     extern const char optional_kwd[];
+    extern const char with_kwd[];
+    extern const char without_kwd[];
+    extern const char all_kwd[];
+    extern const char rule_kwd[];
 
     // css standard units
     extern const char em_kwd[];

--- a/cssize.cpp
+++ b/cssize.cpp
@@ -32,6 +32,53 @@ namespace Sass {
     return bb;
   }
 
+  Statement* Cssize::operator()(At_Rule* r)
+  {
+    if (!r->block() || !r->block()->length()) return r;
+
+    if (/*!r->is_keyframes() &&*/
+        parent()->statement_type() == Statement::RULESET)
+    {
+      return (r->is_keyframes()) ? new (ctx.mem) Bubble(r->pstate(), r) : bubble(r);
+    }
+
+    At_Rule* rr = new (ctx.mem) At_Rule(r->pstate(),
+                                        r->keyword(),
+                                        r->selector(),
+                                        r->block() ? r->block()->perform(this)->block() : 0);
+    if (r->value()) rr->value(r->value());
+
+    // if (!r->is_keyframes()) return debubble(rr->block(), rr)->block();
+
+    bool directive_exists = false;
+    size_t L = rr->block() ? rr->block()->length() : 0;
+    for (size_t i = 0; i < L && !directive_exists; ++i) {
+      Statement* s = (*r->block())[i];
+      if (s->statement_type() != Statement::BUBBLE) directive_exists = true;
+      else {
+        s = static_cast<Bubble*>(s)->node();
+        if (s->statement_type() != Statement::DIRECTIVE) directive_exists = false;
+        else directive_exists = (static_cast<At_Rule*>(s)->keyword() == rr->keyword());
+      }
+
+    }
+
+    Block* result = new (ctx.mem) Block(rr->pstate());
+    if (!(directive_exists && rr->is_keyframes()))
+    {
+      At_Rule* empty_node = static_cast<At_Rule*>(rr);
+      empty_node->block(new (ctx.mem) Block(rr->block() ? rr->block()->pstate() : rr->pstate()));
+      *result << empty_node;
+    }
+
+    Statement* ss = debubble(rr->block() ? rr->block() : new (ctx.mem) Block(rr->pstate()), rr);
+    for (size_t i = 0, L = ss->block()->length(); i < L; ++i) {
+      *result << (*ss->block())[i];
+    }
+
+    return result;
+  }
+
   Statement* Cssize::operator()(Ruleset* r)
   {
     p_stack.push_back(r);
@@ -144,6 +191,30 @@ namespace Sass {
     }
 
     return bubble(m);
+  }
+
+  Statement* Cssize::bubble(At_Rule* m)
+  {
+    Block* bb = new (ctx.mem) Block(this->parent()->pstate());
+    Has_Block* new_rule = static_cast<Has_Block*>(this->parent());
+    new_rule->block(bb);
+    new_rule->tabs(this->parent()->tabs());
+
+    size_t L = m->block() ? m->block()->length() : 0;
+    for (size_t i = 0; i < L; ++i) {
+      *new_rule->block() << (*m->block())[i];
+    }
+
+    Block* wrapper_block = new (ctx.mem) Block(m->block() ? m->block()->pstate() : m->pstate());
+    *wrapper_block << new_rule;
+    At_Rule* mm = new (ctx.mem) At_Rule(m->pstate(),
+                                        m->keyword(),
+                                        m->selector(),
+                                        wrapper_block);
+    if (m->value()) mm->value(m->value());
+
+    Bubble* bubble = new (ctx.mem) Bubble(mm->pstate(), mm);
+    return bubble;
   }
 
   Statement* Cssize::bubble(At_Root_Block* m)

--- a/cssize.cpp
+++ b/cssize.cpp
@@ -131,10 +131,10 @@ namespace Sass {
     if (!tmp)
     {
       Block* bb = m->block()->perform(this)->block();
-      //   results.each {|c| c.tabs += node.tabs if bubblable?(c)}
-      //   if !results.empty? && bubblable?(results.last)
-      //     results.last.group_end = node.group_end
-      //   end
+      for (size_t i = 0, L = bb->length(); i < L; ++i) {
+        if (bubblable(m)) (*m->block())[i]->tabs((*m->block())[i]->tabs() + m->tabs());
+      }
+      if (bb->length() && bubblable(bb->last())) bb->last()->group_end(m->group_end());
       return bb;
     }
 

--- a/cssize.hpp
+++ b/cssize.hpp
@@ -36,7 +36,7 @@ namespace Sass {
     Statement* operator()(Media_Block*);
     Statement* operator()(Feature_Block*);
     Statement* operator()(At_Root_Block*);
-    // Statement* operator()(At_Rule*);
+    Statement* operator()(At_Rule*);
     // Statement* operator()(Declaration*);
     // Statement* operator()(Assignment*);
     // Statement* operator()(Import*);
@@ -56,6 +56,7 @@ namespace Sass {
 
     Statement* parent();
     vector<pair<bool, Block*>> slice_by_bubble(Statement*);
+    Statement* bubble(At_Rule*);
     Statement* bubble(At_Root_Block*);
     Statement* bubble(Media_Block*);
     Statement* bubble(Feature_Block*);

--- a/cssize.hpp
+++ b/cssize.hpp
@@ -35,6 +35,7 @@ namespace Sass {
     // Statement* operator()(Bubble*);
     Statement* operator()(Media_Block*);
     // Statement* operator()(Feature_Block*);
+    Statement* operator()(At_Root_Block*);
     // Statement* operator()(At_Rule*);
     // Statement* operator()(Declaration*);
     // Statement* operator()(Assignment*);
@@ -55,6 +56,7 @@ namespace Sass {
 
     Statement* parent();
     vector<pair<bool, Block*>> slice_by_bubble(Statement*);
+    Statement* bubble(At_Root_Block*);
     Statement* bubble(Media_Block*);
     Statement* debubble(Block* children, Statement* parent = 0);
     Statement* flatten(Statement*);

--- a/cssize.hpp
+++ b/cssize.hpp
@@ -34,7 +34,7 @@ namespace Sass {
     // Statement* operator()(Propset*);
     // Statement* operator()(Bubble*);
     Statement* operator()(Media_Block*);
-    // Statement* operator()(Feature_Block*);
+    Statement* operator()(Feature_Block*);
     Statement* operator()(At_Root_Block*);
     // Statement* operator()(At_Rule*);
     // Statement* operator()(Declaration*);
@@ -58,6 +58,7 @@ namespace Sass {
     vector<pair<bool, Block*>> slice_by_bubble(Statement*);
     Statement* bubble(At_Root_Block*);
     Statement* bubble(Media_Block*);
+    Statement* bubble(Feature_Block*);
     Statement* debubble(Block* children, Statement* parent = 0);
     Statement* flatten(Statement*);
     bool bubblable(Statement*);

--- a/eval.cpp
+++ b/eval.cpp
@@ -756,6 +756,19 @@ namespace Sass {
     return cc;
   }
 
+  Expression* Eval::operator()(At_Root_Expression* e)
+  {
+    Expression* feature = e->feature();
+    feature = (feature ? feature->perform(this) : 0);
+    Expression* value = e->value();
+    value = (value ? value->perform(this) : 0);
+    Expression* ee = new (ctx.mem) At_Root_Expression(e->pstate(),
+                                                      static_cast<String*>(feature),
+                                                      value,
+                                                      e->is_interpolated());
+    return ee;
+  }
+
   Expression* Eval::operator()(Media_Query* q)
   {
     To_String to_string;

--- a/eval.hpp
+++ b/eval.hpp
@@ -55,6 +55,7 @@ namespace Sass {
     Expression* operator()(String_Constant*);
     Expression* operator()(Media_Query*);
     Expression* operator()(Media_Query_Expression*);
+    Expression* operator()(At_Root_Expression*);
     Expression* operator()(Feature_Query*);
     Expression* operator()(Feature_Query_Condition*);
     Expression* operator()(Null*);

--- a/expand.cpp
+++ b/expand.cpp
@@ -20,6 +20,8 @@ namespace Sass {
     block_stack(vector<Block*>()),
     property_stack(vector<String*>()),
     selector_stack(vector<Selector*>()),
+    at_root_selector_stack(vector<Selector*>()),
+    in_at_root(false),
     backtrace(bt)
   { selector_stack.push_back(0); }
 
@@ -38,9 +40,13 @@ namespace Sass {
 
   Statement* Expand::operator()(Ruleset* r)
   {
-    To_String to_string;
+    bool old_in_at_root = in_at_root;
+    in_at_root = false;
 
     Contextualize* contextual = contextualize->with(selector_stack.back(), env, backtrace);
+    if (old_in_at_root && !r->selector()->has_reference())
+      contextual = contextualize->with(at_root_selector_stack.back(), env, backtrace);
+
     Selector* sel_ctx = r->selector()->perform(contextual);
 
     Inspect isp(0);
@@ -75,6 +81,8 @@ namespace Sass {
                                         sel_ctx,
                                         r->block()->perform(this)->block());
     selector_stack.pop_back();
+    in_at_root = old_in_at_root;
+    old_in_at_root = false;
     return rr;
   }
 
@@ -134,8 +142,9 @@ namespace Sass {
 
   Statement* Expand::operator()(At_Root_Block* a)
   {
+    in_at_root = true;
+    at_root_selector_stack.push_back(0);
     Block* ab = a->block();
-    selector_stack.push_back(0);
     Expression* ae = a->expression();
     if (ae) ae = ae->perform(eval->with(env, backtrace));
     else ae = new (ctx.mem) At_Root_Expression(a->pstate());
@@ -143,7 +152,8 @@ namespace Sass {
     At_Root_Block* aa = new (ctx.mem) At_Root_Block(a->pstate(),
                                                     bb,
                                                     static_cast<At_Root_Expression*>(ae));
-    selector_stack.pop_back();
+    at_root_selector_stack.pop_back();
+    in_at_root = false;
     return aa;
   }
 

--- a/expand.cpp
+++ b/expand.cpp
@@ -132,6 +132,21 @@ namespace Sass {
     return mm;
   }
 
+  Statement* Expand::operator()(At_Root_Block* a)
+  {
+    Block* ab = a->block();
+    selector_stack.push_back(0);
+    Expression* ae = a->expression();
+    if (ae) ae = ae->perform(eval->with(env, backtrace));
+    else ae = new (ctx.mem) At_Root_Expression(a->pstate());
+    Block* bb = ab ? ab->perform(this)->block() : 0;
+    At_Root_Block* aa = new (ctx.mem) At_Root_Block(a->pstate(),
+                                                    bb,
+                                                    static_cast<At_Root_Expression*>(ae));
+    selector_stack.pop_back();
+    return aa;
+  }
+
   Statement* Expand::operator()(At_Rule* a)
   {
     Block* ab = a->block();

--- a/expand.hpp
+++ b/expand.hpp
@@ -27,6 +27,8 @@ namespace Sass {
     vector<Block*>    block_stack;
     vector<String*>   property_stack;
     vector<Selector*> selector_stack;
+    vector<Selector*> at_root_selector_stack;
+    bool              in_at_root;
     Backtrace*        backtrace;
 
     Statement* fallback_impl(AST_Node* n);

--- a/expand.hpp
+++ b/expand.hpp
@@ -42,6 +42,7 @@ namespace Sass {
     Statement* operator()(Propset*);
     Statement* operator()(Media_Block*);
     Statement* operator()(Feature_Block*);
+    Statement* operator()(At_Root_Block*);
     Statement* operator()(At_Rule*);
     Statement* operator()(Declaration*);
     Statement* operator()(Assignment*);

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -76,6 +76,13 @@ namespace Sass {
     feature_block->block()->perform(this);
   }
 
+  void Inspect::operator()(At_Root_Block* at_root_block)
+  {
+    append_to_buffer("@at-root ", at_root_block, " ");
+    if(at_root_block->expression()) at_root_block->expression()->perform(this);
+    at_root_block->block()->perform(this);
+  }
+
   void Inspect::operator()(At_Rule* at_rule)
   {
     append_to_buffer(at_rule->keyword());
@@ -538,6 +545,22 @@ namespace Sass {
         mqe->value()->perform(this);
         if (ctx) ctx->source_map.add_close_mapping(mqe->value());
         source_map.add_close_mapping(mqe->value());
+      }
+      append_to_buffer(")");
+    }
+  }
+
+  void Inspect::operator()(At_Root_Expression* ae)
+  {
+    if (ae->is_interpolated()) {
+      ae->feature()->perform(this);
+    }
+    else {
+      append_to_buffer("(");
+      ae->feature()->perform(this);
+      if (ae->value()) {
+        append_to_buffer(": ");
+        ae->value()->perform(this);
       }
       append_to_buffer(")");
     }

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -43,6 +43,7 @@ namespace Sass {
     virtual void operator()(Bubble*);
     virtual void operator()(Feature_Block*);
     virtual void operator()(Media_Block*);
+    virtual void operator()(At_Root_Block*);
     virtual void operator()(At_Rule*);
     virtual void operator()(Declaration*);
     virtual void operator()(Assignment*);
@@ -79,6 +80,7 @@ namespace Sass {
     virtual void operator()(Feature_Query_Condition*);
     virtual void operator()(Media_Query*);
     virtual void operator()(Media_Query_Expression*);
+    virtual void operator()(At_Root_Expression*);
     virtual void operator()(Null*);
     // parameters and arguments
     virtual void operator()(Parameter*);

--- a/operation.hpp
+++ b/operation.hpp
@@ -21,6 +21,7 @@ namespace Sass {
     virtual T operator()(Bubble* x)                 = 0;
     virtual T operator()(Feature_Block* x)          = 0;
     virtual T operator()(Media_Block* x)            = 0;
+    virtual T operator()(At_Root_Block* x)          = 0;
     virtual T operator()(At_Rule* x)                = 0;
     virtual T operator()(Declaration* x)            = 0;
     virtual T operator()(Assignment* x)             = 0;
@@ -57,6 +58,7 @@ namespace Sass {
     virtual T operator()(Feature_Query_Condition* x)= 0;
     virtual T operator()(Media_Query* x)            = 0;
     virtual T operator()(Media_Query_Expression* x) = 0;
+    virtual T operator()(At_Root_Expression* x)     = 0;
     virtual T operator()(Null* x)                   = 0;
     // parameters and arguments
     virtual T operator()(Parameter* x)              = 0;
@@ -92,6 +94,7 @@ namespace Sass {
     virtual T operator()(Bubble* x)                 { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Feature_Block* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Block* x)            { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(At_Root_Block* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(At_Rule* x)                { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Declaration* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Assignment* x)             { return static_cast<D*>(this)->fallback(x); }
@@ -128,6 +131,7 @@ namespace Sass {
     virtual T operator()(Feature_Query_Condition* x){ return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Query* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Query_Expression* x) { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(At_Root_Expression* x)     { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Null* x)                   { return static_cast<D*>(this)->fallback(x); }
     // parameters and arguments
     virtual T operator()(Parameter* x)              { return static_cast<D*>(this)->fallback(x); }

--- a/output_nested.cpp
+++ b/output_nested.cpp
@@ -79,6 +79,7 @@ namespace Sass {
 
     if (b->has_non_hoistable()) {
       decls = true;
+      indentation += r->tabs();
       indent();
       if (source_comments) {
         stringstream ss;
@@ -116,13 +117,15 @@ namespace Sass {
         if (!stm->is_hoistable() && bPrintExpression) {
           if (!stm->block()) indent();
           stm->perform(this);
-          append_to_buffer(ctx->linefeed);
+          if (i < L-1) append_to_buffer(ctx->linefeed);
         }
       }
       --indentation;
-      buffer.erase(buffer.length()-1);
-      if (ctx) ctx->source_map.remove_line();
-      append_to_buffer(" }" + ctx->linefeed);
+      indentation -= r->tabs();
+      // buffer.erase(buffer.length()-1);
+      // if (ctx) ctx->source_map.remove_line();
+      append_to_buffer(" }");
+      if (r->group_end()) append_to_buffer(ctx->linefeed);
     }
 
     if (b->has_hoistable()) {
@@ -176,13 +179,13 @@ namespace Sass {
         if (!stm->is_hoistable()) {
           if (!stm->block()) indent();
           stm->perform(this);
-          append_to_buffer(ctx->linefeed);
+          if (i < L-1) append_to_buffer(ctx->linefeed);
         }
       }
       --indentation;
 
-      buffer.erase(buffer.length()-1);
-      if (ctx) ctx->source_map.remove_line();
+      // buffer.erase(buffer.length()-1);
+      // if (ctx) ctx->source_map.remove_line();
       append_to_buffer(" }" + ctx->linefeed);
       --indentation;
 
@@ -211,9 +214,13 @@ namespace Sass {
       --indentation;
     }
 
-    buffer.erase(buffer.length()-1);
-    if (ctx) ctx->source_map.remove_line();
-    append_to_buffer(" }" + ctx->linefeed);
+    while (buffer.substr(buffer.length()-ctx->linefeed.length()) == ctx->linefeed) {
+      buffer.erase(buffer.length()-1);
+      if (ctx) ctx->source_map.remove_line();
+    }
+
+    append_to_buffer(" }");
+    if (f->group_end()) append_to_buffer(ctx->linefeed);
   }
 
   void Output_Nested::operator()(Media_Block* m)
@@ -257,13 +264,13 @@ namespace Sass {
         if (!stm->is_hoistable()) {
           if (!stm->block()) indent();
           stm->perform(this);
-          append_to_buffer(ctx->linefeed);
+          if (i < L-1) append_to_buffer(ctx->linefeed);
         }
       }
       --indentation;
 
-      buffer.erase(buffer.length()-1);
-      if (ctx) ctx->source_map.remove_line();
+      // buffer.erase(buffer.length()-1);
+      // if (ctx) ctx->source_map.remove_line();
       append_to_buffer(" }" + ctx->linefeed);
       --indentation;
 
@@ -292,8 +299,11 @@ namespace Sass {
       --indentation;
     }
 
-    buffer.erase(buffer.length()-1);
-    if (ctx) ctx->source_map.remove_line();
+    while (buffer.substr(buffer.length()-ctx->linefeed.length()) == ctx->linefeed) {
+      buffer.erase(buffer.length()-1);
+      if (ctx) ctx->source_map.remove_line();
+    }
+
     append_to_buffer(" }");
     if (m->group_end()) append_to_buffer(ctx->linefeed);
 
@@ -347,12 +357,11 @@ namespace Sass {
     }
     if (decls) --indentation;
 
-    buffer.erase(buffer.length()-1);
-    if (ctx) ctx->source_map.remove_line();
-    if (b->has_hoistable()) {
+    while (buffer.substr(buffer.length()-ctx->linefeed.length()) == ctx->linefeed) {
       buffer.erase(buffer.length()-1);
       if (ctx) ctx->source_map.remove_line();
     }
+
     append_to_buffer(" }" + ctx->linefeed);
   }
 

--- a/parser.cpp
+++ b/parser.cpp
@@ -1762,6 +1762,7 @@ namespace Sass {
     in_at_root = true;
     if (peek< exactly<'('> >()) {
       expr = parse_at_root_expression();
+      body = parse_block();
     }
     else if (peek< exactly<'{'> >()) {
       body = parse_block();

--- a/parser.cpp
+++ b/parser.cpp
@@ -1791,9 +1791,16 @@ namespace Sass {
     }
 
     Declaration* declaration = parse_declaration();
+    List* value = new (ctx.mem) List(declaration->value()->pstate(), 1);
+
+    if (declaration->value()->concrete_type() == Expression::LIST) {
+        value = static_cast<List*>(declaration->value());
+    }
+    else *value << declaration->value();
+
     At_Root_Expression* cond = new (ctx.mem) At_Root_Expression(declaration->pstate(),
                                                                 declaration->property(),
-                                                                declaration->value());
+                                                                value);
     if (!lex< exactly<')'> >()) error("unclosed parenthesis in @at-root expression", pstate);
     return cond;
   }

--- a/parser.hpp
+++ b/parser.hpp
@@ -257,6 +257,8 @@ namespace Sass {
     Feature_Query_Condition* parse_supports_conjunction();
     Feature_Query_Condition* parse_supports_disjunction();
     Feature_Query_Condition* parse_supports_declaration();
+    At_Root_Block* parse_at_root_block();
+    At_Root_Expression* parse_at_root_expression();
     At_Rule* parse_at_rule();
     Warning* parse_warning();
     Error* parse_error();

--- a/parser.hpp
+++ b/parser.hpp
@@ -42,11 +42,12 @@ namespace Sass {
 
     Token lexed;
     bool dequote;
+    bool in_at_root;
 
     Parser(Context& ctx, ParserState pstate)
     : ParserState(pstate), ctx(ctx), stack(vector<Syntactic_Context>()),
       source(0), position(0), end(0), before_token(pstate), after_token(pstate), pstate("[NULL]")
-    { dequote = false; stack.push_back(nothing); }
+    { dequote = false; in_at_root = false; stack.push_back(nothing); }
 
     static Parser from_string(string src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
     static Parser from_c_str(const char* src, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -213,6 +213,22 @@ namespace Sass {
       return exactly<import_kwd>(src);
     }
 
+    const char* at_root(const char* src) {
+      return exactly<at_root_kwd>(src);
+    }
+
+    const char* with_directive(const char* src) {
+      return exactly<with_kwd>(src);
+    }
+
+    const char* without_directive(const char* src) {
+      return exactly<without_kwd>(src);
+    }
+
+    const char* until_closing_paren(const char* src) {
+      return until<')'>(src);
+    }
+
     const char* media(const char* src) {
       return exactly<media_kwd>(src);
     }

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -54,6 +54,14 @@ namespace Sass {
     }
 
     // Match a sequence of characters up to the next newline.
+    template <char end>
+    const char* until(const char* src) {
+      if (*src == '\n' && exactly<end>(src)) return 0;
+      while (*src && *src != '\n' && !exactly<end>(src)) ++src;
+      return ++src;
+    }
+
+    // Match a sequence of characters up to the next newline.
     template <const char* prefix>
     const char* to_endl(const char* src) {
       if (!(src = exactly<prefix>(src))) return 0;
@@ -330,6 +338,7 @@ namespace Sass {
     const char* identifier_fragment(const char* src);
     // Match selector names.
     const char* sel_ident(const char* src);
+    const char* until_closing_paren(const char* src);
     // Match interpolant schemas
     const char* identifier_schema(const char* src);
     const char* value_schema(const char* src);
@@ -341,6 +350,9 @@ namespace Sass {
     // Match CSS '@' keywords.
     const char* at_keyword(const char* src);
     const char* import(const char* src);
+    const char* at_root(const char* src);
+    const char* with_directive(const char* src);
+    const char* without_directive(const char* src);
     const char* media(const char* src);
     const char* supports(const char* src);
     const char* keyframes(const char* src);


### PR DESCRIPTION
This PR implements `@at-root`.

### TODO

- [x] [basic](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/at-root/basic)
- [x] [nested](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/at-root/nested)
- [x] [@media](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/at-root/media)
- [x] [@keyframes](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/at-root/keyframes)
- [x] [@entends](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/at-root/extend)
- [x] [&](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/at-root/ampersand)
- [x] [with and without](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/at-root/with_without)
- [x] maintain the correct indentation for nested output mode

This feature is good to go. 

Fixes https://github.com/sass/libsass/issues/353. Specs added https://github.com/sass/sass-spec/pull/175, https://github.com/sass/sass-spec/pull/217, https://github.com/sass/sass-spec/pull/219.

***
It turns out there were a lot of todo tests lying around addressing at-root. As a result the following specs now pass with this PR.

- [135_test_simple_at_root](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/135_test_simple_at_root)
- [136_test_at_root_with_selector](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/136_test_at_root_with_selector)
- [137_test_at_root_in_mixin](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/137_test_at_root_in_mixin)
- [138_test_at_root_in_media](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/138_test_at_root_in_media)
- [139_test_at_root_in_bubbled_media](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/139_test_at_root_in_bubbled_media)
- [140_test_at_root_in_unknown_directive](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/140_test_at_root_in_unknown_directive) 
- [141_test_at_root_with_parent_ref](https://github.com/sass/sass-spec/tree/master/spec/ibsass-todo-tests/scss-tests/141_test_at_root_with_parent_ref)
- [142_test_multi_level_at_root_with_parent_ref](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/scss-tests/142_test_multi_level_at_root_with_parent_ref)
- [143_test_multi_level_at_root_with_inner_parent_ref](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/scss-tests/143_test_multi_level_at_root_with_inner_parent_ref)




