### PR TITLE
[3.2] Bubble media queries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ SOURCES = \
 	context.cpp \
 	contextualize.cpp \
 	copy_c_str.cpp \
+	cssize.cpp \
 	error_handling.cpp \
 	eval.cpp \
 	expand.cpp \
@@ -127,14 +128,14 @@ SOURCES = \
 
 CSOURCES = cencode.c
 
-RESOURCES = 
+RESOURCES =
 
 LIBRARIES = lib/libsass.so
 
 ifeq (MinGW,$(UNAME))
 	ifeq (shared,$(BUILD))
-		CFLAGS    += -D ADD_EXPORTS 
-		CXXFLAGS  += -D ADD_EXPORTS 
+		CFLAGS    += -D ADD_EXPORTS
+		CXXFLAGS  += -D ADD_EXPORTS
 		LIBRARIES += lib/libsass.dll
 		RESOURCES += res/resource.rc
 	endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -53,6 +53,7 @@ libsass_la_SOURCES = \
 	eval.cpp eval.hpp \
 	expand.cpp expand.hpp \
 	extend.cpp extend.hpp \
+	cssize.cpp cssize.hpp \
 	file.cpp file.hpp \
 	functions.cpp functions.hpp \
 	inspect.cpp inspect.hpp \

--- a/ast.hpp
+++ b/ast.hpp
@@ -173,6 +173,7 @@ namespace Sass {
     virtual ~Vectorized() = 0;
     size_t length() const   { return elements_.size(); }
     bool empty() const      { return elements_.empty(); }
+    T last()                { return elements_.back(); }
     T& operator[](size_t i) { return elements_[i]; }
     const T& operator[](size_t i) const { return elements_[i]; }
     Vectorized& operator<<(T element)
@@ -275,10 +276,12 @@ namespace Sass {
   private:
     ADD_PROPERTY(Block*, block);
     ADD_PROPERTY(Statement_Type, statement_type);
+    ADD_PROPERTY(size_t, tabs);
+    ADD_PROPERTY(bool, group_end);
   public:
-    Statement(string path, Position position, Statement_Type st = NONE)
+    Statement(string path, Position position, Statement_Type st = NONE, size_t t = 0)
     : AST_Node(path, position),
-      statement_type_(st)
+      statement_type_(st), tabs_(t), group_end_(false)
      { }
     virtual ~Statement() = 0;
     // needed for rearranging nested rulesets during CSS emission
@@ -362,11 +365,10 @@ namespace Sass {
   class Bubble : public Statement {
     ADD_PROPERTY(Statement*, node);
     ADD_PROPERTY(Statement*, group_end);
-    ADD_PROPERTY(size_t, tabs);
   public:
     Bubble(string path, Position position, Statement* n, Statement* g = 0, size_t t = 0)
-    : Statement(path, position), node_(n), group_end_(g), tabs_(t)
-    { statement_type(BUBBLE); }
+    : Statement(path, position, Statement::BUBBLE, t), node_(n), group_end_(g)
+    { }
     bool bubbles() { return true; }
     ATTACH_OPERATIONS();
   };

--- a/ast.hpp
+++ b/ast.hpp
@@ -279,6 +279,7 @@ namespace Sass {
     // needed for rearranging nested rulesets during CSS emission
     virtual bool   is_hoistable() { return false; }
     virtual bool   is_invisible() { return false; }
+    virtual bool   bubbles() { return false; }
     virtual Block* block()  { return 0; }
   };
   inline Statement::~Statement() { }
@@ -361,6 +362,7 @@ namespace Sass {
     Bubble(string path, Position position, Statement* n, Statement* g = 0, size_t t = 0)
     : Statement(path, position), node_(n), group_end_(g), tabs_(t)
     { statement_type(BUBBLE); }
+    bool bubbles() { return true; }
     ATTACH_OPERATIONS();
   };
 
@@ -378,6 +380,7 @@ namespace Sass {
     Media_Block(string path, Position position, List* mqs, Block* b, Selector* s)
     : Has_Block(path, position, b), media_queries_(mqs), selector_(s)
     { statement_type(MEDIA); }
+    bool bubbles() { return true; }
     bool is_hoistable() { return true; }
     bool is_invisible() {
       bool is_invisible = true;

--- a/ast.hpp
+++ b/ast.hpp
@@ -187,6 +187,11 @@ namespace Sass {
       for (size_t i = 0, L = v->length(); i < L; ++i) *this << (*v)[i];
       return *this;
     }
+    Vectorized& unshift(T element)
+    {
+      elements_.insert(elements_.begin(), element);
+      return *this;
+    }
     vector<T>& elements() { return elements_; }
     const vector<T>& elements() const { return elements_; }
     vector<T>& elements(vector<T>& e) { elements_ = e; return elements_; }

--- a/ast.hpp
+++ b/ast.hpp
@@ -258,7 +258,23 @@ namespace Sass {
   /////////////////////////////////////////////////////////////////////////
   class Statement : public AST_Node {
   public:
-    Statement(string path, Position position) : AST_Node(path, position) { }
+    enum Statement_Type {
+      NONE,
+      RULESET,
+      MEDIA,
+      DIRECTIVE,
+      KEYFRAME,
+      FEATURE,
+      BUBBLE
+    };
+  private:
+    ADD_PROPERTY(Block*, block);
+    ADD_PROPERTY(Statement_Type, statement_type);
+  public:
+    Statement(string path, Position position, Statement_Type st = NONE)
+    : AST_Node(path, position),
+      statement_type_(st)
+     { }
     virtual ~Statement() = 0;
     // needed for rearranging nested rulesets during CSS emission
     virtual bool   is_hoistable() { return false; }
@@ -314,7 +330,7 @@ namespace Sass {
   public:
     Ruleset(string path, Position position, Selector* s, Block* b)
     : Has_Block(path, position, b), selector_(s)
-    { }
+    { statement_type(RULESET); }
     bool is_invisible();
     // nested rulesets need to be hoisted out of their enclosing blocks
     bool is_hoistable() { return true; }
@@ -335,6 +351,20 @@ namespace Sass {
   };
 
   /////////////////
+  // Bubble.
+  /////////////////
+  class Bubble : public Statement {
+    ADD_PROPERTY(Statement*, node);
+    ADD_PROPERTY(Statement*, group_end);
+    ADD_PROPERTY(size_t, tabs);
+  public:
+    Bubble(string path, Position position, Statement* n, Statement* g = 0, size_t t = 0)
+    : Statement(path, position), node_(n), group_end_(g), tabs_(t)
+    { statement_type(BUBBLE); }
+    ATTACH_OPERATIONS();
+  };
+
+  /////////////////
   // Media queries.
   /////////////////
   class List;
@@ -344,7 +374,10 @@ namespace Sass {
   public:
     Media_Block(string path, Position position, List* mqs, Block* b)
     : Has_Block(path, position, b), media_queries_(mqs), selector_(0)
-    { }
+    { statement_type(MEDIA); }
+    Media_Block(string path, Position position, List* mqs, Block* b, Selector* s)
+    : Has_Block(path, position, b), media_queries_(mqs), selector_(s)
+    { statement_type(MEDIA); }
     bool is_hoistable() { return true; }
     bool is_invisible() {
       bool is_invisible = true;

--- a/ast_fwd_decl.hpp
+++ b/ast_fwd_decl.hpp
@@ -9,6 +9,7 @@ namespace Sass {
   class Block;
   class Ruleset;
   class Propset;
+  class Bubble;
   class Media_Block;
   class Feature_Block;
   class At_Rule;

--- a/context.cpp
+++ b/context.cpp
@@ -18,6 +18,7 @@
 #include "expand.hpp"
 #include "eval.hpp"
 #include "contextualize.hpp"
+#include "cssize.hpp"
 #include "extend.hpp"
 #include "remove_placeholders.hpp"
 #include "copy_c_str.hpp"
@@ -282,10 +283,12 @@ namespace Sass {
     Eval eval(*this, &tge, &backtrace);
     Contextualize contextualize(*this, &eval, &tge, &backtrace);
     Expand expand(*this, &eval, &contextualize, &tge, &backtrace);
+    Cssize cssize(*this, &tge);
     // Inspect inspect(this);
     // Output_Nested output_nested(*this);
 
     root = root->perform(&expand)->block();
+    root = root->perform(&cssize)->block();
     if (!subset_map.empty()) {
       Extend extend(*this, subset_map);
       root->perform(&extend);

--- a/cssize.cpp
+++ b/cssize.cpp
@@ -35,6 +35,18 @@ namespace Sass {
     return bb;
   }
 
+  Statement* Cssize::operator()(Ruleset* r)
+  {
+    p_stack.push_back(r);
+    Ruleset* rr = new (ctx.mem) Ruleset(r->path(),
+                                        r->position(),
+                                        r->selector(),
+                                        r->block()->perform(this)->block());
+    p_stack.pop_back();
+
+    return rr;
+  }
+
   Statement* Cssize::operator()(Media_Block* m)
   {
     if (parent()->statement_type() == Statement::MEDIA)
@@ -49,6 +61,11 @@ namespace Sass {
     p_stack.pop_back();
 
     return debubble(mm->block(), mm)->block();
+  }
+
+  bool Cssize::bubblable(Statement* s)
+  {
+    return s->statement_type() == Statement::RULESET || s->bubbles();
   }
 
   Statement* Cssize::flatten(Statement* s)
@@ -103,7 +120,10 @@ namespace Sass {
       Block* slice = baz[i].second;
 
       if (!is_bubble) {
-        if (!previous_parent) {
+        if (!parent) {
+          *result << slice;
+        }
+        else if (!previous_parent) {
           previous_parent = static_cast<Has_Block*>(parent);
 
           Has_Block* new_parent = static_cast<Has_Block*>(parent);
@@ -122,8 +142,20 @@ namespace Sass {
       for (size_t j = 0, K = slice->length(); j < K; ++j)
       {
         Statement* ss = 0;
-        if ((*slice)[j]->statement_type() == Statement::BUBBLE) {
-          ss = static_cast<Bubble*>((*slice)[j])->node();
+        Bubble* b = static_cast<Bubble*>((*slice)[j]);
+
+        if (!parent ||
+            b->node()->statement_type() != Statement::MEDIA ||
+            static_cast<Media_Block*>(b->node())->media_queries() == static_cast<Media_Block*>(parent)->media_queries())
+        {
+          ss = b->node();
+        }
+        else
+        {
+          List* mq = merge_media_queries(static_cast<Media_Block*>(b->node()), static_cast<Media_Block*>(parent));
+          if (!mq->length()) continue;
+          static_cast<Media_Block*>(b->node())->media_queries(mq);
+          ss = b->node();
         }
 
         if (!ss) continue;
@@ -161,5 +193,76 @@ namespace Sass {
         *current_block << ith;
       }
     }
+  }
+
+  List* Cssize::merge_media_queries(Media_Block* m1, Media_Block* m2)
+  {
+    List* qq = new (ctx.mem) List(m1->media_queries()->path(),
+                                  m1->media_queries()->position(),
+                                  m1->media_queries()->length());
+
+    for (size_t i = 0, L = m1->media_queries()->length(); i < L; i++) {
+      for (size_t j = 0, K = m2->media_queries()->length(); j < K; j++) {
+        Media_Query* mq1 = static_cast<Media_Query*>((*m1->media_queries())[i]);
+        Media_Query* mq2 = static_cast<Media_Query*>((*m2->media_queries())[j]);
+        Media_Query* mq = merge_media_query(mq1, mq2);
+
+        if (mq) *qq << mq;
+      }
+    }
+
+    return qq;
+  }
+
+
+  Media_Query* Cssize::merge_media_query(Media_Query* mq1, Media_Query* mq2)
+  {
+    To_String to_string;
+
+    string type;
+    string mod;
+
+    string m1 = string(mq1->is_restricted() ? "only" : mq1->is_negated() ? "not" : "");
+    string t1 = mq1->media_type() ? mq1->media_type()->perform(&to_string) : "";
+    string m2 = string(mq2->is_restricted() ? "only" : mq1->is_negated() ? "not" : "");
+    string t2 = mq2->media_type() ? mq2->media_type()->perform(&to_string) : "";
+
+
+    if (t1.empty()) t1 = t2;
+    if (t2.empty()) t2 = t1;
+
+    if ((m1 == "not") ^ (m2 == "not")) {
+      if (t1 == t2) {
+        return 0;
+      }
+      type = m1 == "not" ? t2 : t1;
+      mod = m1 == "not" ? m2 : m1;
+    }
+    else if (m1 == "not" && m2 == "not") {
+      if (t1 != t2) {
+        return 0;
+      }
+      type = t1;
+      mod = "not";
+    }
+    else if (t1 != t2) {
+      return 0;
+    } else {
+      type = t1;
+      mod = m1.empty() ? m2 : m1;
+    }
+
+    Media_Query* mm = new (ctx.mem) Media_Query(
+      mq1->path(), mq1->position(), 0,
+      mq1->length() + mq2->length(), mod == "not", mod == "only"
+    );
+
+    if (!type.empty()) {
+      mm->media_type(new (ctx.mem) String_Constant(mq1->path(), mq1->position(), type));
+    }
+
+    *mm += mq2;
+    *mm += mq1;
+    return mm;
   }
 }

--- a/cssize.cpp
+++ b/cssize.cpp
@@ -1,0 +1,165 @@
+#include "cssize.hpp"
+#include "to_string.hpp"
+
+#include <iostream>
+#include <typeinfo>
+
+#ifndef SASS_CONTEXT
+#include "context.hpp"
+#endif
+
+namespace Sass {
+
+  Cssize::Cssize(Context& ctx, Env* env)
+  : ctx(ctx),
+    env(env),
+    block_stack(vector<Block*>()),
+    p_stack(vector<Statement*>())
+  {  }
+
+  Statement* Cssize::parent()
+  {
+    return p_stack.size() ? p_stack.back() : block_stack.front();
+  }
+
+  Statement* Cssize::operator()(Block* b)
+  {
+    Env new_env;
+    new_env.link(*env);
+    env = &new_env;
+    Block* bb = new (ctx.mem) Block(b->path(), b->position(), b->length(), b->is_root());
+    block_stack.push_back(bb);
+    append_block(b);
+    block_stack.pop_back();
+    env = env->parent();
+    return bb;
+  }
+
+  Statement* Cssize::operator()(Media_Block* m)
+  {
+    if (parent()->statement_type() == Statement::MEDIA)
+    { return new (ctx.mem) Bubble(m->path(), m->position(), m); }
+
+    p_stack.push_back(m);
+
+    Media_Block* mm = new (ctx.mem) Media_Block(m->path(),
+                                                m->position(),
+                                                m->media_queries(),
+                                                m->block()->perform(this)->block());
+    p_stack.pop_back();
+
+    return debubble(mm->block(), mm)->block();
+  }
+
+  Statement* Cssize::flatten(Statement* s)
+  {
+    Block* bb = s->block();
+    Block* result = new (ctx.mem) Block(bb->path(), bb->position(), 0, bb->is_root());
+    for (size_t i = 0, L = bb->length(); i < L; ++i) {
+      Statement* ss = (*bb)[i];
+      if (ss->block()) {
+        ss = flatten(ss);
+        for (size_t j = 0, K = ss->block()->length(); j < K; ++j) {
+          *result << (*ss->block())[j];
+        }
+      }
+      else {
+        *result << ss;
+      }
+    }
+    return result;
+  }
+
+  vector<pair<bool, Block*>> Cssize::slice_by_bubble(Statement* b)
+  {
+    vector<pair<bool, Block*>> results;
+    for (size_t i = 0, L = b->block()->length(); i < L; ++i) {
+      Statement* value = (*b->block())[i];
+      bool key = value->statement_type() == Statement::BUBBLE;
+
+      if (!results.empty() && results.back().first == key)
+      {
+        Block* wrapper_block = results.back().second;
+        *wrapper_block << value;
+      }
+      else
+      {
+        Block* wrapper_block = new (ctx.mem) Block(value->path(), value->position());
+        *wrapper_block << value;
+        results.push_back(make_pair(key, wrapper_block));
+      }
+    }
+    return results;
+  }
+
+  Statement* Cssize::debubble(Block* children, Statement* parent)
+  {
+    Has_Block* previous_parent = 0;
+    vector<pair<bool, Block*>> baz = slice_by_bubble(children);
+    Block* result = new (ctx.mem) Block(parent->path(), parent->position());
+
+    for (size_t i = 0, L = baz.size(); i < L; ++i) {
+      bool is_bubble = baz[i].first;
+      Block* slice = baz[i].second;
+
+      if (!is_bubble) {
+        if (!previous_parent) {
+          previous_parent = static_cast<Has_Block*>(parent);
+
+          Has_Block* new_parent = static_cast<Has_Block*>(parent);
+          new_parent->block(slice);
+
+          *result << new_parent;
+        }
+        continue;
+      }
+
+      Block* wrapper_block = new (ctx.mem) Block(parent->block()->path(),
+                                                 parent->block()->position(),
+                                                 parent->block()->length(),
+                                                 parent->block()->is_root());
+
+      for (size_t j = 0, K = slice->length(); j < K; ++j)
+      {
+        Statement* ss = 0;
+        if ((*slice)[j]->statement_type() == Statement::BUBBLE) {
+          ss = static_cast<Bubble*>((*slice)[j])->node();
+        }
+
+        if (!ss) continue;
+
+        Statement* ssss = ss->perform(this);
+        Statement* wrapper = flatten(ssss);
+        *wrapper_block << wrapper;
+      }
+
+      if (wrapper_block) {
+        *result << flatten(wrapper_block);
+      }
+    }
+
+    return flatten(result);
+  }
+
+  Statement* Cssize::fallback_impl(AST_Node* n)
+  {
+    return static_cast<Statement*>(n);
+  }
+
+  void Cssize::append_block(Block* b)
+  {
+    Block* current_block = block_stack.back();
+
+    for (size_t i = 0, L = b->length(); i < L; ++i) {
+      Statement* ith = (*b)[i]->perform(this);
+      if (ith && ith->block()) {
+        for (size_t j = 0, K = ith->block()->length(); j < K; ++j) {
+          *current_block << (*ith->block())[j];
+        }
+      }
+      else if (ith) {
+        *current_block << ith;
+      }
+    }
+  }
+}

--- a/cssize.hpp
+++ b/cssize.hpp
@@ -1,0 +1,77 @@
+#ifndef SASS_CSSIZE
+#define SASS_CSSIZE
+
+#include <vector>
+#include <iostream>
+
+#ifndef SASS_AST
+#include "ast.hpp"
+#endif
+
+#ifndef SASS_OPERATION
+#include "operation.hpp"
+#endif
+
+#ifndef SASS_ENVIRONMENT
+#include "environment.hpp"
+#endif
+
+namespace Sass {
+  using namespace std;
+
+  struct Context;
+  typedef Environment<AST_Node*> Env;
+
+  class Cssize : public Operation_CRTP<Statement*, Cssize> {
+
+    Context&            ctx;
+    Env*                env;
+    vector<Block*>      block_stack;
+    vector<Statement*>  p_stack;
+
+    Statement* fallback_impl(AST_Node* n);
+
+  public:
+    Cssize(Context&, Env*);
+    virtual ~Cssize() { }
+
+    using Operation<Statement*>::operator();
+
+    Statement* operator()(Block*);
+    // Statement* operator()(Ruleset*);
+    // Statement* operator()(Propset*);
+    // Statement* operator()(Bubble*);
+    Statement* operator()(Media_Block*);
+    // Statement* operator()(Feature_Block*);
+    // Statement* operator()(At_Rule*);
+    // Statement* operator()(Declaration*);
+    // Statement* operator()(Assignment*);
+    // Statement* operator()(Import*);
+    // Statement* operator()(Import_Stub*);
+    // Statement* operator()(Warning*);
+    // Statement* operator()(Error*);
+    // Statement* operator()(Comment*);
+    // Statement* operator()(If*);
+    // Statement* operator()(For*);
+    // Statement* operator()(Each*);
+    // Statement* operator()(While*);
+    // Statement* operator()(Return*);
+    // Statement* operator()(Extension*);
+    // Statement* operator()(Definition*);
+    // Statement* operator()(Mixin_Call*);
+    // Statement* operator()(Content*);
+
+    Statement* parent();
+    vector<pair<bool, Block*>> slice_by_bubble(Statement*);
+    Statement* debubble(Block*, Statement*);
+    Statement* flatten(Statement*);
+
+    template <typename U>
+    Statement* fallback(U x) { return fallback_impl(x); }
+
+    void append_block(Block*);
+  };
+
+}
+
+#endif

--- a/cssize.hpp
+++ b/cssize.hpp
@@ -38,7 +38,7 @@ namespace Sass {
     using Operation<Statement*>::operator();
 
     Statement* operator()(Block*);
-    // Statement* operator()(Ruleset*);
+    Statement* operator()(Ruleset*);
     // Statement* operator()(Propset*);
     // Statement* operator()(Bubble*);
     Statement* operator()(Media_Block*);
@@ -63,8 +63,12 @@ namespace Sass {
 
     Statement* parent();
     vector<pair<bool, Block*>> slice_by_bubble(Statement*);
-    Statement* debubble(Block*, Statement*);
+    Statement* debubble(Block* children, Statement* parent = 0);
     Statement* flatten(Statement*);
+    bool bubblable(Statement*);
+
+    List* merge_media_queries(Media_Block*, Media_Block*);
+    Media_Query* merge_media_query(Media_Query*, Media_Query*);
 
     template <typename U>
     Statement* fallback(U x) { return fallback_impl(x); }

--- a/cssize.hpp
+++ b/cssize.hpp
@@ -63,6 +63,7 @@ namespace Sass {
 
     Statement* parent();
     vector<pair<bool, Block*>> slice_by_bubble(Statement*);
+    Statement* bubble(Media_Block*);
     Statement* debubble(Block* children, Statement* parent = 0);
     Statement* flatten(Statement*);
     bool bubblable(Statement*);

--- a/eval.cpp
+++ b/eval.cpp
@@ -9,6 +9,7 @@
 #include "context.hpp"
 #include "backtrace.hpp"
 #include "prelexer.hpp"
+#include "parser.hpp"
 
 #include <cstdlib>
 #include <cmath>
@@ -767,6 +768,7 @@ namespace Sass {
 
   Expression* Eval::operator()(Media_Query* q)
   {
+    To_String to_string;
     String* t = q->media_type();
     t = static_cast<String*>(t ? t->perform(this) : 0);
     Media_Query* qq = new (ctx.mem) Media_Query(q->path(),
@@ -778,7 +780,7 @@ namespace Sass {
     for (size_t i = 0, L = q->length(); i < L; ++i) {
       *qq << static_cast<Media_Query_Expression*>((*q)[i]->perform(this));
     }
-    return qq;
+    return Parser::from_c_str(qq->perform(&to_string).c_str(), ctx, qq->path(), qq->position()).parse_media_query();;
   }
 
   Expression* Eval::operator()(Media_Query_Expression* e)

--- a/expand.cpp
+++ b/expand.cpp
@@ -105,8 +105,8 @@ namespace Sass {
     Media_Block* mm = new (ctx.mem) Media_Block(m->path(),
                                                 m->position(),
                                                 static_cast<List*>(media_queries),
-                                                m->block()->perform(this)->block());
-    mm->selector(selector_stack.back());
+                                                m->block()->perform(this)->block(),
+                                                selector_stack.back());
     return mm;
   }
 

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -53,6 +53,13 @@ namespace Sass {
     propset->block()->perform(this);
   }
 
+  void Inspect::operator()(Bubble* bubble)
+  {
+    append_to_buffer("Bubble ( ");
+    bubble->node()->perform(this);
+    append_to_buffer(" )");
+  }
+
   void Inspect::operator()(Media_Block* media_block)
   {
     if (ctx) ctx->source_map.add_mapping(media_block);

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -40,6 +40,7 @@ namespace Sass {
     virtual void operator()(Block*);
     virtual void operator()(Ruleset*);
     virtual void operator()(Propset*);
+    virtual void operator()(Bubble*);
     virtual void operator()(Feature_Block*);
     virtual void operator()(Media_Block*);
     virtual void operator()(At_Rule*);

--- a/operation.hpp
+++ b/operation.hpp
@@ -17,6 +17,7 @@ namespace Sass {
     virtual T operator()(Block* x)                  = 0;
     virtual T operator()(Ruleset* x)                = 0;
     virtual T operator()(Propset* x)                = 0;
+    virtual T operator()(Bubble* x)                 = 0;
     virtual T operator()(Feature_Block* x)          = 0;
     virtual T operator()(Media_Block* x)            = 0;
     virtual T operator()(At_Rule* x)                = 0;
@@ -87,6 +88,7 @@ namespace Sass {
     virtual T operator()(Block* x)                  { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Ruleset* x)                { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Propset* x)                { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Bubble* x)                 { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Feature_Block* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Block* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(At_Rule* x)                { return static_cast<D*>(this)->fallback(x); }

--- a/output_nested.cpp
+++ b/output_nested.cpp
@@ -229,6 +229,7 @@ namespace Sass {
       return;
     }
 
+    indentation += m->tabs();
     indent();
     ctx->source_map.add_mapping(m);
     append_to_buffer("@media ");
@@ -286,7 +287,8 @@ namespace Sass {
 
     buffer.erase(buffer.length()-1);
     if (ctx) ctx->source_map.remove_line();
-    append_to_buffer(" }" + ctx->linefeed);
+    append_to_buffer(" }");
+    if (m->group_end()) append_to_buffer(ctx->linefeed);
   }
 
   void Output_Nested::operator()(At_Rule* a)

--- a/win/libsass.filters
+++ b/win/libsass.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="..\expand.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\cssize.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\extend.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -186,6 +189,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\expand.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\cssize.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\extend.hpp">

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -168,6 +168,7 @@
     <ClCompile Include="..\error_handling.cpp" />
     <ClCompile Include="..\eval.cpp" />
     <ClCompile Include="..\expand.cpp" />
+    <ClCompile Include="..\cssize.cpp" />
     <ClCompile Include="..\extend.cpp" />
     <ClCompile Include="..\file.cpp" />
     <ClCompile Include="..\functions.cpp" />
@@ -184,7 +185,7 @@
     <ClCompile Include="..\sass_interface.cpp" />
     <ClCompile Include="..\sass_context.cpp" />
     <ClCompile Include="..\sass_functions.cpp" />
-    <ClCompile Include="..\sass_values.cpp" />	
+    <ClCompile Include="..\sass_values.cpp" />
     <ClCompile Include="..\sass_util.cpp" />
     <ClCompile Include="..\source_map.cpp" />
     <ClCompile Include="..\to_c.cpp" />
@@ -212,6 +213,7 @@
     <ClInclude Include="..\error_handling.hpp" />
     <ClInclude Include="..\eval.hpp" />
     <ClInclude Include="..\expand.hpp" />
+    <ClInclude Include="..\cssize.hpp" />
     <ClInclude Include="..\extend.hpp" />
     <ClInclude Include="..\file.hpp" />
     <ClInclude Include="..\functions.hpp" />


### PR DESCRIPTION
This PR implements bubbling and merging of media queries.

Fixes #185. Specs added https://github.com/sass/sass-spec/pull/215.

To get this over the line I enlisted the help of @HugoGiraudel to buff up our `@media` bubbling spec coverage.

#### TODO

- [x] [hoisting](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-issues/issue_185/hoisting)
- [x] [media_level_4](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-issues/issue_185/media_level_4)
- [x] [media_wrapper_selector](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-issues/issue_185/media_wrapper_selector)
- [x] [mixin](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-issues/issue_185/mixin)
- [x] [merge_no_repeat](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-issues/issue_185/merge_no_repeat)
- [x] [selector_wrapper_media](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-issues/issue_185/selector_wrapper_media)
- [x] maintain the correct indentation for nested output mode

As a side affect of these fixes the following tests an [outstanding @extends spec](https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/extend-tests/220_test_extend_in_double_nested_media_query) now also passes.

### Bonus

This the `cssize` visitor added will also for the basis of `@at-root`!!!

***

This PR is ready to go for 3.2!
