### PR TITLE
Don't output blocks with only unresolved placeholder selectors

### DIFF
--- a/output_compressed.cpp
+++ b/output_compressed.cpp
@@ -88,6 +88,8 @@ namespace Sass {
 
   void Output_Compressed::operator()(Media_Block* m)
   {
+    if (m->is_invisible()) return;
+
     List*  q     = m->media_queries();
     Block* b     = m->block();
 

--- a/output_nested.cpp
+++ b/output_nested.cpp
@@ -213,6 +213,8 @@ namespace Sass {
 
   void Output_Nested::operator()(Media_Block* m)
   {
+    if (m->is_invisible()) return;
+
     List*  q     = m->media_queries();
     Block* b     = m->block();
 


### PR DESCRIPTION
This PR smartens up the logic around whether to output a block. This has been cherry-picked out of #800.

If all the selectors for a ruleset are unresolved placeholders we mark that block as invisible. If a media query has only invisible blocks it is also marked as invisible.

There's no spec for this since spec are currently not whitespace sensitive https://github.com/sass/sass-spec/issues/131.