### PR TITLE
Fix the incorrect rendering of @media with interpolant

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -780,7 +780,7 @@ namespace Sass {
     for (size_t i = 0, L = q->length(); i < L; ++i) {
       *qq << static_cast<Media_Query_Expression*>((*q)[i]->perform(this));
     }
-    return Parser::from_c_str(qq->perform(&to_string).c_str(), ctx, qq->path(), qq->position()).parse_media_query();;
+    return qq;
   }
 
   Expression* Eval::operator()(Media_Query_Expression* e)

--- a/expand.cpp
+++ b/expand.cpp
@@ -101,10 +101,12 @@ namespace Sass {
 
   Statement* Expand::operator()(Media_Block* m)
   {
-    Expression* media_queries = m->media_queries()->perform(eval->with(env, backtrace));
+    To_String to_string;
+    Expression* mq = m->media_queries()->perform(eval->with(env, backtrace));
+    mq = Parser::from_c_str(mq->perform(&to_string).c_str(), ctx, mq->path(), mq->position()).parse_media_queries();
     Media_Block* mm = new (ctx.mem) Media_Block(m->path(),
                                                 m->position(),
-                                                static_cast<List*>(media_queries),
+                                                static_cast<List*>(mq),
                                                 m->block()->perform(this)->block(),
                                                 selector_stack.back());
     return mm;


### PR DESCRIPTION
This PR fixes a regression introduced in #800 which caused `@media #{foo}` to render incorrect if `$foo` was a media query list.

Fixes https://github.com/sass/libsass/issues/803. Specs added https://github.com/sass/sass-spec/pull/223.