### PR TITLE
str-slice() $end-at should default to -1 if omitted

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -904,7 +904,10 @@ namespace Sass {
 
         // `str-slice` should always return an empty string when $end-at == 0
         // `normalize_index` normalizes 1 -> 0 so we need to check the original value
-        if(start == end && m->value() > 0) {
+        if(m->value() == 0) {
+          if(!quotemark) return new (ctx.mem) Null(pstate);
+          newstr = "";
+        } else if(start == end && m->value() != 0) {
           newstr = str.substr(start, 1);
         } else if(end > start) {
           newstr = str.substr(start, end - start + UTF_8::code_point_size_at_offset(str, end));


### PR DESCRIPTION
This PR fixes a regression in `str-slice()` when `$end-at` is omitted.

Fixes https://github.com/sass/libsass/issues/815. Specs added https://github.com/sass/sass-spec/pull/225.