### PR TITLE
Normalise CSS function string arguments to double quotes

### DIFF
--- a/inspect.cpp
+++ b/inspect.cpp
@@ -607,7 +607,11 @@ namespace Sass {
     if (a->value()->concrete_type() == Expression::NULL_VAL) {
       return;
     }
-    a->value()->perform(this);
+    if (a->value()->concrete_type() == Expression::STRING) {
+      String_Constant* s = static_cast<String_Constant*>(a->value());
+      if (s->is_quoted()) s->value(quote(unquote(s->value()), String_Constant::double_quote()));
+      s->perform(this);
+    } else a->value()->perform(this);
     if (a->is_rest_argument()) {
       append_to_buffer("...");
     }


### PR DESCRIPTION
This PR normalises CSS function string arguments to double quotes when output.

Fixes https://github.com/sass/libsass/issues/817. Specs added https://github.com/sass/sass-spec/pull/226.