### PR TITLE
Improved handling of negative numbers in declaraion lists

### DIFF
--- a/inspect.hpp
+++ b/inspect.hpp
@@ -19,6 +19,8 @@ namespace Sass {
     string buffer;
     size_t indentation;
     Context* ctx;
+    bool in_declaration;
+    bool in_declaration_list;
 
     void fallback_impl(AST_Node* n);
 

--- a/parser.cpp
+++ b/parser.cpp
@@ -1035,8 +1035,8 @@ namespace Sass {
     Expression* term1 = parse_term();
     // if it's a singleton, return it directly; don't wrap it
     if (!(peek< exactly<'+'> >(position) ||
-          (peek< no_spaces >(position) && peek< sequence< negate< digits >, exactly<'-'> > >(position)) ||
-          (peek< sequence< negate< digits >, exactly<'-'>, negate< digits > > >(position))) ||
+          (peek< no_spaces >(position) && peek< sequence< negate< unsigned_number >, exactly<'-'>, negate< space > > >(position)) ||
+          (peek< sequence< negate< unsigned_number >, exactly<'-'>, negate< unsigned_number > > >(position))) ||
           peek< identifier >(position))
     { return term1; }
 
@@ -1198,14 +1198,16 @@ namespace Sass {
     if (lex< percentage >())
     { return new (ctx.mem) Textual(pstate, Textual::PERCENTAGE, lexed); }
 
-    if (lex< dimension >())
+    // match hex number first because 0x000 looks like a number followed by an indentifier
+    if (lex< alternatives< hex, hex0 > >())
+    { return new (ctx.mem) Textual(pstate, Textual::HEX, lexed); }
+
+    // also handle the 10em- foo special case
+    if (lex< sequence< dimension, optional< sequence< exactly<'-'>, negate< digit > > > > >())
     { return new (ctx.mem) Textual(pstate, Textual::DIMENSION, lexed); }
 
     if (lex< number >())
     { return new (ctx.mem) Textual(pstate, Textual::NUMBER, lexed); }
-
-    if (lex< hex >())
-    { return new (ctx.mem) Textual(pstate, Textual::HEX, lexed); }
 
     if (peek< string_constant >())
     { return parse_string(); }

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -409,7 +409,7 @@ namespace Sass {
       return sequence< number, exactly<em_kwd> >(src);
     }
     const char* dimension(const char* src) {
-      return sequence<number, identifier>(src);
+      return sequence<number, one_plus< alpha > >(src);
     }
     const char* hex(const char* src) {
       const char* p = sequence< exactly<'#'>, one_plus<xdigit> >(src);
@@ -420,6 +420,11 @@ namespace Sass {
       const char* p = sequence< exactly<'#'>, one_plus<xdigit> >(src);
       ptrdiff_t len = p - src;
       return (len != 4 && len != 7 && len != 9) ? 0 : p;
+    }
+    const char* hex0(const char* src) {
+      const char* p = sequence< exactly<'0'>, exactly<'x'>, one_plus<xdigit> >(src);
+      ptrdiff_t len = p - src;
+      return (len != 5 && len != 8) ? 0 : p;
     }
 
     const char* rgb_prefix(const char* src) {

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -411,6 +411,7 @@ namespace Sass {
     const char* dimension(const char* src);
     const char* hex(const char* src);
     const char* hexa(const char* src);
+    const char* hex0(const char* src);
     const char* rgb_prefix(const char* src);
     // Match CSS uri specifiers.
     const char* uri_prefix(const char* src);


### PR DESCRIPTION
This PR improves the handling of negative numbers in declaration lists.

It turns out Ruby sass treats `0.75em` and `.75em` differently when it comes to parsing `-`. This is likely a bug, but I've replicated the behaviour until it's changed upstream.

I'll open an issue to track this behaviour.

Fixes https://github.com/sass/libsass/issues/828. Specs added https://github.com/sass/sass-spec/pull/235.