### PR TITLE
Don't crash with encountering a css comment in a function definition

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -855,6 +855,11 @@ namespace Sass {
     return aa;
   }
 
+  Expression* Eval::operator()(Comment* c)
+  {
+    return 0;
+  }
+
   inline Expression* Eval::fallback_impl(AST_Node* n)
   {
     return static_cast<Expression*>(n);

--- a/eval.hpp
+++ b/eval.hpp
@@ -61,6 +61,7 @@ namespace Sass {
     Expression* operator()(Null*);
     Expression* operator()(Argument*);
     Expression* operator()(Arguments*);
+    Expression* operator()(Comment*);
 
     template <typename U>
     Expression* fallback(U x) { return fallback_impl(x); }


### PR DESCRIPTION
This PR prevents crashing when encountering a css comment in a function definition.

Fixes https://github.com/sass/libsass/issues/646. Specs added https://github.com/sass/sass-spec/pull/241.