### PR TITLE
Correctly bubble keyfrome directives

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -254,7 +254,8 @@ namespace Sass {
       DIRECTIVE,
       FEATURE,
       ATROOT,
-      BUBBLE
+      BUBBLE,
+      KEYFRAMERULE
     };
   private:
     ADD_PROPERTY(Block*, block);
@@ -408,7 +409,24 @@ namespace Sass {
     : Has_Block(pstate, b), keyword_(kwd), selector_(sel), value_(0) // set value manually if needed
     { statement_type(DIRECTIVE); }
     bool bubbles() { return true; }
-    bool is_keyframes() { return keyword_.compare("keyframes"); }
+    bool is_keyframes() {
+      return keyword_.compare("@-webkit-keyframes") == 0 ||
+             keyword_.compare("@-moz-keyframes") == 0 ||
+             keyword_.compare("@-o-keyframes") == 0 ||
+             keyword_.compare("@keyframes") == 0;
+    }
+    ATTACH_OPERATIONS();
+  };
+
+  ///////////////////////////////////////////////////////////////////////
+  // Keyframe-rules -- the child blocks of "@keyframes" nodes.
+  ///////////////////////////////////////////////////////////////////////
+  class Keyframe_Rule : public Has_Block {
+    ADD_PROPERTY(String*, rules);
+  public:
+    Keyframe_Rule(ParserState pstate, Block* b)
+    : Has_Block(pstate, b), rules_(0)
+    { statement_type(KEYFRAMERULE); }
     ATTACH_OPERATIONS();
   };
 

--- a/ast_factory.hpp
+++ b/ast_factory.hpp
@@ -19,6 +19,7 @@ namespace Sass {
     Media_Query* new_Media_Query(string p, size_t l, List* q, Block* b);
     At_Root_Block* new_At_Root_Block(string p, size_t l, Selector* sel, Block* b);
     At_Rule* new_At_Rule(string p, size_t l, string kwd, Selector* sel, Block* b);
+    Keyframe_Rule* new_Keyframe_Rule(string p, size_t l, Block* b);
     Declaration* new_Declaration(string p, size_t l, String* prop, List* vals);
     Assignment* new_Assignment(string p, size_t l, string var, Expression* val, bool guarded = false);
     Import<Function_Call*>* new_CSS_Import(string p, size_t l, Function_Call* loc);

--- a/ast_fwd_decl.hpp
+++ b/ast_fwd_decl.hpp
@@ -16,6 +16,7 @@ namespace Sass {
   class Media_Block;
   class Feature_Block;
   class At_Rule;
+  class Keyframe_Rule;
   class At_Root_Block;
   class Declaration;
   class Assignment;

--- a/cssize.hpp
+++ b/cssize.hpp
@@ -39,6 +39,7 @@ namespace Sass {
     Statement* operator()(Feature_Block*);
     Statement* operator()(At_Root_Block*);
     Statement* operator()(At_Rule*);
+    Statement* operator()(Keyframe_Rule*);
     // Statement* operator()(Declaration*);
     // Statement* operator()(Assignment*);
     // Statement* operator()(Import*);

--- a/expand.hpp
+++ b/expand.hpp
@@ -29,6 +29,7 @@ namespace Sass {
     vector<Selector*> selector_stack;
     vector<Selector*> at_root_selector_stack;
     bool              in_at_root;
+    bool              in_keyframes;
     Backtrace*        backtrace;
 
     Statement* fallback_impl(AST_Node* n);

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -54,6 +54,12 @@ namespace Sass {
     ruleset->block()->perform(this);
   }
 
+  void Inspect::operator()(Keyframe_Rule* rule)
+  {
+    if (rule->rules()) rule->rules()->perform(this);
+    rule->block()->perform(this);
+  }
+
   void Inspect::operator()(Propset* propset)
   {
     propset->property_fragment()->perform(this);

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -47,6 +47,7 @@ namespace Sass {
     virtual void operator()(Media_Block*);
     virtual void operator()(At_Root_Block*);
     virtual void operator()(At_Rule*);
+    virtual void operator()(Keyframe_Rule*);
     virtual void operator()(Declaration*);
     virtual void operator()(Assignment*);
     virtual void operator()(Import*);

--- a/operation.hpp
+++ b/operation.hpp
@@ -23,6 +23,7 @@ namespace Sass {
     virtual T operator()(Media_Block* x)            = 0;
     virtual T operator()(At_Root_Block* x)          = 0;
     virtual T operator()(At_Rule* x)                = 0;
+    virtual T operator()(Keyframe_Rule* x)          = 0;
     virtual T operator()(Declaration* x)            = 0;
     virtual T operator()(Assignment* x)             = 0;
     virtual T operator()(Import* x)                 = 0;
@@ -96,6 +97,7 @@ namespace Sass {
     virtual T operator()(Media_Block* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(At_Root_Block* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(At_Rule* x)                { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Keyframe_Rule* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Declaration* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Assignment* x)             { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Import* x)                 { return static_cast<D*>(this)->fallback(x); }

--- a/output_compressed.cpp
+++ b/output_compressed.cpp
@@ -134,6 +134,39 @@ namespace Sass {
     append_singleline_part_to_buffer("}");
   }
 
+  void Output_Compressed::operator()(Keyframe_Rule* r)
+  {
+    String* v       = r->rules();
+    Block*  b       = r->block();
+
+    if (v) {
+      append_singleline_part_to_buffer(" ");
+      v->perform(this);
+    }
+
+    if (!b) {
+      append_singleline_part_to_buffer(";");
+      return;
+    }
+
+    append_singleline_part_to_buffer("{");
+    for (size_t i = 0, L = b->length(); i < L; ++i) {
+      Statement* stm = (*b)[i];
+      if (!stm->is_hoistable()) {
+        stm->perform(this);
+      }
+    }
+
+    for (size_t i = 0, L = b->length(); i < L; ++i) {
+      Statement* stm = (*b)[i];
+      if (stm->is_hoistable()) {
+        stm->perform(this);
+      }
+    }
+
+    append_singleline_part_to_buffer("}");
+  }
+
   void Output_Compressed::operator()(At_Rule* a)
   {
     string      kwd   = a->keyword();

--- a/output_compressed.hpp
+++ b/output_compressed.hpp
@@ -31,6 +31,7 @@ namespace Sass {
     // virtual void operator()(Propset*);
     virtual void operator()(Media_Block*);
     virtual void operator()(At_Rule*);
+    virtual void operator()(Keyframe_Rule*);
     virtual void operator()(Declaration*);
     // virtual void operator()(Assignment*);
     virtual void operator()(Import*);

--- a/output_nested.hpp
+++ b/output_nested.hpp
@@ -36,6 +36,7 @@ namespace Sass {
     virtual void operator()(Feature_Block*);
     virtual void operator()(Media_Block*);
     virtual void operator()(At_Rule*);
+    virtual void operator()(Keyframe_Rule*);
     // virtual void operator()(Declaration*);
     // virtual void operator()(Assignment*);
     virtual void operator()(Import*);


### PR DESCRIPTION
This PR implements the incorrect bubbling for `@keyframes`.

Fixes #472. Specs added https://github.com/sass/sass-spec/pull/245.