### PR TITLE
Fix crash in Parser::parse_term()

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1056,12 +1056,8 @@ namespace Sass {
 
     // Special case: Ruby sass never tries to modulo if the lhs contains an interpolant
     if (peek< exactly<'%'> >(position) && fact1->concrete_type() == Expression::STRING) {
-      try {
-        String_Schema* ss = dynamic_cast<String_Schema*>(fact1);
-        if (ss->has_interpolants()) return fact1;
-      }
-      catch (bad_cast&) {}
-      catch (...) { throw; }
+      String_Schema* ss = dynamic_cast<String_Schema*>(fact1);
+      if (ss && ss->has_interpolants()) return fact1;
     }
 
     // if it's a singleton, return it directly; don't wrap it


### PR DESCRIPTION
`Parser::parse_term` uses `dynamic_cast` to attempt to see if the LHS of an expression can be treated as a `String_Schema` in order to check if string interpolation is in play. Unfortunately, it relies on `dynamic_cast` throwing an exception if the cast fails, which is not how C++11 behaves. An exception is only thrown from `dynamic_cast` when references are being cast, not pointers (since a reference cannot be null, but a pointer can):

http://stackoverflow.com/questions/16476613/when-dynamic-cast-will-throw-exception-in-case-used-with-pointer

The change in this pull request removes the try/catch construct, and replaces it with a simple check to see if the pointer is null or not.