### PR TITLE
Improve interpolate parsing and unquote output

### DIFF
--- a/error_handling.cpp
+++ b/error_handling.cpp
@@ -13,7 +13,7 @@ namespace Sass {
 
   void error(string msg, ParserState pstate, Backtrace* bt)
   {
-    if (!pstate.path.empty() && Prelexer::string_constant(pstate.path.c_str()))
+    if (!pstate.path.empty() && Prelexer::quoted_string(pstate.path.c_str()))
       pstate.path = pstate.path.substr(1, pstate.path.size() - 1);
 
     Backtrace top(bt, pstate, "");

--- a/parser.cpp
+++ b/parser.cpp
@@ -108,7 +108,7 @@ namespace Sass {
       }
       // ignore the @charset directive for now
       else if (lex< exactly< charset_kwd > >()) {
-        lex< string_constant >();
+        lex< quoted_string >();
         lex< one_plus< exactly<';'> > >();
       }
       else if (peek< at_keyword >()) {
@@ -164,7 +164,7 @@ namespace Sass {
     Import* imp = new (ctx.mem) Import(pstate);
     bool first = true;
     do {
-      if (lex< string_constant >()) {
+      if (lex< quoted_string >()) {
         string import_path(lexed);
 
         // struct Sass_Options opt = sass_context_get_options(ctx)
@@ -514,10 +514,10 @@ namespace Sass {
         return seq;
       }
     }
-    if (sawsomething && lex< sequence< negate< functional >, alternatives< identifier_fragment, universal, string_constant, dimension, percentage, number > > >()) {
+    if (sawsomething && lex< sequence< negate< functional >, alternatives< identifier_fragment, universal, quoted_string, dimension, percentage, number > > >()) {
       // saw an ampersand, then allow type selectors with arbitrary number of hyphens at the beginning
       (*seq) << new (ctx.mem) Type_Selector(pstate, lexed);
-    } else if (lex< sequence< negate< functional >, alternatives< type_selector, universal, string_constant, dimension, percentage, number > > >()) {
+    } else if (lex< sequence< negate< functional >, alternatives< type_selector, universal, quoted_string, dimension, percentage, number > > >()) {
       // if you see a type selector
       (*seq) << new (ctx.mem) Type_Selector(pstate, lexed);
       sawsomething = true;
@@ -546,7 +546,7 @@ namespace Sass {
     if (lex< id_name >() || lex< class_name >()) {
       return new (ctx.mem) Selector_Qualifier(pstate, lexed);
     }
-    else if (lex< string_constant >() || lex< number >()) {
+    else if (lex< quoted_string >() || lex< number >()) {
       return new (ctx.mem) Type_Selector(pstate, lexed);
     }
     else if (peek< pseudo_not >()) {
@@ -619,7 +619,7 @@ namespace Sass {
         lex< identifier >();
         expr = new (ctx.mem) String_Constant(p, lexed);
       }
-      else if (lex< string_constant >()) {
+      else if (lex< quoted_string >()) {
         expr = new (ctx.mem) String_Constant(p, lexed);
       }
       else if (peek< exactly<')'> >()) {
@@ -661,7 +661,7 @@ namespace Sass {
     if (lex< identifier >()) {
       value = new (ctx.mem) String_Constant(p, lexed, true);
     }
-    else if (lex< string_constant >()) {
+    else if (lex< quoted_string >()) {
       value = parse_interpolated_chunk(lexed);
     }
     else {
@@ -795,7 +795,7 @@ namespace Sass {
       }
       // ignore the @charset directive for now
       else if (lex< exactly< charset_kwd > >()) {
-        lex< string_constant >();
+        lex< quoted_string >();
         lex< one_plus< exactly<';'> > >();
       }
       else if (peek< at_keyword >()) {
@@ -1209,7 +1209,7 @@ namespace Sass {
     if (lex< number >())
     { return new (ctx.mem) Textual(pstate, Textual::NUMBER, lexed); }
 
-    if (peek< string_constant >())
+    if (peek< quoted_string >())
     { return parse_string(); }
 
     if (lex< variable >())
@@ -1278,7 +1278,7 @@ namespace Sass {
 
   String* Parser::parse_string()
   {
-    lex< string_constant >();
+    lex< quoted_string >();
     Token str(lexed);
     return parse_interpolated_chunk(str);
     // const char* i = str.begin;
@@ -1408,7 +1408,7 @@ namespace Sass {
       else if (lex< hex >()) {
         (*schema) << new (ctx.mem) Textual(pstate, Textual::HEX, lexed);
       }
-      else if (lex< string_constant >()) {
+      else if (lex< quoted_string >()) {
         (*schema) << new (ctx.mem) String_Constant(pstate, lexed);
         if (!num_items) schema->quote_mark(*lexed.begin);
       }
@@ -1875,7 +1875,7 @@ namespace Sass {
            (q = peek< sequence< pseudo_prefix, identifier > >(p))  ||
            (q = peek< percentage >(p))                             ||
            (q = peek< dimension >(p))                              ||
-           (q = peek< string_constant >(p))                        ||
+           (q = peek< quoted_string >(p))                        ||
            (q = peek< exactly<'*'> >(p))                           ||
            (q = peek< exactly<'('> >(p))                           ||
            (q = peek< exactly<')'> >(p))                           ||
@@ -1933,7 +1933,7 @@ namespace Sass {
            (q = peek< sequence< pseudo_prefix, identifier > >(p))  ||
            (q = peek< percentage >(p))                             ||
            (q = peek< dimension >(p))                              ||
-           (q = peek< string_constant >(p))                        ||
+           (q = peek< quoted_string >(p))                        ||
            (q = peek< exactly<'*'> >(p))                           ||
            (q = peek< exactly<'('> >(p))                           ||
            (q = peek< exactly<')'> >(p))                           ||

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -592,8 +592,7 @@ namespace Sass {
             > >
           > >,
           spaces_and_comments,
-          exactly<')'>,
-          spaces_and_comments
+          exactly<')'>
         > >
       >(src);
     }
@@ -686,6 +685,7 @@ namespace Sass {
     const char* static_component(const char* src) {
       return alternatives< identifier,
                            static_string,
+                           percentage,
                            hex,
                            number,
                            sequence< exactly<'!'>, exactly<important_kwd> >
@@ -696,8 +696,11 @@ namespace Sass {
       return sequence< static_component,
                        zero_plus < sequence<
                                    alternatives<
-                                     sequence< optional_spaces, exactly<'/'>, optional_spaces >,
-                                     sequence< optional_spaces, exactly<','>, optional_spaces >,
+                                     sequence< optional_spaces, alternatives<
+                                       exactly < '/' >,
+                                       exactly < ',' >,
+                                       exactly < ' ' >
+                                     >, optional_spaces >,
                                      spaces
                                    >,
                                    static_component

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -130,7 +130,7 @@ namespace Sass {
 
 
     const char* interpolant(const char* src) {
-      return delimited_by<hash_lbrace, rbrace, false>(src);
+      return smartdel_by<hash_lbrace, rbrace, false>(src);
     }
 
     // Whitespace handling.

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -19,7 +19,12 @@ namespace Sass {
     template <const char* prefix>
     const char* exactly(const char* src) {
       const char* pre = prefix;
-      while (*pre && *src == *pre) ++src, ++pre;
+      if (*src == 0) return 0;
+      // there is a small chance that the search prefix
+      // is longer than the rest of the string to look at
+      while (*pre && *src == *pre) {
+      	++src, ++pre;
+      }
       return *pre ? 0 : src;
     }
 
@@ -423,7 +428,7 @@ namespace Sass {
     // Match double- and single-quoted strings.
     const char* double_quoted_string(const char* src);
     const char* single_quoted_string(const char* src);
-    const char* string_constant(const char* src);
+    const char* quoted_string(const char* src);
     // Match interpolants.
     const char* interpolant(const char* src);
 

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -83,6 +83,58 @@ namespace Sass {
       }
     }
 
+    // Match a sequence of characters delimited by the supplied chars.
+    template <char beg, char end, bool esc>
+    const char* smartdel_by(const char* src) {
+
+      size_t level = 0;
+      bool in_squote = false;
+      bool in_dquote = false;
+      // bool in_braces = false;
+
+      src = exactly<beg>(src);
+
+      if (!src) return 0;
+
+      while (1) {
+
+        // end of string?
+        if (!*src) return 0;
+
+        // has escaped sequence?
+        if (!esc && *src == '\\') {
+          ++ src; // skip this (and next)
+        }
+        else if (*src == '"') {
+          in_dquote = ! in_dquote;
+        }
+        else if (*src == '\'') {
+          in_squote = ! in_squote;
+        }
+        else if (in_dquote || in_squote) {
+          // take everything literally
+        }
+
+        // find another opener inside?
+        else if (exactly<beg>(src)) {
+          ++ level; // increase counter
+        }
+
+        // look for the closer (maybe final, maybe not)
+        else if (const char* stop = exactly<end>(src)) {
+          // only close one level?
+          if (level > 0) -- level;
+          // return position at end of stop
+          // delimiter may be multiple chars
+          else return stop;
+        }
+
+        // next
+        ++ src;
+
+      }
+    }
+
     // Match a sequence of characters delimited by the supplied strings.
     template <const char* beg, const char* end, bool esc>
     const char* delimited_by(const char* src) {
@@ -94,6 +146,58 @@ namespace Sass {
         stop = exactly<end>(src);
         if (stop && (!esc || *(src - 1) != '\\')) return stop;
         src = stop ? stop : src + 1;
+      }
+    }
+
+    // Match a sequence of characters delimited by the supplied strings.
+    template <const char* beg, const char* end, bool esc>
+    const char* smartdel_by(const char* src) {
+
+      size_t level = 0;
+      bool in_squote = false;
+      bool in_dquote = false;
+      // bool in_braces = false;
+
+      src = exactly<beg>(src);
+
+      if (!src) return 0;
+
+      while (1) {
+
+        // end of string?
+        if (!*src) return 0;
+
+        // has escaped sequence?
+        if (!esc && *src == '\\') {
+          ++ src; // skip this (and next)
+        }
+        else if (*src == '"') {
+          in_dquote = ! in_dquote;
+        }
+        else if (*src == '\'') {
+          in_squote = ! in_squote;
+        }
+        else if (in_dquote || in_squote) {
+          // take everything literally
+        }
+
+        // find another opener inside?
+        else if (exactly<beg>(src)) {
+          ++ level; // increase counter
+        }
+
+        // look for the closer (maybe final, maybe not)
+        else if (const char* stop = exactly<end>(src)) {
+          // only close one level?
+          if (level > 0) -- level;
+          // return position at end of stop
+          // delimiter may be multiple chars
+          else return stop;
+        }
+
+        // next
+        ++ src;
+
       }
     }
 


### PR DESCRIPTION
This is an extracted patch from my current work on the output part.
- It makes the parsing for interpolations more robust
- Adds correct unescaping in unquote (unicode chars)

This should fix the following todo tests:
(It does at least with my WIP branch ...)
- libsass-todo-tests/25_basic_string_interpolation
- libsass-todo-tests/42_css_imports
- libsass-todo-tests/unquote

And there's more where this is coming from :wink:
~~@xzyfer travis seems to break on the [newest added test] [1] !?~~ 

[1]: https://github.com/sass/sass-spec/commit/ddbd785cbb351b69635a94930dbc0c870e0add2a