### PR TITLE
Pass "keep comments" flag to improve error message line numbers

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -298,7 +298,7 @@ namespace Sass {
     if (!source_c_str) return 0;
     queue.clear();
     if(is_indented_syntax_src) {
-      char * contents = sass2scss(source_c_str, SASS2SCSS_PRETTIFY_1);
+      char * contents = sass2scss(source_c_str, SASS2SCSS_PRETTIFY_1 | SASS2SCSS_KEEP_COMMENT);
       add_source(input_path, input_path, contents);
       return parse_file();
     }

--- a/file.cpp
+++ b/file.cpp
@@ -284,7 +284,7 @@ namespace Sass {
       for(size_t i=0; i<extension.size();++i)
         extension[i] = tolower(extension[i]);
       if (extension == ".sass" && contents != 0) {
-        char * converted = sass2scss(contents, SASS2SCSS_PRETTIFY_1);
+        char * converted = sass2scss(contents, SASS2SCSS_PRETTIFY_1 | SASS2SCSS_KEEP_COMMENT);
         delete[] contents; // free the indented contents
         return converted; // should be freed by caller
       } else {


### PR DESCRIPTION
Currently, if I have a Sass file with invalid syntax and comments, the line numbers are off because the sass2scss process doesn't preserve comments. This is fixed by changing the options bit int passed to the sass2scss function.

Hopefully I got the bit flag right, I don't work with this sort of thing on a regular basis!

Before:
```
$ cat -n ../test.sass 
     1	// some comment
     2	;
$ ./sassc/bin/sassc ../test.sass 
/home/andreas/dev/test.sass:1: invalid top-level expression
```

After:
```
$ ./sassc/bin/sassc ../test.sass 
/home/andreas/dev/test.sass:2: invalid top-level expression
```