### PR TITLE
Add support for -ms-calc

### DIFF
--- a/constants.cpp
+++ b/constants.cpp
@@ -76,6 +76,7 @@ namespace Sass {
     extern const char calc_kwd[]         = "calc(";
     extern const char moz_calc_kwd[]     = "-moz-calc(";
     extern const char webkit_calc_kwd[]  = "-webkit-calc(";
+    extern const char ms_calc_kwd[]      = "-ms-calc(";
 
     // css attribute-matching operators
     extern const char tilde_equal[]  = "~=";

--- a/constants.hpp
+++ b/constants.hpp
@@ -78,6 +78,7 @@ namespace Sass {
     extern const char calc_kwd[];
     extern const char moz_calc_kwd[];
     extern const char webkit_calc_kwd[];
+    extern const char ms_calc_kwd[];
 
     // css attribute-matching operators
     extern const char tilde_equal[];

--- a/parser.cpp
+++ b/parser.cpp
@@ -1103,6 +1103,7 @@ namespace Sass {
     }
     else if (peek< exactly< calc_kwd > >() ||
              peek< exactly< moz_calc_kwd > >() ||
+             peek< exactly< ms_calc_kwd > >() ||
              peek< exactly< webkit_calc_kwd > >()) {
       return parse_calc_function();
     }


### PR DESCRIPTION
This PR adds support for the `-ms` vendor prefix to `calc()`

Fixes https://github.com/sass/libsass/issues/842. Spec added https://github.com/sass/sass-spec/pull/264.