### PR TITLE
Allow comments in propsets

### DIFF
--- a/expand.cpp
+++ b/expand.cpp
@@ -122,6 +122,9 @@ namespace Sass {
         dec->property(combined_prop);
         *current_block << dec;
       }
+      else if (typeid(*stm) == typeid(Comment)) {
+        // drop comments in propsets
+      }
       else {
         error("contents of namespaced properties must result in style declarations only", stm->pstate(), backtrace);
       }


### PR DESCRIPTION
This PR allows comments in propsets. These comments are removed from the output as per the behaviour in Sass 3.4.11.

Fixes https://github.com/sass/libsass/issues/890. Specs added https://github.com/sass/sass-spec/pull/265/files.