### PR TITLE
Rename prelexer helper spaces_and_comments to optional_spaces_and_comments for accuracy

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -123,7 +123,7 @@ namespace Sass {
         lex< one_plus< exactly<';'> > >();
       }
       else {
-        lex< spaces_and_comments >();
+        lex< optional_spaces_and_comments >();
         if (position >= end) break;
         error("invalid top-level expression", pstate);
       }
@@ -319,7 +319,7 @@ namespace Sass {
   Argument* Parser::parse_argument()
   {
     Argument* arg;
-    if (peek< sequence < variable, spaces_and_comments, exactly<':'> > >()) {
+    if (peek< sequence < variable, optional_spaces_and_comments, exactly<':'> > >()) {
       lex< variable >();
       string name(Util::normalize_underscores(lexed));
       ParserState p = pstate;
@@ -431,7 +431,7 @@ namespace Sass {
   Selector_List* Parser::parse_selector_group()
   {
     To_String to_string;
-    lex< spaces_and_comments >();
+    lex< optional_spaces_and_comments >();
     Selector_List* group = new (ctx.mem) Selector_List(pstate);
     do {
       if (peek< exactly<'{'> >() ||
@@ -456,14 +456,14 @@ namespace Sass {
       }
       (*group) << comb;
     }
-    while (lex< one_plus< sequence< spaces_and_comments, exactly<','> > > >());
+    while (lex< one_plus< sequence< optional_spaces_and_comments, exactly<','> > > >());
     while (lex< optional >());    // JMA - ignore optional flag if it follows the selector group
     return group;
   }
 
   Complex_Selector* Parser::parse_selector_combination()
   {
-    lex< spaces_and_comments >();
+    lex< optional_spaces_and_comments >();
     Position sel_source_position(-1);
     Compound_Selector* lhs;
     if (peek< exactly<'+'> >() ||
@@ -605,7 +605,7 @@ namespace Sass {
       else if (peek< sequence< optional<sign>,
                                optional<digits>,
                                exactly<'n'>,
-                               spaces_and_comments,
+                               optional_spaces_and_comments,
                                exactly<')'> > >()) {
         lex< sequence< optional<sign>,
                        optional<digits>,
@@ -615,7 +615,7 @@ namespace Sass {
       else if (lex< sequence< optional<sign>, digits > >()) {
         expr = new (ctx.mem) String_Constant(p, lexed);
       }
-      else if (peek< sequence< identifier, spaces_and_comments, exactly<')'> > >()) {
+      else if (peek< sequence< identifier, optional_spaces_and_comments, exactly<')'> > >()) {
         lex< identifier >();
         expr = new (ctx.mem) String_Constant(p, lexed);
       }
@@ -1116,13 +1116,13 @@ namespace Sass {
     else if (peek< functional >() && !peek< uri_prefix >()) {
       return parse_function_call();
     }
-    else if (lex< sequence< exactly<'+'>, spaces_and_comments, negate< number > > >()) {
+    else if (lex< sequence< exactly<'+'>, optional_spaces_and_comments, negate< number > > >()) {
       return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::PLUS, parse_factor());
     }
-    else if (lex< sequence< exactly<'-'>, spaces_and_comments, negate< number> > >()) {
+    else if (lex< sequence< exactly<'-'>, optional_spaces_and_comments, negate< number> > >()) {
       return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::MINUS, parse_factor());
     }
-    else if (lex< sequence< not_op, spaces_and_comments > >()) {
+    else if (lex< sequence< not_op, optional_spaces_and_comments > >()) {
       return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::NOT, parse_factor());
     }
     else {

--- a/parser.hpp
+++ b/parser.hpp
@@ -93,7 +93,7 @@ namespace Sass {
         it_before_token = position;
       }
       else {
-        it_before_token = spaces_and_comments(start);
+        it_before_token = optional_spaces_and_comments(start);
       }
       const char* it_after_token = mx(it_before_token);
       if (it_after_token) {
@@ -142,7 +142,7 @@ namespace Sass {
       }
       else {
         // most can be preceded by spaces and comments
-        it_before_token = spaces_and_comments(position);
+        it_before_token = optional_spaces_and_comments(position);
       }
 
       // now call matcher to get position after token

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -88,8 +88,11 @@ namespace Sass {
     // Whitespace handling.
     const char* optional_spaces(const char* src) { return optional<spaces>(src); }
     const char* optional_comment(const char* src) { return optional<comment>(src); }
-    const char* spaces_and_comments(const char* src) {
+    const char* optional_spaces_and_comments(const char* src) {
       return zero_plus< alternatives<spaces, comment> >(src);
+    }
+    const char* spaces_and_comments(const char* src) {
+      return one_plus< alternatives<spaces, comment> >(src);
     }
     const char* no_spaces(const char* src) {
       return negate< spaces >(src);
@@ -288,7 +291,7 @@ namespace Sass {
     }
     const char* elseif_directive(const char* src) {
       return sequence< else_directive,
-                       spaces_and_comments,
+                       optional_spaces_and_comments,
                        exactly< if_after_else_kwd > >(src);
     }
 
@@ -460,25 +463,25 @@ namespace Sass {
     // Match CSS "!important" keyword.
     const char* important(const char* src) {
       return sequence< exactly<'!'>,
-                       spaces_and_comments,
+                       optional_spaces_and_comments,
                        exactly<important_kwd> >(src);
     }
     // Match CSS "!optional" keyword.
     const char* optional(const char* src) {
       return sequence< exactly<'!'>,
-      spaces_and_comments,
+      optional_spaces_and_comments,
       exactly<optional_kwd> >(src);
     }
     // Match Sass "!default" keyword.
     const char* default_flag(const char* src) {
       return sequence< exactly<'!'>,
-                       spaces_and_comments,
+                       optional_spaces_and_comments,
                        exactly<default_kwd> >(src);
     }
     // Match Sass "!global" keyword.
     const char* global_flag(const char* src) {
       return sequence< exactly<'!'>,
-                       spaces_and_comments,
+                       optional_spaces_and_comments,
                        exactly<global_kwd> >(src);
     }
     // Match CSS pseudo-class/element prefixes.
@@ -576,27 +579,27 @@ namespace Sass {
         > >,
         zero_plus < sequence<
           exactly<'('>,
-          spaces_and_comments,
+          optional_spaces_and_comments,
           optional < sequence<
             alternatives< variable, identifier_schema, identifier >,
-            spaces_and_comments,
+            optional_spaces_and_comments,
             exactly<'='>,
-            spaces_and_comments,
+            optional_spaces_and_comments,
             alternatives< variable, identifier_schema, identifier, quoted_string, number, hexa >,
             zero_plus< sequence<
-              spaces_and_comments,
+              optional_spaces_and_comments,
               exactly<','>,
-              spaces_and_comments,
+              optional_spaces_and_comments,
               sequence<
                 alternatives< variable, identifier_schema, identifier >,
-                spaces_and_comments,
+                optional_spaces_and_comments,
                 exactly<'='>,
-                spaces_and_comments,
+                optional_spaces_and_comments,
                 alternatives< variable, identifier_schema, identifier, quoted_string, number, hexa >
               >
             > >
           > >,
-          spaces_and_comments,
+          optional_spaces_and_comments,
           exactly<')'>
         > >
       >(src);
@@ -610,15 +613,15 @@ namespace Sass {
 
     // const char* ie_args(const char* src) {
     //   return sequence< alternatives< ie_keyword_arg, value_schema, quoted_string, interpolant, number, identifier, delimited_by< '(', ')', true> >,
-    //                    zero_plus< sequence< spaces_and_comments, exactly<','>, spaces_and_comments, alternatives< ie_keyword_arg, value_schema, quoted_string, interpolant, number, identifier, delimited_by<'(', ')', true> > > > >(src);
+    //                    zero_plus< sequence< optional_spaces_and_comments, exactly<','>, optional_spaces_and_comments, alternatives< ie_keyword_arg, value_schema, quoted_string, interpolant, number, identifier, delimited_by<'(', ')', true> > > > >(src);
     // }
 
     const char* ie_keyword_arg(const char* src) {
       return sequence<
         alternatives< variable, identifier_schema, identifier >,
-        spaces_and_comments,
+        optional_spaces_and_comments,
         exactly<'='>,
-        spaces_and_comments,
+        optional_spaces_and_comments,
         alternatives< variable, identifier_schema, identifier, quoted_string, number, hexa >
       >(src);
     }

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -435,6 +435,7 @@ namespace Sass {
     // Whitespace handling.
     const char* optional_spaces(const char* src);
     const char* optional_comment(const char* src);
+    const char* optional_spaces_and_comments(const char* src);
     const char* spaces_and_comments(const char* src);
     const char* no_spaces(const char* src);
 


### PR DESCRIPTION
## Problem

Whilst looking into issues with the `not` operator (https://github.com/sass/libsass/issues/873).

I noticed the cause was due to the parse not forcing spaces or comments after `not` token as the code would suggest.

```c++
else if (lex< sequence< not_op, spaces_and_comments > >()) {
  return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::NOT, parse_factor());
}
```

On further investigation it turns out the prelexer helper `spaces_and_comments` doesn't fail if there is infact no space or comment.

**I expect there are more bugs due this unexpected behaviour**

## Solution

I've updated the `spaces_and_comments` implementation to force at least a single space or comment.
I've also added an `optional_spaces_and_comments` implementation.
To prevent possible regression I've updated all existing uses of `spaces_and_comments` to use `optional_spaces_and_comments`.