### PR TITLE
Fix the greedy not operator

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1122,7 +1122,7 @@ namespace Sass {
     else if (lex< sequence< exactly<'-'>, optional_spaces_and_comments, negate< number> > >()) {
       return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::MINUS, parse_factor());
     }
-    else if (lex< sequence< not_op, optional_spaces_and_comments > >()) {
+    else if (lex< sequence< not_op, spaces_and_comments > >()) {
       return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::NOT, parse_factor());
     }
     else {


### PR DESCRIPTION
This PR fixes the greedy not operator.

Fixes https://github.com/sass/libsass/issues/873. Specs added sass/sass-spec#255, https://github.com/sass/sass-spec/pull/266.