### PR TITLE
Fix multiple open issues

### DIFF
--- a/ast.cpp
+++ b/ast.cpp
@@ -414,7 +414,9 @@ namespace Sass {
   {
     if (!tail()) return 0;
     if (!head()) return tail()->context(ctx);
-    return new (ctx.mem) Complex_Selector(pstate(), combinator(), head(), tail()->context(ctx));
+    Complex_Selector* cpy = new (ctx.mem) Complex_Selector(pstate(), combinator(), head(), tail()->context(ctx));
+    cpy->media_block(media_block());
+    return cpy;
   }
 
   Complex_Selector* Complex_Selector::innermost()

--- a/ast.hpp
+++ b/ast.hpp
@@ -1704,6 +1704,8 @@ namespace Sass {
     ADD_PROPERTY(bool, has_line_feed);
     // line break after list separator
     ADD_PROPERTY(bool, has_line_break);
+    // maybe we have optional flag
+    ADD_PROPERTY(bool, is_optional);
     // parent media block (for extend check)
     ADD_PROPERTY(Media_Block*, media_block);
   public:
@@ -1713,6 +1715,7 @@ namespace Sass {
       has_placeholder_(h),
       has_line_feed_(false),
       has_line_break_(false),
+      is_optional_(false),
       media_block_(0)
     { }
     virtual ~Selector() = 0;

--- a/ast.hpp
+++ b/ast.hpp
@@ -44,6 +44,7 @@
 #include "ast_def_macros.hpp"
 #include "ast_fwd_decl.hpp"
 #include "to_string.hpp"
+#include "source_map.hpp"
 
 #include "sass.h"
 #include "sass_values.h"

--- a/ast.hpp
+++ b/ast.hpp
@@ -1704,13 +1704,16 @@ namespace Sass {
     ADD_PROPERTY(bool, has_line_feed);
     // line break after list separator
     ADD_PROPERTY(bool, has_line_break);
+    // parent media block (for extend check)
+    ADD_PROPERTY(Media_Block*, media_block);
   public:
     Selector(ParserState pstate, bool r = false, bool h = false)
     : AST_Node(pstate),
       has_reference_(r),
       has_placeholder_(h),
       has_line_feed_(false),
-      has_line_break_(false)
+      has_line_break_(false),
+      media_block_(0)
     { }
     virtual ~Selector() = 0;
     // virtual Selector_Placeholder* find_placeholder();
@@ -1962,9 +1965,9 @@ namespace Sass {
     ADD_PROPERTY(Complex_Selector*, tail);
   public:
     Complex_Selector(ParserState pstate,
-                         Combinator c,
-                         Compound_Selector* h,
-                         Complex_Selector* t)
+                     Combinator c,
+                     Compound_Selector* h,
+                     Complex_Selector* t)
     : Selector(pstate), combinator_(c), head_(h), tail_(t)
     {
       if ((h && h->has_reference())   || (t && t->has_reference()))   has_reference(true);

--- a/backtrace.hpp
+++ b/backtrace.hpp
@@ -3,11 +3,8 @@
 
 #include <sstream>
 
-#include "position.hpp"
-
-#ifndef SASS_FILE
 #include "file.hpp"
-#endif
+#include "position.hpp"
 
 namespace Sass {
 

--- a/context.cpp
+++ b/context.cpp
@@ -279,7 +279,8 @@ namespace Sass {
     if (!root) return 0;
     root->perform(&emitter);
     emitter.finalize();
-    string output = emitter.get_buffer();
+    OutputBuffer emitted = emitter.get_buffer();
+    string output = emitted.buffer;
     if (source_map_file != "" && !omit_source_map_url) {
       output += linefeed + format_source_mapping_url(source_map_file);
     }

--- a/contextualize.cpp
+++ b/contextualize.cpp
@@ -64,6 +64,7 @@ namespace Sass {
   {
     To_String to_string(&ctx);
     Complex_Selector* ss = new (ctx.mem) Complex_Selector(*s);
+    // ss->media_block(s->media_block());
     Compound_Selector* new_head = 0;
     Complex_Selector* new_tail = 0;
     if (ss->head()) {
@@ -72,6 +73,7 @@ namespace Sass {
     }
     if (ss->tail()) {
       new_tail = static_cast<Complex_Selector*>(s->tail()->perform(this));
+      // new_tail->media_block(s->media_block());
       ss->tail(new_tail);
     }
     if ((new_head && new_head->has_placeholder()) || (new_tail && new_tail->has_placeholder())) {
@@ -95,6 +97,7 @@ namespace Sass {
       return extender;
     }
     Compound_Selector* ss = new (ctx.mem) Compound_Selector(s->pstate(), s->length());
+    ss->media_block(s->media_block());
     ss->has_line_break(s->has_line_break());
     for (size_t i = 0, L = s->length(); i < L; ++i) {
       Simple_Selector* simp = static_cast<Simple_Selector*>((*s)[i]->perform(this));

--- a/cssize.cpp
+++ b/cssize.cpp
@@ -102,17 +102,12 @@ namespace Sass {
     p_stack.pop_back();
 
     Block* props = new (ctx.mem) Block(rr->block()->pstate());
-    for (size_t i = 0, L = rr->block()->length(); i < L; i++)
-    {
-      Statement* s = (*rr->block())[i];
-      if (!bubblable(s)) *props << s;
-    }
-
     Block* rules = new (ctx.mem) Block(rr->block()->pstate());
     for (size_t i = 0, L = rr->block()->length(); i < L; i++)
     {
       Statement* s = (*rr->block())[i];
       if (bubblable(s)) *rules << s;
+      if (!bubblable(s)) *props << s;
     }
 
     if (props->length())

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -40,6 +40,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
 
     cerr << ind << "Selector_List " << selector
       << " [mq:" << selector->media_block() << "]"
+      << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
     << endl;
@@ -54,6 +55,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     Complex_Selector* selector = dynamic_cast<Complex_Selector*>(node);
     cerr << ind << "Complex_Selector " << selector
       << " [mq:" << selector->media_block() << "]"
+      << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -") << " -> ";
       switch (selector->combinator()) {
@@ -69,6 +71,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     Compound_Selector* selector = dynamic_cast<Compound_Selector*>(node);
     cerr << ind << "Compound_Selector " << selector
       << " [mq:" << selector->media_block() << "]"
+      << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -") <<
       " <" << prettyprint(selector->pstate().token.ws_before()) << "> X <" << prettyprint(selector->pstate().token.ws_after()) << ">" << endl;
@@ -101,6 +104,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     Selector_Placeholder* selector = dynamic_cast<Selector_Placeholder*>(node);
     cerr << ind << "Selector_Placeholder [" << selector->name() << "] " << selector
       << " [mq:" << selector->media_block() << "]"
+      << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
     << endl;

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -1,6 +1,7 @@
 #ifndef SASS_DEBUGGER_H
 #define SASS_DEBUGGER_H
 
+#include <string>
 #include "ast_fwd_decl.hpp"
 
 using namespace std;
@@ -128,6 +129,15 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
     << endl;
+
+  } else if (dynamic_cast<Media_Query_Expression*>(node)) {
+    Media_Query_Expression* block = dynamic_cast<Media_Query_Expression*>(node);
+    cerr << ind << "Media_Query_Expression " << block
+      << (block->is_interpolated() ? " [is_interpolated]": " -")
+    << endl;
+    debug_ast(block->feature(), ind + " f) ");
+    debug_ast(block->value(), ind + " v) ");
+
   } else if (dynamic_cast<Media_Query*>(node)) {
     Media_Query* block = dynamic_cast<Media_Query*>(node);
     cerr << ind << "Media_Query " << block
@@ -135,6 +145,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
       << (block->is_restricted() ? " [is_restricted]": " -")
     << endl;
     debug_ast(block->media_type(), ind + " ");
+    for(auto i : block->elements()) { debug_ast(i, ind + " ", env); }
 
   } else if (dynamic_cast<Media_Block*>(node)) {
     Media_Block* block = dynamic_cast<Media_Block*>(node);

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -37,7 +37,13 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     if (root_block->block()) for(auto i : root_block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Selector_List*>(node)) {
     Selector_List* selector = dynamic_cast<Selector_List*>(node);
-    cerr << ind << "Selector_List " << selector << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << endl;
+
+    cerr << ind << "Selector_List " << selector
+      << " [mq:" << selector->media_block() << "]"
+      << (selector->has_line_break() ? " [line-break]": " -")
+      << (selector->has_line_feed() ? " [line-feed]": " -")
+    << endl;
+
     for(auto i : selector->elements()) { debug_ast(i, ind + " ", env); }
 
 //  } else if (dynamic_cast<Expression*>(node)) {
@@ -46,7 +52,10 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
 
   } else if (dynamic_cast<Complex_Selector*>(node)) {
     Complex_Selector* selector = dynamic_cast<Complex_Selector*>(node);
-    cerr << ind << "Complex_Selector " << selector << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << " -> ";
+    cerr << ind << "Complex_Selector " << selector
+      << " [mq:" << selector->media_block() << "]"
+      << (selector->has_line_break() ? " [line-break]": " -")
+      << (selector->has_line_feed() ? " [line-feed]": " -") << " -> ";
       switch (selector->combinator()) {
         case Complex_Selector::PARENT_OF:   cerr << "{>}"; break;
         case Complex_Selector::PRECEDES:    cerr << "{~}"; break;
@@ -58,7 +67,10 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     debug_ast(selector->tail(), ind + "-", env);
   } else if (dynamic_cast<Compound_Selector*>(node)) {
     Compound_Selector* selector = dynamic_cast<Compound_Selector*>(node);
-    cerr << ind << "Compound_Selector " << selector << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") <<
+    cerr << ind << "Compound_Selector " << selector
+      << " [mq:" << selector->media_block() << "]"
+      << (selector->has_line_break() ? " [line-break]": " -")
+      << (selector->has_line_feed() ? " [line-feed]": " -") <<
       " <" << prettyprint(selector->pstate().token.ws_before()) << "> X <" << prettyprint(selector->pstate().token.ws_after()) << ">" << endl;
     for(auto i : selector->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Propset*>(node)) {
@@ -85,8 +97,14 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << ind << "Type_Selector " << selector << " <<" << selector->name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") <<
       " <" << prettyprint(selector->pstate().token.ws_before()) << "> X <" << prettyprint(selector->pstate().token.ws_after()) << ">" << endl;
   } else if (dynamic_cast<Selector_Placeholder*>(node)) {
+
     Selector_Placeholder* selector = dynamic_cast<Selector_Placeholder*>(node);
-    cerr << ind << "Selector_Placeholder [" << selector->name() << "] " << selector << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << endl;
+    cerr << ind << "Selector_Placeholder [" << selector->name() << "] " << selector
+      << " [mq:" << selector->media_block() << "]"
+      << (selector->has_line_break() ? " [line-break]": " -")
+      << (selector->has_line_feed() ? " [line-feed]": " -")
+    << endl;
+
   } else if (dynamic_cast<Selector_Reference*>(node)) {
     Selector_Reference* selector = dynamic_cast<Selector_Reference*>(node);
     cerr << ind << "Selector_Reference " << selector << " @ref " << selector->selector() << endl;

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -124,10 +124,23 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
 
   } else if (dynamic_cast<Selector*>(node)) {
     Selector* selector = dynamic_cast<Selector*>(node);
-    cerr << ind << "Selector " << selector << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << endl;
+    cerr << ind << "Selector " << selector
+      << (selector->has_line_break() ? " [line-break]": " -")
+      << (selector->has_line_feed() ? " [line-feed]": " -")
+    << endl;
+  } else if (dynamic_cast<Media_Query*>(node)) {
+    Media_Query* block = dynamic_cast<Media_Query*>(node);
+    cerr << ind << "Media_Query " << block
+      << (block->is_negated() ? " [is_negated]": " -")
+      << (block->is_restricted() ? " [is_restricted]": " -")
+    << endl;
+    debug_ast(block->media_type(), ind + " ");
+
   } else if (dynamic_cast<Media_Block*>(node)) {
     Media_Block* block = dynamic_cast<Media_Block*>(node);
     cerr << ind << "Media_Block " << block << " " << block->tabs() << endl;
+    debug_ast(block->media_queries(), ind + " =@ ");
+    debug_ast(block->selector(), ind + " -@ ");
     if (block->block()) for(auto i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Feature_Block*>(node)) {
     Feature_Block* block = dynamic_cast<Feature_Block*>(node);

--- a/emitter.cpp
+++ b/emitter.cpp
@@ -85,6 +85,13 @@ namespace Sass {
     }
   }
 
+  // prepend some text or token to the buffer
+  void Emitter::prepend_string(const string& text)
+  {
+    // update source-map for new text
+    wbuf.buffer = text + wbuf.buffer;
+  }
+
   // append some text or token to the buffer
   void Emitter::append_string(const string& text)
   {

--- a/emitter.cpp
+++ b/emitter.cpp
@@ -86,9 +86,16 @@ namespace Sass {
   }
 
   // prepend some text or token to the buffer
+  void Emitter::prepend_output(const OutputBuffer& output)
+  {
+    wbuf.smap.prepend(output);
+    wbuf.buffer = output.buffer + wbuf.buffer;
+  }
+
+  // prepend some text or token to the buffer
   void Emitter::prepend_string(const string& text)
   {
-    // update source-map for new text
+    wbuf.smap.prepend(Offset(text));
     wbuf.buffer = text + wbuf.buffer;
   }
 
@@ -104,12 +111,12 @@ namespace Sass {
       // add to buffer
       wbuf.buffer += out;
       // account for data in source-maps
-      wbuf.smap.update_column(out);
+      wbuf.smap.append(Offset(out));
     } else {
       // add to buffer
       wbuf.buffer += text;
       // account for data in source-maps
-      wbuf.smap.update_column(text);
+      wbuf.smap.append(Offset(text));
     }
   }
 

--- a/emitter.hpp
+++ b/emitter.hpp
@@ -9,17 +9,6 @@ namespace Sass {
   class Context;
   using namespace std;
 
-  class OutputBuffer {
-    public:
-      OutputBuffer(void)
-      : buffer(""),
-        smap()
-      { }
-    public:
-      string buffer;
-      SourceMap smap;
-  };
-
   class Emitter {
 
     public:
@@ -31,6 +20,7 @@ namespace Sass {
     public:
       const string buffer(void) { return wbuf.buffer; }
       const SourceMap smap(void) { return wbuf.smap; }
+      const OutputBuffer output(void) { return wbuf; }
       // proxy methods for source maps
       void add_source_index(size_t idx);
       void set_filename(const string& str);
@@ -64,6 +54,7 @@ namespace Sass {
       void flush_schedules(void);
       // prepend some text or token to the buffer
       void prepend_string(const string& text);
+      void prepend_output(const OutputBuffer& out);
       // append some text or token to the buffer
       void append_string(const string& text);
       // append some white-space only text

--- a/emitter.hpp
+++ b/emitter.hpp
@@ -62,6 +62,8 @@ namespace Sass {
       void finalize(void);
       // flush scheduled space/linefeed
       void flush_schedules(void);
+      // prepend some text or token to the buffer
+      void prepend_string(const string& text);
       // append some text or token to the buffer
       void append_string(const string& text);
       // append some white-space only text

--- a/eval.cpp
+++ b/eval.cpp
@@ -604,7 +604,7 @@ namespace Sass {
     string name(v->name());
     Expression* value = 0;
     if (env->has(name)) value = static_cast<Expression*>((*env)[name]);
-    else error("unbound variable " + v->name(), v->pstate());
+    else error("Undefined variable: \"" + v->name() + "\".", v->pstate());
     // cerr << "name: " << v->name() << "; type: " << typeid(*value).name() << "; value: " << value->perform(&to_string) << endl;
     if (typeid(*value) == typeid(Argument)) value = static_cast<Argument*>(value)->value();
 
@@ -770,7 +770,7 @@ namespace Sass {
     } else if (Variable* var = dynamic_cast<Variable*>(s)) {
 
       string name(var->name());
-      if (!env->has(name)) return name;
+      if (!env->has(name)) error("Undefined variable: \"" + var->name() + "\".", var->pstate());
       Expression* value = static_cast<Expression*>((*env)[name]);
       return evacuate_quotes(interpolation(value));
 

--- a/eval.cpp
+++ b/eval.cpp
@@ -658,19 +658,19 @@ namespace Sass {
     {
       case Textual::NUMBER:
         result = new (ctx.mem) Number(t->pstate(),
-                                      atof(num.c_str()),
+                                      sass_atof(num.c_str()),
                                       "",
                                       zero);
         break;
       case Textual::PERCENTAGE:
         result = new (ctx.mem) Number(t->pstate(),
-                                      atof(num.c_str()),
+                                      sass_atof(num.c_str()),
                                       "%",
                                       zero);
         break;
       case Textual::DIMENSION:
         result = new (ctx.mem) Number(t->pstate(),
-                                      atof(num.c_str()),
+                                      sass_atof(num.c_str()),
                                       Token(number(text.c_str()), t->pstate()),
                                       zero);
         break;

--- a/expand.cpp
+++ b/expand.cpp
@@ -70,22 +70,23 @@ namespace Sass {
     string str = isp.get_buffer();
     str += ";";
 
-    Parser p(ctx, ParserState("[REPARSE]", 0));
+    Parser p(ctx, r->pstate());
+    p.last_media_block = r->selector() ? r->selector()->media_block() : 0;
     p.source   = str.c_str();
     p.position = str.c_str();
     p.end      = str.c_str() + strlen(str.c_str());
     Selector_List* sel_lst = p.parse_selector_group();
-    sel_lst->pstate(isp.remap(sel_lst->pstate()));
+    // sel_lst->pstate(isp.remap(sel_lst->pstate()));
 
     for(size_t i = 0; i < sel_lst->length(); i++) {
 
       Complex_Selector* pIter = (*sel_lst)[i];
       while (pIter) {
         Compound_Selector* pHead = pIter->head();
-        pIter->pstate(isp.remap(pIter->pstate()));
+        // pIter->pstate(isp.remap(pIter->pstate()));
         if (pHead) {
-          pHead->pstate(isp.remap(pHead->pstate()));
-          (*pHead)[0]->pstate(isp.remap((*pHead)[0]->pstate()));
+          // pHead->pstate(isp.remap(pHead->pstate()));
+          // (*pHead)[0]->pstate(isp.remap((*pHead)[0]->pstate()));
         }
         pIter = pIter->tail();
       }

--- a/expand.cpp
+++ b/expand.cpp
@@ -404,7 +404,8 @@ namespace Sass {
     To_String to_string(&ctx);
     Selector_List* extender = static_cast<Selector_List*>(selector_stack.back());
     if (!extender) return 0;
-    Selector_List* extendee = static_cast<Selector_List*>(e->selector()->perform(contextualize->with(0, env, backtrace)));
+    Selector_List* org_extendee = static_cast<Selector_List*>(e->selector());
+    Selector_List* extendee = static_cast<Selector_List*>(org_extendee->perform(contextualize->with(0, env, backtrace)));
     if (extendee->length() != 1) {
       error("selector groups may not be extended", extendee->pstate(), backtrace);
     }
@@ -413,7 +414,7 @@ namespace Sass {
       error("nested selectors may not be extended", c->pstate(), backtrace);
     }
     Compound_Selector* s = c->head();
-
+    s->is_optional(org_extendee->is_optional());
     // // need to convert the compound selector into a by-value data structure
     // vector<string> target_vec;
     // for (size_t i = 0, L = s->length(); i < L; ++i)

--- a/extend.cpp
+++ b/extend.cpp
@@ -235,6 +235,7 @@ namespace Sass {
     return os;
   }
 #endif
+
   static bool parentSuperselector(Complex_Selector* pOne, Complex_Selector* pTwo, Context& ctx) {
     // TODO: figure out a better way to create a Complex_Selector from scratch
     // TODO: There's got to be a better way. This got ugly quick...

--- a/extend.cpp
+++ b/extend.cpp
@@ -5,7 +5,6 @@
 #include "backtrace.hpp"
 #include "paths.hpp"
 #include "parser.hpp"
-#include "debugger.hpp"
 #include "node.hpp"
 #include "sass_util.hpp"
 #include "debug.hpp"
@@ -1580,7 +1579,6 @@ namespace Sass {
       // out and aren't operated on.
       Complex_Selector* pNewSelector = pExtComplexSelector->cloneFully(ctx);
       Complex_Selector* pNewInnerMost = new (ctx.mem) Complex_Selector(pSelector->pstate(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, NULL);
-      // pNewInnerMost->media_block(pSelector->media_block());
       Complex_Selector::Combinator combinator = pNewSelector->clear_innermost();
       pNewSelector->set_innermost(pNewInnerMost, combinator);
 
@@ -1753,11 +1751,9 @@ namespace Sass {
     pComplexSelector->tail()->has_line_feed(pComplexSelector->has_line_feed());
 
     Node complexSelector = complexSelectorToNode(pComplexSelector, ctx);
-// debug_ast(pComplexSelector->parent());
     DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTEND COMPLEX: " << complexSelector)
 
     Node extendedNotExpanded = Node::createCollection();
-    // extendedNotExpanded.media_block = pComplexSelector->media_block();
 
     for (NodeDeque::iterator complexSelIter = complexSelector.collection()->begin(), complexSelIterEnd = complexSelector.collection()->end(); complexSelIter != complexSelIterEnd; ++complexSelIter) {
       Node& sseqOrOp = *complexSelIter;

--- a/output.cpp
+++ b/output.cpp
@@ -44,9 +44,8 @@ namespace Sass {
 
     // flush scheduled outputs
     inspect.finalize();
-    // create combined buffer string
-    wbuf.buffer = inspect.buffer()
-                + this->buffer();
+    // prepend buffer on top
+    prepend_output(inspect.output());
     // make sure we end with a linefeed
     if (!ends_with(wbuf.buffer, ctx->linefeed)) {
       // if the output is not completely empty

--- a/output.cpp
+++ b/output.cpp
@@ -24,7 +24,7 @@ namespace Sass {
     top_imports.push_back(imp);
   }
 
-  string Output::get_buffer(void)
+  OutputBuffer Output::get_buffer(void)
   {
 
     Emitter emitter(ctx);
@@ -45,16 +45,16 @@ namespace Sass {
     // flush scheduled outputs
     inspect.finalize();
     // create combined buffer string
-    string buffer = inspect.buffer()
-                  + this->buffer();
+    wbuf.buffer = inspect.buffer()
+                + this->buffer();
     // make sure we end with a linefeed
-    if (!ends_with(buffer, ctx->linefeed)) {
+    if (!ends_with(wbuf.buffer, ctx->linefeed)) {
       // if the output is not completely empty
-      if (!buffer.empty()) buffer += ctx->linefeed;
+      if (!wbuf.buffer.empty()) append_string(ctx->linefeed);
     }
 
     // search for unicode char
-    for(const char& chr : buffer) {
+    for(const char& chr : wbuf.buffer) {
       // skip all ascii chars
       if (chr >= 0) continue;
       // declare the charset
@@ -67,7 +67,9 @@ namespace Sass {
     }
 
     // add charset as first line, before comments and imports
-    return (charset.empty() ? "" : charset) + buffer;
+    if (!charset.empty()) prepend_string(charset);
+
+    return wbuf;
 
   }
 

--- a/output.hpp
+++ b/output.hpp
@@ -34,7 +34,7 @@ namespace Sass {
     vector<Comment*> top_comments;
 
   public:
-    string get_buffer(void);
+    OutputBuffer get_buffer(void);
 
     virtual void operator()(Ruleset*);
     // virtual void operator()(Propset*);

--- a/parser.cpp
+++ b/parser.cpp
@@ -728,7 +728,7 @@ namespace Sass {
     bool semicolon = false;
     Selector_Lookahead lookahead_result;
     Block* block = new (ctx.mem) Block(pstate);
-    lex< spaces_and_comments >();
+    // lex< zero_plus < alternatives < space, line_comment > > >();
     // JMA - ensure that a block containing only block_comments is parsed
     while (lex< block_comment >()) {
       bool is_important = lexed.begin[2] == '!';

--- a/parser.cpp
+++ b/parser.cpp
@@ -497,7 +497,9 @@ namespace Sass {
       (*group) << comb;
     }
     while (reloop);
-    while (lex< optional >());    // JMA - ignore optional flag if it follows the selector group
+    while (lex< optional >()) {
+      group->is_optional(true);
+    }
     return group;
   }
 

--- a/parser.cpp
+++ b/parser.cpp
@@ -728,7 +728,7 @@ namespace Sass {
     bool semicolon = false;
     Selector_Lookahead lookahead_result;
     Block* block = new (ctx.mem) Block(pstate);
-
+    lex< spaces_and_comments >();
     // JMA - ensure that a block containing only block_comments is parsed
     while (lex< block_comment >()) {
       bool is_important = lexed.begin[2] == '!';
@@ -774,6 +774,9 @@ namespace Sass {
       else if (lex< variable >()) {
         (*block) << parse_assignment();
         semicolon = true;
+      }
+      else if (lex< line_comment >()) {
+        // throw line comments away
       }
       else if (peek< if_directive >()) {
         (*block) << parse_if_directive();

--- a/parser.cpp
+++ b/parser.cpp
@@ -565,6 +565,9 @@ namespace Sass {
     bool sawsomething = false;
     if (lex< exactly<'&'> >()) {
       // if you see a &
+      if (block_stack.size() == 0) {
+        error("Base-level rules cannot contain the parent-selector-referencing character '&'.", pstate);
+      }
       (*seq) << new (ctx.mem) Selector_Reference(pstate);
       sawsomething = true;
       // if you see a space after a &, then you're done
@@ -738,6 +741,7 @@ namespace Sass {
     bool semicolon = false;
     Selector_Lookahead lookahead_result;
     Block* block = new (ctx.mem) Block(pstate);
+    block_stack.push_back(block);
     lex< zero_plus < alternatives < space, line_comment > > >();
     // JMA - ensure that a block containing only block_comments is parsed
     while (lex< block_comment >()) {
@@ -909,6 +913,7 @@ namespace Sass {
         (*block) << comment;
       }
     }
+    block_stack.pop_back();
     return block;
   }
 

--- a/parser.cpp
+++ b/parser.cpp
@@ -1696,11 +1696,18 @@ namespace Sass {
     else if (lex< exactly< only_kwd > >()) media_query->is_restricted(true);
 
     if (peek< identifier_schema >()) media_query->media_type(parse_identifier_schema());
-    else if (lex< identifier >())    media_query->media_type(new (ctx.mem) String_Quoted(pstate, lexed));
+    else if (lex< identifier >())    media_query->media_type(parse_interpolated_chunk(lexed));
     else                             (*media_query) << parse_media_expression();
 
     while (lex< exactly< and_kwd > >()) (*media_query) << parse_media_expression();
-
+    if (peek< identifier_schema >()) {
+      String_Schema* schema = new (ctx.mem) String_Schema(pstate);
+      *schema << media_query->media_type();
+      *schema << new (ctx.mem) String_Constant(pstate, " ");
+      *schema << parse_identifier_schema();
+      media_query->media_type(schema);
+    }
+    while (lex< exactly< and_kwd > >()) (*media_query) << parse_media_expression();
     return media_query;
   }
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -32,6 +32,7 @@ namespace Sass {
 
     Context& ctx;
     vector<Syntactic_Context> stack;
+    Media_Block* last_media_block;
     const char* source;
     const char* position;
     const char* end;
@@ -44,8 +45,8 @@ namespace Sass {
     Token lexed;
     bool in_at_root;
 
-    Parser(Context& ctx, ParserState pstate)
-    : ParserState(pstate), ctx(ctx), stack(vector<Syntactic_Context>()),
+    Parser(Context& ctx, const ParserState& pstate)
+    : ParserState(pstate), ctx(ctx), stack(0), last_media_block(0),
       source(0), position(0), end(0), before_token(pstate), after_token(pstate), pstate("[NULL]"), indentation(0)
     { in_at_root = false; stack.push_back(nothing); }
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -147,6 +147,9 @@ namespace Sass {
       else if (mx == optional_spaces_and_comments) {
         it_before_token = position;
       }
+      else if (mx == spaces_and_comments) {
+        it_before_token = position;
+      }
 
       else if (mx == optional_spaces) {
         // ToDo: what are optiona_spaces ???

--- a/parser.hpp
+++ b/parser.hpp
@@ -31,6 +31,7 @@ namespace Sass {
     enum Syntactic_Context { nothing, mixin_def, function_def };
 
     Context& ctx;
+    vector<Block*> block_stack;
     vector<Syntactic_Context> stack;
     Media_Block* last_media_block;
     const char* source;
@@ -46,7 +47,7 @@ namespace Sass {
     bool in_at_root;
 
     Parser(Context& ctx, const ParserState& pstate)
-    : ParserState(pstate), ctx(ctx), stack(0), last_media_block(0),
+    : ParserState(pstate), ctx(ctx), block_stack(0), stack(0), last_media_block(0),
       source(0), position(0), end(0), before_token(pstate), after_token(pstate), pstate("[NULL]"), indentation(0)
     { in_at_root = false; stack.push_back(nothing); }
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -234,6 +234,7 @@ namespace Sass {
     Simple_Selector* parse_pseudo_selector();
     Attribute_Selector* parse_attribute_selector();
     Block* parse_block();
+    bool parse_number_prefix();
     Declaration* parse_declaration();
     Expression* parse_map_value();
     Expression* parse_map();

--- a/position.cpp
+++ b/position.cpp
@@ -4,6 +4,18 @@ namespace Sass {
 
   using namespace std;
 
+  Offset::Offset(const char* string)
+  : line(0), column(0)
+  {
+    *this = inc(string, string + strlen(string));
+  }
+
+  Offset::Offset(const string& text)
+  : line(0), column(0)
+  {
+    *this = inc(text.c_str(), text.c_str() + text.size());
+  }
+
   Offset::Offset(const size_t line, const size_t column)
   : line(line), column(column) { }
 
@@ -34,7 +46,12 @@ namespace Sass {
     return line != pos.line || column != pos.column;
   }
 
-  const Offset Offset::operator+ (const Offset &off) const
+  void Offset::operator+= (const Offset &off)
+  {
+    *this = Offset(line + off.line, off.line > 0 ? off.column : off.column + column);
+  }
+
+  Offset Offset::operator+ (const Offset &off) const
   {
     return Offset(line + off.line, off.line > 0 ? off.column : off.column + column);
   }
@@ -67,7 +84,7 @@ namespace Sass {
   Position Position::inc(const char* begin, const char* end) const
   {
     Offset offset(line, column);
-    offset.inc(begin, end);
+    offset = offset.inc(begin, end);
     return Position(file, offset);
   }
 
@@ -79,6 +96,11 @@ namespace Sass {
   bool Position::operator!= (const Position &pos) const
   {
     return file == pos.file || line != pos.line || column != pos.column;
+  }
+
+  void Position::operator+= (const Offset &off)
+  {
+    *this = Position(file, line + off.line, off.line > 0 ? off.column : off.column + column);
   }
 
   const Position Position::operator+ (const Offset &off) const

--- a/position.hpp
+++ b/position.hpp
@@ -14,15 +14,18 @@ namespace Sass {
   class Offset {
 
     public: // c-tor
+      Offset(const char* string);
+      Offset(const string& text);
       Offset(const size_t line, const size_t column);
 
       // return new position, incremented by the given string
       Offset inc(const char* begin, const char* end) const;
 
     public: // overload operators for position
+      void operator+= (const Offset &pos);
       bool operator== (const Offset &pos) const;
       bool operator!= (const Offset &pos) const;
-      const Offset operator+ (const Offset &off) const;
+      Offset operator+ (const Offset &off) const;
 
     public: // overload output stream operator
       // friend ostream& operator<<(ostream& strm, const Offset& off);
@@ -45,6 +48,7 @@ namespace Sass {
       Position(const size_t file, const size_t line, const size_t column);
 
     public: // overload operators for position
+      void operator+= (const Offset &off);
       bool operator== (const Position &pos) const;
       bool operator!= (const Position &pos) const;
       const Position operator+ (const Offset &off) const;

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -147,6 +147,18 @@ namespace Sass {
       return sequence< exactly<'-'>, exactly<'-'>, identifier >(src);
     }
 
+    // Match number prefix ([\+\-]+)
+    const char* number_prefix(const char* src) {
+      return alternatives <
+        exactly < '+' >,
+        sequence <
+          exactly < '-' >,
+          optional_spaces_and_comments,
+          exactly< '-' >
+        >
+      >(src);
+    }
+
     // Match interpolant schemas
     const char* identifier_schema(const char* src) {
       // follows this pattern: (x*ix*)+ ... well, not quite

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -59,7 +59,7 @@ namespace Sass {
     }
     // Match either comment.
     const char* comment(const char* src) {
-      return alternatives<block_comment, line_comment>(src);
+      return line_comment(src);
     }
 
     const char* wspaces(const char* src) {
@@ -100,10 +100,10 @@ namespace Sass {
     const char* optional_spaces(const char* src) { return optional<spaces>(src); }
     // const char* optional_comment(const char* src) { return optional<comment>(src); }
     const char* optional_spaces_and_comments(const char* src) {
-      return zero_plus< alternatives<spaces, comment> >(src);
+      return zero_plus< alternatives<spaces, line_comment> >(src);
     }
     const char* spaces_and_comments(const char* src) {
-      return one_plus< alternatives<spaces, comment> >(src);
+      return one_plus< alternatives<spaces, line_comment> >(src);
     }
     const char* no_spaces(const char* src) {
       return negate< spaces >(src);

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -396,6 +396,8 @@ namespace Sass {
     const char* quoted_string(const char* src);
     // Match interpolants.
     const char* interpolant(const char* src);
+    // Match number prefix ([\+\-]+)
+    const char* number_prefix(const char* src);
 
     // Whitespace handling.
     const char* optional_spaces(const char* src);

--- a/source_map.hpp
+++ b/source_map.hpp
@@ -5,12 +5,17 @@
 
 #include "ast_fwd_decl.hpp"
 #include "base64vlq.hpp"
+#include "position.hpp"
 #include "mapping.hpp"
+
+#define VECTOR_PUSH(vec, ins) vec.insert(vec.end(), ins.begin(), ins.end())
+#define VECTOR_UNSHIFT(vec, ins) vec.insert(vec.begin(), ins.begin(), ins.end())
 
 namespace Sass {
   using std::vector;
 
   class Context;
+  class OutputBuffer;
 
   class SourceMap {
 
@@ -22,7 +27,10 @@ namespace Sass {
     void setFile(const string& str) {
       file = str;
     }
-    void update_column(const string& str);
+    void append(const Offset& offset);
+    void prepend(const Offset& offset);
+    void append(const OutputBuffer& out);
+    void prepend(const OutputBuffer& out);
     void add_open_mapping(AST_Node* node);
     void add_close_mapping(AST_Node* node);
 
@@ -39,6 +47,17 @@ public:
     string file;
 private:
     Base64VLQ base64vlq;
+  };
+
+  class OutputBuffer {
+    public:
+      OutputBuffer(void)
+      : buffer(""),
+        smap()
+      { }
+    public:
+      string buffer;
+      SourceMap smap;
   };
 
 }

--- a/subset_map.hpp
+++ b/subset_map.hpp
@@ -82,6 +82,7 @@ namespace Sass {
     vector<V> get_v(const vector<K>& s);
     bool empty() { return values_.empty(); }
     void clear() { values_.clear(); hash_.clear(); }
+    const vector<V> values(void) { return values_; }
   };
 
   template<typename K, typename V>

--- a/util.cpp
+++ b/util.cpp
@@ -21,6 +21,16 @@ namespace Sass {
     return ret;
   }
 
+  /* Locale unspecific atof function. */
+  double sass_atof(const char *str)
+  {
+    char* locale = setlocale(LC_NUMERIC, NULL);
+    setlocale(LC_NUMERIC, "C");
+    double val = atof(str);
+    setlocale(LC_NUMERIC, locale);
+    return val;
+  }
+
   // double escape every escape sequences
   // escape unescaped quotes and backslashes
   string string_escape(const string& str)

--- a/util.hpp
+++ b/util.hpp
@@ -9,6 +9,7 @@ namespace Sass {
   using namespace std;
 
   char* sass_strdup(const char* str);
+  double sass_atof(const char* str);
   string string_escape(const string& str);
   string string_unescape(const string& str);
   string evacuate_quotes(const string& str);


### PR DESCRIPTION
Addresses/Fixes #317 and ~~#871~~

Added a lot of other small fixes ("low hanging fruits")!

- Adds is_optional flag for selectors
- Add media_block flag for selectors
- Prints error message on invalid extends
- Changes format how errors are reported to match ruby sass
- Fix illegal extending accross media blocks (fixes #712)
- Improved some OutputBuffer behavior (preparation for #879)
- Parse line comments in blocks (fixes #533)
- Fix interpolation in media queries (fixes #346)
- Add error for parent selectors in root blocks (fixes #325)
- Implement number prefix parsing (/[\+\-]+/) (fixes #535)