### PR TITLE
Fix regression introduced in "root parent selector error"

### DIFF
--- a/ast.cpp
+++ b/ast.cpp
@@ -416,6 +416,7 @@ namespace Sass {
     if (!head()) return tail()->context(ctx);
     Complex_Selector* cpy = new (ctx.mem) Complex_Selector(pstate(), combinator(), head(), tail()->context(ctx));
     cpy->media_block(media_block());
+    cpy->last_block(last_block());
     return cpy;
   }
 

--- a/ast.hpp
+++ b/ast.hpp
@@ -1707,7 +1707,8 @@ namespace Sass {
     ADD_PROPERTY(bool, has_line_break);
     // maybe we have optional flag
     ADD_PROPERTY(bool, is_optional);
-    // parent media block (for extend check)
+    // parent block pointers
+    ADD_PROPERTY(Block*, last_block);
     ADD_PROPERTY(Media_Block*, media_block);
   public:
     Selector(ParserState pstate, bool r = false, bool h = false)

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -40,7 +40,9 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     Selector_List* selector = dynamic_cast<Selector_List*>(node);
 
     cerr << ind << "Selector_List " << selector
-      << " [mq:" << selector->media_block() << "]"
+      << " [block:" << selector->last_block() << "]"
+      << (selector->last_block() && selector->last_block()->is_root() ? " [root]" : "")
+      << " [@media:" << selector->media_block() << "]"
       << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
@@ -55,7 +57,9 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
   } else if (dynamic_cast<Complex_Selector*>(node)) {
     Complex_Selector* selector = dynamic_cast<Complex_Selector*>(node);
     cerr << ind << "Complex_Selector " << selector
-      << " [mq:" << selector->media_block() << "]"
+      << " [block:" << selector->last_block() << "]"
+      << (selector->last_block() && selector->last_block()->is_root() ? " [root]" : "")
+      << " [@media:" << selector->media_block() << "]"
       << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -") << " -> ";
@@ -71,7 +75,9 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
   } else if (dynamic_cast<Compound_Selector*>(node)) {
     Compound_Selector* selector = dynamic_cast<Compound_Selector*>(node);
     cerr << ind << "Compound_Selector " << selector
-      << " [mq:" << selector->media_block() << "]"
+      << " [block:" << selector->last_block() << "]"
+      << (selector->last_block() && selector->last_block()->is_root() ? " [root]" : "")
+      << " [@media:" << selector->media_block() << "]"
       << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -") <<
@@ -104,7 +110,8 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
 
     Selector_Placeholder* selector = dynamic_cast<Selector_Placeholder*>(node);
     cerr << ind << "Selector_Placeholder [" << selector->name() << "] " << selector
-      << " [mq:" << selector->media_block() << "]"
+      << " [block:" << selector->last_block() << "]"
+      << " [@media:" << selector->media_block() << "]"
       << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
@@ -119,7 +126,14 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
 
   } else if (dynamic_cast<Selector_Schema*>(node)) {
     Selector_Schema* selector = dynamic_cast<Selector_Schema*>(node);
-    cerr << ind << "Selector_Schema " << selector << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << endl;
+    cerr << ind << "Selector_Schema " << selector
+      << " [block:" << selector->last_block() << "]"
+      << (selector->last_block() && selector->last_block()->is_root() ? " [root]" : "")
+      << " [@media:" << selector->media_block() << "]"
+      << (selector->has_line_break() ? " [line-break]": " -")
+      << (selector->has_line_feed() ? " [line-feed]": " -")
+    << endl;
+
     debug_ast(selector->contents(), ind + " ");
     // for(auto i : selector->elements()) { debug_ast(i, ind + " ", env); }
 

--- a/expand.cpp
+++ b/expand.cpp
@@ -71,6 +71,7 @@ namespace Sass {
     str += ";";
 
     Parser p(ctx, r->pstate());
+    p.block_stack.push_back(r->selector() ? r->selector()->last_block() : 0);
     p.last_media_block = r->selector() ? r->selector()->media_block() : 0;
     p.source   = str.c_str();
     p.position = str.c_str();

--- a/parser.cpp
+++ b/parser.cpp
@@ -293,8 +293,7 @@ namespace Sass {
         do (*params) << parse_parameter();
         while (lex< alternatives < spaces,block_comment, exactly<','> > >());
       }
-    while (lex< alternatives < spaces, block_comment > >());
-      if (!peek< exactly<')'> >()) cerr << "BALAB [" << position << "]\n";
+      while (lex< alternatives < spaces, block_comment > >()) {};
       if (!lex< exactly<')'> >()) error("expected a variable name (e.g. $x) or ')' for the parameter list for " + name, pstate);
     }
     return params;
@@ -348,7 +347,6 @@ namespace Sass {
         while (lex< alternatives < block_comment, exactly<','> > >());
       }
       while (lex< block_comment >());
-      if (!peek< exactly<')'> >()) cerr << "BALAB [" << position << "]\n";
       if (!lex< exactly<')'> >()) error("expected a variable name (e.g. $x) or ')' for the parameter list for " + name, pstate);
     }
 
@@ -363,7 +361,7 @@ namespace Sass {
       lex< variable >();
       string name(Util::normalize_underscores(lexed));
       ParserState p = pstate;
-    while (lex< alternatives < spaces, block_comment > >());
+      while (lex< alternatives < spaces, block_comment > >()) {};
       lex< exactly<':'> >();
       Expression* val = parse_space_list();
       val->is_delayed(false);

--- a/parser.cpp
+++ b/parser.cpp
@@ -22,6 +22,9 @@ namespace Sass {
     p.source   = str;
     p.position = p.source;
     p.end      = str + strlen(str);
+    Block* root = new (ctx.mem) Block(pstate);
+    p.block_stack.push_back(root);
+    root->is_root(true);
     return p;
   }
 
@@ -31,6 +34,9 @@ namespace Sass {
     p.source   = beg;
     p.position = p.source;
     p.end      = end;
+    Block* root = new (ctx.mem) Block(pstate);
+    p.block_stack.push_back(root);
+    root->is_root(true);
     return p;
   }
 
@@ -45,12 +51,16 @@ namespace Sass {
     p.source   = t.begin;
     p.position = p.source;
     p.end      = t.end;
+    Block* root = new (ctx.mem) Block(pstate);
+    p.block_stack.push_back(root);
+    root->is_root(true);
     return p;
   }
 
   Block* Parser::parse()
   {
     Block* root = new (ctx.mem) Block(pstate);
+    block_stack.push_back(root);
     root->is_root(true);
     read_bom();
     lex< optional_spaces >();
@@ -143,6 +153,7 @@ namespace Sass {
       }
       lex< optional_spaces >();
     }
+    block_stack.pop_back();
     return root;
   }
 
@@ -458,7 +469,10 @@ namespace Sass {
       }
     }
     position = end_of_selector;
-    return new (ctx.mem) Selector_Schema(pstate, schema);
+    Selector_Schema* selector_schema = new (ctx.mem) Selector_Schema(pstate, schema);
+    selector_schema->media_block(last_media_block);
+    selector_schema->last_block(block_stack.back());
+    return selector_schema;
   }
 
   Selector_List* Parser::parse_selector_group()
@@ -468,6 +482,7 @@ namespace Sass {
     lex< optional_spaces_and_comments >();
     Selector_List* group = new (ctx.mem) Selector_List(pstate);
     group->media_block(last_media_block);
+    group->last_block(block_stack.back());
     do {
       reloop = false;
       if (peek< exactly<'{'> >() ||
@@ -481,6 +496,7 @@ namespace Sass {
         Selector_Reference* ref = new (ctx.mem) Selector_Reference(sel_source_position);
         Compound_Selector* ref_wrap = new (ctx.mem) Compound_Selector(sel_source_position);
         ref_wrap->media_block(last_media_block);
+        ref_wrap->last_block(block_stack.back());
         (*ref_wrap) << ref;
         if (!comb->head()) {
           comb->head(ref_wrap);
@@ -489,6 +505,7 @@ namespace Sass {
         else {
           comb = new (ctx.mem) Complex_Selector(sel_source_position, Complex_Selector::ANCESTOR_OF, ref_wrap, comb);
           comb->media_block(last_media_block);
+          comb->last_block(block_stack.back());
           comb->has_reference(true);
         }
         if (peek_newline()) ref_wrap->has_line_break(true);
@@ -551,8 +568,9 @@ namespace Sass {
       sel_source_position = before_token;
     }
     if (!sel_source_position.line) sel_source_position = before_token;
-    Complex_Selector* cpx = new (ctx.mem) Complex_Selector(ParserState(path, sel_source_position, Offset(0, 0)), cmb, lhs, rhs);
+    Complex_Selector* cpx = new (ctx.mem) Complex_Selector(ParserState(path, sel_source_position), cmb, lhs, rhs);
     cpx->media_block(last_media_block);
+    cpx->last_block(block_stack.back());
     if (cpx_lf) cpx->has_line_break(cpx_lf);
     return cpx;
   }
@@ -561,10 +579,11 @@ namespace Sass {
   {
     Compound_Selector* seq = new (ctx.mem) Compound_Selector(pstate);
     seq->media_block(last_media_block);
+    seq->last_block(block_stack.back());
     bool sawsomething = false;
     if (lex< exactly<'&'> >()) {
-      // if you see a &
-      if (block_stack.size() == 0) {
+      // check if we have a parent selector on the root level block
+      if (block_stack.back() && block_stack.back()->is_root()) {
         error("Base-level rules cannot contain the parent-selector-referencing character '&'.", pstate);
       }
       (*seq) << new (ctx.mem) Selector_Reference(pstate);
@@ -621,6 +640,7 @@ namespace Sass {
     else if (lex< placeholder >()) {
       Selector_Placeholder* sel = new (ctx.mem) Selector_Placeholder(pstate, unquote(lexed));
       sel->media_block(last_media_block);
+      sel->last_block(block_stack.back());
       return sel;
     }
     else {

--- a/parser.hpp
+++ b/parser.hpp
@@ -51,7 +51,7 @@ namespace Sass {
       source(0), position(0), end(0), before_token(pstate), after_token(pstate), pstate("[NULL]"), indentation(0)
     { in_at_root = false; stack.push_back(nothing); }
 
-    static Parser from_string(const string& src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
+    // static Parser from_string(const string& src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
     static Parser from_c_str(const char* src, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));
     static Parser from_c_str(const char* beg, const char* end, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));
     static Parser from_token(Token t, Context& ctx, ParserState pstate = ParserState("[TOKEN]"));


### PR DESCRIPTION
This is a bugfix PR to fix https://github.com/sass/libsass/issues/930 (Regression in c64f22804b6d6bf95d18543b8664980fb9270e31)
Happened because "re-parsing" is often made without any context!
~~Added "root" block (`0`) to block_stack when called via "from_c_str".~~
Added a pointer to selectors for their parent block, to check it is root or not.
