### PR TITLE
[WIP] Parse function arguments with equal sign correctly

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -873,12 +873,13 @@ namespace Sass {
   class Argument : public Expression {
     ADD_PROPERTY(Expression*, value);
     ADD_PROPERTY(string, name);
+    ADD_PROPERTY(char, sign);
     ADD_PROPERTY(bool, is_rest_argument);
     ADD_PROPERTY(bool, is_keyword_argument);
     size_t hash_;
   public:
-    Argument(ParserState pstate, Expression* val, string n = "", bool rest = false, bool keyword = false)
-    : Expression(pstate), value_(val), name_(n), is_rest_argument_(rest), is_keyword_argument_(keyword), hash_(0)
+    Argument(ParserState pstate, Expression* val, string n = "", bool rest = false, bool keyword = false, char sign = ':')
+    : Expression(pstate), value_(val), name_(n), sign_(sign), is_rest_argument_(rest), is_keyword_argument_(keyword), hash_(0)
     {
       if (!name_.empty() && is_rest_argument_) {
         error("variable-length argument may not be passed by name", pstate);

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -282,7 +282,10 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     for(auto i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Argument*>(node)) {
     Argument* expression = dynamic_cast<Argument*>(node);
-    cerr << ind << "Argument " << expression << " [" << expression->value() << "]" << endl;
+    cerr << ind << "Argument " << expression
+      << " {" << expression->sign() << "}"
+      << " [" << expression->value() << "]"
+    << endl;
     debug_ast(expression->value(), ind + " value: ", env);
   } else if (dynamic_cast<Unary_Expression*>(node)) {
     Unary_Expression* expression = dynamic_cast<Unary_Expression*>(node);

--- a/eval.cpp
+++ b/eval.cpp
@@ -921,7 +921,8 @@ namespace Sass {
                                   val,
                                   a->name(),
                                   is_rest_argument,
-                                  is_keyword_argument);
+                                  is_keyword_argument,
+                                  a->sign());
   }
 
   Expression* Eval::operator()(Arguments* a)

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -695,7 +695,11 @@ namespace Sass {
   {
     if (!a->name().empty()) {
       append_token(a->name(), a);
-      append_colon_separator();
+      if (a->sign() == ':') {
+        append_colon_separator();
+      } else {
+        append_string(string(1, a->sign()));
+      }
     }
     // Special case: argument nulls can be ignored
     if (a->value()->concrete_type() == Expression::NULL_VAL) {

--- a/parser.cpp
+++ b/parser.cpp
@@ -367,6 +367,16 @@ namespace Sass {
       val->is_delayed(false);
       arg = new (ctx.mem) Argument(p, val, name);
     }
+    else if (peek< sequence < identifier, zero_plus < alternatives < spaces, line_comment, block_comment > >, exactly<'='> > >()) {
+      lex< identifier >();
+      string name(lexed);
+      ParserState p = pstate;
+      while (lex< alternatives < spaces, block_comment > >()) {};
+      lex< exactly<'='> >();
+      Expression* val = parse_space_list();
+      val->is_delayed(false);
+      arg = new (ctx.mem) Argument(p, val, name, false, false, '=');
+    }
     else {
       bool is_arglist = false;
       bool is_keyword = false;


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/931

This is not a 100% fix, since ruby sass also allows pretty strange inputs:
```CSS
$trans: 42;
.foo {
  filter : fn(foo=bar=baz=10*4.2 = a-1=""="\"ad\"" = 42   =  3 + a + "9#{$trans}");
}
################################################################################################
.foo {
  filter: fn(foo=bar=baz=42=a-1=""='"ad"'=42=3a942); }
```

BTW. ruby sass give an error for this input:
```CSS
.foo {
  filter : fn(foo=bar=);
}
################################################################################################
Error: Invalid CSS after "...r : fn(foo=bar=": expected expression (e.g. 1px, bold), was ");"
        on line 3 of test.scss
  Use --trace for backtrace.
```

This PR "hotfixes" the simple case with just one equal sign (which is IMO the main use case here).