### PR TITLE
Move rpm spec file into contrib folder

### DIFF
--- a/contrib/libsass.spec
+++ b/contrib/libsass.spec
@@ -1,7 +1,7 @@
 Name:           libsass
-Version:        3.1.0
+Version:        %{version}
 Release:        1%{?dist}
-Summary:        A C/C++ implementation of a Sass compiler 
+Summary:        A C/C++ implementation of a Sass compiler
 
 License:        MIT
 URL:            http://libsass.org


### PR DESCRIPTION
Removed hard-coded version string because it's nearly impossible to maintain it while under source control. IMO this should only be a [reference for downstream] [1] to create their packaging for releases.
[1]: http://stackoverflow.com/questions/19082451/rpm-spec-files-in-version-control-system#comment28268846_19083011