### PR TITLE
Refactor parser for css block comments

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -297,7 +297,7 @@ namespace Sass {
         0, 0
       );
       import_stack.push_back(import);
-      Parser p(Parser::from_c_str(queue[i].source, *this, ParserState(queue[i].abs_path, i)));
+      Parser p(Parser::from_c_str(queue[i].source, *this, ParserState(queue[i].abs_path, queue[i].source, i)));
       Block* ast = p.parse();
       sass_delete_import(import_stack.back());
       import_stack.pop_back();

--- a/error_handling.cpp
+++ b/error_handling.cpp
@@ -13,8 +13,6 @@ namespace Sass {
 
   void error(string msg, ParserState pstate, Backtrace* bt)
   {
-    if (!pstate.path.empty() && Prelexer::quoted_string(pstate.path.c_str()))
-      pstate.path = pstate.path.substr(1, pstate.path.size() - 1);
 
     Backtrace top(bt, pstate, "");
     msg += top.to_string();

--- a/error_handling.hpp
+++ b/error_handling.hpp
@@ -14,7 +14,6 @@ namespace Sass {
     enum Type { read, write, syntax, evaluation };
 
     Type type;
-    string path;
     ParserState pstate;
     string message;
 

--- a/eval.cpp
+++ b/eval.cpp
@@ -671,7 +671,7 @@ namespace Sass {
       case Textual::DIMENSION:
         result = new (ctx.mem) Number(t->pstate(),
                                       sass_atof(num.c_str()),
-                                      Token(number(text.c_str()), t->pstate()),
+                                      Token(number(text.c_str())),
                                       zero);
         break;
       case Textual::HEX: {

--- a/parser.cpp
+++ b/parser.cpp
@@ -213,7 +213,7 @@ namespace Sass {
               // char *srcmap = sass_import_take_srcmap(include);
               if (message) {
                 if (line == string::npos && column == string::npos) error(message, pstate);
-                else error(message, ParserState(message, Position(line, column)));
+                else error(message, ParserState(message, source, Position(line, column)));
               } else if (source) {
                 if (file) {
                   ctx.add_source(file, inc_path, source);
@@ -564,7 +564,7 @@ namespace Sass {
       sel_source_position = before_token;
     }
     if (!sel_source_position.line) sel_source_position = before_token;
-    Complex_Selector* cpx = new (ctx.mem) Complex_Selector(ParserState(path, sel_source_position), cmb, lhs, rhs);
+    Complex_Selector* cpx = new (ctx.mem) Complex_Selector(ParserState(path, source, sel_source_position), cmb, lhs, rhs);
     cpx->media_block(last_media_block);
     cpx->last_block(block_stack.back());
     if (cpx_lf) cpx->has_line_break(cpx_lf);
@@ -2184,7 +2184,7 @@ namespace Sass {
 
   void Parser::error(string msg, Position pos)
   {
-    throw Sass_Error(Sass_Error::syntax, ParserState(path, pos.line ? pos : before_token, Offset(0, 0)), msg);
+    throw Sass_Error(Sass_Error::syntax, ParserState(path, source, pos.line ? pos : before_token, Offset(0, 0)), msg);
   }
 
 }

--- a/parser.cpp
+++ b/parser.cpp
@@ -505,10 +505,10 @@ namespace Sass {
         }
         if (peek_newline()) ref_wrap->has_line_break(true);
       }
-      while (peek< sequence< optional_css_whitespace, optional < block_comment >, exactly<','> > >())
+      while (peek< sequence < optional_css_whitespace, optional < block_comment >, exactly<','> > >())
       {
         // consume everything up and including the comma speparator
-        reloop = lex< sequence< optional_css_comments, exactly<','> > >() != 0;
+        reloop = lex< sequence < optional_css_comments, exactly<','> > >() != 0;
         // remember line break (also between some commas)
         if (peek_newline()) comb->has_line_feed(true);
         if (comb->tail() && peek_newline()) comb->tail()->has_line_feed(true);
@@ -1114,12 +1114,13 @@ namespace Sass {
   {
     Expression* expr1 = parse_expression();
     // if it's a singleton, return it directly; don't wrap it
-    if (!(peek< alternatives < eq_op,
-                               neq_op,
-                               gte_op,
-                               gt_op,
-                               lte_op,
-                               lt_op
+    if (!(peek< alternatives <
+            eq_op,
+            neq_op,
+            gte_op,
+            gt_op,
+            lte_op,
+            lt_op
           > >(position)))
     { return expr1; }
 
@@ -1363,7 +1364,7 @@ namespace Sass {
         const char* j = skip_over_scopes< exactly<hash_lbrace>, exactly<rbrace> >(p + 2, chunk.end); // find the closing brace
         if (j) { --j;
           // parse the interpolant and accumulate it
-          Expression* interp_node = Parser::from_token(Token(p+2, j, before_token), ctx, pstate).parse_list();
+          Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, pstate).parse_list();
           interp_node->is_interpolant(true);
           (*schema) << interp_node;
           i = j;
@@ -1424,7 +1425,7 @@ namespace Sass {
         const char* j = skip_over_scopes< exactly<hash_lbrace>, exactly<rbrace> >(p+2, str.end); // find the closing brace
         if (j) {
           // parse the interpolant and accumulate it
-          Expression* interp_node = Parser::from_token(Token(p+2, j, before_token), ctx, pstate).parse_list();
+          Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, pstate).parse_list();
           interp_node->is_interpolant(true);
           (*schema) << interp_node;
           i = j;
@@ -1467,7 +1468,7 @@ namespace Sass {
     size_t num_items = 0;
     while (position < stop) {
       if (lex< interpolant >()) {
-        Token insides(Token(lexed.begin + 2, lexed.end - 1, before_token));
+        Token insides(Token(lexed.begin + 2, lexed.end - 1));
         Expression* interp_node = Parser::from_token(insides, ctx, pstate).parse_list();
         interp_node->is_interpolant(true);
         (*schema) << interp_node;
@@ -1561,7 +1562,7 @@ namespace Sass {
         const char* j = skip_over_scopes< exactly<hash_lbrace>, exactly<rbrace> >(p+2, id.end); // find the closing brace
         if (j) {
           // parse the interpolant and accumulate it
-          Expression* interp_node = Parser::from_token(Token(p+2, j, before_token), ctx, pstate).parse_list();
+          Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, pstate).parse_list();
           interp_node->is_interpolant(true);
           (*schema) << interp_node;
           schema->has_interpolants(true);
@@ -1592,7 +1593,7 @@ namespace Sass {
     const char* arg_end = position;
     lex< exactly<')'> >();
 
-    Argument* arg = new (ctx.mem) Argument(arg_pos, parse_interpolated_chunk(Token(arg_beg, arg_end, before_token)));
+    Argument* arg = new (ctx.mem) Argument(arg_pos, parse_interpolated_chunk(Token(arg_beg, arg_end)));
     Arguments* args = new (ctx.mem) Arguments(arg_pos);
     *args << arg;
     return new (ctx.mem) Function_Call(call_pos, name, args);
@@ -1895,7 +1896,7 @@ namespace Sass {
     if (!peek< alternatives< with_directive, without_directive > >()) {
       const char* i = position;
       const char* p = peek< until<')'> >(i);
-      Token* t = new Token(i, p, Position(0, 0));
+      Token* t = new Token(i, p);
       error("Invalid CSS after \"(\": expected \"with\" or \"without\", was \""+t->to_string()+"\"", pstate);
     }
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -99,7 +99,7 @@ namespace Sass {
         it_before_token = position;
       }
       else {
-        it_before_token = optional_spaces_and_comments(start);
+        it_before_token = optional_css_whitespace(start);
       }
       const char* it_after_token = mx(it_before_token);
       if (it_after_token) {
@@ -145,10 +145,11 @@ namespace Sass {
         }
       }
 
-      else if (mx == optional_spaces_and_comments) {
-        it_before_token = position;
-      }
-      else if (mx == spaces_and_comments) {
+      else if (mx == css_comments ||
+               mx == css_whitespace ||
+               mx == optional_css_comments ||
+               mx == optional_css_whitespace
+      ) {
         it_before_token = position;
       }
 
@@ -158,7 +159,7 @@ namespace Sass {
       }
       else {
         // most can be preceded by spaces and comments
-        it_before_token = optional_spaces_and_comments(position);
+        it_before_token = optional_css_whitespace(position);
       }
 
       // now call matcher to get position after token
@@ -196,7 +197,7 @@ namespace Sass {
       after_token = after_token + size;
 
       // create parsed token string (public member)
-      lexed = Token(wspace_start, it_before_token, it_after_token, optional_spaces_and_comments(it_after_token) ? optional_spaces_and_comments(it_after_token) : it_after_token, before_token);
+      lexed = Token(wspace_start, it_before_token, it_after_token, optional_css_whitespace(it_after_token) ? optional_css_whitespace(it_after_token) : it_after_token, before_token);
       Position pos(before_token.file, before_token.line, before_token.column);
       pstate = ParserState(path, lexed, pos, size);
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -197,7 +197,7 @@ namespace Sass {
       after_token = after_token + size;
 
       // create parsed token string (public member)
-      lexed = Token(wspace_start, it_before_token, it_after_token, optional_css_whitespace(it_after_token) ? optional_css_whitespace(it_after_token) : it_after_token, before_token);
+      lexed = Token(wspace_start, it_before_token, it_after_token);
       Position pos(before_token.file, before_token.line, before_token.column);
       pstate = ParserState(path, lexed, pos, size);
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -283,6 +283,8 @@ namespace Sass {
     Error* parse_error();
     Debug* parse_debug();
 
+    void parse_block_comments(Block* block);
+
     Selector_Lookahead lookahead_for_selector(const char* start = 0);
     Selector_Lookahead lookahead_for_extension_target(const char* start = 0);
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -139,7 +139,7 @@ namespace Sass {
       after_token = before_token.inc(it_before_token, it_after_token);
 
       // ToDo: could probably do this incremetal on original object
-      pstate = ParserState(path, lexed, before_token, after_token - before_token);
+      pstate = ParserState(path, source, lexed, before_token, after_token - before_token);
 
       // advance internal char iterator
       return position = it_after_token;

--- a/position.cpp
+++ b/position.cpp
@@ -94,14 +94,14 @@ namespace Sass {
   : Offset(line, column), file(file) { }
 
 
-  ParserState::ParserState(string path, const size_t file)
-  : Position(file, 0, 0), path(path), offset(0, 0), token() { }
+  ParserState::ParserState(string path, const char* src, const size_t file)
+  : Position(file, 0, 0), path(path), src(src), offset(0, 0), token() { }
 
-  ParserState::ParserState(string path, Position position, Offset offset)
-  : Position(position), path(path), offset(offset), token() { }
+  ParserState::ParserState(string path, const char* src, Position position, Offset offset)
+  : Position(position), path(path), src(src), offset(offset), token() { }
 
-  ParserState::ParserState(string path, Token token, Position position, Offset offset)
-  : Position(position), path(path), offset(offset), token(token) { }
+  ParserState::ParserState(string path, const char* src, Token token, Position position, Offset offset)
+  : Position(position), path(path), src(src), offset(offset), token(token) { }
 
   void Position::add(const char* begin, const char* end)
   {

--- a/position.cpp
+++ b/position.cpp
@@ -33,8 +33,9 @@ namespace Sass {
   // increase offset by given string (mostly called by lexer)
   // increase line counter and count columns on the last line
   // ToDo: make the col count utf8 aware
-  void Offset::add(const char* begin, const char* end)
+  Offset Offset::add(const char* begin, const char* end)
   {
+    if (end == 0) return *this;
     while (begin < end && *begin) {
       if (*begin == '\n') {
         ++ line;
@@ -45,6 +46,7 @@ namespace Sass {
       }
       ++begin;
     }
+    return *this;
   }
 
   // increase offset by given string (mostly called by lexer)
@@ -103,9 +105,10 @@ namespace Sass {
   ParserState::ParserState(string path, const char* src, Token token, Position position, Offset offset)
   : Position(position), path(path), src(src), offset(offset), token(token) { }
 
-  void Position::add(const char* begin, const char* end)
+  Position Position::add(const char* begin, const char* end)
   {
     Offset::add(begin, end);
+    return *this;
   }
 
   Position Position::inc(const char* begin, const char* end) const

--- a/position.hpp
+++ b/position.hpp
@@ -19,13 +19,18 @@ namespace Sass {
       Offset(const size_t line, const size_t column);
 
       // return new position, incremented by the given string
+      void add(const char* begin, const char* end);
       Offset inc(const char* begin, const char* end) const;
+
+      // init/create instance from const char substring
+      static Offset init(const char* beg, const char* end);
 
     public: // overload operators for position
       void operator+= (const Offset &pos);
       bool operator== (const Offset &pos) const;
       bool operator!= (const Offset &pos) const;
       Offset operator+ (const Offset &off) const;
+      Offset operator- (const Offset &off) const;
 
     public: // overload output stream operator
       // friend ostream& operator<<(ostream& strm, const Offset& off);
@@ -52,7 +57,9 @@ namespace Sass {
       bool operator== (const Position &pos) const;
       bool operator!= (const Position &pos) const;
       const Position operator+ (const Offset &off) const;
+      const Offset operator- (const Offset &off) const;
       // return new position, incremented by the given string
+      void add(const char* begin, const char* end);
       Position inc(const char* begin, const char* end) const;
 
     public: // overload output stream operator
@@ -69,25 +76,19 @@ namespace Sass {
     const char* prefix;
     const char* begin;
     const char* end;
-    const char* suffix;
-    Position start;
-    Position stop;
 
     Token()
-    : prefix(0), begin(0), end(0), suffix(0), start(0), stop(0) { }
-    Token(const char* b, const char* e, const Position pos)
-    : prefix(b), begin(b), end(e), suffix(e), start(pos), stop(pos.inc(b, e)) { }
-    Token(const char* s, const Position pos)
-    : prefix(s), begin(s), end(s + strlen(s)), suffix(end), start(pos), stop(pos.inc(s, s + strlen(s))) { }
-    Token(const char* p, const char* b, const char* e, const char* s, const Position pos)
-    : prefix(p), begin(b), end(e), suffix(s), start(pos), stop(pos.inc(b, e)) { }
+    : prefix(0), begin(0), end(0) { }
+    Token(const char* b, const char* e)
+    : prefix(b), begin(b), end(e) { }
+    Token(const char* str)
+    : prefix(str), begin(str), end(str + strlen(str)) { }
+    Token(const char* p, const char* b, const char* e)
+    : prefix(p), begin(b), end(e) { }
 
     size_t length()    const { return end - begin; }
     string ws_before() const { return string(prefix, begin); }
     string to_string() const { return string(begin, end); }
-    string ws_after() const { return string(end, suffix); }
-
-    // string unquote() const;
 
     operator bool()   { return begin && end && begin >= end; }
     operator string() { return to_string(); }
@@ -98,8 +99,7 @@ namespace Sass {
   class ParserState : public Position {
 
     public: // c-tor
-      ParserState(string path);
-      ParserState(string path, const size_t file);
+      ParserState(string path, const size_t file = string::npos);
       ParserState(string path, Position position, Offset offset = Offset(0, 0));
       ParserState(string path, Token token, Position position, Offset offset = Offset(0, 0));
 

--- a/position.hpp
+++ b/position.hpp
@@ -99,9 +99,9 @@ namespace Sass {
   class ParserState : public Position {
 
     public: // c-tor
-      ParserState(string path, const size_t file = string::npos);
-      ParserState(string path, Position position, Offset offset = Offset(0, 0));
-      ParserState(string path, Token token, Position position, Offset offset = Offset(0, 0));
+      ParserState(string path, const char* src = 0, const size_t file = string::npos);
+      ParserState(string path, const char* src, Position position, Offset offset = Offset(0, 0));
+      ParserState(string path, const char* src, Token token, Position position, Offset offset = Offset(0, 0));
 
     public: // down casts
       Offset off() { return *this; };
@@ -109,6 +109,7 @@ namespace Sass {
 
     public:
       string path;
+      const char* src;
       Offset offset;
       Token token;
 

--- a/position.hpp
+++ b/position.hpp
@@ -19,7 +19,7 @@ namespace Sass {
       Offset(const size_t line, const size_t column);
 
       // return new position, incremented by the given string
-      void add(const char* begin, const char* end);
+      Offset add(const char* begin, const char* end);
       Offset inc(const char* begin, const char* end) const;
 
       // init/create instance from const char substring
@@ -59,7 +59,7 @@ namespace Sass {
       const Position operator+ (const Offset &off) const;
       const Offset operator- (const Offset &off) const;
       // return new position, incremented by the given string
-      void add(const char* begin, const char* end);
+      Position add(const char* begin, const char* end);
       Position inc(const char* begin, const char* end) const;
 
     public: // overload output stream operator

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -734,7 +734,7 @@ namespace Sass {
     const char* static_string(const char* src) {
       const char* pos = src;
       const char * s = quoted_string(pos);
-      Token t(pos, s, Position(0, 0));
+      Token t(pos, s);
       const unsigned int p = count_interval< interpolant >(t.begin, t.end);
       return (p == 0) ? t.end : 0;
     }

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -98,17 +98,24 @@ namespace Sass {
 
     // Whitespace handling.
     const char* optional_spaces(const char* src) { return optional<spaces>(src); }
-    // const char* optional_comment(const char* src) { return optional<comment>(src); }
-    const char* optional_spaces_and_comments(const char* src) {
+    const char* no_spaces(const char* src) { return negate< spaces >(src); }
+
+    // Match zero plus white-space or line_comments
+    const char* optional_css_whitespace(const char* src) {
       return zero_plus< alternatives<spaces, line_comment> >(src);
     }
-    const char* spaces_and_comments(const char* src) {
+    const char* css_whitespace(const char* src) {
       return one_plus< alternatives<spaces, line_comment> >(src);
     }
-    const char* no_spaces(const char* src) {
-      return negate< spaces >(src);
+    // Match optional_css_whitepace plus block_comments
+    const char* optional_css_comments(const char* src) {
+      return zero_plus< alternatives<spaces, line_comment, block_comment> >(src);
+    }
+    const char* css_comments(const char* src) {
+      return one_plus< alternatives<spaces, line_comment, block_comment> >(src);
     }
 
+    // Match one backslash escaped char /\\./
     const char* backslash_something(const char* src) {
       return sequence< exactly<'\\'>, any_char >(src);
     }
@@ -153,7 +160,7 @@ namespace Sass {
         exactly < '+' >,
         sequence <
           exactly < '-' >,
-          optional_spaces_and_comments,
+          optional_css_whitespace,
           exactly< '-' >
         >
       >(src);
@@ -315,7 +322,7 @@ namespace Sass {
     }
     const char* elseif_directive(const char* src) {
       return sequence< else_directive,
-                       optional_spaces_and_comments,
+                       optional_css_whitespace,
                        exactly< if_after_else_kwd > >(src);
     }
 
@@ -493,25 +500,25 @@ namespace Sass {
     // Match CSS "!important" keyword.
     const char* important(const char* src) {
       return sequence< exactly<'!'>,
-                       optional_spaces_and_comments,
+                       optional_css_whitespace,
                        exactly<important_kwd> >(src);
     }
     // Match CSS "!optional" keyword.
     const char* optional(const char* src) {
       return sequence< exactly<'!'>,
-      optional_spaces_and_comments,
+      optional_css_whitespace,
       exactly<optional_kwd> >(src);
     }
     // Match Sass "!default" keyword.
     const char* default_flag(const char* src) {
       return sequence< exactly<'!'>,
-                       optional_spaces_and_comments,
+                       optional_css_whitespace,
                        exactly<default_kwd> >(src);
     }
     // Match Sass "!global" keyword.
     const char* global_flag(const char* src) {
       return sequence< exactly<'!'>,
-                       optional_spaces_and_comments,
+                       optional_css_whitespace,
                        exactly<global_kwd> >(src);
     }
     // Match CSS pseudo-class/element prefixes.
@@ -610,27 +617,27 @@ namespace Sass {
         > >,
         zero_plus < sequence<
           exactly<'('>,
-          optional_spaces_and_comments,
+          optional_css_whitespace,
           optional < sequence<
             alternatives< variable, identifier_schema, identifier >,
-            optional_spaces_and_comments,
+            optional_css_whitespace,
             exactly<'='>,
-            optional_spaces_and_comments,
+            optional_css_whitespace,
             alternatives< variable, identifier_schema, identifier, quoted_string, number, hexa >,
             zero_plus< sequence<
-              optional_spaces_and_comments,
+              optional_css_whitespace,
               exactly<','>,
-              optional_spaces_and_comments,
+              optional_css_whitespace,
               sequence<
                 alternatives< variable, identifier_schema, identifier >,
-                optional_spaces_and_comments,
+                optional_css_whitespace,
                 exactly<'='>,
-                optional_spaces_and_comments,
+                optional_css_whitespace,
                 alternatives< variable, identifier_schema, identifier, quoted_string, number, hexa >
               >
             > >
           > >,
-          optional_spaces_and_comments,
+          optional_css_whitespace,
           exactly<')'>
         > >
       >(src);
@@ -644,15 +651,15 @@ namespace Sass {
 
     // const char* ie_args(const char* src) {
     //   return sequence< alternatives< ie_keyword_arg, value_schema, quoted_string, interpolant, number, identifier, delimited_by< '(', ')', true> >,
-    //                    zero_plus< sequence< optional_spaces_and_comments, exactly<','>, optional_spaces_and_comments, alternatives< ie_keyword_arg, value_schema, quoted_string, interpolant, number, identifier, delimited_by<'(', ')', true> > > > >(src);
+    //                    zero_plus< sequence< optional_css_whitespace, exactly<','>, optional_css_whitespace, alternatives< ie_keyword_arg, value_schema, quoted_string, interpolant, number, identifier, delimited_by<'(', ')', true> > > > >(src);
     // }
 
     const char* ie_keyword_arg(const char* src) {
       return sequence<
         alternatives< variable, identifier_schema, identifier >,
-        optional_spaces_and_comments,
+        optional_css_whitespace,
         exactly<'='>,
-        optional_spaces_and_comments,
+        optional_css_whitespace,
         alternatives< variable, identifier_schema, identifier, quoted_string, number, hexa >
       >(src);
     }

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -401,11 +401,16 @@ namespace Sass {
 
     // Whitespace handling.
     const char* optional_spaces(const char* src);
-    // const char* optional_comment(const char* src);
-    const char* optional_spaces_and_comments(const char* src);
-    const char* spaces_and_comments(const char* src);
     const char* no_spaces(const char* src);
 
+    // Match zero plus white-space or line_comments
+    const char* optional_css_whitespace(const char* src);
+    const char* css_whitespace(const char* src);
+    // Match optional_css_whitepace plus block_comments
+    const char* optional_css_comments(const char* src);
+    const char* css_comments(const char* src);
+
+    // Match one backslash escaped char
     const char* backslash_something(const char* src);
 
     // Match CSS css variables.

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -23,7 +23,7 @@ namespace Sass {
       // there is a small chance that the search prefix
       // is longer than the rest of the string to look at
       while (*pre && *src == *pre) {
-      	++src, ++pre;
+        ++src, ++pre;
       }
       return *pre ? 0 : src;
     }
@@ -202,142 +202,26 @@ namespace Sass {
       return src;
     }
 
-    // Tries the matchers in sequence and returns the first match (or none)
-    template <prelexer mx1, prelexer mx2>
+    // Tries the matchers in sequence and succeeds if they all succeed.
+    template <prelexer... mxs>
     const char* alternatives(const char* src) {
       const char* rslt;
-      (rslt = mx1(src)) || (rslt = mx2(src));
-      return rslt;
-    }
-
-    // Same as above, but with 3 arguments.
-    template <prelexer mx1, prelexer mx2, prelexer mx3>
-    const char* alternatives(const char* src) {
-      const char* rslt;
-      (rslt = mx1(src)) || (rslt = mx2(src)) || (rslt = mx3(src));
-      return rslt;
-    }
-
-    // Same as above, but with 4 arguments.
-    template <prelexer mx1, prelexer mx2, prelexer mx3, prelexer mx4>
-    const char* alternatives(const char* src) {
-      const char* rslt;
-      (rslt = mx1(src)) || (rslt = mx2(src)) ||
-      (rslt = mx3(src)) || (rslt = mx4(src));
-      return rslt;
-    }
-
-    // Same as above, but with 5 arguments.
-    template <prelexer mx1, prelexer mx2, prelexer mx3,
-              prelexer mx4, prelexer mx5>
-    const char* alternatives(const char* src) {
-      const char* rslt;
-      (rslt = mx1(src)) || (rslt = mx2(src)) || (rslt = mx3(src)) ||
-      (rslt = mx4(src)) || (rslt = mx5(src));
-      return rslt;
-    }
-
-    // Same as above, but with 6 arguments.
-    template <prelexer mx1, prelexer mx2, prelexer mx3,
-              prelexer mx4, prelexer mx5, prelexer mx6>
-    const char* alternatives(const char* src) {
-      const char* rslt;
-      (rslt = mx1(src)) || (rslt = mx2(src)) || (rslt = mx3(src)) ||
-      (rslt = mx4(src)) || (rslt = mx5(src)) || (rslt = mx6(src));
-      return rslt;
-    }
-
-    // Same as above, but with 7 arguments.
-    template <prelexer mx1, prelexer mx2,
-              prelexer mx3, prelexer mx4,
-              prelexer mx5, prelexer mx6,
-              prelexer mx7>
-    const char* alternatives(const char* src) {
-      const char* rslt;
-      (rslt = mx1(src)) || (rslt = mx2(src)) ||
-      (rslt = mx3(src)) || (rslt = mx4(src)) ||
-      (rslt = mx5(src)) || (rslt = mx6(src)) ||
-      (rslt = mx7(src));
-      return rslt;
-    }
-
-    // Same as above, but with 8 arguments.
-    template <prelexer mx1, prelexer mx2,
-              prelexer mx3, prelexer mx4,
-              prelexer mx5, prelexer mx6,
-              prelexer mx7, prelexer mx8>
-    const char* alternatives(const char* src) {
-      const char* rslt;
-      (rslt = mx1(src)) || (rslt = mx2(src)) ||
-      (rslt = mx3(src)) || (rslt = mx4(src)) ||
-      (rslt = mx5(src)) || (rslt = mx6(src)) ||
-      (rslt = mx7(src)) || (rslt = mx8(src));
-      return rslt;
+      for (prelexer mx : { mxs... }) {
+        if ((rslt = mx(src))) return rslt;
+      }
+      return 0;
     }
 
     // Tries the matchers in sequence and succeeds if they all succeed.
-    template <prelexer mx1, prelexer mx2>
+    template <prelexer... mxs>
     const char* sequence(const char* src) {
       const char* rslt = src;
-      (rslt = mx1(rslt)) && (rslt = mx2(rslt));
+      for (prelexer mx : { mxs... }) {
+        if (!(rslt = mx(rslt))) return 0;
+      }
       return rslt;
     }
-
-    // Same as above, but with 3 arguments.
-    template <prelexer mx1, prelexer mx2, prelexer mx3>
-    const char* sequence(const char* src) {
-      const char* rslt = src;
-      (rslt = mx1(rslt)) && (rslt = mx2(rslt)) && (rslt = mx3(rslt));
-      return rslt;
-    }
-
-    // Same as above, but with 4 arguments.
-    template <prelexer mx1, prelexer mx2, prelexer mx3, prelexer mx4>
-    const char* sequence(const char* src) {
-      const char* rslt = src;
-      (rslt = mx1(rslt)) && (rslt = mx2(rslt)) &&
-      (rslt = mx3(rslt)) && (rslt = mx4(rslt));
-      return rslt;
-    }
-
-    // Same as above, but with 5 arguments.
-    template <prelexer mx1, prelexer mx2,
-              prelexer mx3, prelexer mx4,
-              prelexer mx5>
-    const char* sequence(const char* src) {
-      const char* rslt = src;
-      (rslt = mx1(rslt)) && (rslt = mx2(rslt)) &&
-      (rslt = mx3(rslt)) && (rslt = mx4(rslt)) &&
-      (rslt = mx5(rslt));
-      return rslt;
-    }
-
-    // Same as above, but with 6 arguments.
-    template <prelexer mx1, prelexer mx2,
-              prelexer mx3, prelexer mx4,
-              prelexer mx5, prelexer mx6>
-    const char* sequence(const char* src) {
-      const char* rslt = src;
-      (rslt = mx1(rslt)) && (rslt = mx2(rslt)) &&
-      (rslt = mx3(rslt)) && (rslt = mx4(rslt)) &&
-      (rslt = mx5(rslt)) && (rslt = mx6(rslt));
-      return rslt;
-    }
-
-    // Same as above, but with 7 arguments.
-    template <prelexer mx1, prelexer mx2,
-              prelexer mx3, prelexer mx4,
-              prelexer mx5, prelexer mx6,
-              prelexer mx7>
-    const char* sequence(const char* src) {
-      const char* rslt = src;
-      (rslt = mx1(rslt)) && (rslt = mx2(rslt)) &&
-      (rslt = mx3(rslt)) && (rslt = mx4(rslt)) &&
-      (rslt = mx5(rslt)) && (rslt = mx6(rslt)) &&
-      (rslt = mx7(rslt));
-      return rslt;
-    }
-
+    
     // Match a pattern or not. Always succeeds.
     template <prelexer mx>
     const char* optional(const char* src) {

--- a/sass_context.cpp
+++ b/sass_context.cpp
@@ -128,6 +128,7 @@ extern "C" {
     char* error_file;
     size_t error_line;
     size_t error_column;
+    const char* error_src;
 
     // report imported files
     char** included_files;
@@ -256,6 +257,7 @@ extern "C" {
       c_ctx->error_file = sass_strdup(e.pstate.path.c_str());
       c_ctx->error_line = e.pstate.line+1;
       c_ctx->error_column = e.pstate.column+1;
+      c_ctx->error_src = e.pstate.src;
       c_ctx->output_string = 0;
       c_ctx->source_map_string = 0;
       json_delete(json_err);
@@ -406,6 +408,7 @@ extern "C" {
       c_ctx->error_message = 0;
       c_ctx->error_status = 0;
       // reset error position
+      c_ctx->error_src = 0;
       c_ctx->error_file = 0;
       c_ctx->error_line = string::npos;
       c_ctx->error_column = string::npos;
@@ -757,6 +760,7 @@ extern "C" {
   IMPLEMENT_SASS_CONTEXT_GETTER(const char*, error_file);
   IMPLEMENT_SASS_CONTEXT_GETTER(size_t, error_line);
   IMPLEMENT_SASS_CONTEXT_GETTER(size_t, error_column);
+  IMPLEMENT_SASS_CONTEXT_GETTER(const char*, error_src);
   IMPLEMENT_SASS_CONTEXT_GETTER(const char*, output_string);
   IMPLEMENT_SASS_CONTEXT_GETTER(const char*, source_map_string);
   IMPLEMENT_SASS_CONTEXT_GETTER(char**, included_files);

--- a/sass_context.cpp
+++ b/sass_context.cpp
@@ -407,8 +407,8 @@ extern "C" {
       c_ctx->error_status = 0;
       // reset error position
       c_ctx->error_file = 0;
-      c_ctx->error_line = -1;
-      c_ctx->error_column = -1;
+      c_ctx->error_line = string::npos;
+      c_ctx->error_column = string::npos;
 
       // use to parse block
       return cpp_ctx;

--- a/sass_context.h
+++ b/sass_context.h
@@ -104,6 +104,7 @@ ADDAPI const char* ADDCALL sass_context_get_error_json (struct Sass_Context* ctx
 ADDAPI const char* ADDCALL sass_context_get_error_text (struct Sass_Context* ctx);
 ADDAPI const char* ADDCALL sass_context_get_error_message (struct Sass_Context* ctx);
 ADDAPI const char* ADDCALL sass_context_get_error_file (struct Sass_Context* ctx);
+ADDAPI const char* ADDCALL sass_context_get_error_src (struct Sass_Context* ctx);
 ADDAPI size_t ADDCALL sass_context_get_error_line (struct Sass_Context* ctx);
 ADDAPI size_t ADDCALL sass_context_get_error_column (struct Sass_Context* ctx);
 ADDAPI const char* ADDCALL sass_context_get_source_map_string (struct Sass_Context* ctx);

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -236,7 +236,7 @@ extern "C" {
     }
     catch (Sass_Error& e) {
       stringstream msg_stream;
-      msg_stream << e.path << ":" << e.pstate.line << ": " << e.message << endl;
+      msg_stream << e.pstate.path << ":" << e.pstate.line << ": " << e.message << endl;
       c_ctx->error_message = sass_strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;

--- a/source_map.cpp
+++ b/source_map.cpp
@@ -175,9 +175,9 @@ namespace Sass {
         mappings[i].generated_position.file == pstate.file &&
         mappings[i].generated_position.line == pstate.line &&
         mappings[i].generated_position.column == pstate.column
-      ) return ParserState(pstate.path, mappings[i].original_position, pstate.offset);
+      ) return ParserState(pstate.path, pstate.src, mappings[i].original_position, pstate.offset);
     }
-    return ParserState(pstate.path, Position(-1, -1, -1), Offset(0, 0));
+    return ParserState(pstate.path, pstate.src, Position(-1, -1, -1), Offset(0, 0));
 
   }
 

--- a/util.cpp
+++ b/util.cpp
@@ -308,7 +308,7 @@ namespace Sass {
         // don't be that strict
         return s;
         // this basically always means an internal error and not users fault
-        error("Unescaped delimiter in string to unquote found. [" + s + "]", ParserState("[UNQUOTE]", -1));
+        error("Unescaped delimiter in string to unquote found. [" + s + "]", ParserState("[UNQUOTE]"));
       }
       else {
         skipped = false;

--- a/util.cpp
+++ b/util.cpp
@@ -380,10 +380,12 @@ namespace Sass {
 
   bool peek_linefeed(const char* start)
   {
-    if(*start == '\n' || *start == '\r') return true;;
-    const char* linefeed = Prelexer::wspaces(start);
-    if (linefeed == 0) return false;
-    return *linefeed == '\n' || *linefeed == '\r';
+    while (*start) {
+      if (*start == '\n' || *start == '\r') return true;
+      if (*start != ' ' && *start != '\t') return false;
+      ++ start;
+    }
+    return false;
   }
 
   namespace Util {


### PR DESCRIPTION
The latest output emitter refactoring removed the silent parsing of css block comments. This PR tries to ease the pain due to this change. Previously libsass was eating away some block comments that ruby sass preserved. We now don't do that anymore, but some parsing will choke if unexpected block comments occur. I created two new lexer functions (`lex_css` and `peek_css`), to mimic the old behavior (ie. skipping over block comments).

Fixes #941 and should improve handling of other similar cases, but is far from complete. Actually we should have spec-tests that do test where block comments are allowed! So if anybody wants to volunteer to create (quite) a few tests that cover all parser cases for comment; please step forward :wink: 

This refactoring also brings a few code optimizations, most notably the variadic template functions (c++11) for `alternatives` and `sequence`. I hope this doesn't raise the bar for the compilers too much; the benefits are IMO worth it (unlimited or/and prelexer clauses)!

Also added some minor optimizations to the parser where I saw potential. Mostly merged multiple `peek` calls into one `alternative` call. This way the parser only has to skip over the white-space once!