### PR TITLE
Add parsing error for empty declaration value

### DIFF
--- a/debugger.hpp
+++ b/debugger.hpp
@@ -298,7 +298,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << ind << "Map " << expression << " [Hashed]" << endl;
   } else if (dynamic_cast<List*>(node)) {
     List* expression = dynamic_cast<List*>(node);
-    cerr << ind << "List " << expression <<
+    cerr << ind << "List " << expression << " (" << expression->length() << ") " <<
       (expression->separator() == Sass::List::Separator::COMMA ? "Comma " : "Space ") <<
       " [delayed: " << expression->is_delayed() << "] " <<
       " [interpolant: " << expression->is_interpolant() << "] " <<

--- a/parser.cpp
+++ b/parser.cpp
@@ -2187,4 +2187,39 @@ namespace Sass {
     throw Sass_Error(Sass_Error::syntax, ParserState(path, pos.line ? pos : before_token, Offset(0, 0)), msg);
   }
 
+  // print a css parsing error with actual context information from parsed source
+  void Parser::css_error(const string& msg, const string& prefix, const string& middle)
+  {
+    int max_len = 14;
+    const char* pos = peek < optional_spaces >();
+    bool ellipsis_left = false;
+    const char* pos_left(pos);
+    while (*pos_left && pos_left >= source) {
+      if (pos - pos_left > max_len) {
+        ellipsis_left = true;
+        break;
+      }
+      if (*pos_left == '\r') break;
+      if (*pos_left == '\n') break;
+      -- pos_left;
+    }
+    bool ellipsis_right = false;
+    const char* pos_right(pos);
+    while (*pos_right && pos_right <= end) {
+      if (pos_right - pos > max_len) {
+        ellipsis_right = true;
+        break;
+      }
+      if (*pos_right == '\r') break;
+      if (*pos_right == '\n') break;
+      ++ pos_right;
+    }
+    string left(pos_left, pos);
+    string right(pos, pos_right);
+    if (ellipsis_left) left = ellipsis + left;
+    if (ellipsis_right) right = right + ellipsis;
+    // now pass new message to the more generic error function
+    error(msg + prefix + quote(left) + middle + quote(right), pstate);
+  }
+
 }

--- a/parser.cpp
+++ b/parser.cpp
@@ -954,7 +954,13 @@ namespace Sass {
       return new (ctx.mem) Declaration(prop->pstate(), prop, parse_static_value()/*, lex<important>()*/);
     }
     else {
-      return new (ctx.mem) Declaration(prop->pstate(), prop, parse_list()/*, lex<important>()*/);
+      Expression* list_ex = parse_list();
+      if (List* list = dynamic_cast<List*>(list_ex)) {
+        if (list->length() == 0 && !peek< exactly <'{'> >()) {
+          css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
+        }
+      }
+      return new (ctx.mem) Declaration(prop->pstate(), prop, list_ex/*, lex<important>()*/);
     }
   }
 

--- a/parser.hpp
+++ b/parser.hpp
@@ -212,6 +212,11 @@ namespace Sass {
 #endif
 
     void error(string msg, Position pos);
+    // generate message with given and expected sample
+    // text before and in the middle are configurable
+    void css_error(const string& msg,
+                   const string& prefix = " after ",
+                   const string& middle = ", was: ");
     void read_bom();
 
     Block* parse();


### PR DESCRIPTION
Fixes #945 - Adds a function to output errors in the same way as ruby sass does, which IMO is the final goal. IMO it doesn't matter too much if error messages are not consistent in libsass for the time beeing, so we can gradually change all errors to give the same output (IMO this is easier once we actually can test errors with spec tests).