### PR TITLE
SourceMap: Fixes relative file path issue

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -111,7 +111,7 @@ namespace Sass {
       }
     }
 
-    emitter.set_filename(output_path);
+    emitter.set_filename(resolve_relative_path(output_path, source_map_file, cwd));
 
   }
 


### PR DESCRIPTION
This fixes the issue described here: sass/node-sass#764.

> When `output_path` is set as absolute path, the path should be resolved with respect to map file path for emitter.
