### PR TITLE
#548 squashed commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,9 @@ SOURCES = \
 	constants.cpp \
 	context.cpp \
 	contextualize.cpp \
+	contextualize_eval.cpp \
 	cssize.cpp \
+	listize.cpp \
 	error_handling.cpp \
 	eval.cpp \
 	expand.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,11 +55,13 @@ libsass_la_SOURCES = \
 	constants.cpp constants.hpp \
 	context.cpp context.hpp \
 	contextualize.cpp contextualize.hpp \
+	contextualize_eval.cpp contextualize_eval.hpp \
 	error_handling.cpp error_handling.hpp \
 	eval.cpp eval.hpp \
 	expand.cpp expand.hpp \
 	extend.cpp extend.hpp \
 	cssize.cpp cssize.hpp \
+	listize.cpp listize.hpp \
 	file.cpp file.hpp \
 	functions.cpp functions.hpp \
 	inspect.cpp inspect.hpp \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ environment:
     ruby_version: "21-x64"
 
 cache:
+  - C:\mingw64
   - C:\Ruby%ruby_version%\lib\ruby\gems
 
 install:
@@ -63,7 +64,7 @@ test_script:
         ruby sass-spec\sass-spec.rb -c sassc\bin\sassc.exe -s --ignore-todo sass-spec/spec
       } else {
         if ($env:Config -eq "Debug") {
-          echo "test runner in debug mode build via msvc will throw debug assertions"
+          echo test runner in debug mode build via msvc will throw debug assertions
           echo ruby sass-spec\sass-spec.rb -c win\bin\Debug\sassc.exe -s --ignore-todo sass-spec/spec
         } else {
           ruby sass-spec\sass-spec.rb -c win\bin\sassc.exe -s --ignore-todo sass-spec/spec

--- a/ast.hpp
+++ b/ast.hpp
@@ -87,6 +87,7 @@ namespace Sass {
       STRING,
       LIST,
       MAP,
+      SELECTOR,
       NULL_VAL,
       NUM_TYPES
     };
@@ -1694,6 +1695,22 @@ namespace Sass {
   // Additional method on Lists to retrieve values directly or from an encompassed Argument.
   //////////////////////////////////////////////////////////////////////////////////////////
   inline Expression* List::value_at_index(size_t i) { return is_arglist_ ? ((Argument*)(*this)[i])->value() : (*this)[i]; }
+
+  ////////////
+  // The Parent Selector Expression.
+  ////////////
+  class Parent_Selector : public Expression {
+    ADD_PROPERTY(Selector*, selector);
+  public:
+    Parent_Selector(ParserState pstate, Selector* r = 0)
+    : Expression(pstate), selector_(r)
+    { concrete_type(SELECTOR); }
+    virtual Selector* selector() { return selector_; }
+    string type() { return "selector"; }
+    static string type_name() { return "selector"; }
+
+    ATTACH_OPERATIONS();
+  };
 
   /////////////////////////////////////////
   // Abstract base class for CSS selectors.

--- a/ast_factory.hpp
+++ b/ast_factory.hpp
@@ -69,6 +69,7 @@ namespace Sass {
     String_Constant* new_String_Constant(string p, size_t l, const char* beg, const char* end);
     Feature_Query_Condition* new_Feature_Query_Condition(string p, size_t l, String* f, Expression* v);
     Media_Expression* new_Media_Expression(string p, size_t l, String* f, Expression* v);
+    Parent_Selector* new_Parent_Selector(string p, size_t l, Selector* s);
     // parameters and arguments
     Parameter* new_Parameter(string p, size_t l, string n, Expression* def = 0, bool rest = false);
     Parameters* new_Parameters(string p, size_t l);
@@ -76,6 +77,7 @@ namespace Sass {
     Arguments* new_Arguments(string p, size_t l);
     // selectors
     Selector_Schema* new_Selector_Schema(string p, size_t l, String* c);
+    Attribute_Selector* new_Attribute_Selector(string p, size_t l, string n, string m, String* v);
     Simple_Selector* new_Simple_Selector(string p, size_t l, string c);
     Reference_Selector* new_Reference_Selector(string p, size_t l);
     Placeholder_Selector* new_Placeholder_Selector(string p, size_t l, string n);

--- a/ast_fwd_decl.hpp
+++ b/ast_fwd_decl.hpp
@@ -60,6 +60,7 @@ namespace Sass {
   class Feature_Query_Condition;
   class At_Root_Expression;
   class Null;
+  class Parent_Selector;
   // parameters and arguments
   class Parameter;
   class Parameters;

--- a/bind.cpp
+++ b/bind.cpp
@@ -161,9 +161,11 @@ namespace Sass {
           // make sure to eval the default value in the env that we've been populating
           Env* old_env = eval->env;
           Backtrace* old_bt = eval->backtrace;
+          Contextualize* old_context = eval->contextualize;
           Expression* dv = leftover->default_value()->perform(eval->with(env, eval->backtrace));
           eval->env = old_env;
           eval->backtrace = old_bt;
+          eval->contextualize = old_context;
           // dv->perform(&to_string);
           env->current_frame()[leftover->name()] = dv;
         }

--- a/context.cpp
+++ b/context.cpp
@@ -17,7 +17,9 @@
 #include "expand.hpp"
 #include "eval.hpp"
 #include "contextualize.hpp"
+#include "contextualize_eval.hpp"
 #include "cssize.hpp"
+#include "listize.hpp"
 #include "extend.hpp"
 #include "remove_placeholders.hpp"
 #include "color_names.hpp"
@@ -311,9 +313,11 @@ namespace Sass {
     for (size_t i = 0, S = c_functions.size(); i < S; ++i) {
       register_c_function(*this, &tge, c_functions[i]);
     }
-    Eval eval(*this, &tge, &backtrace);
-    Contextualize contextualize(*this, &eval, &tge, &backtrace);
-    Expand expand(*this, &eval, &contextualize, &tge, &backtrace);
+    Contextualize contextualize(*this, &tge, &backtrace);
+    Listize listize(*this, &tge, &backtrace);
+    Eval eval(*this, &contextualize, &listize, &tge, &backtrace);
+    Contextualize_Eval contextualize_eval(*this, &eval, &tge, &backtrace);
+    Expand expand(*this, &eval, &contextualize_eval, &tge, &backtrace);
     Cssize cssize(*this, &tge, &backtrace);
     root = root->perform(&expand)->block();
     root = root->perform(&cssize)->block();

--- a/context.cpp
+++ b/context.cpp
@@ -113,7 +113,7 @@ namespace Sass {
       }
     }
 
-    emitter.set_filename(resolve_relative_path(output_path, source_map_file, cwd));
+    emitter.set_filename(output_path);
 
   }
 

--- a/contextualize_eval.cpp
+++ b/contextualize_eval.cpp
@@ -1,0 +1,88 @@
+#include "contextualize_eval.hpp"
+#include "ast.hpp"
+#include "eval.hpp"
+#include "backtrace.hpp"
+#include "to_string.hpp"
+#include "parser.hpp"
+
+namespace Sass {
+
+  Contextualize_Eval::Contextualize_Eval(Context& ctx, Eval* eval, Env* env, Backtrace* bt)
+  : Contextualize(ctx, env, bt), eval(eval)
+  { }
+
+  Contextualize_Eval::~Contextualize_Eval() { }
+
+  Selector* Contextualize_Eval::fallback_impl(AST_Node* n)
+  { return Contextualize::fallback_impl(n); }
+
+  Contextualize_Eval* Contextualize_Eval::with(Selector* s, Env* e, Backtrace* bt, Selector* p, Selector* ex)
+  {
+    Contextualize::with(s, e, bt, p, ex);
+    eval = eval->with(s, e, bt, p, ex);
+    return this;
+  }
+
+  Selector* Contextualize_Eval::operator()(Selector_Schema* s)
+  {
+    To_String to_string;
+    string result_str(s->contents()->perform(eval)->perform(&to_string));
+    result_str += '{'; // the parser looks for a brace to end the selector
+    Selector* result_sel = Parser::from_c_str(result_str.c_str(), ctx, s->pstate()).parse_selector_group();
+    return result_sel->perform(this);
+  }
+
+  Selector* Contextualize_Eval::operator()(Selector_List* s)
+  {
+    return Contextualize::operator ()(s);
+  }
+
+  Selector* Contextualize_Eval::operator()(Complex_Selector* s)
+  {
+    return Contextualize::operator ()(s);
+  }
+
+  Selector* Contextualize_Eval::operator()(Compound_Selector* s)
+  {
+    return Contextualize::operator ()(s);
+  }
+
+  Selector* Contextualize_Eval::operator()(Wrapped_Selector* s)
+  {
+    return Contextualize::operator ()(s);
+  }
+
+  Selector* Contextualize_Eval::operator()(Pseudo_Selector* s)
+  {     return Contextualize::operator ()(s); }
+
+  Selector* Contextualize_Eval::operator()(Attribute_Selector* s)
+  {
+    // the value might be interpolated; evaluate it
+    String* v = s->value();
+    if (v && eval) {
+     v = static_cast<String*>(v->perform(eval->with(env, backtrace)));
+    }
+    To_String toString;
+    Attribute_Selector* ss = new (ctx.mem) Attribute_Selector(*s);
+    ss->value(v);
+    return ss;
+  }
+
+  Selector* Contextualize_Eval::operator()(Selector_Qualifier* s)
+  {     return Contextualize::operator ()(s);
+ }
+
+  Selector* Contextualize_Eval::operator()(Type_Selector* s)
+  {     return Contextualize::operator ()(s);
+ }
+
+  Selector* Contextualize_Eval::operator()(Selector_Placeholder* p)
+  {
+    return Contextualize::operator ()(p);
+  }
+
+  Selector* Contextualize_Eval::operator()(Selector_Reference* s)
+  {
+    return Contextualize::operator ()(s);
+  }
+}

--- a/contextualize_eval.hpp
+++ b/contextualize_eval.hpp
@@ -1,6 +1,7 @@
-#ifndef SASS_CONTEXTUALIZE_H
-#define SASS_CONTEXTUALIZE_H
+#ifndef SASS_CONTEXTUALIZE_EVAL_H
+#define SASS_CONTEXTUALIZE_EVAL_H
 
+#include "eval.hpp"
 #include "context.hpp"
 #include "operation.hpp"
 #include "environment.hpp"
@@ -11,28 +12,25 @@ namespace Sass {
 
   typedef Environment<AST_Node*> Env;
 
-  class Contextualize : public Operation_CRTP<Selector*, Contextualize> {
+  class Contextualize_Eval : public Contextualize {
 
-
-  public:
-    Context&   ctx;
-    Env*       env;
-    Backtrace* backtrace;
-    Selector*  parent;
-    Selector* placeholder;
-    Selector* extender;
+    Eval*      eval;
 
     Selector* fallback_impl(AST_Node* n);
-    Contextualize(Context&, Env*, Backtrace*, Selector* placeholder = 0, Selector* extender = 0);
-    virtual ~Contextualize();
-    Contextualize* with(Selector*, Env*, Backtrace*, Selector* placeholder = 0, Selector* extender = 0);
+
+  public:
+    Contextualize_Eval(Context&, Eval*, Env*, Backtrace*);
+    virtual ~Contextualize_Eval();
+    Contextualize_Eval* with(Selector*, Env*, Backtrace*, Selector* placeholder = 0, Selector* extender = 0);
     using Operation<Selector*>::operator();
 
+    Selector* operator()(Selector_Schema*);
     Selector* operator()(Selector_List*);
     Selector* operator()(Complex_Selector*);
     Selector* operator()(Compound_Selector*);
     Selector* operator()(Wrapped_Selector*);
     Selector* operator()(Pseudo_Selector*);
+    Selector* operator()(Attribute_Selector*);
     Selector* operator()(Selector_Qualifier*);
     Selector* operator()(Type_Selector*);
     Selector* operator()(Selector_Placeholder*);

--- a/eval.hpp
+++ b/eval.hpp
@@ -7,6 +7,8 @@
 #include "position.hpp"
 #include "operation.hpp"
 #include "environment.hpp"
+#include "contextualize.hpp"
+#include "listize.hpp"
 #include "sass_values.h"
 
 namespace Sass {
@@ -14,6 +16,8 @@ namespace Sass {
 
   typedef Environment<AST_Node*> Env;
   struct Backtrace;
+  class Contextualize;
+  class Listize;
 
   class Eval : public Operation_CRTP<Expression*, Eval> {
 
@@ -22,11 +26,14 @@ namespace Sass {
     Expression* fallback_impl(AST_Node* n);
 
   public:
+    Contextualize* contextualize;
+    Listize*   listize;
     Env*       env;
     Backtrace* backtrace;
-    Eval(Context&, Env*, Backtrace*);
+    Eval(Context&, Contextualize*, Listize*, Env*, Backtrace*);
     virtual ~Eval();
     Eval* with(Env* e, Backtrace* bt); // for setting the env before eval'ing an expression
+    Eval* with(Selector* c, Env* e, Backtrace* bt, Selector* placeholder = 0, Selector* extender = 0); // for setting the env before eval'ing an expression
     using Operation<Expression*>::operator();
 
     // for evaluating function bodies
@@ -62,6 +69,7 @@ namespace Sass {
     Expression* operator()(Argument*);
     Expression* operator()(Arguments*);
     Expression* operator()(Comment*);
+    Expression* operator()(Parent_Selector* p);
 
     template <typename U>
     Expression* fallback(U x) { return fallback_impl(x); }

--- a/expand.hpp
+++ b/expand.hpp
@@ -14,6 +14,9 @@
 namespace Sass {
   using namespace std;
 
+  class Context;
+  class Eval;
+  class Contextualize_Eval;
   typedef Environment<AST_Node*> Env;
   struct Backtrace;
 
@@ -21,7 +24,7 @@ namespace Sass {
 
     Context&          ctx;
     Eval*             eval;
-    Contextualize*    contextualize;
+    Contextualize_Eval*    contextualize_eval;
     Env*              env;
     vector<Block*>    block_stack;
     vector<String*>   property_stack;
@@ -34,7 +37,7 @@ namespace Sass {
     Statement* fallback_impl(AST_Node* n);
 
   public:
-    Expand(Context&, Eval*, Contextualize*, Env*, Backtrace*);
+    Expand(Context&, Eval*, Contextualize_Eval*, Env*, Backtrace*);
     virtual ~Expand() { }
 
     using Operation<Statement*>::operator();

--- a/functions.cpp
+++ b/functions.cpp
@@ -1467,7 +1467,9 @@ namespace Sass {
         *args << arg;
       }
       Function_Call* func = new (ctx.mem) Function_Call(pstate, name, args);
-      Eval eval(ctx, &d_env, backtrace);
+      Contextualize contextualize(ctx, &d_env, backtrace);
+      Listize listize(ctx, &d_env, backtrace);
+      Eval eval(ctx, &contextualize, &listize, &d_env, backtrace);
       return func->perform(&eval);
 
     }
@@ -1485,7 +1487,9 @@ namespace Sass {
     // { return ARG("$condition", Expression)->is_false() ? ARG("$if-false", Expression) : ARG("$if-true", Expression); }
     BUILT_IN(sass_if)
     {
-      Eval eval(ctx, &d_env, backtrace);
+      Contextualize contextualize(ctx, &d_env, backtrace);
+      Listize listize(ctx, &d_env, backtrace);
+      Eval eval(ctx, &contextualize, &listize, &d_env, backtrace);
       bool is_true = !ARG("$condition", Expression)->perform(&eval)->is_false();
       if (is_true) {
         return ARG("$if-true", Expression)->perform(&eval);

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -665,6 +665,17 @@ namespace Sass {
     append_token("null", n);
   }
 
+  void Inspect::operator()(Parent_Selector* p)
+  {
+    if (p->selector()) {
+      p->selector()->perform(this);
+      append_delimiter();
+    }
+    else {
+      append_string("&");
+    }
+  }
+
   // parameters and arguments
   void Inspect::operator()(Parameter* p)
   {

--- a/inspect.hpp
+++ b/inspect.hpp
@@ -71,6 +71,7 @@ namespace Sass {
     virtual void operator()(Media_Query_Expression*);
     virtual void operator()(At_Root_Expression*);
     virtual void operator()(Null*);
+    virtual void operator()(Parent_Selector* p);
     // parameters and arguments
     virtual void operator()(Parameter*);
     virtual void operator()(Parameters*);

--- a/listize.cpp
+++ b/listize.cpp
@@ -1,0 +1,95 @@
+#include <iostream>
+#include <typeinfo>
+
+#include "listize.hpp"
+#include "to_string.hpp"
+#include "context.hpp"
+#include "backtrace.hpp"
+#include "error_handling.hpp"
+
+namespace Sass {
+
+  Listize::Listize(Context& ctx, Env* env, Backtrace* bt)
+  : ctx(ctx),
+    env(env),
+    backtrace(bt)
+  {  }
+
+  Expression* Listize::operator()(Selector_List* sel)
+  {
+    List* l = new (ctx.mem) List(sel->pstate(), sel->length(), List::COMMA);
+    for (size_t i = 0, L = sel->length(); i < L; ++i) {
+      *l << (*sel)[i]->perform(this);
+    }
+    return l;
+  }
+
+  Expression* Listize::operator()(Compound_Selector* sel)
+  {
+    To_String to_string;
+    string str;
+    for (size_t i = 0, L = sel->length(); i < L; ++i) {
+      Expression* e = (*sel)[i]->perform(this);
+      if (e) str += e->perform(&to_string);
+    }
+    return new (ctx.mem) String_Constant(sel->pstate(), str);
+  }
+
+  Expression* Listize::operator()(Type_Selector* sel)
+  {
+    return new (ctx.mem) String_Constant(sel->pstate(), sel->name());
+  }
+
+  Expression* Listize::operator()(Selector_Qualifier* sel)
+  {
+    return new (ctx.mem) String_Constant(sel->pstate(), sel->name());
+  }
+
+  Expression* Listize::operator()(Complex_Selector* sel)
+  {
+    List* l = new (ctx.mem) List(sel->pstate(), 2);
+
+    Compound_Selector* head = sel->head();
+    if (head && !head->is_empty_reference())
+    {
+      Expression* hh = head->perform(this);
+      if (hh) *l << hh;
+    }
+
+    switch(sel->combinator())
+    {
+      case Complex_Selector::PARENT_OF:
+        *l << new (ctx.mem) String_Constant(sel->pstate(), ">");
+      break;
+      case Complex_Selector::ADJACENT_TO:
+        *l << new (ctx.mem) String_Constant(sel->pstate(), "+");
+      break;
+      case Complex_Selector::PRECEDES:
+        *l << new (ctx.mem) String_Constant(sel->pstate(), "~");
+      break;
+      case Complex_Selector::ANCESTOR_OF:
+      break;
+    }
+
+    Complex_Selector* tail = sel->tail();
+    if (tail)
+    {
+      Expression* tt = tail->perform(this);
+      if (tt && tt->concrete_type() == Expression::LIST)
+      { *l += static_cast<List*>(tt); }
+      else if (tt) *l << static_cast<List*>(tt);
+    }
+    if (l->length() == 0) return 0;
+    return l;
+  }
+
+  Expression* Listize::operator()(Selector_Reference* sel)
+  {
+    return 0;
+  }
+
+  Expression* Listize::fallback_impl(AST_Node* n)
+  {
+    return 0;
+  }
+}

--- a/listize.hpp
+++ b/listize.hpp
@@ -1,0 +1,45 @@
+#ifndef SASS_LISTIZE_H
+#define SASS_LISTIZE_H
+
+#include <vector>
+#include <iostream>
+
+#include "ast.hpp"
+#include "context.hpp"
+#include "operation.hpp"
+#include "environment.hpp"
+
+namespace Sass {
+  using namespace std;
+
+  typedef Environment<AST_Node*> Env;
+  struct Backtrace;
+
+  class Listize : public Operation_CRTP<Expression*, Listize> {
+
+    Context&            ctx;
+    Env*                env;
+    Backtrace*          backtrace;
+
+    Expression* fallback_impl(AST_Node* n);
+
+  public:
+    Listize(Context&, Env*, Backtrace*);
+    virtual ~Listize() { }
+
+    using Operation<Expression*>::operator();
+
+    Expression* operator()(Selector_List*);
+    Expression* operator()(Complex_Selector*);
+    Expression* operator()(Compound_Selector*);
+    Expression* operator()(Type_Selector*);
+    Expression* operator()(Selector_Qualifier*);
+    Expression* operator()(Selector_Reference*);
+
+    template <typename U>
+    Expression* fallback(U x) { return fallback_impl(x); }
+  };
+
+}
+
+#endif

--- a/operation.hpp
+++ b/operation.hpp
@@ -61,6 +61,7 @@ namespace Sass {
     virtual T operator()(Media_Query_Expression* x) = 0;
     virtual T operator()(At_Root_Expression* x)     = 0;
     virtual T operator()(Null* x)                   = 0;
+    virtual T operator()(Parent_Selector* x)        = 0;
     // parameters and arguments
     virtual T operator()(Parameter* x)              = 0;
     virtual T operator()(Parameters* x)             = 0;
@@ -135,6 +136,7 @@ namespace Sass {
     virtual T operator()(Media_Query_Expression* x) { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(At_Root_Expression* x)     { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Null* x)                   { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Parent_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
     // parameters and arguments
     virtual T operator()(Parameter* x)              { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Parameters* x)             { return static_cast<D*>(this)->fallback(x); }

--- a/parser.cpp
+++ b/parser.cpp
@@ -582,12 +582,12 @@ namespace Sass {
     if (lex< exactly<'&'> >()) {
       // check if we have a parent selector on the root level block
       if (block_stack.back() && block_stack.back()->is_root()) {
-        error("Base-level rules cannot contain the parent-selector-referencing character '&'.", pstate);
+        //error("Base-level rules cannot contain the parent-selector-referencing character '&'.", pstate);
       }
       (*seq) << new (ctx.mem) Selector_Reference(pstate);
       sawsomething = true;
       // if you see a space after a &, then you're done
-      if(peek< spaces >()) {
+      if(peek< spaces >() || peek< alternatives < spaces, exactly<';'> > >()) {
         return seq;
       }
     }
@@ -1285,6 +1285,10 @@ namespace Sass {
       if (!lex< exactly<')'> >()) error("URI is missing ')'", pstate);
       return result;
     }
+
+    if (lex< ampersand >())
+    {
+      return new (ctx.mem) Parent_Selector(pstate, parse_selector_group()); }
 
     if (lex< important >())
     { return new (ctx.mem) String_Constant(pstate, "!important"); }

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -437,6 +437,9 @@ namespace Sass {
     const char* percentage(const char* src) {
       return sequence< number, exactly<'%'> >(src);
     }
+    const char* ampersand(const char* src) {
+      return exactly<'&'>(src);
+    }
 
     /* not used anymore - remove?
     const char* em(const char* src) {

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -484,6 +484,7 @@ namespace Sass {
     const char* coefficient(const char* src);
     const char* binomial(const char* src);
     const char* percentage(const char* src);
+    const char* ampersand(const char* src);
     const char* dimension(const char* src);
     const char* hex(const char* src);
     const char* hexa(const char* src);

--- a/win/libsass.filters
+++ b/win/libsass.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="..\cssize.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\listize.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\extend.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -192,6 +195,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\cssize.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\listize.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\extend.hpp">

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -164,10 +164,12 @@
     <ClCompile Include="..\constants.cpp" />
     <ClCompile Include="..\context.cpp" />
     <ClCompile Include="..\contextualize.cpp" />
+    <ClCompile Include="..\contextualize_eval.cpp" />
     <ClCompile Include="..\error_handling.cpp" />
     <ClCompile Include="..\eval.cpp" />
     <ClCompile Include="..\expand.cpp" />
     <ClCompile Include="..\cssize.cpp" />
+    <ClCompile Include="..\listize.cpp" />
     <ClCompile Include="..\extend.cpp" />
     <ClCompile Include="..\file.cpp" />
     <ClCompile Include="..\functions.cpp" />
@@ -208,12 +210,14 @@
     <ClInclude Include="..\constants.hpp" />
     <ClInclude Include="..\context.hpp" />
     <ClInclude Include="..\contextualize.hpp" />
+    <ClInclude Include="..\contextualize_eval.hpp" />
     <ClInclude Include="..\debug.hpp" />
     <ClInclude Include="..\environment.hpp" />
     <ClInclude Include="..\error_handling.hpp" />
     <ClInclude Include="..\eval.hpp" />
     <ClInclude Include="..\expand.hpp" />
     <ClInclude Include="..\cssize.hpp" />
+    <ClInclude Include="..\listize.hpp" />
     <ClInclude Include="..\extend.hpp" />
     <ClInclude Include="..\file.hpp" />
     <ClInclude Include="..\functions.hpp" />


### PR DESCRIPTION
includes from parent selector:
158a5af Support parent selector & in values / and/or interpolations #548
d10b572 Merge branch 'master' into parent-selector
829fef7 merge from master to parent-selector
e1f78c0 Merge commit 'dea27e5e3cc61a0d9f00ffa3f598a1080c6502d6' into parent-selector
ef73c1b issue 548
776e997 #548 Fixed the interpolation~!
324b14f #548 Fixing orphaned variable
1c15df0 #548 fixes for eval calling var->perform(this) edits responding to comments for append_string typo for the broken line comma added contextualize_eval to the visual studio project file.
d9090b3 #548 fixed the set fault tests...
92e3f0b #548 removing commented out code thanks @mgreter.
98977d8 #548 removed commented code
5b6d06a #548 applied @xzyfer patch. Some clean up of commented out code