### PR TITLE
Make @error fatal.  Resolves #967.

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -265,10 +265,7 @@ namespace Sass {
     }
 
     string result(unquote(message->perform(&to_string)));
-    Backtrace top(backtrace, e->pstate(), "");
-    cerr << "Error: " << result;
-    cerr << top.to_string(true);
-    cerr << endl << endl;
+    error(result, e->pstate());
     return 0;
   }
 


### PR DESCRIPTION
Manual testing as requested!
```
$ ./bin/sassc test.scss 
Error: hai
        on line 1 of test.scss
>> a { @error 'hai'; }
   ----^
$ echo $?
1
```
