### PR TITLE
Use autoconf to detect -dl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Makefile.in
 /m4/ltsugar.m4
 /m4/ltversion.m4
 /m4/lt~obsolete.m4
+/script/ar-lib
 /script/compile
 /script/config.guess
 /script/config.sub

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,30 +1,16 @@
 ACLOCAL_AMFLAGS = -I m4
 
-AM_LDFLAGS = -lstdc++ -lm
-AM_CFLAGS = -Wall
-AM_CXXFLAGS = -Wall
-
-if COMPILER_IS_MINGW32
-  AM_CXXFLAGS += -std=gnu++0x
-else
-  AM_CFLAGS += -fPIC
-  AM_CXXFLAGS += -fPIC
-  AM_CXXFLAGS += -std=c++0x
-  AM_LDFLAGS += -ldl
-endif
-
-AM_CFLAGS += -DLIBSASS_VERSION="\"$(VERSION)\""
-AM_CXXFLAGS += -DLIBSASS_VERSION="\"$(VERSION)\""
+AM_COPT = -Wall -O2
+AM_COVLDFLAGS =
 
 if ENABLE_COVERAGE
-	AM_CFLAGS += -O0 --coverage
-	AM_CXXFLAGS += -O0 --coverage
-	AM_LDFLAGS += -O0 --coverage -lgcov
-else
-	AM_CFLAGS += -O2
-	AM_CXXFLAGS += -O2
-	AM_LDFLAGS += -O2
+	AM_COPT = -O0 --coverage
+	AM_COVLDFLAGS = -lgcov
 endif
+
+AM_CFLAGS =   $(AM_COPT)
+AM_CXXFLAGS = $(AM_COPT) -std=c++0x
+AM_LDFLAGS =  $(AM_COPT) $(AM_COVLDFLAGS)
 
 EXTRA_DIST = \
 	COPYING \
@@ -87,8 +73,6 @@ libsass_la_SOURCES = \
 	utf8_string.cpp utf8_string.hpp \
 	util.cpp util.hpp
 
-libsass_la_CFLAGS = $(AM_CFLAGS)
-libsass_la_CXXFLAGS = $(AM_CXXFLAGS)
 libsass_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined -version-info 0:9:0
 
 include_HEADERS = sass2scss.h sass_context.h sass_functions.h sass_values.h sass.h

--- a/Makefile.am
+++ b/Makefile.am
@@ -138,12 +138,7 @@ else
 endif
 
 SASS_TESTER = $(RUBY) $(SASS_SPEC_PATH)/sass-spec.rb
-
-if COMPILER_IS_MINGW32
-  SASS_TESTER += -c $(SASS_LIBSASS_PATH)/tester.exe
-else
-  SASS_TESTER += -c $(SASS_LIBSASS_PATH)/tester
-endif
+SASS_TESTER += -c $(SASS_LIBSASS_PATH)/tester$(EXEEXT)
 
 test:
 	$(SASS_TESTER) --ignore-todo $(LOG_FLAGS) $(SASS_SPEC_PATH) $(SASS_TEST_FLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -7,13 +7,15 @@ AC_INIT([libsass], m4_esyscmd_s([./version.sh]), [support@moovweb.com])
 AC_CONFIG_SRCDIR([ast.hpp])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_FILES([sass.h])
 AC_CONFIG_AUX_DIR([script])
 AM_INIT_AUTOMAKE([foreign parallel-tests])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([no])])
-LT_INIT
 
 # Checks for programs.
 AC_PROG_CXX
+AM_PROG_AR
+LT_INIT([dlopen])
 
 AC_LANG([C++])
 
@@ -30,6 +32,12 @@ AC_CHECK_FUNCS([floor getcwd strtol])
 # Checks for testing.
 AC_ARG_ENABLE(tests, AS_HELP_STRING([--enable-tests], [enable testing the build]),
               [enable_tests="$enableval"], [enable_tests=no])
+
+dnl The dlopen() function is in the C library for *BSD and in
+dnl libdl on GLIBC-based systems
+AC_SEARCH_LIBS([dlopen], [dl dld], [], [
+  AC_MSG_ERROR([unable to find the dlopen() function])
+])
 
 if test "x$enable_tests" = "xyes"; then
   AC_PROG_CC
@@ -107,8 +115,7 @@ fi
 
 AM_CONDITIONAL(ENABLE_COVERAGE, test "x$enable_cov" = "xyes")
 
-AS_CASE([$host], [*-*-mingw32], [is_mingw32=yes], [is_mingw32=no])
-AM_CONDITIONAL(COMPILER_IS_MINGW32, test "x$is_mingw32" = "xyes")
+AC_SUBST(PACKAGE_VERSION)
 
 AC_MSG_NOTICE([Building libsass ($VERSION)])
 

--- a/sass.h.in
+++ b/sass.h.in
@@ -1,0 +1,66 @@
+#ifndef SASS_H
+#define SASS_H
+
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifdef __GNUC__
+  #define DEPRECATED(func) func __attribute__ ((deprecated))
+#elif defined(_MSC_VER)
+  #define DEPRECATED(func) __declspec(deprecated) func
+#else
+  #pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+  #define DEPRECATED(func) func
+#endif
+
+#ifdef _WIN32
+
+  /* You should define ADD_EXPORTS *only* when building the DLL. */
+  #ifdef ADD_EXPORTS
+    #define ADDAPI __declspec(dllexport)
+	#define ADDCALL __cdecl
+  #else
+    #define ADDAPI
+	#define ADDCALL
+  #endif
+
+#else /* _WIN32 not defined. */
+
+  /* Define with no value on non-Windows OSes. */
+  #define ADDAPI
+  #define ADDCALL
+
+#endif
+
+#define LIBSASS_VERSION "@PACKAGE_VERSION@"
+
+// include API headers
+#include "sass_values.h"
+#include "sass_functions.h"
+
+/* Make sure functions are exported with C linkage under C++ compilers. */
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+// Different render styles
+enum Sass_Output_Style {
+  SASS_STYLE_NESTED,
+  SASS_STYLE_EXPANDED,
+  SASS_STYLE_COMPACT,
+  SASS_STYLE_COMPRESSED
+};
+
+// Some convenient string helper function
+ADDAPI char* ADDCALL sass_string_quote (const char *str, const char quote_mark);
+ADDAPI char* ADDCALL sass_string_unquote (const char *str);
+
+// Get compiled libsass version
+ADDAPI const char* ADDCALL libsass_version(void);
+
+#ifdef __cplusplus
+} // __cplusplus defined.
+#endif
+
+#endif


### PR DESCRIPTION
Do not hardcode -ldl, -lstdc++ and linker flags.
Simplify automake/autoconf configuration