### PR TITLE
Handle only the required nodes in Listize

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -316,7 +316,7 @@ namespace Sass {
       register_c_function(*this, &tge, c_functions[i]);
     }
     Contextualize contextualize(*this, &tge, &backtrace);
-    Listize listize(*this, &tge, &backtrace);
+    Listize listize(*this);
     Eval eval(*this, &contextualize, &listize, &tge, &backtrace);
     Contextualize_Eval contextualize_eval(*this, &eval, &tge, &backtrace);
     Expand expand(*this, &eval, &contextualize_eval, &tge, &backtrace);

--- a/functions.cpp
+++ b/functions.cpp
@@ -1468,7 +1468,7 @@ namespace Sass {
       }
       Function_Call* func = new (ctx.mem) Function_Call(pstate, name, args);
       Contextualize contextualize(ctx, &d_env, backtrace);
-      Listize listize(ctx, &d_env, backtrace);
+      Listize listize(ctx);
       Eval eval(ctx, &contextualize, &listize, &d_env, backtrace);
       return func->perform(&eval);
 
@@ -1488,7 +1488,7 @@ namespace Sass {
     BUILT_IN(sass_if)
     {
       Contextualize contextualize(ctx, &d_env, backtrace);
-      Listize listize(ctx, &d_env, backtrace);
+      Listize listize(ctx);
       Eval eval(ctx, &contextualize, &listize, &d_env, backtrace);
       bool is_true = !ARG("$condition", Expression)->perform(&eval)->is_false();
       if (is_true) {

--- a/listize.cpp
+++ b/listize.cpp
@@ -9,10 +9,8 @@
 
 namespace Sass {
 
-  Listize::Listize(Context& ctx, Env* env, Backtrace* bt)
-  : ctx(ctx),
-    env(env),
-    backtrace(bt)
+  Listize::Listize(Context& ctx)
+  : ctx(ctx)
   {  }
 
   Expression* Listize::operator()(Selector_List* sel)
@@ -33,16 +31,6 @@ namespace Sass {
       if (e) str += e->perform(&to_string);
     }
     return new (ctx.mem) String_Constant(sel->pstate(), str);
-  }
-
-  Expression* Listize::operator()(Type_Selector* sel)
-  {
-    return new (ctx.mem) String_Constant(sel->pstate(), sel->name());
-  }
-
-  Expression* Listize::operator()(Selector_Qualifier* sel)
-  {
-    return new (ctx.mem) String_Constant(sel->pstate(), sel->name());
   }
 
   Expression* Listize::operator()(Complex_Selector* sel)
@@ -90,6 +78,6 @@ namespace Sass {
 
   Expression* Listize::fallback_impl(AST_Node* n)
   {
-    return 0;
+    return static_cast<Expression*>(n);
   }
 }

--- a/listize.hpp
+++ b/listize.hpp
@@ -18,13 +18,11 @@ namespace Sass {
   class Listize : public Operation_CRTP<Expression*, Listize> {
 
     Context&            ctx;
-    Env*                env;
-    Backtrace*          backtrace;
 
     Expression* fallback_impl(AST_Node* n);
 
   public:
-    Listize(Context&, Env*, Backtrace*);
+    Listize(Context&);
     virtual ~Listize() { }
 
     using Operation<Expression*>::operator();
@@ -32,8 +30,6 @@ namespace Sass {
     Expression* operator()(Selector_List*);
     Expression* operator()(Complex_Selector*);
     Expression* operator()(Compound_Selector*);
-    Expression* operator()(Type_Selector*);
-    Expression* operator()(Selector_Qualifier*);
     Expression* operator()(Selector_Reference*);
 
     template <typename U>


### PR DESCRIPTION
This PR does some clean up of the recent `&` in SassScript feature https://github.com/sass/libsass/pull/966.

/cc @ekskimn