### PR TITLE
Performance and Memory improvement for loops

### DIFF
--- a/environment.hpp
+++ b/environment.hpp
@@ -5,7 +5,9 @@
 #include <string>
 #include <iostream>
 
+#include "ast_fwd_decl.hpp"
 #include "ast_def_macros.hpp"
+#include "memory_manager.hpp"
 
 namespace Sass {
   using std::string;
@@ -20,6 +22,7 @@ namespace Sass {
     ADD_PROPERTY(Environment*, parent);
 
   public:
+    Memory_Manager<AST_Node> mem;
     Environment() : current_frame_(map<string, T>()), parent_(0) { }
 
     map<string, T>& current_frame() { return current_frame_; }


### PR DESCRIPTION
Added some performance improvements for some loops. Currently libsass allocates a new variable in a `for` loop for each iteration. This is not the best strategy, as it costs us performance and memory (since all these allocations would not be freed until context is freed). I have added two different optimizations and we should try to find more spots which could optimize the same way.

- Added Memory Manger to Environment, so stuff that really only lives in a certain Env can be re-claimed when the Environment goes out of scope (mostly variables).
- Changed `for` loop to re-use the same variable as iterator (maybe we should make sure that we reset the unit in case the user has changed it, since we only change the actual value ... can we even iterate over pixels?).

Made some benchmarks with a very big for loop:

```CSS
@for $i from 1 through 20000000 {}
// from: 10 wallclock secs ( 9.30 usr +  0.67 sys =  9.97 CPU) and ~ 3GB RAM
// to  :  0 wallclock secs ( 0.05 usr +  0.00 sys =  0.05 CPU) and no ram inc
```