### PR TITLE
Refactor prelexer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ SOURCES = \
 	file.cpp \
 	functions.cpp \
 	inspect.cpp \
+	lexer.cpp \
 	node.cpp \
 	json.cpp \
 	emitter.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,6 +65,7 @@ libsass_la_SOURCES = \
 	file.cpp file.hpp \
 	functions.cpp functions.hpp \
 	inspect.cpp inspect.hpp \
+	lexer.cpp lexer.hpp \
 	node.cpp node.hpp \
 	json.cpp json.hpp \
 	emitter.cpp emitter.hpp \

--- a/ast.hpp
+++ b/ast.hpp
@@ -460,14 +460,14 @@ namespace Sass {
   class Assignment : public Statement {
     ADD_PROPERTY(string, variable);
     ADD_PROPERTY(Expression*, value);
-    ADD_PROPERTY(bool, is_guarded);
+    ADD_PROPERTY(bool, is_default);
     ADD_PROPERTY(bool, is_global);
   public:
     Assignment(ParserState pstate,
                string var, Expression* val,
-               bool guarded = false,
-               bool global = false)
-    : Statement(pstate), variable_(var), value_(val), is_guarded_(guarded), is_global_(global)
+               bool is_default = false,
+               bool is_global = false)
+    : Statement(pstate), variable_(var), value_(val), is_default_(is_default), is_global_(is_global)
     { }
     ATTACH_OPERATIONS();
   };

--- a/bind.cpp
+++ b/bind.cpp
@@ -20,7 +20,7 @@ namespace Sass {
       Parameter*  p = (*ps)[i];
       param_map[p->name()] = p;
       // if (p->default_value()) {
-      //   env->current_frame()[p->name()] = p->default_value()->perform(eval->with(env));
+      //   env->local_frame()[p->name()] = p->default_value()->perform(eval->with(env));
       // }
     }
 
@@ -41,12 +41,12 @@ namespace Sass {
       if (p->is_rest_parameter()) {
         if (a->is_rest_argument()) {
           // rest param and rest arg -- just add one to the other
-          if (env->current_frame_has(p->name())) {
-            *static_cast<List*>(env->current_frame()[p->name()])
+          if (env->has_local(p->name())) {
+            *static_cast<List*>(env->local_frame()[p->name()])
             += static_cast<List*>(a->value());
           }
           else {
-            env->current_frame()[p->name()] = a->value();
+            env->local_frame()[p->name()] = a->value();
           }
         } else {
 
@@ -55,7 +55,7 @@ namespace Sass {
                                              0,
                                              List::COMMA,
                                              true);
-          env->current_frame()[p->name()] = arglist;
+          env->local_frame()[p->name()] = arglist;
           while (ia < LA) {
             a = (*as)[ia];
             (*arglist) << new (ctx.mem) Argument(a->pstate(),
@@ -99,7 +99,7 @@ namespace Sass {
             msg << callee << " has no parameter named " << name;
             error(msg.str(), a->pstate());
           }
-          env->current_frame()[name] = argmap->at(key);
+          env->local_frame()[name] = argmap->at(key);
         }
         ++ia;
         continue;
@@ -108,14 +108,14 @@ namespace Sass {
       }
 
       if (a->name().empty()) {
-        if (env->current_frame_has(p->name())) {
+        if (env->has_local(p->name())) {
           stringstream msg;
           msg << "parameter " << p->name()
           << " provided more than once in call to " << callee;
           error(msg.str(), a->pstate());
         }
         // ordinal arg -- bind it to the next param
-        env->current_frame()[p->name()] = a->value();
+        env->local_frame()[p->name()] = a->value();
         ++ip;
       }
       else {
@@ -131,13 +131,13 @@ namespace Sass {
               << "cannot be used as named argument";
           error(msg.str(), a->pstate());
         }
-        if (env->current_frame_has(a->name())) {
+        if (env->has_local(a->name())) {
           stringstream msg;
           msg << "parameter " << p->name()
               << "provided more than once in call to " << callee;
           error(msg.str(), a->pstate());
         }
-        env->current_frame()[a->name()] = a->value();
+        env->local_frame()[a->name()] = a->value();
       }
     }
 
@@ -150,9 +150,9 @@ namespace Sass {
       // cerr << "env for default params:" << endl;
       // env->print();
       // cerr << "********" << endl;
-      if (!env->current_frame_has(leftover->name())) {
+      if (!env->has_local(leftover->name())) {
         if (leftover->is_rest_parameter()) {
-          env->current_frame()[leftover->name()] = new (ctx.mem) List(leftover->pstate(),
+          env->local_frame()[leftover->name()] = new (ctx.mem) List(leftover->pstate(),
                                                                       0,
                                                                       List::COMMA,
                                                                       true);
@@ -167,7 +167,7 @@ namespace Sass {
           eval->backtrace = old_bt;
           eval->contextualize = old_context;
           // dv->perform(&to_string);
-          env->current_frame()[leftover->name()] = dv;
+          env->local_frame()[leftover->name()] = dv;
         }
         else {
           // param is unbound and has no default value -- error

--- a/eval.cpp
+++ b/eval.cpp
@@ -65,14 +65,21 @@ namespace Sass {
   {
     string var(a->variable());
     if (a->is_global()) {
-      env->global_frame_set(var, a->value()->perform(this));
+      env->set_global(var, a->value()->perform(this));
     }
-    else if (env->has(var)) {
-      Expression* v = static_cast<Expression*>((*env)[var]);
-      if (!a->is_guarded() || v->concrete_type() == Expression::NULL_VAL) (*env)[var] = a->value()->perform(this);
+    else if (a->is_default()) {
+      if (env->has_lexical(var)) return 0;
+      if (env->has_global(var)) {
+        Expression* e = static_cast<Expression*>(env->get_global(var));
+        if (e->concrete_type() == Expression::NULL_VAL) {
+          env->set_global(var, a->value()->perform(this));
+        }
+      } else {
+        env->set_global(var, a->value()->perform(this));
+      }
     }
     else {
-      env->current_frame_set(var, a->value()->perform(this));
+      env->set_lexical(var, a->value()->perform(this));
     }
     return 0;
   }
@@ -89,6 +96,8 @@ namespace Sass {
     return 0;
   }
 
+  // For does not create a new env scope
+  // But iteration vars are reset afterwards
   Expression* Eval::operator()(For* f)
   {
     string variable(f->variable());
@@ -100,21 +109,30 @@ namespace Sass {
     if (high->concrete_type() != Expression::NUMBER) {
       error("upper bound of `@for` directive must be numeric", high->pstate());
     }
-    double start = static_cast<Number*>(low)->value();
-    double end = static_cast<Number*>(high)->value();
-    Env new_env;
+    Number* sass_start = static_cast<Number*>(low);
+    Number* sass_end = static_cast<Number*>(high);
+    // check if units are valid for sequence
+    if (sass_start->unit() != sass_end->unit()) {
+      stringstream msg; msg << "Incompatible units: '"
+        << sass_start->unit() << "' and '"
+        << sass_end->unit() << "'.";
+      error(msg.str(), low->pstate(), backtrace);
+    }
+    double start = sass_start->value();
+    double end = sass_end->value();
     // only create iterator once in this environment
-    Number* it = new (new_env.mem) Number(low->pstate(), start);
-    new_env[variable] = it;
-    new_env.link(env);
-    env = &new_env;
+    Number* it = new (env->mem) Number(low->pstate(), start, sass_end->unit());
+    AST_Node* old_var = env->get_local(variable);
+    env->set_local(variable, it);
     Block* body = f->block();
     Expression* val = 0;
     if (start < end) {
       if (f->is_inclusive()) ++end;
       for (double i = start;
            i < end;
-           it->value(++i)) {
+           ++i) {
+        it->value(i);
+        env->set_local(variable, it);
         val = body->perform(this);
         if (val) break;
       }
@@ -122,35 +140,43 @@ namespace Sass {
       if (f->is_inclusive()) --end;
       for (double i = start;
            i > end;
-           it->value(--i)) {
+           --i) {
+        it->value(i);
+        env->set_local(variable, it);
         val = body->perform(this);
         if (val) break;
       }
     }
-    env = new_env.parent();
+    // restore original environment
+    if (!old_var) env->del_local(variable);
+    else env->set_local(variable, old_var);
     return val;
   }
 
+  // Eval does not create a new env scope
+  // But iteration vars are reset afterwards
   Expression* Eval::operator()(Each* e)
   {
     vector<string> variables(e->variables());
     Expression* expr = e->list()->perform(this);
     List* list = 0;
     Map* map = 0;
-    Env new_env;
     if (expr->concrete_type() == Expression::MAP) {
       map = static_cast<Map*>(expr);
     }
     else if (expr->concrete_type() != Expression::LIST) {
-      list = new (new_env.mem) List(expr->pstate(), 1, List::COMMA);
+      list = new (ctx.mem) List(expr->pstate(), 1, List::COMMA);
       *list << expr;
     }
     else {
       list = static_cast<List*>(expr);
     }
-    for (size_t i = 0, L = variables.size(); i < L; ++i) new_env[variables[i]] = 0;
-    new_env.link(env);
-    env = &new_env;
+    // remember variables and then reset them
+    vector<AST_Node*> old_vars(variables.size());
+    for (size_t i = 0, L = variables.size(); i < L; ++i) {
+      old_vars[i] = env->get_local(variables[i]);
+      env->set_local(variables[i], 0);
+    }
     Block* body = e->block();
     Expression* val = 0;
 
@@ -159,13 +185,13 @@ namespace Sass {
         Expression* value = map->at(key);
 
         if (variables.size() == 1) {
-          List* variable = new (new_env.mem) List(map->pstate(), 2, List::SPACE);
+          List* variable = new (ctx.mem) List(map->pstate(), 2, List::SPACE);
           *variable << key;
           *variable << value;
-          (*env)[variables[0]] = variable;
+          env->set_local(variables[0], variable);
         } else {
-          (*env)[variables[0]] = key;
-          (*env)[variables[1]] = value;
+          env->set_local(variables[0], key);
+          env->set_local(variables[1], value);
         }
 
         val = body->perform(this);
@@ -176,7 +202,7 @@ namespace Sass {
       for (size_t i = 0, L = list->length(); i < L; ++i) {
         List* variable = 0;
         if ((*list)[i]->concrete_type() != Expression::LIST || variables.size() == 1) {
-          variable = new (new_env.mem) List((*list)[i]->pstate(), 1, List::COMMA);
+          variable = new (ctx.mem) List((*list)[i]->pstate(), 1, List::COMMA);
           *variable << (*list)[i];
         }
         else {
@@ -184,10 +210,10 @@ namespace Sass {
         }
         for (size_t j = 0, K = variables.size(); j < K; ++j) {
           if (j < variable->length()) {
-            (*env)[variables[j]] = (*variable)[j];
+            env->set_local(variables[j], (*variable)[j]);
           }
           else {
-            (*env)[variables[j]] = new (new_env.mem) Null(expr->pstate());
+            env->set_local(variables[j], new (ctx.mem) Null(expr->pstate()));
           }
           val = body->perform(this);
           if (val) break;
@@ -195,7 +221,11 @@ namespace Sass {
         if (val) break;
       }
     }
-    env = new_env.parent();
+    // restore original environment
+    for (size_t j = 0, K = variables.size(); j < K; ++j) {
+      if(!old_vars[j]) env->del_local(variables[j]);
+      else env->set_local(variables[j], old_vars[j]);
+    }
     return val;
   }
 
@@ -539,10 +569,10 @@ namespace Sass {
       backtrace = &here;
 
       To_C to_c;
-      union Sass_Value* c_args = sass_make_list(env->current_frame().size(), SASS_COMMA);
+      union Sass_Value* c_args = sass_make_list(env->local_frame().size(), SASS_COMMA);
       for(size_t i = 0; i < params[0].length(); i++) {
         string key = params[0][i]->name();
-        AST_Node* node = env->current_frame().at(key);
+        AST_Node* node = env->local_frame().at(key);
         Expression* arg = static_cast<Expression*>(node);
         sass_list_set_value(c_args, i, arg->perform(&to_c));
       }

--- a/expand.cpp
+++ b/expand.cpp
@@ -220,14 +220,21 @@ namespace Sass {
     string var(a->variable());
     Selector* p = selector_stack.size() <= 1 ? 0 : selector_stack.back();
     if (a->is_global()) {
-      env->global_frame_set(var, a->value()->perform(eval->with(p, env, backtrace)));
+      env->set_global(var, a->value()->perform(eval->with(p, env, backtrace)));
     }
-    else if (env->has(var)) {
-      Expression* v = static_cast<Expression*>((*env)[var]);
-      if (!a->is_guarded() || v->concrete_type() == Expression::NULL_VAL) (*env)[var] = a->value()->perform(eval->with(p, env, backtrace));
+    else if (a->is_default()) {
+      if (env->has_lexical(var)) return 0;
+      if (env->has_global(var)) {
+        Expression* e = static_cast<Expression*>(env->get_global(var));
+        if (e->concrete_type() == Expression::NULL_VAL) {
+          env->set_global(var, a->value()->perform(eval->with(p, env, backtrace)));
+        }
+      } else {
+        env->set_global(var, a->value()->perform(eval->with(p, env, backtrace)));
+      }
     }
     else {
-      env->current_frame_set(var, a->value()->perform(eval->with(p, env, backtrace)));
+      env->set_lexical(var, a->value()->perform(eval->with(p, env, backtrace)));
     }
     return 0;
   }
@@ -286,6 +293,8 @@ namespace Sass {
     return 0;
   }
 
+  // For does not create a new env scope
+  // But iteration vars are reset afterwards
   Statement* Expand::operator()(For* f)
   {
     string variable(f->variable());
@@ -297,54 +306,71 @@ namespace Sass {
     if (high->concrete_type() != Expression::NUMBER) {
       error("upper bound of `@for` directive must be numeric", high->pstate(), backtrace);
     }
-    double start = static_cast<Number*>(low)->value();
-    double end = static_cast<Number*>(high)->value();
-    Env new_env;
+    Number* sass_start = static_cast<Number*>(low);
+    Number* sass_end = static_cast<Number*>(high);
+    // check if units are valid for sequence
+    if (sass_start->unit() != sass_end->unit()) {
+      stringstream msg; msg << "Incompatible units: '"
+        << sass_start->unit() << "' and '"
+        << sass_end->unit() << "'.";
+      error(msg.str(), low->pstate(), backtrace);
+    }
+    double start = sass_start->value();
+    double end = sass_end->value();
     // only create iterator once in this environment
-    Number* it = new (new_env.mem) Number(low->pstate(), start);
-    new_env[variable] = it;
-    new_env.link(env);
-    env = &new_env;
+    Number* it = new (env->mem) Number(low->pstate(), start, sass_end->unit());
+    AST_Node* old_var = env->get_local(variable);
+    env->set_local(variable, it);
     Block* body = f->block();
     if (start < end) {
       if (f->is_inclusive()) ++end;
       for (double i = start;
            i < end;
-           it->value(++i)) {
+           ++i) {
+        it->value(i);
+        env->set_local(variable, it);
         append_block(body);
       }
     } else {
       if (f->is_inclusive()) --end;
       for (double i = start;
            i > end;
-           it->value(--i)) {
+           --i) {
+        it->value(i);
+        env->set_local(variable, it);
         append_block(body);
       }
     }
-    env = new_env.parent();
+    // restore original environment
+    if (!old_var) env->del_local(variable);
+    else env->set_local(variable, old_var);
     return 0;
   }
 
+  // Eval does not create a new env scope
+  // But iteration vars are reset afterwards
   Statement* Expand::operator()(Each* e)
   {
     vector<string> variables(e->variables());
     Expression* expr = e->list()->perform(eval->with(env, backtrace));
     List* list = 0;
     Map* map = 0;
-    Env new_env;
     if (expr->concrete_type() == Expression::MAP) {
       map = static_cast<Map*>(expr);
     }
     else if (expr->concrete_type() != Expression::LIST) {
-      list = new (new_env.mem) List(expr->pstate(), 1, List::COMMA);
+      list = new (ctx.mem) List(expr->pstate(), 1, List::COMMA);
       *list << expr;
     }
     else {
       list = static_cast<List*>(expr);
     }
-    for (size_t i = 0, L = variables.size(); i < L; ++i) new_env[variables[i]] = 0;
-    new_env.link(env);
-    env = &new_env;
+    // remember variables and then reset them
+    vector<AST_Node*> old_vars(variables.size());
+    for (size_t i = 0, L = variables.size(); i < L; ++i) {
+      old_vars[i] = env->get_local(variables[i]);
+      env->set_local(variables[i], 0);
+    }
     Block* body = e->block();
 
     if (map) {
@@ -353,13 +379,13 @@ namespace Sass {
         Expression* v = map->at(key)->perform(eval->with(env, backtrace));
 
         if (variables.size() == 1) {
-          List* variable = new (new_env.mem) List(map->pstate(), 2, List::SPACE);
+          List* variable = new (ctx.mem) List(map->pstate(), 2, List::SPACE);
           *variable << k;
           *variable << v;
-          (*env)[variables[0]] = variable;
+          env->set_local(variables[0], variable);
         } else {
-          (*env)[variables[0]] = k;
-          (*env)[variables[1]] = v;
+          env->set_local(variables[0], k);
+          env->set_local(variables[1], v);
         }
         append_block(body);
       }
@@ -368,7 +394,7 @@ namespace Sass {
       for (size_t i = 0, L = list->length(); i < L; ++i) {
         List* variable = 0;
         if ((*list)[i]->concrete_type() != Expression::LIST  || variables.size() == 1) {
-          variable = new (new_env.mem) List((*list)[i]->pstate(), 1, List::COMMA);
+          variable = new (ctx.mem) List((*list)[i]->pstate(), 1, List::COMMA);
           *variable << (*list)[i];
         }
         else {
@@ -376,16 +402,20 @@ namespace Sass {
         }
         for (size_t j = 0, K = variables.size(); j < K; ++j) {
           if (j < variable->length()) {
-            (*env)[variables[j]] = (*variable)[j]->perform(eval->with(env, backtrace));
+            env->set_local(variables[j], (*variable)[j]->perform(eval->with(env, backtrace)));
           }
           else {
-            (*env)[variables[j]] = new (new_env.mem) Null(expr->pstate());
+            env->set_local(variables[j], new (ctx.mem) Null(expr->pstate()));
           }
         }
         append_block(body);
       }
     }
-    env = new_env.parent();
+    // restore original environment
+    for (size_t j = 0, K = variables.size(); j < K; ++j) {
+      if(!old_vars[j]) env->del_local(variables[j]);
+      else env->set_local(variables[j], old_vars[j]);
+    }
     return 0;
   }
 
@@ -437,7 +467,7 @@ namespace Sass {
   Statement* Expand::operator()(Definition* d)
   {
     Definition* dd = new (ctx.mem) Definition(*d);
-    env->current_frame()[d->name() +
+    env->local_frame()[d->name() +
                         (d->type() == Definition::MIXIN ? "[m]" : "[f]")] = dd;
     // set the static link so we can have lexical scoping
     dd->environment(env);
@@ -469,7 +499,7 @@ namespace Sass {
                                                    c->block(),
                                                    Definition::MIXIN);
       thunk->environment(env);
-      new_env.current_frame()["@content[m]"] = thunk;
+      new_env.local_frame()["@content[m]"] = thunk;
     }
     bind("mixin " + c->name(), params, args, ctx, &new_env, eval);
     Env* old_env = env;

--- a/functions.cpp
+++ b/functions.cpp
@@ -1410,7 +1410,7 @@ namespace Sass {
     {
       string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
 
-      if(d_env.global_frame_has("$"+s)) {
+      if(d_env.has_global("$"+s)) {
         return new (ctx.mem) Boolean(pstate, true);
       }
       else {
@@ -1423,7 +1423,7 @@ namespace Sass {
     {
       string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
 
-      if(d_env.global_frame_has(s+"[f]")) {
+      if(d_env.has_global(s+"[f]")) {
         return new (ctx.mem) Boolean(pstate, true);
       }
       else {
@@ -1436,7 +1436,7 @@ namespace Sass {
     {
       string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
 
-      if(d_env.global_frame_has(s+"[m]")) {
+      if(d_env.has_global(s+"[m]")) {
         return new (ctx.mem) Boolean(pstate, true);
       }
       else {

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -141,7 +141,7 @@ namespace Sass {
     append_token(assn->variable(), assn);
     append_colon_separator();
     assn->value()->perform(this);
-    if (assn->is_guarded()) {
+    if (assn->is_default()) {
       append_optional_space();
       append_string("!default");
     }

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -1,0 +1,119 @@
+#include <cctype>
+#include <cstddef>
+#include <iostream>
+#include <iomanip>
+#include "lexer.hpp"
+#include "constants.hpp"
+
+
+namespace Sass {
+  using namespace Constants;
+
+  namespace Prelexer {
+
+    //####################################
+    // implement some function that do exist in the standard
+    // but those are locale aware which brought some trouble
+    // this even seems to improve performance by quite a bit
+    //####################################
+
+    const bool is_alpha(const char& chr)
+    {
+      return unsigned(chr - 'A') <= 'Z' - 'A' ||
+             unsigned(chr - 'a') <= 'z' - 'a';
+    }
+
+    const bool is_space(const char& chr)
+    {
+      // adapted the technique from is_alpha
+      return chr == ' ' || unsigned(chr - '\t') <= '\r' - '\t';
+    }
+
+    const bool is_digit(const char& chr)
+    {
+      // adapted the technique from is_alpha
+      return unsigned(chr - '0') <= '9' - '0';
+    }
+
+    const bool is_xdigit(const char& chr)
+    {
+      // adapted the technique from is_alpha
+      return unsigned(chr - '0') <= '9' - '0' ||
+             unsigned(chr - 'a') <= 'f' - 'a' ||
+             unsigned(chr - 'A') <= 'F' - 'A';
+    }
+
+    const bool is_punct(const char& chr)
+    {
+      // locale independent
+      return chr == '.';
+    }
+
+    const bool is_alnum(const char& chr)
+    {
+      return is_alpha(chr) || is_digit(chr);
+    }
+
+    // check if char is outside ascii range
+    const bool is_unicode(const char& chr)
+    {
+      // check for unicode range
+      return unsigned(chr) > 127;
+    }
+
+    // Match word character (look ahead)
+    const bool is_character(const char& chr)
+    {
+      // valid alpha, numeric or unicode char (plus hyphen)
+      return is_alnum(chr) || is_unicode(chr) || chr == '-';
+    }
+
+    //####################################
+    // BASIC CHARACTER MATCHERS
+    //####################################
+
+    // create matchers that advance the position
+    const char* space(const char* src) { return is_space(*src) ? src + 1 : 0; }
+    const char* alpha(const char* src) { return is_alpha(*src) ? src + 1 : 0; }
+    const char* unicode(const char* src) { return is_unicode(*src) ? src + 1 : 0; }
+    const char* digit(const char* src) { return is_digit(*src) ? src + 1 : 0; }
+    const char* xdigit(const char* src) { return is_xdigit(*src) ? src + 1 : 0; }
+    const char* alnum(const char* src) { return is_alnum(*src) ? src + 1 : 0; }
+    const char* punct(const char* src) { return is_punct(*src) ? src + 1 : 0; }
+    const char* character(const char* src) { return is_character(*src) ? src + 1 : 0; }
+
+    // Match multiple ctype characters.
+    const char* spaces(const char* src) { return one_plus<space>(src); }
+    const char* digits(const char* src) { return one_plus<digit>(src); }
+
+    // Whitespace handling.
+    const char* no_spaces(const char* src) { return negate< space >(src); }
+    const char* optional_spaces(const char* src) { return zero_plus< space >(src); }
+
+    // Match any single character.
+    const char* any_char(const char* src) { return *src ? src + 1 : src; }
+
+    // Match word boundary (zero-width lookahead).
+    const char* word_boundary(const char* src) { return is_character(*src) ? 0 : src; }
+
+    // Match linefeed /(?:\n|\r\n?)/
+    const char* re_linebreak(const char* src)
+    {
+      // end of file or unix linefeed return here
+      if (*src == 0 || *src == '\n') return src + 1;
+      // a carriage return may optionally be followed by a linefeed
+      if (*src == '\r') return *(src + 1) == '\n' ? src + 2 : src + 1;
+      // no linefeed
+      return 0;
+    }
+
+    // Assert string boundaries (/\Z|\z|\A/)
+    // This is a zero-width positive lookahead
+    const char* end_of_line(const char* src)
+    {
+      // end of file or unix linefeed return here
+      return *src == 0 || *src == '\n' || *src == '\r' ? src : 0;
+    }
+
+  }
+}

--- a/lexer.hpp
+++ b/lexer.hpp
@@ -1,0 +1,210 @@
+#ifndef SASS_LEXER_H
+#define SASS_LEXER_H
+
+#include <cstring>
+
+namespace Sass {
+  namespace Prelexer {
+
+    //####################################
+    // BASIC CHARACTER MATCHERS
+    //####################################
+
+    // These are locale independant
+    const bool is_space(const char& src);
+    const bool is_alpha(const char& src);
+    const bool is_punct(const char& src);
+    const bool is_digit(const char& src);
+    const bool is_alnum(const char& src);
+    const bool is_xdigit(const char& src);
+    const bool is_unicode(const char& src);
+    const bool is_character(const char& src);
+
+    // Match a single ctype predicate.
+    const char* space(const char* src);
+    const char* alpha(const char* src);
+    const char* digit(const char* src);
+    const char* xdigit(const char* src);
+    const char* alnum(const char* src);
+    const char* punct(const char* src);
+    const char* unicode(const char* src);
+    const char* character(const char* src);
+
+    // Match multiple ctype characters.
+    const char* spaces(const char* src);
+    const char* digits(const char* src);
+
+    // Whitespace handling.
+    const char* no_spaces(const char* src);
+    const char* optional_spaces(const char* src);
+
+    // Match any single character (/./).
+    const char* any_char(const char* src);
+
+    // Assert word boundary (/\b/)
+    // Is a zero-width positive lookaheads
+    const char* word_boundary(const char* src);
+
+    // Match a single linebreak (/(?:\n|\r\n?)/).
+    const char* re_linebreak(const char* src);
+
+    // Assert string boundaries (/\Z|\z|\A/)
+    // There are zero-width positive lookaheads
+    const char* end_of_line(const char* src);
+    // const char* end_of_string(const char* src);
+    // const char* start_of_string(const char* src);
+
+    // Type definition for prelexer functions
+    typedef const char* (*prelexer)(const char*);
+
+    //####################################
+    // BASIC "REGEX" CONSTRUCTORS
+    //####################################
+
+    // Match a single character literal.
+    // Regex equivalent: /(?:literal)/
+    template <char pre>
+    const char* exactly(const char* src) {
+      return *src == pre ? src + 1 : 0;
+    }
+
+    // Match a string constant.
+    // Regex equivalent: /[axy]/
+    template <const char* prefix>
+    const char* exactly(const char* src) {
+      if (prefix == 0) return 0;
+      const char* pre = prefix;
+      if (src == 0) return 0;
+      // there is a small chance that the search prefix
+      // is longer than the rest of the string to look at
+      while (*pre && *src == *pre) {
+        ++src, ++pre;
+      }
+      return *pre ? 0 : src;
+    }
+
+    // Match for members of char class.
+    // Regex equivalent: /[axy]/
+    template <const char* char_class>
+    const char* class_char(const char* src) {
+      const char* cc = char_class;
+      while (*cc && *src != *cc) ++cc;
+      return *cc ? src + 1 : 0;
+    }
+
+    // Match for members of char class.
+    // Regex equivalent: /[axy]/
+    template <const char* char_class>
+    const char* class_chars(const char* src) {
+      const char* p = src;
+      while (class_char<char_class>(p)) ++p;
+      return p == src ? 0 : p;
+    }
+
+    // Match all except the supplied one.
+    // Regex equivalent: /[^x]/
+    template <const char c>
+    const char* any_char_but(const char* src) {
+      return (*src && *src != c) ? src + 1 : 0;
+    }
+
+    // Succeeds if the matcher fails.
+    // Aka. zero-width negative lookahead.
+    // Regex equivalent: /(?!literal)/
+    template <prelexer mx>
+    const char* negate(const char* src) {
+      return mx(src) ? 0 : src;
+    }
+
+    // Succeeds if the matcher succeeds.
+    // Aka. zero-width positive lookahead.
+    // Regex equivalent: /(?=literal)/
+    // just hangs around until we need it
+    // template <prelexer mx>
+    // const char* lookahead(const char* src) {
+    //   return mx(src) ? src : 0;
+    // }
+
+    // Tries supplied matchers in order.
+    // Succeeds if one of them succeeds.
+    // Regex equivalent: /(?:FOO|BAR)/
+    template <prelexer... mxs>
+    const char* alternatives(const char* src) {
+      const char* rslt;
+      for (prelexer mx : { mxs... }) {
+        if ((rslt = mx(src))) return rslt;
+      }
+      return 0;
+    }
+
+    // Tries supplied matchers in order.
+    // Succeeds if all of them succeeds.
+    // Regex equivalent: /(?:FOO)(?:BAR)/
+    template <prelexer... mxs>
+    const char* sequence(const char* src) {
+      const char* rslt = src;
+      for (prelexer mx : { mxs... }) {
+        if (!(rslt = mx(rslt))) return 0;
+      }
+      return rslt;
+    }
+
+    // Match a pattern or not. Always succeeds.
+    // Regex equivalent: /(?:literal)?/
+    template <prelexer mx>
+    const char* optional(const char* src) {
+      const char* p = mx(src);
+      return p ? p : src;
+    }
+
+    // Match zero or more of the patterns.
+    // Regex equivalent: /(?:literal)*/
+    template <prelexer mx>
+    const char* zero_plus(const char* src) {
+      const char* p = mx(src);
+      while (p) src = p, p = mx(src);
+      return src;
+    }
+
+    // Match one or more of the patterns.
+    // Regex equivalent: /(?:literal)+/
+    template <prelexer mx>
+    const char* one_plus(const char* src) {
+      const char* p = mx(src);
+      if (!p) return 0;
+      while (p) src = p, p = mx(src);
+      return src;
+    }
+
+    // Match mx non-greedy until delimiter.
+    // Other prelexers are greedy by default.
+    // Regex equivalent: /(?:$mx)*?(?=$delim)\b/
+    template <prelexer mx, prelexer delim>
+    const char* non_greedy(const char* src) {
+      while (!delim(src)) {
+        const char* p = mx(src);
+        if (p == src) return 0;
+        if (p == 0) return 0;
+        src = p;
+      }
+      return src;
+    }
+
+    //####################################
+    // ADVANCED "REGEX" CONSTRUCTORS
+    //####################################
+
+    // Match with word boundary rule.
+    // Regex equivalent: /(?:$mx)\b/
+    template <const char* mx>
+    const char* word(const char* src) {
+      return sequence <
+               exactly < mx >,
+               word_boundary
+             >(src);
+    }
+
+  }
+}
+
+#endif

--- a/parser.cpp
+++ b/parser.cpp
@@ -67,7 +67,7 @@ namespace Sass {
     Selector_Lookahead lookahead_result;
     while (position < end) {
       parse_block_comments(root);
-      if (peek< import >()) {
+      if (peek< kwd_import >()) {
         Import* imp = parse_import();
         if (!imp->urls().empty()) (*root) << imp;
         if (!imp->files().empty()) {
@@ -77,7 +77,7 @@ namespace Sass {
         }
         if (!lex< one_plus< exactly<';'> > >()) error("top-level @import directive must be terminated by ';'", pstate);
       }
-      else if (peek< mixin >() || peek< function >()) {
+      else if (peek< kwd_mixin >() || peek< kwd_function >()) {
         (*root) << parse_definition();
       }
       else if (peek< variable >()) {
@@ -87,41 +87,41 @@ namespace Sass {
       /*else if (peek< sequence< optional< exactly<'*'> >, alternatives< identifier_schema, identifier >, optional_spaces, exactly<':'>, optional_spaces, exactly<'{'> > >(position)) {
         (*root) << parse_propset();
       }*/
-      else if (peek< include >() /* || peek< exactly<'+'> >() */) {
+      else if (peek< kwd_include >() /* || peek< exactly<'+'> >() */) {
         Mixin_Call* mixin_call = parse_mixin_call();
         (*root) << mixin_call;
         if (!mixin_call->block() && !lex< one_plus< exactly<';'> > >()) error("top-level @include directive must be terminated by ';'", pstate);
       }
-      else if (peek< if_directive >()) {
+      else if (peek< kwd_if_directive >()) {
         (*root) << parse_if_directive();
       }
-      else if (peek< for_directive >()) {
+      else if (peek< kwd_for_directive >()) {
         (*root) << parse_for_directive();
       }
-      else if (peek< each_directive >()) {
+      else if (peek< kwd_each_directive >()) {
         (*root) << parse_each_directive();
       }
-      else if (peek< while_directive >()) {
+      else if (peek< kwd_while_directive >()) {
         (*root) << parse_while_directive();
       }
-      else if (peek< media >()) {
+      else if (peek< kwd_media >()) {
         (*root) << parse_media_block();
       }
-      else if (peek< at_root >()) {
+      else if (peek< kwd_at_root >()) {
         (*root) << parse_at_root_block();
       }
-      else if (peek< supports >()) {
+      else if (peek< kwd_supports >()) {
         (*root) << parse_feature_block();
       }
-      else if (peek< warn >()) {
+      else if (peek< kwd_warn >()) {
         (*root) << parse_warning();
         if (!lex< one_plus< exactly<';'> > >()) error("top-level @warn directive must be terminated by ';'", pstate);
       }
-      else if (peek< err >()) {
+      else if (peek< kwd_err >()) {
         (*root) << parse_error();
         if (!lex< one_plus< exactly<';'> > >()) error("top-level @error directive must be terminated by ';'", pstate);
       }
-      else if (peek< dbg >()) {
+      else if (peek< kwd_dbg >()) {
         (*root) << parse_debug();
         if (!lex< one_plus< exactly<';'> > >()) error("top-level @debug directive must be terminated by ';'", pstate);
       }
@@ -181,7 +181,7 @@ namespace Sass {
 
   Import* Parser::parse_import()
   {
-    lex< import >();
+    lex< kwd_import >();
     Import* imp = new (ctx.mem) Import(pstate);
     bool first = true;
     do {
@@ -261,8 +261,8 @@ namespace Sass {
   Definition* Parser::parse_definition()
   {
     Definition::Type which_type = Definition::MIXIN;
-    if      (lex< mixin >())    which_type = Definition::MIXIN;
-    else if (lex< function >()) which_type = Definition::FUNCTION;
+    if      (lex< kwd_mixin >())    which_type = Definition::MIXIN;
+    else if (lex< kwd_function >()) which_type = Definition::FUNCTION;
     string which_str(lexed);
     if (!lex< identifier >()) error("invalid name in " + which_str + " definition", pstate);
     string name(Util::normalize_underscores(lexed));
@@ -318,7 +318,7 @@ namespace Sass {
 
   Mixin_Call* Parser::parse_mixin_call()
   {
-    lex< include >() /* || lex< exactly<'+'> >() */;
+    lex< kwd_include >() /* || lex< exactly<'+'> >() */;
     if (!lex< identifier >()) error("invalid name in @include directive", pstate);
     ParserState source_position_of_call = pstate;
     string name(Util::normalize_underscores(lexed));
@@ -385,13 +385,13 @@ namespace Sass {
     if (!lex< exactly<':'> >()) error("expected ':' after " + name + " in assignment statement", pstate);
     Expression* val = parse_list();
     val->is_delayed(false);
-    bool is_guarded = false;
+    bool is_default = false;
     bool is_global = false;
     while (peek< default_flag >() || peek< global_flag >()) {
-      is_guarded = lex< default_flag >() || is_guarded;
+      is_default = lex< default_flag >() || is_default;
       is_global = lex< global_flag >() || is_global;
     }
-    Assignment* var = new (ctx.mem) Assignment(var_source_position, name, val, is_guarded, is_global);
+    Assignment* var = new (ctx.mem) Assignment(var_source_position, name, val, is_default, is_global);
     return var;
   }
 
@@ -590,7 +590,7 @@ namespace Sass {
         return seq;
       }
     }
-    if (sawsomething && lex_css< sequence< negate< functional >, alternatives< identifier_fragment, universal, quoted_string, dimension, percentage, number > > >()) {
+    if (sawsomething && lex_css< sequence< negate< functional >, alternatives< identifier_alnums, universal, quoted_string, dimension, percentage, number > > >()) {
       // saw an ampersand, then allow type selectors with arbitrary number of hyphens at the beginning
       (*seq) << new (ctx.mem) Type_Selector(pstate, unquote(lexed));
     } else if (lex_css< sequence< negate< functional >, alternatives< type_selector, universal, quoted_string, dimension, percentage, number > > >()) {
@@ -677,7 +677,7 @@ namespace Sass {
         lex< sign >();
         String_Constant* op = new (ctx.mem) String_Quoted(p, lexed);
         // Binary_Expression::Type op = (lexed == "+" ? Binary_Expression::ADD : Binary_Expression::SUB);
-        lex< digits >();
+        lex< one_plus < digit > >();
         String_Constant* constant = new (ctx.mem) String_Quoted(p, lexed);
         // expr = new (ctx.mem) Binary_Expression(p, op, var_coef, constant);
         String_Schema* schema = new (ctx.mem) String_Schema(p, 3);
@@ -685,16 +685,16 @@ namespace Sass {
         expr = schema;
       }
       else if (peek< sequence< optional<sign>,
-                               optional<digits>,
+                               zero_plus<digit>,
                                exactly<'n'>,
                                optional_css_whitespace,
                                exactly<')'> > >()) {
         lex< sequence< optional<sign>,
-                       optional<digits>,
+                       zero_plus<digit>,
                        exactly<'n'> > >();
         expr = new (ctx.mem) String_Quoted(p, lexed);
       }
-      else if (lex< sequence< optional<sign>, digits > >()) {
+      else if (lex< sequence< optional<sign>, one_plus < digit > > >()) {
         expr = new (ctx.mem) String_Quoted(p, lexed);
       }
       else if (peek< sequence< identifier, optional_css_whitespace, exactly<')'> > >()) {
@@ -785,9 +785,9 @@ namespace Sass {
         parse_block_comments(block);
         if (lex< sequence< exactly<'}'>, zero_plus< exactly<';'> > > >()) break;
       }
-      else if (peek< import >(position)) {
+      else if (peek< kwd_import >(position)) {
         if (stack.back() == mixin_def || stack.back() == function_def) {
-          lex< import >(); // to adjust the before_token number
+          lex< kwd_import >(); // to adjust the before_token number
           error("@import directives are not allowed inside mixins and functions", pstate);
         }
         Import* imp = parse_import();
@@ -806,47 +806,47 @@ namespace Sass {
       else if (lex< line_comment >()) {
         // throw line comments away
       }
-      else if (peek< if_directive >()) {
+      else if (peek< kwd_if_directive >()) {
         (*block) << parse_if_directive();
       }
-      else if (peek< for_directive >()) {
+      else if (peek< kwd_for_directive >()) {
         (*block) << parse_for_directive();
       }
-      else if (peek< each_directive >()) {
+      else if (peek< kwd_each_directive >()) {
         (*block) << parse_each_directive();
       }
-      else if (peek < while_directive >()) {
+      else if (peek < kwd_while_directive >()) {
         (*block) << parse_while_directive();
       }
-      else if (lex < return_directive >()) {
+      else if (lex < kwd_return_directive >()) {
         (*block) << new (ctx.mem) Return(pstate, parse_list());
         semicolon = true;
       }
-      else if (peek< warn >()) {
+      else if (peek< kwd_warn >()) {
         (*block) << parse_warning();
         semicolon = true;
       }
-      else if (peek< err >()) {
+      else if (peek< kwd_err >()) {
         (*block) << parse_error();
         semicolon = true;
       }
-      else if (peek< dbg >()) {
+      else if (peek< kwd_dbg >()) {
         (*block) << parse_debug();
         semicolon = true;
       }
       else if (stack.back() == function_def) {
         error("only variable declarations and control directives are allowed inside functions", pstate);
       }
-      else if (peek< mixin >() || peek< function >()) {
+      else if (peek< kwd_mixin >() || peek< kwd_function >()) {
         (*block) << parse_definition();
       }
-      else if (peek< include >(position)) {
+      else if (peek< kwd_include >(position)) {
         Mixin_Call* the_call = parse_mixin_call();
         (*block) << the_call;
         // don't need a semicolon after a content block
         semicolon = (the_call->block()) ? false : true;
       }
-      else if (lex< content >()) {
+      else if (lex< kwd_content >()) {
         if (stack.back() != mixin_def) {
           error("@content may only be used within a mixin", pstate);
         }
@@ -859,7 +859,7 @@ namespace Sass {
         semicolon = true;
       }
       */
-      else if (lex< extend >()) {
+      else if (lex< kwd_extend >()) {
         Selector_Lookahead lookahead = lookahead_for_extension_target(position);
         if (!lookahead.found) error("invalid selector for @extend", pstate);
         Selector* target;
@@ -868,13 +868,13 @@ namespace Sass {
         (*block) << new (ctx.mem) Extension(pstate, target);
         semicolon = true;
       }
-      else if (peek< media >()) {
+      else if (peek< kwd_media >()) {
         (*block) << parse_media_block();
       }
-      else if (peek< supports >()) {
+      else if (peek< kwd_supports >()) {
         (*block) << parse_feature_block();
       }
-      else if (peek< at_root >()) {
+      else if (peek< kwd_at_root >()) {
         (*block) << parse_at_root_block();
       }
       // ignore the @charset directive for now
@@ -932,9 +932,6 @@ namespace Sass {
       prop = parse_identifier_schema();
     }
     else if (lex< sequence< optional< exactly<'*'> >, identifier > >()) {
-      prop = new (ctx.mem) String_Quoted(pstate, lexed);
-    }
-    else if (lex< custom_property_name >()) {
       prop = new (ctx.mem) String_Quoted(pstate, lexed);
     }
     else {
@@ -1097,10 +1094,10 @@ namespace Sass {
   {
     Expression* conj1 = parse_conjunction();
     // if it's a singleton, return it directly; don't wrap it
-    if (!peek< sequence< or_op, negate< identifier > > >()) return conj1;
+    if (!peek< sequence< kwd_or, negate< identifier > > >()) return conj1;
 
     vector<Expression*> operands;
-    while (lex< sequence< or_op, negate< identifier > > >())
+    while (lex< sequence< kwd_or, negate< identifier > > >())
       operands.push_back(parse_conjunction());
 
     return fold_operands(conj1, operands, Binary_Expression::OR);
@@ -1110,10 +1107,10 @@ namespace Sass {
   {
     Expression* rel1 = parse_relation();
     // if it's a singleton, return it directly; don't wrap it
-    if (!peek< sequence< and_op, negate< identifier > > >()) return rel1;
+    if (!peek< sequence< kwd_and, negate< identifier > > >()) return rel1;
 
     vector<Expression*> operands;
-    while (lex< sequence< and_op, negate< identifier > > >())
+    while (lex< sequence< kwd_and, negate< identifier > > >())
       operands.push_back(parse_relation());
 
     return fold_operands(rel1, operands, Binary_Expression::AND);
@@ -1124,22 +1121,22 @@ namespace Sass {
     Expression* expr1 = parse_expression();
     // if it's a singleton, return it directly; don't wrap it
     if (!(peek< alternatives <
-            eq_op,
-            neq_op,
-            gte_op,
-            gt_op,
-            lte_op,
-            lt_op
+            kwd_eq,
+            kwd_neq,
+            kwd_gte,
+            kwd_gt,
+            kwd_lte,
+            kwd_lt
           > >(position)))
     { return expr1; }
 
     Binary_Expression::Type op
-    = lex<eq_op>()  ? Binary_Expression::EQ
-    : lex<neq_op>() ? Binary_Expression::NEQ
-    : lex<gte_op>() ? Binary_Expression::GTE
-    : lex<lte_op>() ? Binary_Expression::LTE
-    : lex<gt_op>()  ? Binary_Expression::GT
-    : lex<lt_op>()  ? Binary_Expression::LT
+    = lex<kwd_eq>()  ? Binary_Expression::EQ
+    : lex<kwd_neq>() ? Binary_Expression::NEQ
+    : lex<kwd_gte>() ? Binary_Expression::GTE
+    : lex<kwd_lte>() ? Binary_Expression::LTE
+    : lex<kwd_gt>()  ? Binary_Expression::GT
+    : lex<kwd_lt>()  ? Binary_Expression::LT
     :                 Binary_Expression::LT; // whatever
 
     Expression* expr2 = parse_expression();
@@ -1159,7 +1156,7 @@ namespace Sass {
 
     vector<Expression*> operands;
     vector<Binary_Expression::Type> operators;
-    while (lex< exactly<'+'> >() || lex< sequence< negate< digits >, exactly<'-'> > >()) {
+    while (lex< exactly<'+'> >() || lex< sequence< negate< digit >, exactly<'-'> > >()) {
       operators.push_back(lexed.to_string() == "+" ? Binary_Expression::ADD : Binary_Expression::SUB);
       operands.push_back(parse_term());
     }
@@ -1240,7 +1237,7 @@ namespace Sass {
     else if (lex< sequence< exactly<'-'>, optional_css_whitespace, negate< number> > >()) {
       return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::MINUS, parse_factor());
     }
-    else if (lex< sequence< not_op, css_whitespace > >()) {
+    else if (lex< sequence< kwd_not, css_whitespace > >()) {
       return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::NOT, parse_factor());
     }
     else if (peek < sequence < one_plus < alternatives < css_whitespace, exactly<'-'>, exactly<'+'> > >, number > >()) {
@@ -1267,7 +1264,7 @@ namespace Sass {
       try {
         // special case -- if there's a comment, treat it as part of a URL
         lex<spaces>();
-        if (peek<line_comment_prefix>() || peek<block_comment_prefix>()) error("comment in URL", pstate); // doesn't really matter what we throw
+        if (peek<line_comment>() || peek<block_comment_prefix>()) error("comment in URL", pstate); // doesn't really matter what we throw
         Expression* expr = parse_list();
         if (!lex< exactly<')'> >()) error("dangling expression in URL", pstate); // doesn't really matter what we throw
         Argument* arg = new (ctx.mem) Argument(expr->pstate(), expr);
@@ -1304,13 +1301,13 @@ namespace Sass {
     if ((stop = peek< value_schema >()))
     { return parse_value_schema(stop); }
 
-    if (lex< sequence< true_val, negate< identifier > > >())
+    if (lex< sequence< kwd_true, negate< identifier > > >())
     { return new (ctx.mem) Boolean(pstate, true); }
 
-    if (lex< sequence< false_val, negate< identifier > > >())
+    if (lex< sequence< kwd_false, negate< identifier > > >())
     { return new (ctx.mem) Boolean(pstate, false); }
 
-    if (lex< sequence< null, negate< identifier > > >())
+    if (lex< sequence< kwd_null, negate< identifier > > >())
     { return new (ctx.mem) Null(pstate); }
 
     if (lex< identifier >()) {
@@ -1633,14 +1630,14 @@ namespace Sass {
 
   If* Parser::parse_if_directive(bool else_if)
   {
-    lex< if_directive >() || (else_if && lex< exactly<if_after_else_kwd> >());
+    lex< kwd_if_directive >() || (else_if && lex< exactly<if_after_else_kwd> >());
     ParserState if_source_position = pstate;
     Expression* predicate = parse_list();
     predicate->is_delayed(false);
     if (!peek< exactly<'{'> >()) error("expected '{' after the predicate for @if", pstate);
     Block* consequent = parse_block();
     Block* alternative = 0;
-    if (lex< else_directive >()) {
+    if (lex< kwd_else_directive >()) {
       if (peek< exactly<if_after_else_kwd> >()) {
         alternative = new (ctx.mem) Block(pstate);
         (*alternative) << parse_if_directive(true);
@@ -1657,16 +1654,16 @@ namespace Sass {
 
   For* Parser::parse_for_directive()
   {
-    lex< for_directive >();
+    lex< kwd_for_directive >();
     ParserState for_source_position = pstate;
     if (!lex< variable >()) error("@for directive requires an iteration variable", pstate);
     string var(Util::normalize_underscores(lexed));
-    if (!lex< from >()) error("expected 'from' keyword in @for directive", pstate);
+    if (!lex< kwd_from >()) error("expected 'from' keyword in @for directive", pstate);
     Expression* lower_bound = parse_expression();
     lower_bound->is_delayed(false);
     bool inclusive = false;
-    if (lex< through >()) inclusive = true;
-    else if (lex< to >()) inclusive = false;
+    if (lex< kwd_through >()) inclusive = true;
+    else if (lex< kwd_to >()) inclusive = false;
     else                  error("expected 'through' or 'to' keyword in @for directive", pstate);
     Expression* upper_bound = parse_expression();
     upper_bound->is_delayed(false);
@@ -1677,7 +1674,7 @@ namespace Sass {
 
   Each* Parser::parse_each_directive()
   {
-    lex < each_directive >();
+    lex < kwd_each_directive >();
     ParserState each_source_position = pstate;
     if (!lex< variable >()) error("@each directive requires an iteration variable", pstate);
     vector<string> vars;
@@ -1686,7 +1683,7 @@ namespace Sass {
       if (!lex< variable >()) error("@each directive requires an iteration variable", pstate);
       vars.push_back(Util::normalize_underscores(lexed));
     }
-    if (!lex< in >()) error("expected 'in' keyword in @each directive", pstate);
+    if (!lex< kwd_in >()) error("expected 'in' keyword in @each directive", pstate);
     Expression* list = parse_list();
     list->is_delayed(false);
     if (list->concrete_type() == Expression::LIST) {
@@ -1702,7 +1699,7 @@ namespace Sass {
 
   While* Parser::parse_while_directive()
   {
-    lex< while_directive >();
+    lex< kwd_while_directive >();
     ParserState while_source_position = pstate;
     Expression* predicate = parse_list();
     predicate->is_delayed(false);
@@ -1712,7 +1709,7 @@ namespace Sass {
 
   Media_Block* Parser::parse_media_block()
   {
-    lex< media >();
+    lex< kwd_media >();
     ParserState media_source_position = pstate;
 
     List* media_queries = parse_media_queries();
@@ -1787,7 +1784,7 @@ namespace Sass {
 
   Feature_Block* Parser::parse_feature_block()
   {
-    lex< supports >();
+    lex< kwd_supports >();
     ParserState supports_source_position = pstate;
 
     Feature_Query* feature_queries = parse_feature_queries();
@@ -1816,9 +1813,9 @@ namespace Sass {
 
   Feature_Query_Condition* Parser::parse_feature_query()
   {
-    if (peek< not_op >(position)) return parse_supports_negation();
-    else if (peek< and_op >(position)) return parse_supports_conjunction();
-    else if (peek< or_op >(position)) return parse_supports_disjunction();
+    if (peek< kwd_not >(position)) return parse_supports_negation();
+    else if (peek< kwd_and >(position)) return parse_supports_conjunction();
+    else if (peek< kwd_or >(position)) return parse_supports_disjunction();
     else if (peek< exactly<'('> >(position)) return parse_feature_query_in_parens();
     else return parse_supports_declaration();
   }
@@ -1837,7 +1834,7 @@ namespace Sass {
 
   Feature_Query_Condition* Parser::parse_supports_negation()
   {
-    lex< not_op >();
+    lex< kwd_not >();
 
     Feature_Query_Condition* cond = parse_feature_query();
     cond->operand(Feature_Query_Condition::NOT);
@@ -1847,7 +1844,7 @@ namespace Sass {
 
   Feature_Query_Condition* Parser::parse_supports_conjunction()
   {
-    lex< and_op >();
+    lex< kwd_and >();
 
     Feature_Query_Condition* cond = parse_feature_query();
     cond->operand(Feature_Query_Condition::AND);
@@ -1857,7 +1854,7 @@ namespace Sass {
 
   Feature_Query_Condition* Parser::parse_supports_disjunction()
   {
-    lex< or_op >();
+    lex< kwd_or >();
 
     Feature_Query_Condition* cond = parse_feature_query();
     cond->operand(Feature_Query_Condition::OR);
@@ -1877,7 +1874,7 @@ namespace Sass {
 
   At_Root_Block* Parser::parse_at_root_block()
   {
-    lex<at_root>();
+    lex<kwd_at_root>();
     ParserState at_source_position = pstate;
     Block* body = 0;
     At_Root_Expression* expr = 0;
@@ -1906,11 +1903,8 @@ namespace Sass {
     lex< exactly<'('> >();
     if (peek< exactly<')'> >()) error("at-root feature required in at-root expression", pstate);
 
-    if (!peek< alternatives< with_directive, without_directive > >()) {
-      const char* i = position;
-      const char* p = peek< until<')'> >(i);
-      Token* t = new Token(i, p);
-      error("Invalid CSS after \"(\": expected \"with\" or \"without\", was \""+t->to_string()+"\"", pstate);
+    if (!peek< alternatives< kwd_with_directive, kwd_without_directive > >()) {
+      css_error("Invalid CSS", " after ", ": expected \"with\" or \"without\", was ");
     }
 
     Declaration* declaration = parse_declaration();
@@ -1956,19 +1950,19 @@ namespace Sass {
 
   Warning* Parser::parse_warning()
   {
-    lex< warn >();
+    lex< kwd_warn >();
     return new (ctx.mem) Warning(pstate, parse_list());
   }
 
   Error* Parser::parse_error()
   {
-    lex< err >();
+    lex< kwd_err >();
     return new (ctx.mem) Error(pstate, parse_list());
   }
 
   Debug* Parser::parse_debug()
   {
-    lex< dbg >();
+    lex< kwd_dbg >();
     return new (ctx.mem) Debug(pstate, parse_list());
   }
 
@@ -2002,13 +1996,13 @@ namespace Sass {
            (q = peek< binomial >(p))                               ||
            (q = peek< block_comment >(p))                          ||
            (q = peek< sequence< optional<sign>,
-                                optional<digits>,
+                                zero_plus<digit>,
                                 exactly<'n'> > >(p))               ||
            (q = peek< sequence< optional<sign>,
-                                digits > >(p))                     ||
+                                one_plus<digit> > >(p))                     ||
            (q = peek< number >(p))                                 ||
            (q = peek< sequence< exactly<'&'>,
-                                identifier_fragment > >(p))        ||
+                                identifier_alnums > >(p))        ||
            (q = peek< exactly<'&'> >(p))                           ||
            (q = peek< exactly<'%'> >(p))                           ||
            (q = peek< alternatives<exact_match,
@@ -2062,13 +2056,13 @@ namespace Sass {
            (q = peek< binomial >(p))                               ||
            (q = peek< block_comment >(p))                          ||
            (q = peek< sequence< optional<sign>,
-                                optional<digits>,
+                                zero_plus<digit>,
                                 exactly<'n'> > >(p))               ||
            (q = peek< sequence< optional<sign>,
-                                digits > >(p))                     ||
+                                one_plus<digit> > >(p))                     ||
            (q = peek< number >(p))                                 ||
            (q = peek< sequence< exactly<'&'>,
-                                identifier_fragment > >(p))        ||
+                                identifier_alnums > >(p))        ||
            (q = peek< exactly<'&'> >(p))                           ||
            (q = peek< exactly<'%'> >(p))                           ||
            (q = peek< alternatives<exact_match,

--- a/util.cpp
+++ b/util.cpp
@@ -27,7 +27,7 @@ namespace Sass {
     char separator = *(localeconv()->decimal_point);
     if(separator != '.'){
       // The current locale specifies another
-      // separator. convert the separator to the 
+      // separator. convert the separator to the
       // one understood by the locale if needed
       const char *found = strchr(str, '.');
       if(found != NULL){
@@ -619,8 +619,8 @@ namespace Sass {
       }
     }
 
-     bool isAscii(int ch) {
-         return ch >= 0 && ch < 128;
+     bool isAscii(const char chr) {
+       return unsigned(chr) < 128;
      }
 
   }

--- a/util.hpp
+++ b/util.hpp
@@ -41,7 +41,7 @@ namespace Sass {
     bool isPrintable(Feature_Block* r, Output_Style style = NESTED);
     bool isPrintable(Media_Block* r, Output_Style style = NESTED);
     bool isPrintable(Block* b, Output_Style style = NESTED);
-    bool isAscii(int ch);
+    bool isAscii(const char chr);
 
   }
 }

--- a/win/libsass.filters
+++ b/win/libsass.filters
@@ -84,6 +84,9 @@
     <ClCompile Include="..\position.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\lexer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\prelexer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -243,6 +246,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\position.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\lexer.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\prelexer.hpp">

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -181,6 +181,7 @@
     <ClCompile Include="..\parser.cpp" />
     <ClCompile Include="..\plugins.cpp" />
     <ClCompile Include="..\position.cpp" />
+    <ClCompile Include="..\lexer.cpp" />
     <ClCompile Include="..\prelexer.cpp" />
     <ClCompile Include="..\remove_placeholders.cpp" />
     <ClCompile Include="..\sass.cpp" />
@@ -234,6 +235,7 @@
     <ClInclude Include="..\plugins.hpp" />
     <ClInclude Include="..\paths.hpp" />
     <ClInclude Include="..\position.hpp" />
+    <ClInclude Include="..\lexer.hpp" />
     <ClInclude Include="..\prelexer.hpp" />
     <ClInclude Include="..\remove_placeholders.hpp" />
     <ClInclude Include="..\sass.h" />


### PR DESCRIPTION
- Moved some basic parts out of prelexer into a speperate file .
- Re-implemented some standard functions to make them locale unware (like ispunct).
- This seems to improve performance by quite a bit actually (25%?)!
- Prefixed all prelexer keywords to recognise them easier.
- Thinking abour prefixing all other prelexers with `re_` (for RegEx)?

My perl-libsass spec runner report this speed increase:
```
before: in 14 wallclock secs (14.24 usr +  0.47 sys = 14.71 CPU)
after: in 12 wallclock secs (10.94 usr +  0.58 sys = 11.51 CPU)
```

Waiting for some other PRs to be merged and will then rebase this PR!