### PR TITLE
Simplify autotools build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Makefile.in
 /m4/ltsugar.m4
 /m4/ltversion.m4
 /m4/lt~obsolete.m4
+/script/ar-lib
 /script/compile
 /script/config.guess
 /script/config.sub

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,29 +1,21 @@
 ACLOCAL_AMFLAGS = -I m4
 
-AM_LDFLAGS = -lstdc++ -lm
-AM_CFLAGS = -Wall
-AM_CXXFLAGS = -Wall
+AM_COPT = -Wall -O2
+AM_COVLDFLAGS =
+
+if ENABLE_COVERAGE
+	AM_COPT = -O0 --coverage
+	AM_COVLDFLAGS += -lgcov
+endif
+
+AM_CFLAGS =   $(AM_COPT)
+AM_CXXFLAGS = $(AM_COPT)
+AM_LDFLAGS =  $(AM_COPT) $(AM_COVLDFLAGS)
 
 if COMPILER_IS_MINGW32
   AM_CXXFLAGS += -std=gnu++0x
 else
-  AM_CFLAGS += -fPIC
-  AM_CXXFLAGS += -fPIC
   AM_CXXFLAGS += -std=c++0x
-  AM_LDFLAGS += -ldl
-endif
-
-AM_CFLAGS += -DLIBSASS_VERSION="\"$(VERSION)\""
-AM_CXXFLAGS += -DLIBSASS_VERSION="\"$(VERSION)\""
-
-if ENABLE_COVERAGE
-	AM_CFLAGS += -O0 --coverage
-	AM_CXXFLAGS += -O0 --coverage
-	AM_LDFLAGS += -O0 --coverage -lgcov
-else
-	AM_CFLAGS += -O2
-	AM_CXXFLAGS += -O2
-	AM_LDFLAGS += -O2
 endif
 
 EXTRA_DIST = \
@@ -88,8 +80,6 @@ libsass_la_SOURCES = \
 	utf8_string.cpp utf8_string.hpp \
 	util.cpp util.hpp
 
-libsass_la_CFLAGS = $(AM_CFLAGS)
-libsass_la_CXXFLAGS = $(AM_CXXFLAGS)
 libsass_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined -version-info 0:9:0
 
 include_HEADERS = sass2scss.h sass_context.h sass_functions.h sass_values.h sass.h
@@ -139,12 +129,7 @@ else
 endif
 
 SASS_TESTER = $(RUBY) $(SASS_SPEC_PATH)/sass-spec.rb
-
-if COMPILER_IS_MINGW32
-  SASS_TESTER += -c $(SASS_LIBSASS_PATH)/tester.exe
-else
-  SASS_TESTER += -c $(SASS_LIBSASS_PATH)/tester
-endif
+SASS_TESTER += -c $(SASS_LIBSASS_PATH)/tester$(EXEEXT)
 
 test:
 	$(SASS_TESTER) --ignore-todo $(LOG_FLAGS) $(SASS_SPEC_PATH) $(SASS_TEST_FLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -7,15 +7,17 @@ AC_INIT([libsass], m4_esyscmd_s([./version.sh]), [support@moovweb.com])
 AC_CONFIG_SRCDIR([ast.hpp])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_FILES([sass_version.h])
 AC_CONFIG_AUX_DIR([script])
-AM_INIT_AUTOMAKE([foreign parallel-tests])
+# These are flags passed to automake
+# Though they look like gcc flags!
+AM_INIT_AUTOMAKE([foreign parallel-tests -Wall])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([no])])
-LT_INIT
 
 # Checks for programs.
 AC_PROG_CXX
-
 AC_LANG([C++])
+LT_INIT([dlopen])
 
 # Checks for header files.
 AC_CHECK_HEADERS([unistd.h])
@@ -30,6 +32,17 @@ AC_CHECK_FUNCS([floor getcwd strtol])
 # Checks for testing.
 AC_ARG_ENABLE(tests, AS_HELP_STRING([--enable-tests], [enable testing the build]),
               [enable_tests="$enableval"], [enable_tests=no])
+
+AS_CASE([$host], [*-*-mingw32], [is_mingw32=yes], [is_mingw32=no])
+AM_CONDITIONAL(COMPILER_IS_MINGW32, test "x$is_mingw32" = "xyes")
+
+dnl The dlopen() function is in the C library for *BSD and in
+dnl libdl on GLIBC-based systems
+if test "x$is_mingw32" != "xyes"; then
+  AC_SEARCH_LIBS([dlopen], [dl dld], [], [
+    AC_MSG_ERROR([unable to find the dlopen() function])
+  ])
+fi
 
 if test "x$enable_tests" = "xyes"; then
   AC_PROG_CC
@@ -107,8 +120,7 @@ fi
 
 AM_CONDITIONAL(ENABLE_COVERAGE, test "x$enable_cov" = "xyes")
 
-AS_CASE([$host], [*-*-mingw32], [is_mingw32=yes], [is_mingw32=no])
-AM_CONDITIONAL(COMPILER_IS_MINGW32, test "x$is_mingw32" = "xyes")
+AC_SUBST(PACKAGE_VERSION)
 
 AC_MSG_NOTICE([Building libsass ($VERSION)])
 

--- a/sass.h
+++ b/sass.h
@@ -32,11 +32,8 @@
 
 #endif
 
-#ifndef LIBSASS_VERSION
-#define LIBSASS_VERSION "[NA]"
-#endif
-
 // include API headers
+#include "sass_version.h"
 #include "sass_values.h"
 #include "sass_functions.h"
 

--- a/sass_version.h
+++ b/sass_version.h
@@ -1,0 +1,8 @@
+#ifndef SASS_VERSION_H
+#define SASS_VERSION_H
+
+#ifndef LIBSASS_VERSION
+#define LIBSASS_VERSION "[NA]"
+#endif
+
+#endif

--- a/sass_version.h.in
+++ b/sass_version.h.in
@@ -1,0 +1,8 @@
+#ifndef SASS_VERSION_H
+#define SASS_VERSION_H
+
+#ifndef LIBSASS_VERSION
+#define LIBSASS_VERSION "@PACKAGE_VERSION@"
+#endif
+
+#endif


### PR DESCRIPTION
- Generate sass_version.h
- Use $(EXEEXT) for executables
- No need for -lm and C++ library.
- They should be provided by libtool.

Work done by @saper !