### PR TITLE
Implement `/deep/` shadow DOM selector

### DIFF
--- a/constants.cpp
+++ b/constants.cpp
@@ -78,6 +78,9 @@ namespace Sass {
     extern const char webkit_calc_kwd[]  = "-webkit-calc(";
     extern const char ms_calc_kwd[]      = "-ms-calc(";
 
+    // css selector keywords
+    extern const char sel_deep_kwd[] = "/deep/";
+
     // css attribute-matching operators
     extern const char tilde_equal[]  = "~=";
     extern const char pipe_equal[]   = "|=";

--- a/constants.hpp
+++ b/constants.hpp
@@ -80,6 +80,9 @@ namespace Sass {
     extern const char webkit_calc_kwd[];
     extern const char ms_calc_kwd[];
 
+    // css selector keywords
+    extern const char sel_deep_kwd[];
+
     // css attribute-matching operators
     extern const char tilde_equal[];
     extern const char pipe_equal[];

--- a/parser.cpp
+++ b/parser.cpp
@@ -628,6 +628,9 @@ namespace Sass {
     else if (lex< quoted_string >() || lex< number >()) {
       return new (ctx.mem) Type_Selector(pstate, unquote(lexed));
     }
+    else if (lex< exactly < sel_deep_kwd > >()) {
+      return new (ctx.mem) Type_Selector(pstate, unquote(lexed));
+    }
     else if (peek< pseudo_not >()) {
       return parse_negated_selector();
     }
@@ -1984,6 +1987,7 @@ namespace Sass {
            (q = peek< dimension >(p))                              ||
            (q = peek< quoted_string >(p))                          ||
            (q = peek< exactly<'*'> >(p))                           ||
+           (q = peek< exactly<sel_deep_kwd> >(p))                           ||
            (q = peek< exactly<'('> >(p))                           ||
            (q = peek< exactly<')'> >(p))                           ||
            (q = peek< exactly<'['> >(p))                           ||


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/452 (spec-tests: https://github.com/sass/sass-spec/pull/287)