### PR TITLE
autoconf macros to improve C++11 compat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,8 @@ AC_TYPE_SIZE_T
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([floor getcwd strtol])
 
+CXX11_UNORDERED_MAP
+
 # Checks for testing.
 AC_ARG_ENABLE(tests, AS_HELP_STRING([--enable-tests], [enable testing the build]),
               [enable_tests="$enableval"], [enable_tests=no])

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ AC_TYPE_SIZE_T
 AC_FUNC_MALLOC
 AC_CHECK_FUNCS([floor getcwd strtol])
 
+CXX11_AUTO
 CXX11_UNORDERED_MAP
 
 # Checks for testing.

--- a/m4/cxx11_auto.m4
+++ b/m4/cxx11_auto.m4
@@ -1,0 +1,21 @@
+#serial 1
+AC_DEFUN([CXX11_AUTO],
+[
+  AC_REQUIRE([CXX11_STD_AVAILABLE])
+  CXX11_STD_TRY([auto], [
+#include <string>
+], [[
+using namespace std;
+  class A {
+    void m() {
+      auto string = 2;
+    }
+  }
+]],
+  [ $cxx11_cv_prog_cxx_cxx11 ],
+  [
+    AC_DEFINE([HAVE_CXX11_AUTO],[1],
+      [Define to 1 C++11 auto variables are available])
+  ],
+  [])
+])

--- a/m4/cxx11_headers.m4
+++ b/m4/cxx11_headers.m4
@@ -1,0 +1,61 @@
+#serial 1
+AC_DEFUN([CXX11_CHECK_HEADER],
+[
+  AC_REQUIRE([CXX11_STD_AVAILABLE])
+  AH_TEMPLATE(AS_TR_CPP([HAVE_CXX_$1]),
+    [Define to 1 if you have <$1> C++ header file.])
+  AC_MSG_CHECKING([for <$1>])
+  _CXX11_STD_TRY(m4_translit(AS_TR_CPP($1), [A-Z], [a-z]), [[#include <$1>]], $2, [ "" $cxx11_cv_prog_cxx_cxx11 ])
+  AS_IF([test "x$cxx11_cv_prog_cxx_$1" != xno],
+    [AC_DEFINE_UNQUOTED(AS_TR_CPP([HAVE_CXX_]$1))])
+])
+AC_DEFUN([CXX11_HEADER_SUCCESSION],
+[
+  CXX11_CHECK_HEADER([$1], [$2])
+  AS_IF([test "x$cxx11_cv_prog_cxx_$1" = xno], [
+    CXX11_CHECK_HEADER([$3], [$4])
+  ])
+])
+AC_DEFUN([CXX11_TR1_HEADER],
+[
+  AH_TEMPLATE(AS_TR_CPP([[HAVE_CXX_ONLY_TR1_]m4_translit([$1], [a-z], [A-Z])]),
+    [Define to 1 if you only have <tr1/$1> C++ header file working.])
+  CXX11_HEADER_SUCCESSION([$1], [$2], [tr1/$1], [$3])
+  AS_IF([test "x$cxx11_cv_prog_cxx_$1" = xno], [
+    AS_IF([test "x$cxx11_cv_prog_cxx_tr1_$1" != xno],
+      [AC_DEFINE_UNQUOTED(AS_TR_CPP([[HAVE_CXX_ONLY_TR1_]m4_translit([$1], [a-z], [A-Z])]))]
+    )
+  ])
+])
+AC_DEFUN([CXX11_RANDOM], [CXX11_TR1_HEADER([random],
+  [[std::uniform_real_distribution<double> distributor(1, 30);]],
+  [[std::tr1::uniform_real<double> distributor(1, 30);]])
+])
+AC_DEFUN([_CXX11_UNORDERED_MAP_TEST_HEADER], [[
+#ifdef HAVE_CXX_UNORDERED_MAP
+#include <unordered_map>
+#define NS(A) std::A
+#else
+#include <tr1/unordered_map>
+#define NS(A) std::tr1::##A
+#endif
+]])
+AC_DEFUN([CXX11_UNORDERED_MAP], [
+  CXX11_TR1_HEADER([unordered_map],
+    [[ std::unordered_map<int, int> m; m[[0]] = 1;]],
+    [[ std::tr1::unordered_map<int, int> m; ]])
+  CXX11_STD_TRY([unordered_map_reserve], [_CXX11_UNORDERED_MAP_TEST_HEADER],
+    [[NS(unordered_map)<int, int> m; m.reserve(6);]],
+  [ $cxx11_cv_prog_cxx_cxx11 ],
+  [ AC_DEFINE([HAVE_CXX_UNORDERED_MAP_RESERVE], [1],
+       [Define to 1 if your unordered_map has reserve()]) ])
+  CXX11_STD_TRY([unordered_map_at], [_CXX11_UNORDERED_MAP_TEST_HEADER],
+    [[NS(unordered_map)<int, int> m; m[[0]] = 1; int z = m.at(0);]],
+  [ $cxx11_cv_prog_cxx_cxx11 ],
+  [ AC_DEFINE([HAVE_CXX_UNORDERED_MAP_AT], [1],
+       [Define to 1 if your unordered_map has at()]) ])
+])
+AC_DEFUN([CXX11_ATOMIC], [CXX11_HEADER_SUCCESSION(
+  [atomic], [[ std::atomic_bool b1]],
+  [cstdatomic], [[ std::atomic_bool b1]])
+])

--- a/m4/cxx11_nullptr.m4
+++ b/m4/cxx11_nullptr.m4
@@ -1,0 +1,12 @@
+#serial 1
+AC_DEFUN([CXX11_NULLPTR],
+[
+  AC_REQUIRE([CXX11_STD_AVAILABLE])
+  CXX11_STD_TRY([nullptr], [], [[char *s = nullptr;]],
+  [ $cxx11_cv_prog_cxx_cxx11 ],
+  [
+    AC_DEFINE([HAVE_CXX11_NULLPTR],[1],
+      [Define to 1 C++11 nullptr is available])
+  ],
+  [])
+])

--- a/m4/cxx11_rangeloop.m4
+++ b/m4/cxx11_rangeloop.m4
@@ -1,0 +1,17 @@
+#serial 1
+AC_DEFUN([CXX11_RANGELOOP],
+[
+  AC_REQUIRE([CXX11_STD_AVAILABLE])
+  CXX11_STD_TRY([rangeloop],
+  [[#include <string>]],
+  [[
+  std::string str = "Hello";
+  for (char c : str) { }
+  ]],
+  [ $cxx11_cv_prog_cxx_cxx11 ],
+  [
+    AC_DEFINE([HAVE_CXX11_RANGE_LOOP],[1],
+      [Define to 1 C++11 range loops are available])
+  ],
+  [])])
+])

--- a/m4/cxx11_std_try.m4
+++ b/m4/cxx11_std_try.m4
@@ -1,0 +1,54 @@
+#serial 1
+# CXX11_STD_TRY(STANDARD, TEST-PROLOGUE, TEST-BODY, OPTION-LIST,
+#                 ACTION-IF-AVAILABLE, ACTION-IF-UNAVAILABLE)
+# ----------------------------------------------------------------
+# Check whether the C++ compiler accepts features of STANDARD (e.g
+# `cxx98', `cxx11') by trying to compile a program of TEST-PROLOGUE
+# and TEST-BODY.  If this fails, try again with each compiler option
+# in the space-separated OPTION-LIST; if one helps, append it to CXX.
+# If eventually successful, run ACTION-IF-AVAILABLE, else
+# ACTION-IF-UNAVAILABLE.
+AC_DEFUN([_CXX11_STD_TRY],
+[
+AC_LANG_PUSH(C++)dnl
+AC_CACHE_VAL(cxx11_cv_prog_cxx_$1,
+[cxx11_cv_prog_cxx_$1=no
+cxx11_save_CXX=$CXX
+AC_LANG_CONFTEST([AC_LANG_PROGRAM([$2], [$3])])
+for cxx11_arg in $4
+do
+  CXX="$cxx11_save_CXX $cxx11_arg"
+  _AS_ECHO_N([$cxx11_arg ])
+  AC_COMPILE_IFELSE([], [cxx11_cv_prog_cxx_$1=$cxx11_arg])
+  test "x$cxx11_cv_prog_cxx_$1" != "xno" && break
+done
+rm -f conftest.$ac_ext
+CXX=$cxx11_save_CXX
+])# AC_CACHE_VAL
+cxx11_prog_cxx_stdcxx_options=
+case "x$cxx11_cv_prog_cxx_$1" in
+  x)
+    AC_MSG_RESULT([working as-is]) ;;
+  xno)
+    AC_MSG_RESULT([not working]) ;;
+  *)
+    cxx11_prog_cxx_stdcxx_options=" $cxx11_cv_prog_cxx_$1"
+    CXX=$CXX$cxx11_prog_cxx_stdcxx_options
+    AC_MSG_RESULT([working]) ;;
+esac
+AC_LANG_POP(C++)dnl
+])# _CXX11_STD_TRY
+AC_DEFUN([CXX11_STD_TRY], 
+[
+  AC_MSG_CHECKING([for $CXX option to enable ]m4_translit($1, [x], [+])[ feature])
+  _CXX11_STD_TRY($1, $2, $3, ["" m4_expand($4)])
+  AS_IF([test "x$cxx11_cv_prog_cxx_$1" != xno], [$5], [$6])
+])
+AC_DEFUN([CXX11_STD_AVAILABLE],
+[
+  cxx11_save_CXX=$CXX
+  AC_MSG_CHECKING([for $CXX to have C++11 rvalue references])
+  _CXX11_STD_TRY([cxx11], [], [[double&& d = 2]],
+  [[ -std=c++11 -std=c++0x -qlanglvl=extended0x -AA ]])
+  CXX=$cxx11_save_CXX
+])

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1717,7 +1717,7 @@ namespace Sass {
 #ifdef HAVE_CXX_UNORDERED_MAP_AT
       return elements_.at(k);
 #else
-      unordered_map<Expression*, Expression*>::const_iterator it = elements_.find(k);
+      std::_TR1_ unordered_map<Expression*, Expression*>::const_iterator it = elements_.find(k);
       if (it != elements_.end()) {
         return it->second;
       } else {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1713,7 +1713,18 @@ namespace Sass {
   Expression* Hashed::at(Expression* k) const
   {
     if (elements_.count(k))
-    { return elements_.at(k); }
+    {
+#ifdef HAVE_CXX_UNORDERED_MAP_AT
+      return elements_.at(k);
+#else
+      unordered_map<Expression*, Expression*>::const_iterator it = elements_.find(k);
+      if (it != elements_.end()) {
+        return it->second;
+      } else {
+        throw std::out_of_range("item not found");
+      }
+#endif
+    }
     else { return &sass_null; }
   }
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -159,6 +159,9 @@ namespace Sass {
 /////////////////////////////////////////////////////////////////////////////////////
 
 namespace std {
+#ifdef HAVE_CXX_ONLY_TR1_UNORDERED_MAP
+namespace tr1 {
+#endif
   template<>
   struct hash<Sass::Expression*>
   {
@@ -167,6 +170,9 @@ namespace std {
       return s->hash();
     }
   };
+#ifdef HAVE_CXX_ONLY_TR1_UNORDERED_MAP
+}
+#endif
   template<>
   struct equal_to<Sass::Expression*>
   {
@@ -251,7 +257,6 @@ namespace Sass {
   public:
     Hashed(size_t s = 0) : elements_(STDTR1(unordered_map)<Expression*, Expression*>(s)), list_(std::vector<Expression*>())
     { elements_.reserve(s); list_.reserve(s); reset_duplicate_key(); }
-    Hashed(size_t s = 0) : elements_(STDTR1(unordered_map)<Expression*, Expression*>(s)), list_(vector<Expression*>())
     { 
 #ifdef HAVE_CXX_UNORDERED_MAP_RESERVE
       elements_.reserve(s); list_.reserve(s);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -14,10 +14,10 @@
 #endif
 #ifdef   HAVE_CXX_ONLY_TR1_UNORDERED_MAP
 #include <tr1/unordered_map>
-#define  STDTR1(A) std::tr1::##A
+#define  _TR1_ tr1::
 #else
 #include <unordered_map>
-#define  STDTR1(A) std::##A
+#define  _TR1_
 #endif
 
 #ifdef __clang__
@@ -246,7 +246,7 @@ namespace Sass {
   /////////////////////////////////////////////////////////////////////////////
   class Hashed {
   private:
-    STDTR1(unordered_map)<Expression*, Expression*> elements_;
+    std::_TR1_ unordered_map<Expression*, Expression*> elements_;
     std::vector<Expression*> list_;
   protected:
     size_t hash_;
@@ -255,8 +255,7 @@ namespace Sass {
     void reset_duplicate_key() { duplicate_key_ = 0; }
     virtual void adjust_after_pushing(std::pair<Expression*, Expression*> p) { }
   public:
-    Hashed(size_t s = 0) : elements_(STDTR1(unordered_map)<Expression*, Expression*>(s)), list_(std::vector<Expression*>())
-    { elements_.reserve(s); list_.reserve(s); reset_duplicate_key(); }
+    Hashed(size_t s = 0) : elements_(std::_TR1_ unordered_map<Expression*, Expression*>(s)), list_(std::vector<Expression*>())
     { 
 #ifdef HAVE_CXX_UNORDERED_MAP_RESERVE
       elements_.reserve(s); list_.reserve(s);
@@ -270,7 +269,7 @@ namespace Sass {
     Expression* at(Expression* k) const;
     bool has_duplicate_key() const         { return duplicate_key_ != 0; }
     Expression* get_duplicate_key() const  { return duplicate_key_; }
-    const STDTR1(unordered_map)<Expression*, Expression*> elements() { return elements_; }
+    const std::_TR1_ unordered_map<Expression*, Expression*> elements() { return elements_; }
     Hashed& operator<<(std::pair<Expression*, Expression*> p)
     {
       reset_hash();
@@ -298,13 +297,13 @@ namespace Sass {
       reset_duplicate_key();
       return *this;
     }
-    const STDTR1(unordered_map)<Expression*, Expression*>& pairs() const { return elements_; }
+    const std::_TR1_ unordered_map<Expression*, Expression*>& pairs() const { return elements_; }
     const std::vector<Expression*>& keys() const { return list_; }
 
-    STDTR1(unordered_map)<Expression*, Expression*>::iterator end() { return elements_.end(); }
-    STDTR1(unordered_map)<Expression*, Expression*>::iterator begin() { return elements_.begin(); }
-    STDTR1(unordered_map)<Expression*, Expression*>::const_iterator end() const { return elements_.end(); }
-    STDTR1(unordered_map)<Expression*, Expression*>::const_iterator begin() const { return elements_.begin(); }
+    std::_TR1_ unordered_map<Expression*, Expression*>::iterator end() { return elements_.end(); }
+    std::_TR1_ unordered_map<Expression*, Expression*>::iterator begin() { return elements_.begin(); }
+    std::_TR1_ unordered_map<Expression*, Expression*>::const_iterator end() const { return elements_.end(); }
+    std::_TR1_ unordered_map<Expression*, Expression*>::const_iterator begin() const { return elements_.begin(); }
 
   };
   inline Hashed::~Hashed() { }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -9,7 +9,16 @@
 #include <iostream>
 #include <typeinfo>
 #include <algorithm>
+#ifdef   HAVE_CONFIG_H
+#include "config.h"
+#endif
+#ifdef   HAVE_CXX_ONLY_TR1_UNORDERED_MAP
+#include <tr1/unordered_map>
+#define  STDTR1(A) std::tr1::##A
+#else
 #include <unordered_map>
+#define  STDTR1(A) std::##A
+#endif
 
 #ifdef __clang__
 
@@ -231,7 +240,7 @@ namespace Sass {
   /////////////////////////////////////////////////////////////////////////////
   class Hashed {
   private:
-    std::unordered_map<Expression*, Expression*> elements_;
+    STDTR1(unordered_map)<Expression*, Expression*> elements_;
     std::vector<Expression*> list_;
   protected:
     size_t hash_;
@@ -240,8 +249,15 @@ namespace Sass {
     void reset_duplicate_key() { duplicate_key_ = 0; }
     virtual void adjust_after_pushing(std::pair<Expression*, Expression*> p) { }
   public:
-    Hashed(size_t s = 0) : elements_(std::unordered_map<Expression*, Expression*>(s)), list_(std::vector<Expression*>())
+    Hashed(size_t s = 0) : elements_(STDTR1(unordered_map)<Expression*, Expression*>(s)), list_(std::vector<Expression*>())
     { elements_.reserve(s); list_.reserve(s); reset_duplicate_key(); }
+    Hashed(size_t s = 0) : elements_(STDTR1(unordered_map)<Expression*, Expression*>(s)), list_(vector<Expression*>())
+    { 
+#ifdef HAVE_CXX_UNORDERED_MAP_RESERVE
+      elements_.reserve(s); list_.reserve(s);
+#endif
+      reset_duplicate_key();
+    }
     virtual ~Hashed();
     size_t length() const                  { return list_.size(); }
     bool empty() const                     { return list_.empty(); }
@@ -249,7 +265,7 @@ namespace Sass {
     Expression* at(Expression* k) const;
     bool has_duplicate_key() const         { return duplicate_key_ != 0; }
     Expression* get_duplicate_key() const  { return duplicate_key_; }
-    const std::unordered_map<Expression*, Expression*> elements() { return elements_; }
+    const STDTR1(unordered_map)<Expression*, Expression*> elements() { return elements_; }
     Hashed& operator<<(std::pair<Expression*, Expression*> p)
     {
       reset_hash();
@@ -277,13 +293,13 @@ namespace Sass {
       reset_duplicate_key();
       return *this;
     }
-    const std::unordered_map<Expression*, Expression*>& pairs() const { return elements_; }
+    const STDTR1(unordered_map)<Expression*, Expression*>& pairs() const { return elements_; }
     const std::vector<Expression*>& keys() const { return list_; }
 
-    std::unordered_map<Expression*, Expression*>::iterator end() { return elements_.end(); }
-    std::unordered_map<Expression*, Expression*>::iterator begin() { return elements_.begin(); }
-    std::unordered_map<Expression*, Expression*>::const_iterator end() const { return elements_.end(); }
-    std::unordered_map<Expression*, Expression*>::const_iterator begin() const { return elements_.begin(); }
+    STDTR1(unordered_map)<Expression*, Expression*>::iterator end() { return elements_.end(); }
+    STDTR1(unordered_map)<Expression*, Expression*>::iterator begin() { return elements_.begin(); }
+    STDTR1(unordered_map)<Expression*, Expression*>::const_iterator end() const { return elements_.end(); }
+    STDTR1(unordered_map)<Expression*, Expression*>::const_iterator begin() const { return elements_.begin(); }
 
   };
   inline Hashed::~Hashed() { }


### PR DESCRIPTION
Introduce autoconf macros to detect
TR1 and C++11 features.

Don't hardcode -std=c++0x for all compilers.
Detect various variants of `<unordered_map>`
and provide workaround if `at()` is missing.

unordered_map related code should be now compatible
with gcc 4.2 (has no C++11 features)
