### PR TITLE
add sass_version to copied headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ Makefile.in
 /config.log
 /config.status
 /configure
+include/
 /libtool
 /m4/libtool.m4
 /m4/ltoptions.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,7 @@ libsass_la_SOURCES = \
 
 libsass_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined -version-info 0:9:0
 
-include_HEADERS = sass2scss.h sass_context.h sass_functions.h sass_values.h sass.h
+include_HEADERS = sass2scss.h sass_context.h sass_functions.h sass_values.h sass.h sass_version.h
 
 if ENABLE_TESTS
 


### PR DESCRIPTION
- ignore include folder since these only come from the build
- fixes #997