### PR TITLE
[WIP] add length of included_files array

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -89,6 +89,7 @@ namespace Sass {
     if (input_path == "") input_path = "stdin";
     if (output_path == "") output_path = "stdout";
 
+    num_included_files = 0;
     include_paths.push_back(cwd);
     collect_include_paths(initializers.include_paths_c_str());
     collect_include_paths(initializers.include_paths_array());
@@ -396,9 +397,9 @@ namespace Sass {
       return includes;
   }
 
-  int Context::get_num_included_files()
+  int Context::get_num_included_files(size_t skip)
   {
-    return num_included_files;
+    return num_included_files - skip;
   }
 
   string Context::get_cwd()

--- a/context.cpp
+++ b/context.cpp
@@ -220,6 +220,7 @@ namespace Sass {
   {
     sources.push_back(contents);
     included_files.push_back(abs_path);
+    num_included_files = num_included_files + 1;
     queue.push_back(Sass_Queued(load_path, abs_path, contents));
     emitter.add_source_index(sources.size() - 1);
     include_links.push_back(resolve_relative_path(abs_path, source_map_file, cwd));
@@ -393,6 +394,11 @@ namespace Sass {
       // the skip solution seems more robust, as we may have real files named stdin
       // includes.erase( std::remove( includes.begin(), includes.end(), "stdin" ), includes.end() );
       return includes;
+  }
+
+  int Context::get_num_included_files()
+  {
+    return num_included_files;
   }
 
   string Context::get_cwd()

--- a/context.hpp
+++ b/context.hpp
@@ -120,7 +120,7 @@ namespace Sass {
     char* generate_source_map();
 
     vector<string> get_included_files(size_t skip = 0);
-    int get_num_included_files();
+    int get_num_included_files(size_t skip = 0);
   private:
     void collect_plugin_paths(const char* paths_str);
     void collect_plugin_paths(const char** paths_array);

--- a/context.hpp
+++ b/context.hpp
@@ -41,6 +41,8 @@ namespace Sass {
     vector<const char*> sources;
     // absolute paths to includes
     vector<string> included_files;
+    // number of included files
+    int num_included_files;
     // relative links to includes
     vector<string> include_links;
     // vectors above have same size
@@ -118,7 +120,7 @@ namespace Sass {
     char* generate_source_map();
 
     vector<string> get_included_files(size_t skip = 0);
-
+    int get_num_included_files();
   private:
     void collect_plugin_paths(const char* paths_str);
     void collect_plugin_paths(const char** paths_array);

--- a/sass_context.cpp
+++ b/sass_context.cpp
@@ -132,7 +132,7 @@ extern "C" {
 
     // report imported files
     char** included_files;
-
+    int num_included_files;
   };
 
   // struct for file compilation
@@ -472,8 +472,10 @@ extern "C" {
       }
 
       // copy the included files on to the context (dont forget to free)
-      if (root) copy_strings(cpp_ctx->get_included_files(skip), &c_ctx->included_files, skip);
-
+      if (root) {
+        copy_strings(cpp_ctx->get_included_files(skip), &c_ctx->included_files, skip);
+        c_ctx->num_included_files = cpp_ctx->get_num_included_files();
+      }
       // return parsed block
       return root;
 
@@ -728,6 +730,7 @@ extern "C" {
     ctx->source_map_file = 0;
     ctx->source_map_root = 0;
     ctx->included_files = 0;
+    ctx->num_included_files = 0;
     // now clear the options
     sass_clear_options(ctx);
   }
@@ -787,6 +790,7 @@ extern "C" {
   IMPLEMENT_SASS_CONTEXT_GETTER(const char*, output_string);
   IMPLEMENT_SASS_CONTEXT_GETTER(const char*, source_map_string);
   IMPLEMENT_SASS_CONTEXT_GETTER(char**, included_files);
+  IMPLEMENT_SASS_CONTEXT_GETTER(int, num_included_files);
 
   // Take ownership of memory (value on context is set to 0)
   IMPLEMENT_SASS_CONTEXT_TAKER(char*, error_json);

--- a/sass_context.cpp
+++ b/sass_context.cpp
@@ -474,7 +474,7 @@ extern "C" {
       // copy the included files on to the context (dont forget to free)
       if (root) {
         copy_strings(cpp_ctx->get_included_files(skip), &c_ctx->included_files, skip);
-        c_ctx->num_included_files = cpp_ctx->get_num_included_files();
+        c_ctx->num_included_files = cpp_ctx->get_num_included_files(skip);
       }
       // return parsed block
       return root;

--- a/sass_context.h
+++ b/sass_context.h
@@ -109,6 +109,7 @@ ADDAPI size_t ADDCALL sass_context_get_error_line (struct Sass_Context* ctx);
 ADDAPI size_t ADDCALL sass_context_get_error_column (struct Sass_Context* ctx);
 ADDAPI const char* ADDCALL sass_context_get_source_map_string (struct Sass_Context* ctx);
 ADDAPI char** ADDCALL sass_context_get_included_files (struct Sass_Context* ctx);
+ADDAPI int ADDCALL sass_context_get_num_included_files (struct Sass_Context* ctx);
 
 // Take ownership of memory (value on context is set to 0)
 ADDAPI char* ADDCALL sass_context_take_error_json (struct Sass_Context* ctx);

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -141,7 +141,7 @@ extern "C" {
       c_ctx->source_map_string = cpp_ctx.generate_source_map();
       c_ctx->error_message = 0;
       c_ctx->error_status = 0;
-
+      c_ctx->num_included_files = cpp_ctx.get_num_included_files();
       copy_strings(cpp_ctx.get_included_files(1), &c_ctx->included_files, 1);
     }
     catch (Sass_Error& e) {
@@ -231,7 +231,7 @@ extern "C" {
       c_ctx->source_map_string = cpp_ctx.generate_source_map();
       c_ctx->error_message = 0;
       c_ctx->error_status = 0;
-
+      c_ctx->num_included_files = cpp_ctx.get_num_included_files();
       copy_strings(cpp_ctx.get_included_files(), &c_ctx->included_files);
     }
     catch (Sass_Error& e) {

--- a/sass_interface.cpp
+++ b/sass_interface.cpp
@@ -141,7 +141,7 @@ extern "C" {
       c_ctx->source_map_string = cpp_ctx.generate_source_map();
       c_ctx->error_message = 0;
       c_ctx->error_status = 0;
-      c_ctx->num_included_files = cpp_ctx.get_num_included_files();
+      c_ctx->num_included_files = cpp_ctx.get_num_included_files(0);
       copy_strings(cpp_ctx.get_included_files(1), &c_ctx->included_files, 1);
     }
     catch (Sass_Error& e) {
@@ -231,7 +231,7 @@ extern "C" {
       c_ctx->source_map_string = cpp_ctx.generate_source_map();
       c_ctx->error_message = 0;
       c_ctx->error_status = 0;
-      c_ctx->num_included_files = cpp_ctx.get_num_included_files();
+      c_ctx->num_included_files = cpp_ctx.get_num_included_files(0);
       copy_strings(cpp_ctx.get_included_files(), &c_ctx->included_files);
     }
     catch (Sass_Error& e) {


### PR DESCRIPTION
This extends the API to add the length of the included_files array. Without this, it is difficult to determine the length of the C array exposed via the API interface.