### PR TITLE
Fix edge case in `Parent_Selector` evaluation

### DIFF
--- a/contextualize_eval.cpp
+++ b/contextualize_eval.cpp
@@ -14,7 +14,9 @@ namespace Sass {
   Contextualize_Eval::~Contextualize_Eval() { }
 
   Selector* Contextualize_Eval::fallback_impl(AST_Node* n)
-  { return Contextualize::fallback_impl(n); }
+  {
+    return Contextualize::fallback_impl(n);
+  }
 
   Contextualize_Eval* Contextualize_Eval::with(Selector* s, Env* e, Backtrace* bt, Selector* p, Selector* ex)
   {
@@ -53,14 +55,17 @@ namespace Sass {
   }
 
   Selector* Contextualize_Eval::operator()(Pseudo_Selector* s)
-  {     return Contextualize::operator ()(s); }
+  {
+    return Contextualize::operator ()(s);
+  }
 
   Selector* Contextualize_Eval::operator()(Attribute_Selector* s)
   {
     // the value might be interpolated; evaluate it
     String* v = s->value();
     if (v && eval) {
-     v = static_cast<String*>(v->perform(eval->with(env, backtrace)));
+     Eval* eval_with = eval->with(env, backtrace);
+     v = static_cast<String*>(v->perform(eval_with));
     }
     To_String toString;
     Attribute_Selector* ss = new (ctx.mem) Attribute_Selector(*s);

--- a/error_handling.cpp
+++ b/error_handling.cpp
@@ -8,10 +8,12 @@ namespace Sass {
   : type(type), pstate(pstate), message(message)
   { }
 
-  void error(string msg, ParserState pstate)
-  { throw Sass_Error(Sass_Error::syntax, pstate, msg); }
+  void error(string msg, ParserState pstate) throw(Sass_Error)
+  {
+    throw Sass_Error(Sass_Error::syntax, pstate, msg);
+  }
 
-  void error(string msg, ParserState pstate, Backtrace* bt)
+  void error(string msg, ParserState pstate, Backtrace* bt) throw(Sass_Error)
   {
 
     Backtrace top(bt, pstate, "");

--- a/error_handling.hpp
+++ b/error_handling.hpp
@@ -21,8 +21,8 @@ namespace Sass {
 
   };
 
-  void error(string msg, ParserState pstate);
-  void error(string msg, ParserState pstate, Backtrace* bt);
+  void error(string msg, ParserState pstate) throw(Sass_Error);
+  void error(string msg, ParserState pstate, Backtrace* bt) throw(Sass_Error);
 
 }
 

--- a/eval.cpp
+++ b/eval.cpp
@@ -969,8 +969,10 @@ namespace Sass {
   Expression* Eval::operator()(Parent_Selector* p)
   {
     Selector* s = p->perform(contextualize);
-    Expression* e = static_cast<Selector_List*>(s)->perform(listize);
-    return e;
+    // access to parent selector may return 0
+    Selector_List* l = static_cast<Selector_List*>(s);
+    if (!s) { l = new (ctx.mem) Selector_List(p->pstate()); }
+    return l->perform(listize);
   }
 
   inline Expression* Eval::fallback_impl(AST_Node* n)


### PR DESCRIPTION
This only fixes the access to a possibly wild pointer!

Seems to only happen sporadic since it probably points to some other null initialized memory most of the time. But it caused a segfault in my runner at a certain point with the todo spec tests.