### PR TITLE
libtool: Build PIC objects only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,8 +16,10 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([no])])
 
 # Checks for programs.
 AC_PROG_CXX
+AM_PROG_AR
 AC_LANG([C++])
-LT_INIT([dlopen])
+LT_PREREQ([2.4.3])
+LT_INIT([dlopen pic-only])
 
 # Checks for header files.
 AC_CHECK_HEADERS([unistd.h])


### PR DESCRIPTION
By default automake/libtool
produce -fPIC shared library libsass.so
and a non-fPIC static library libsass.a

To enable including of libsass.a
statically into bindings like node-sass
that need to produce a shared object
make sure object files in .a are also
compiled with -fPIC.

libsass has previously hardcoded -fPIC
-dPIC in the Makefile.am

This feature is broken when using
libtool 2.4.2.

While here, restore AM_PROG_AR