### PR TITLE
Code: Fixes dynamic exception as per C++11 specs

### DIFF
--- a/error_handling.cpp
+++ b/error_handling.cpp
@@ -8,12 +8,12 @@ namespace Sass {
   : type(type), pstate(pstate), message(message)
   { }
 
-  void error(string msg, ParserState pstate) throw(Sass_Error)
+  void error(string msg, ParserState pstate)
   {
     throw Sass_Error(Sass_Error::syntax, pstate, msg);
   }
 
-  void error(string msg, ParserState pstate, Backtrace* bt) throw(Sass_Error)
+  void error(string msg, ParserState pstate, Backtrace* bt)
   {
 
     Backtrace top(bt, pstate, "");

--- a/error_handling.hpp
+++ b/error_handling.hpp
@@ -21,8 +21,8 @@ namespace Sass {
 
   };
 
-  void error(string msg, ParserState pstate) throw(Sass_Error);
-  void error(string msg, ParserState pstate, Backtrace* bt) throw(Sass_Error);
+  void error(string msg, ParserState pstate);
+  void error(string msg, ParserState pstate, Backtrace* bt);
 
 }
 

--- a/sass_context.cpp
+++ b/sass_context.cpp
@@ -188,7 +188,7 @@ extern "C" {
     return str == NULL ? "" : str;
   }
 
-  static void copy_strings(const std::vector<std::string>& strings, char*** array) throw() {
+  static void copy_strings(const std::vector<std::string>& strings, char*** array) {
     int num = static_cast<int>(strings.size());
     char** arr = (char**) malloc(sizeof(char*) * (num + 1));
     if (arr == 0) throw(bad_alloc());

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -102,6 +102,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,6 +116,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -130,6 +132,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -147,6 +150,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>SyncCThrow</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
* See http://stackoverflow.com/a/13841791/863980.
* Also fixes a case where non-throw exception<br/>
  was throwing in `sass_context.cpp`.