### PR TITLE
Add the at-error feature flag

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -148,7 +148,8 @@ namespace Sass {
 
     // features
     static set<string> features {
-      "global-variable-shadowing"
+      "global-variable-shadowing",
+      "at-error"
     };
 
     ////////////////


### PR DESCRIPTION
This PR adds the `at-error` feature flag.

Spec added https://github.com/sass/sass-spec/pull/292.