### PR TITLE
Add the units-level-3 feature flag

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -149,7 +149,8 @@ namespace Sass {
     // features
     static set<string> features {
       "global-variable-shadowing",
-      "at-error"
+      "at-error",
+      "units-level-3"
     };
 
     ////////////////


### PR DESCRIPTION
This PR adds the `units-level-3` feature flag.

Spec added https://github.com/sass/sass-spec/pull/293.