### PR TITLE
Fix typo in code coverage config

### DIFF
--- a/script/ci-report-coverage
+++ b/script/ci-report-coverage
@@ -11,7 +11,7 @@ if [ "x$COVERAGE" = "xyes" ]; then
                              --exclude utf8.h --exclude utf8_string.cpp
                              --exclude sass2scss.h --exclude sass2scss.cpp
                              --exclude test --exclude posix
-                             --exlcude debugger.hpp"
+                             --exclude debugger.hpp"
   # debug via gcovr
   gcov -v
   gcovr -r .


### PR DESCRIPTION
This PR fixes a typo in code coverage config introduced in https://github.com/sass/libsass/pull/1014