### PR TITLE
[WIP] Implement support for Selectors Level 4, Reference combinators

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -1983,7 +1983,7 @@ namespace Sass {
   ////////////////////////////////////////////////////////////////////////////
   class Complex_Selector : public Selector {
   public:
-    enum Combinator { ANCESTOR_OF, PARENT_OF, PRECEDES, ADJACENT_TO };
+    enum Combinator { ANCESTOR_OF, PARENT_OF, PRECEDES, ADJACENT_TO, REFERENCE };
   private:
     ADD_PROPERTY(Combinator, combinator);
     ADD_PROPERTY(Compound_Selector*, head);

--- a/constants.cpp
+++ b/constants.cpp
@@ -78,9 +78,6 @@ namespace Sass {
     extern const char webkit_calc_kwd[]  = "-webkit-calc(";
     extern const char ms_calc_kwd[]      = "-ms-calc(";
 
-    // css selector keywords
-    extern const char sel_deep_kwd[] = "/deep/";
-
     // css attribute-matching operators
     extern const char tilde_equal[]  = "~=";
     extern const char pipe_equal[]   = "|=";

--- a/constants.hpp
+++ b/constants.hpp
@@ -80,9 +80,6 @@ namespace Sass {
     extern const char webkit_calc_kwd[];
     extern const char ms_calc_kwd[];
 
-    // css selector keywords
-    extern const char sel_deep_kwd[];
-
     // css attribute-matching operators
     extern const char tilde_equal[];
     extern const char pipe_equal[];

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -73,6 +73,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
         case Complex_Selector::PARENT_OF:   cerr << "{>}"; break;
         case Complex_Selector::PRECEDES:    cerr << "{~}"; break;
         case Complex_Selector::ADJACENT_TO: cerr << "{+}"; break;
+        case Complex_Selector::REFERENCE:   cerr << " /deep/ "; break;
         case Complex_Selector::ANCESTOR_OF: cerr << "{ }"; break;
       }
     cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << endl;

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -817,6 +817,10 @@ namespace Sass {
     if (output_style() == COMPRESSED && comb != Complex_Selector::ANCESTOR_OF) scheduled_space = 0;
 
     switch (comb) {
+      case Complex_Selector::REFERENCE:
+        append_mandatory_space();
+        append_string("/deep/");
+        append_mandatory_space();
       case Complex_Selector::ANCESTOR_OF:
         if (is_tail) append_mandatory_space();
       break;

--- a/listize.cpp
+++ b/listize.cpp
@@ -56,6 +56,7 @@ namespace Sass {
         *l << new (ctx.mem) String_Constant(sel->pstate(), "~");
       break;
       case Complex_Selector::ANCESTOR_OF:
+      case Complex_Selector::REFERENCE:
       break;
     }
 

--- a/parser.cpp
+++ b/parser.cpp
@@ -550,7 +550,8 @@ namespace Sass {
   {
     Position sel_source_position(-1);
     Compound_Selector* lhs;
-    if (peek_css< alternatives <
+    if (peek< reference_combinator >() ||
+        peek_css< alternatives <
           exactly<'+'>,
           exactly<'~'>,
           exactly<'>'>
@@ -564,10 +565,11 @@ namespace Sass {
     }
 
     Complex_Selector::Combinator cmb;
-    if      (lex< exactly<'+'> >()) cmb = Complex_Selector::ADJACENT_TO;
-    else if (lex< exactly<'~'> >()) cmb = Complex_Selector::PRECEDES;
-    else if (lex< exactly<'>'> >()) cmb = Complex_Selector::PARENT_OF;
-    else                            cmb = Complex_Selector::ANCESTOR_OF;
+    if      (lex< exactly<'+'> >())         cmb = Complex_Selector::ADJACENT_TO;
+    else if (lex< reference_combinator >()) cmb = Complex_Selector::REFERENCE;
+    else if (lex< exactly<'~'> >())         cmb = Complex_Selector::PRECEDES;
+    else if (lex< exactly<'>'> >())         cmb = Complex_Selector::PARENT_OF;
+    else                                    cmb = Complex_Selector::ANCESTOR_OF;
     bool cpx_lf = peek_newline();
 
     Complex_Selector* rhs;
@@ -626,6 +628,7 @@ namespace Sass {
 
     while (!peek< spaces >(position) &&
            !(peek_css < alternatives <
+               reference_combinator,
                exactly<'+'>,
                exactly<'~'>,
                exactly<'>'>,
@@ -2009,6 +2012,7 @@ namespace Sass {
            (q = peek< exactly<')'> >(p))                           ||
            (q = peek< exactly<'['> >(p))                           ||
            (q = peek< exactly<']'> >(p))                           ||
+           (q = peek< reference_combinator >(p))                   ||
            (q = peek< exactly<'+'> >(p))                           ||
            (q = peek< exactly<'~'> >(p))                           ||
            (q = peek< exactly<'>'> >(p))                           ||
@@ -2069,6 +2073,7 @@ namespace Sass {
            (q = peek< exactly<')'> >(p))                           ||
            (q = peek< exactly<'['> >(p))                           ||
            (q = peek< exactly<']'> >(p))                           ||
+           (q = peek< reference_combinator >(p))                   ||
            (q = peek< exactly<'+'> >(p))                           ||
            (q = peek< exactly<'~'> >(p))                           ||
            (q = peek< exactly<'>'> >(p))                           ||

--- a/parser.cpp
+++ b/parser.cpp
@@ -649,9 +649,6 @@ namespace Sass {
     else if (lex< quoted_string >()) {
       return new (ctx.mem) Type_Selector(pstate, unquote(lexed));
     }
-    else if (lex< alternatives < number, kwd_sel_deep > >()) {
-      return new (ctx.mem) Type_Selector(pstate, lexed);
-    }
     else if (peek< pseudo_not >()) {
       return parse_negated_selector();
     }
@@ -2008,7 +2005,6 @@ namespace Sass {
            (q = peek< dimension >(p))                              ||
            (q = peek< quoted_string >(p))                          ||
            (q = peek< exactly<'*'> >(p))                           ||
-           (q = peek< exactly<sel_deep_kwd> >(p))                           ||
            (q = peek< exactly<'('> >(p))                           ||
            (q = peek< exactly<')'> >(p))                           ||
            (q = peek< exactly<'['> >(p))                           ||

--- a/parser.hpp
+++ b/parser.hpp
@@ -83,6 +83,7 @@ namespace Sass {
 
       // skip white-space?
       if (mx == url ||
+          mx == reference_combinator ||
           mx == spaces ||
           mx == no_spaces ||
           mx == css_comments ||

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -197,10 +197,6 @@ namespace Sass {
       return sequence<exactly<'@'>, identifier>(src);
     }
 
-    const char* kwd_sel_deep(const char* src) {
-      return word<sel_deep_kwd>(src);
-    }
-
     const char* kwd_import(const char* src) {
       return word<import_kwd>(src);
     }

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -488,6 +488,9 @@ namespace Sass {
     const char* prefix_match(const char* src) { return exactly<caret_equal>(src); }
     const char* suffix_match(const char* src) { return exactly<dollar_equal>(src); }
     const char* substring_match(const char* src) { return exactly<star_equal>(src); }
+    const char* reference_combinator(const char* src) {
+      return sequence<spaces, exactly<'/'>, identifier, exactly<'/'>, spaces >(src);
+    }
     // Match CSS combinators.
     /* not used anymore - remove?
     const char* adjacent_to(const char* src) {

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -172,7 +172,6 @@ namespace Sass {
     const char* identifier_alnums(const char* src);
     // Match selector names.
     // const char* sel_ident(const char* src);
-    const char* kwd_sel_deep(const char* src);
 
     // Match interpolant schemas
     const char* identifier_schema(const char* src);

--- a/prelexer.hpp
+++ b/prelexer.hpp
@@ -273,6 +273,7 @@ namespace Sass {
     const char* suffix_match(const char* src);
     const char* substring_match(const char* src);
     // Match CSS combinators.
+    const char* reference_combinator(const char* src);
     // const char* adjacent_to(const char* src);
     // const char* precedes(const char* src);
     // const char* parent_of(const char* src);


### PR DESCRIPTION
This is update implementation of https://github.com/xzyfer/libsass/pull/1.

This PR implements the [reference combinator](http://www.w3.org/TR/selectors4/#idref-combinators) from CSS Selectors Level 4.

### From the spec

>For intents and purposes the /deep/ combinator acts like the direct sibling combinator except for the shadow dom. [3.2.4 Selecting Through Shadows: the /deep/ combinator](http://dev.w3.org/csswg/css-scoping/#deep-combinator).

>The reference combinator consists of two slashes with an intervening CSS qualified name, and separates two compound selectors, e.g. `A /attr/ B`.

### TODO

- [ ] support generic identifiers as reference combinators
- [ ] work with `@extends`

***

Fixes sass/libsass#452. 
Specs of interest:
- https://github.com/sass/sass-spec/blob/master/spec/libsass-todo-tests/scss-tests/175_test_reference_combinator_with_parent_ref
- https://github.com/sass/sass-spec/blob/master/spec/libsass-todo-tests/scss-tests/117_test_selector_interpolation_in_reference_combinator
- https://github.com/sass/sass-spec/blob/master/spec/libsass-closed-issues/issue_452

/cc @mgreter 