### PR TITLE
Enable Travis OS X Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: cpp
 
 os:
   - linux
-  # - osx
+  - osx
 
 compiler:
   - gcc
@@ -31,6 +31,8 @@ matrix:
   exclude:
     - compiler: clang
       env: AUTOTOOLS=yes COVERAGE=yes BUILD=static
+    - os: osx
+      compiler: gcc
 
 script: ./script/ci-build-libsass
 before_install: ./script/ci-install-deps


### PR DESCRIPTION
Basically just uncommented the prepared osx support in `.travis.yml` and it worked!
Additionally removed gcc compiler target for osx since it is only an alias to clang!