### PR TITLE
Fix tabs when bubbling feature blocks

### DIFF
--- a/cssize.cpp
+++ b/cssize.cpp
@@ -268,6 +268,8 @@ namespace Sass {
                                                     m->feature_queries(),
                                                     wrapper_block);
 
+    mm->tabs(m->tabs());
+
     Bubble* bubble = new (ctx.mem) Bubble(mm->pstate(), mm);
     return bubble;
   }

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -58,14 +58,10 @@ namespace Sass {
   void Inspect::operator()(Bubble* bubble)
   {
     append_indentation();
-    append_token("Bubble", bubble);
-    append_optional_space();
-    append_string("(");
-    append_optional_space();
+    append_token("::BUBBLE", bubble);
+    append_scope_opener();
     bubble->node()->perform(this);
-    append_optional_space();
-    append_string(")");
-    append_optional_space();
+    append_scope_closer();
   }
 
   void Inspect::operator()(Media_Block* media_block)


### PR DESCRIPTION
This is closely related to https://github.com/sass/libsass/issues/1030

Fixes the indentation in output when feature blocks are bubbled up. Also changed the inspect output for `Bubble` nodes. IMO this is only implemented for debug purposes (like debug_ast).