### PR TITLE
Implement handling of nested `:not` pseudo selectors

### DIFF
--- a/output.cpp
+++ b/output.cpp
@@ -72,6 +72,16 @@ namespace Sass {
 
   }
 
+  void Output::operator()(Wrapped_Selector* s)
+  {
+    if (s->name() == ":not(") {
+      if (s->has_child(":has(") || s->has_child(":not(")) {
+        return; // abort
+      }
+    }
+    return Inspect::operator()(s);
+  }
+
   void Output::operator()(Comment* c)
   {
     To_String to_string(ctx);

--- a/output.hpp
+++ b/output.hpp
@@ -42,6 +42,7 @@ namespace Sass {
     virtual void operator()(Media_Block*);
     virtual void operator()(At_Rule*);
     virtual void operator()(Keyframe_Rule*);
+    virtual void operator()(Wrapped_Selector*);
     virtual void operator()(Import*);
     virtual void operator()(Comment*);
     virtual void operator()(String_Quoted*);


### PR DESCRIPTION
They should not appear in the output. Ruby sass seems to
have a minor bug, as it inserts additional spaces before
the comma when the pseudo selector gets eliminated.