### PR TITLE
Fix mathematical operations with different units

### DIFF
--- a/ast.cpp
+++ b/ast.cpp
@@ -813,15 +813,42 @@ namespace Sass {
 
   bool Number::operator== (Expression* rhs) const
   {
-    Number l(pstate_, value_, unit());
-    Number& r = dynamic_cast<Number&>(*rhs);
-    l.normalize(find_convertible_unit());
-    r.normalize(find_convertible_unit());
-    return l.unit() == r.unit() &&
-           l.value() == r.value();
+    try
+    {
+      Number l(pstate_, value_, unit());
+      Number& r = dynamic_cast<Number&>(*rhs);
+      l.normalize(find_convertible_unit());
+      r.normalize(find_convertible_unit());
+      return l.unit() == r.unit() &&
+             l.value() == r.value();
+    }
+    catch (std::bad_cast&) {}
+    catch (...) { throw; }
+    return false;
   }
 
   bool Number::operator== (Expression& rhs) const
+  {
+    return operator==(&rhs);
+  }
+
+  bool List::operator==(Expression* rhs) const
+  {
+    try
+    {
+      List* r = dynamic_cast<List*>(rhs);
+      if (!r || length() != r->length()) return false;
+      if (separator() != r->separator()) return false;
+      for (size_t i = 0, L = r->length(); i < L; ++i)
+        if (*elements()[i] != *(*r)[i]) return false;
+      return true;
+    }
+    catch (std::bad_cast&) {}
+    catch (...) { throw; }
+    return false;
+  }
+
+  bool List::operator== (Expression& rhs) const
   {
     return operator==(&rhs);
   }

--- a/ast.hpp
+++ b/ast.hpp
@@ -1170,25 +1170,13 @@ namespace Sass {
     string unit() const;
 
     bool is_unitless();
-    void normalize(string to = "");
+    void convert(const string& unit = "");
+    void normalize(const string& unit = "");
     // useful for making one number compatible with another
     string find_convertible_unit() const;
 
-    virtual bool operator==(Expression& rhs) const
-    {
-      try
-      {
-        Number& e(dynamic_cast<Number&>(rhs));
-        if (!e) return false;
-        e.normalize(find_convertible_unit());
-        return unit() == e.unit() && value() == e.value();
-      }
-      catch (std::bad_cast&)
-      {
-        return false;
-      }
-      catch (...) { throw; }
-    }
+    virtual bool operator== (Expression& rhs) const;
+    virtual bool operator== (Expression* rhs) const;
 
     virtual size_t hash()
     {

--- a/ast.hpp
+++ b/ast.hpp
@@ -1161,113 +1161,18 @@ namespace Sass {
     vector<string> denominator_units_;
     size_t hash_;
   public:
-    Number(ParserState pstate, double val, string u = "", bool zero = true)
-    : Expression(pstate),
-      value_(val),
-      zero_(zero),
-      numerator_units_(vector<string>()),
-      denominator_units_(vector<string>()),
-      hash_(0)
-    {
-      if (!u.empty()) numerator_units_.push_back(u);
-      concrete_type(NUMBER);
-    }
+    Number(ParserState pstate, double val, string u = "", bool zero = true);
     bool            zero()              { return zero_; }
     vector<string>& numerator_units()   { return numerator_units_; }
     vector<string>& denominator_units() { return denominator_units_; }
     string type() { return "number"; }
     static string type_name() { return "number"; }
-    string unit() const
-    {
-      stringstream u;
-      for (size_t i = 0, S = numerator_units_.size(); i < S; ++i) {
-        if (i) u << '*';
-        u << numerator_units_[i];
-      }
-      if (!denominator_units_.empty()) u << '/';
-      for (size_t i = 0, S = denominator_units_.size(); i < S; ++i) {
-        if (i) u << '*';
-        u << denominator_units_[i];
-      }
-      return u.str();
-    }
-    bool is_unitless()
-    { return numerator_units_.empty() && denominator_units_.empty(); }
-    void normalize(string to = "")
-    {
-      // (multiple passes because I'm too tired to think up something clever)
-      // Find a unit to convert everything to, if one isn't provided.
-      if (to.empty()) {
-        for (size_t i = 0, S = numerator_units_.size(); i < S; ++i) {
-          string u(numerator_units_[i]);
-          if (string_to_unit(u) == INCOMMENSURABLE) {
-            continue;
-          }
-          else {
-            to = u;
-            break;
-          }
-        }
-      }
-      if (to.empty()) {
-        for (size_t i = 0, S = denominator_units_.size(); i < S; ++i) {
-          string u(denominator_units_[i]);
-          if (string_to_unit(u) == INCOMMENSURABLE) {
-            continue;
-          }
-          else {
-            to = u;
-            break;
-          }
-        }
-      }
-      // Now loop through again and do all the conversions.
-      for (size_t i = 0, S = numerator_units_.size(); i < S; ++i) {
-        string from(numerator_units_[i]);
-        if (string_to_unit(from) == INCOMMENSURABLE) continue;
-        value_ *= conversion_factor(from, to);
-        numerator_units_[i] = to;
-      }
-      for (size_t i = 0, S = denominator_units_.size(); i < S; ++i) {
-        string from(denominator_units_[i]);
-        if (string_to_unit(from) == INCOMMENSURABLE) continue;
-        value_ /= conversion_factor(from, to);
-        denominator_units_[i] = to;
-      }
-      // Now divide out identical units in the numerator and denominator.
-      vector<string> ncopy;
-      ncopy.reserve(numerator_units_.size());
-      for (vector<string>::iterator n = numerator_units_.begin();
-           n != numerator_units_.end();
-           ++n) {
-        vector<string>::iterator d = find(denominator_units_.begin(),
-                                          denominator_units_.end(),
-                                          *n);
-        if (d != denominator_units_.end()) {
-          denominator_units_.erase(d);
-        }
-        else {
-          ncopy.push_back(*n);
-        }
-      }
-      numerator_units_ = ncopy;
-      // Sort the units to make them pretty and, well, normal.
-      sort(numerator_units_.begin(), numerator_units_.end());
-      sort(denominator_units_.begin(), denominator_units_.end());
-    }
+    string unit() const;
+
+    bool is_unitless();
+    void normalize(string to = "");
     // useful for making one number compatible with another
-    string find_convertible_unit() const
-    {
-      for (size_t i = 0, S = numerator_units_.size(); i < S; ++i) {
-        string u(numerator_units_[i]);
-        if (string_to_unit(u) != INCOMMENSURABLE) return u;
-      }
-      for (size_t i = 0, S = denominator_units_.size(); i < S; ++i) {
-        string u(denominator_units_[i]);
-        if (string_to_unit(u) != INCOMMENSURABLE) return u;
-      }
-      return string();
-    }
+    string find_convertible_unit() const;
 
     virtual bool operator==(Expression& rhs) const
     {

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -290,6 +290,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << ind << "Import " << block;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " " << block->tabs() << endl;
+    debug_ast(block->media_queries(), ind + " @ ");
     // vector<string>         files_;
     for (auto imp : block->urls()) debug_ast(imp, "@ ", env);
   } else if (dynamic_cast<Assignment*>(node)) {
@@ -374,9 +375,14 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     else if (expression->type() == Textual::PERCENTAGE) cerr << " [PERCENTAGE]";
     else if (expression->type() == Textual::DIMENSION) cerr << " [DIMENSION]";
     else if (expression->type() == Textual::HEX) cerr << " [HEX]";
-    cerr << expression << " [" << expression->value() << "]" << endl;
+    cerr << expression << " [" << expression->value() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
   } else if (dynamic_cast<Variable*>(node)) {
     Variable* expression = dynamic_cast<Variable*>(node);
+    cerr << ind << "Variable " << expression << " [" << expression->name() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Variable " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->name() << "]" << endl;
@@ -384,6 +390,9 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     if (env && env->has(name)) debug_ast(static_cast<Expression*>((*env)[name]), ind + " -> ", env);
   } else if (dynamic_cast<Function_Call_Schema*>(node)) {
     Function_Call_Schema* expression = dynamic_cast<Function_Call_Schema*>(node);
+    cerr << ind << "Function_Call_Schema " << expression << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Function_Call_Schema " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << "" << endl;
@@ -391,18 +400,29 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     debug_ast(expression->arguments(), ind + " args: ", env);
   } else if (dynamic_cast<Function_Call*>(node)) {
     Function_Call* expression = dynamic_cast<Function_Call*>(node);
+    cerr << ind << "Function_Call " << expression << " [" << expression->name() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Function_Call " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->name() << "]" << endl;
     debug_ast(expression->arguments(), ind + " args: ", env);
   } else if (dynamic_cast<Arguments*>(node)) {
     Arguments* expression = dynamic_cast<Arguments*>(node);
+    cerr << ind << "Arguments " << expression << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Arguments " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << endl;
     for(auto i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Argument*>(node)) {
     Argument* expression = dynamic_cast<Argument*>(node);
+    cerr << ind << "Argument " << expression << " [" << expression->value() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    if (expression->is_rest_argument()) cerr << " [is_rest_argument]";
+    if (expression->is_keyword_argument()) cerr << " [is_keyword_argument]";
+    cerr << endl;
     cerr << ind << "Argument " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->value() << "]";
@@ -427,12 +447,18 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << " [rest: " << expression->is_rest_parameter() << "] " << endl;
   } else if (dynamic_cast<Unary_Expression*>(node)) {
     Unary_Expression* expression = dynamic_cast<Unary_Expression*>(node);
+    cerr << ind << "Unary_Expression " << expression << " [" << expression->type_name() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Unary_Expression " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->type() << "]" << endl;
     debug_ast(expression->operand(), ind + " operand: ", env);
   } else if (dynamic_cast<Binary_Expression*>(node)) {
     Binary_Expression* expression = dynamic_cast<Binary_Expression*>(node);
+    cerr << ind << "Binary_Expression " << expression << " [" << expression->type_name() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Binary_Expression " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->type() << "]" << endl;
@@ -450,6 +476,9 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << " (" << expression->length() << ") " <<
       (expression->separator() == Sass::List::Separator::COMMA ? "Comma " : "Space ") <<
       " [delayed: " << expression->is_delayed() << "] " <<
+      " [interpolant: " << expression->is_interpolant() << "]";
+    if (expression->is_arglist()) cerr << " [is_arglist]";
+    cerr << endl;
       " [interpolant: " << expression->is_interpolant() << "] " <<
       " [arglist: " << expression->is_arglist() << "] " <<
       endl;
@@ -461,21 +490,36 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << " [Statement]" << endl;
   } else if (dynamic_cast<Boolean*>(node)) {
     Boolean* expression = dynamic_cast<Boolean*>(node);
+    cerr << ind << "Boolean " << expression << " [" << expression->value() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Boolean " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->value() << "]" << endl;
   } else if (dynamic_cast<Color*>(node)) {
     Color* expression = dynamic_cast<Color*>(node);
+    cerr << ind << "Color " << expression << " [" << expression->r() << ":"  << expression->g() << ":" << expression->b() << "@" << expression->a() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Color " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->r() << ":"  << expression->g() << ":" << expression->b() << "@" << expression->a() << "]" << endl;
   } else if (dynamic_cast<Number*>(node)) {
     Number* expression = dynamic_cast<Number*>(node);
+    cerr << ind << "Number " << expression << " [" << expression->value() << expression->unit() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    cerr << endl;
     cerr << ind << "Number " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->value() << expression->unit() << "]" << endl;
   } else if (dynamic_cast<String_Quoted*>(node)) {
     String_Quoted* expression = dynamic_cast<String_Quoted*>(node);
+    cerr << ind << "String_Quoted : " << expression << " [";
+    cerr << prettyprint(expression->value()) << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    if (expression->sass_fix_1291()) cerr << " [sass_fix_1291]";
+    if (expression->quote_mark()) cerr << " [quote_mark]";
+    cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
     cerr << ind << "String_Quoted : " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << prettyprint(expression->value()) << "]" <<
@@ -486,6 +530,11 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
   } else if (dynamic_cast<String_Constant*>(node)) {
     String_Constant* expression = dynamic_cast<String_Constant*>(node);
     cerr << ind << "String_Constant : " << expression;
+    cerr << " [" << prettyprint(expression->value()) << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    if (expression->sass_fix_1291()) cerr << " [sass_fix_1291]";
+    cerr " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
+    cerr << ind << "String_Constant : " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << prettyprint(expression->value()) << "]" <<
       (expression->is_delayed() ? " {delayed}" : "") <<
@@ -494,6 +543,10 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
       " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
   } else if (dynamic_cast<String_Schema*>(node)) {
     String_Schema* expression = dynamic_cast<String_Schema*>(node);
+    cerr << ind << "String_Schema " << expression << " [" << expression->concrete_type() << "]";
+    if (expression->is_delayed()) cerr << " [delayed]";
+    if (expression->has_interpolants()) cerr << " [has_interpolants]";
+    cerr " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
     cerr << ind << "String_Schema " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " " << expression->concrete_type() <<
@@ -502,6 +555,9 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     for(auto i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<String*>(node)) {
     String* expression = dynamic_cast<String*>(node);
+    cerr << ind << "String " << expression << expression->concrete_type();
+    if (expression->sass_fix_1291()) cerr << " [sass_fix_1291]";
+    cerr " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
     cerr << ind << "String " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << expression->concrete_type() <<

--- a/eval.cpp
+++ b/eval.cpp
@@ -789,6 +789,7 @@ namespace Sass {
 
   Expression* Eval::operator()(Number* n)
   {
+    n->normalize();
     // behave according to as ruby sass (add leading zero)
     return new (ctx.mem) Number(n->pstate(),
                                 n->value(),
@@ -1055,13 +1056,8 @@ namespace Sass {
       } break;
 
       case Expression::NUMBER: {
-        Number* l = static_cast<Number*>(lhs);
-        Number* r = static_cast<Number*>(rhs);
-        Number tmp_r(*r);
-        tmp_r.normalize(l->find_convertible_unit());
-        return l->unit() == tmp_r.unit() && l->value() == tmp_r.value()
-               ? true
-               : false;
+        return *static_cast<Number*>(lhs) ==
+               *static_cast<Number*>(rhs);
       } break;
 
       case Expression::COLOR: {
@@ -1152,8 +1148,8 @@ namespace Sass {
       v->denominator_units() = r->denominator_units();
     }
 
-    v->value(ops[op](lv, tmp.value()));
     if (op == Binary_Expression::MUL) {
+      v->value(ops[op](lv, rv));
       for (size_t i = 0, S = r->numerator_units().size(); i < S; ++i) {
         v->numerator_units().push_back(r->numerator_units()[i]);
       }
@@ -1162,14 +1158,17 @@ namespace Sass {
       }
     }
     else if (op == Binary_Expression::DIV) {
+      v->value(ops[op](lv, rv));
       for (size_t i = 0, S = r->numerator_units().size(); i < S; ++i) {
         v->denominator_units().push_back(r->numerator_units()[i]);
       }
       for (size_t i = 0, S = r->denominator_units().size(); i < S; ++i) {
         v->numerator_units().push_back(r->denominator_units()[i]);
       }
+    } else {
+      v->value(ops[op](lv, tmp.value()));
     }
-    v->normalize();
+    // v->normalize();
     return v;
   }
 

--- a/eval.cpp
+++ b/eval.cpp
@@ -435,8 +435,23 @@ namespace Sass {
     }
     // not a logical connective, so go ahead and eval the rhs
     Expression* rhs = b->right()->perform(this);
-    rhs->is_delayed(false);
-    while (typeid(*rhs) == typeid(Binary_Expression)) rhs = rhs->perform(this);
+    // maybe fully evaluate structure
+    if (op_type == Binary_Expression::EQ ||
+        op_type == Binary_Expression::NEQ ||
+        op_type == Binary_Expression::GT ||
+        op_type == Binary_Expression::GTE ||
+        op_type == Binary_Expression::LT ||
+        op_type == Binary_Expression::LTE)
+    {
+      rhs->is_expanded(false);
+      rhs->set_delayed(false);
+      rhs = rhs->perform(this);
+    }
+    else
+    {
+      rhs->is_delayed(false);
+      rhs = rhs->perform(this);
+    }
 
     // see if it's a relational expression
     switch(op_type) {

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -416,6 +416,7 @@ namespace Sass {
 
   void Inspect::operator()(Number* n)
   {
+    n->normalize();
     stringstream ss;
     ss.precision(ctx ? ctx->precision : 5);
     ss << fixed << n->value();


### PR DESCRIPTION
Fix mathematical operations with different units:

```scss
foo { bar: (1cm*2in/1cm); }
```

Could move `convert` function back to `normalize`, but I don't think we pay much in terms of performance for keeping them apart for now. Made quite a few wrong turns while implementing that, since I intially wanted to use a map table for the units (like counting exponents). But then it was not able to normalize units the way ruby sass does, as insert order is important for that.

So this is not just a cosmetic fix, libsass also calculated wrong results in certain situations (see changes in eval.cpp). I do hope this is on par with ruby sass now :wink: 

Makes it pass this spec test:
- libsass/rel
- libsass/list
- libsass/conversions

IMO it's only missing (optional) performance optimizations!