### PR TITLE
Fix separator preserving with rest args

### DIFF
--- a/bind.cpp
+++ b/bind.cpp
@@ -80,6 +80,11 @@ namespace Sass {
           env->local_frame()[p->name()] = arglist;
           while (ia < LA) {
             a = (*as)[ia];
+            if (a->is_rest_argument()) {
+              if (List* rest = dynamic_cast<List*>(a->value())) {
+                arglist->separator(rest->separator());
+              }
+            }
             (*arglist) << new (ctx.mem) Argument(a->pstate(),
                                                  a->value(),
                                                  a->name(),


### PR DESCRIPTION
Makes it pass these todo spec tests:
- libsass/var-args
- scss-tests/071_test_mixin_splat_args_with_var_args_preserves_separator
- scss-tests/090_test_function_splat_args_with_var_args_preserves_separator