### PR TITLE
Relax compact error to warning

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -512,7 +512,6 @@ namespace Sass {
     register_function(ctx, index_sig, index, env);
     register_function(ctx, join_sig, join, env);
     register_function(ctx, append_sig, append, env);
-    register_function(ctx, compact_sig, compact, env);
     register_function(ctx, zip_sig, zip, env);
     register_function(ctx, list_separator_sig, list_separator, env);
     // Map Functions

--- a/error_handling.cpp
+++ b/error_handling.cpp
@@ -8,6 +8,18 @@ namespace Sass {
   : type(type), pstate(pstate), message(message)
   { }
 
+  void warn(string msg, ParserState pstate)
+  {
+    cerr << "Warning: " << msg<< endl;
+  }
+
+  void warn(string msg, ParserState pstate, Backtrace* bt)
+  {
+    Backtrace top(bt, pstate, "");
+    msg += top.to_string();
+    warn(msg, pstate);
+  }
+
   void error(string msg, ParserState pstate)
   {
     throw Sass_Error(Sass_Error::syntax, pstate, msg);
@@ -15,11 +27,9 @@ namespace Sass {
 
   void error(string msg, ParserState pstate, Backtrace* bt)
   {
-
     Backtrace top(bt, pstate, "");
-    msg += top.to_string();
-
-    throw Sass_Error(Sass_Error::syntax, pstate, msg);
+    msg += "\n" + top.to_string();
+    error(msg, pstate);
   }
 
 }

--- a/error_handling.hpp
+++ b/error_handling.hpp
@@ -21,6 +21,9 @@ namespace Sass {
 
   };
 
+  void warn(string msg, ParserState pstate);
+  void warn(string msg, ParserState pstate, Backtrace* bt);
+
   void error(string msg, ParserState pstate);
   void error(string msg, ParserState pstate, Backtrace* bt);
 

--- a/functions.cpp
+++ b/functions.cpp
@@ -1254,13 +1254,6 @@ namespace Sass {
       return zippers;
     }
 
-    Signature compact_sig = "compact($values...)";
-    BUILT_IN(compact)
-    {
-      error("`compact` has been removed from libsass because it's not part of the Sass spec", pstate);
-      return 0; // suppress warning, error will exit anyway
-    }
-
     Signature list_separator_sig = "list_separator($list)";
     BUILT_IN(list_separator)
     {

--- a/functions.hpp
+++ b/functions.hpp
@@ -78,7 +78,6 @@ namespace Sass {
     extern Signature join_sig;
     extern Signature append_sig;
     extern Signature zip_sig;
-    extern Signature compact_sig;
     extern Signature list_separator_sig;
     extern Signature type_of_sig;
     extern Signature unit_sig;
@@ -153,7 +152,6 @@ namespace Sass {
     BUILT_IN(join);
     BUILT_IN(append);
     BUILT_IN(zip);
-    BUILT_IN(compact);
     BUILT_IN(list_separator);
     BUILT_IN(type_of);
     BUILT_IN(unit);

--- a/parser.cpp
+++ b/parser.cpp
@@ -1619,6 +1619,10 @@ namespace Sass {
   {
     lex< identifier >();
     string name(lexed);
+    if (name == "compact") {
+      warn("`compact` has been removed from libsass because it's not part of the Sass spec", pstate);
+    }
+
     ParserState call_pos = pstate;
     Arguments* args = parse_arguments(name == "url");
     return new (ctx.mem) Function_Call(call_pos, name, args);


### PR DESCRIPTION
This relaxes the error to a warning. Otherwise the function cannot be used by user-code. It will now just spit out a warning, but behavior in output matches ruby sass. Makes a few spec tests to pass now:

- libsass/eq
- libsass/compact