### PR TITLE
Implement initial selector namespace handling

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -1765,6 +1765,7 @@ namespace Sass {
   // Abstract base class for simple selectors.
   ////////////////////////////////////////////
   class Simple_Selector : public Selector {
+    ADD_PROPERTY(string, ns);
   public:
     Simple_Selector(ParserState pstate)
     : Selector(pstate)
@@ -1778,6 +1779,7 @@ namespace Sass {
     inline bool operator!=(const Simple_Selector& rhs) const { return !(*this == rhs); }
 
     bool operator<(const Simple_Selector& rhs) const;
+    ATTACH_OPERATIONS();
   };
   inline Simple_Selector::~Simple_Selector() { }
 
@@ -1819,7 +1821,21 @@ namespace Sass {
   public:
     Type_Selector(ParserState pstate, string n)
     : Simple_Selector(pstate), name_(n)
-    { }
+    {
+      size_t pos = n.find('|');
+      // found some namespace
+      if (pos != string::npos) {
+        ns_ = n.substr(0, pos);
+        name_ = n.substr(pos + 1);
+      }
+    }
+    virtual string ns_name() const
+    {
+      string name("");
+      if (!ns_.empty())
+        name += ns_ + "|";
+      return name + name_;
+    }
     virtual unsigned long specificity()
     {
       // ToDo: What is the specificity of the star selector?
@@ -1838,7 +1854,21 @@ namespace Sass {
   public:
     Selector_Qualifier(ParserState pstate, string n)
     : Simple_Selector(pstate), name_(n)
-    { }
+    {
+      size_t pos = n.find('|');
+      // found some namespace
+      if (pos != string::npos) {
+        ns_ = n.substr(0, pos);
+        name_ = n.substr(pos + 1);
+      }
+    }
+    virtual string ns_name() const
+    {
+      string name("");
+      if (!ns_.empty())
+        name += ns_ + "|";
+      return name + name_;
+    }
     virtual unsigned long specificity()
     {
       if (name()[0] == '#') return Constants::Specificity_ID;
@@ -1859,7 +1889,21 @@ namespace Sass {
   public:
     Attribute_Selector(ParserState pstate, string n, string m, String* v)
     : Simple_Selector(pstate), name_(n), matcher_(m), value_(v)
-    { }
+    {
+      size_t pos = n.find('|');
+      // found some namespace
+      if (pos != string::npos) {
+        ns_ = n.substr(0, pos);
+        name_ = n.substr(pos + 1);
+      }
+    }
+    virtual string ns_name() const
+    {
+      string name("");
+      if (!ns_.empty())
+        name += ns_ + "|";
+      return name + name_;
+    }
     virtual unsigned long specificity()
     {
       return Constants::Specificity_Attr;
@@ -1888,7 +1932,21 @@ namespace Sass {
   public:
     Pseudo_Selector(ParserState pstate, string n, String* expr = 0)
     : Simple_Selector(pstate), name_(n), expression_(expr)
-    { }
+    {
+      size_t pos = n.find('|');
+      // found some namespace
+      if (pos != string::npos) {
+        ns_ = n.substr(0, pos);
+        name_ = n.substr(pos + 1);
+      }
+    }
+    virtual string ns_name() const
+    {
+      string name("");
+      if (!ns_.empty())
+        name += ns_ + "|";
+      return name + name_;
+    }
 
     // A pseudo-class always consists of a "colon" (:) followed by the name
     // of the pseudo-class and optionally by a value between parentheses.

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -751,12 +751,12 @@ namespace Sass {
 
   void Inspect::operator()(Type_Selector* s)
   {
-    append_token(s->name(), s);
+    append_token(s->ns_name(), s);
   }
 
   void Inspect::operator()(Selector_Qualifier* s)
   {
-    append_token(s->name(), s);
+    append_token(s->ns_name(), s);
     if (s->has_line_break()) append_optional_linefeed();
     if (s->has_line_break()) append_indentation();
   }
@@ -765,7 +765,7 @@ namespace Sass {
   {
     append_string("[");
     add_open_mapping(s);
-    append_token(s->name(), s);
+    append_token(s->ns_name(), s);
     if (!s->matcher().empty()) {
       append_string(s->matcher());
       if (s->value()) {
@@ -778,7 +778,7 @@ namespace Sass {
 
   void Inspect::operator()(Pseudo_Selector* s)
   {
-    append_token(s->name(), s);
+    append_token(s->ns_name(), s);
     if (s->expression()) {
       s->expression()->perform(this);
       append_string(")");

--- a/parser.cpp
+++ b/parser.cpp
@@ -1967,6 +1967,7 @@ namespace Sass {
     bool saw_interpolant = false;
 
     while ((q = peek< identifier >(p))                             ||
+           (q = peek< namespace_prefix >(p))                       ||
            (q = peek< hyphens_and_identifier >(p))                 ||
            (q = peek< hyphens_and_name >(p))                       ||
            (q = peek< type_selector >(p))                          ||
@@ -1977,7 +1978,7 @@ namespace Sass {
            (q = peek< dimension >(p))                              ||
            (q = peek< quoted_string >(p))                          ||
            (q = peek< exactly<'*'> >(p))                           ||
-           (q = peek< exactly<sel_deep_kwd> >(p))                           ||
+           (q = peek< exactly<sel_deep_kwd> >(p))                  ||
            (q = peek< exactly<'('> >(p))                           ||
            (q = peek< exactly<')'> >(p))                           ||
            (q = peek< exactly<'['> >(p))                           ||
@@ -1993,10 +1994,10 @@ namespace Sass {
                                 zero_plus<digit>,
                                 exactly<'n'> > >(p))               ||
            (q = peek< sequence< optional<sign>,
-                                one_plus<digit> > >(p))                     ||
+                                one_plus<digit> > >(p))            ||
            (q = peek< number >(p))                                 ||
            (q = peek< sequence< exactly<'&'>,
-                                identifier_alnums > >(p))        ||
+                                identifier_alnums > >(p))          ||
            (q = peek< exactly<'&'> >(p))                           ||
            (q = peek< exactly<'%'> >(p))                           ||
            (q = peek< alternatives<exact_match,
@@ -2030,6 +2031,7 @@ namespace Sass {
     bool saw_stuff = false;
 
     while ((q = peek< identifier >(p))                             ||
+           (q = peek< namespace_prefix >(p))                       ||
            (q = peek< type_selector >(p))                          ||
            (q = peek< id_name >(p))                                ||
            (q = peek< class_name >(p))                             ||
@@ -2053,10 +2055,10 @@ namespace Sass {
                                 zero_plus<digit>,
                                 exactly<'n'> > >(p))               ||
            (q = peek< sequence< optional<sign>,
-                                one_plus<digit> > >(p))                     ||
+                                one_plus<digit> > >(p))            ||
            (q = peek< number >(p))                                 ||
            (q = peek< sequence< exactly<'&'>,
-                                identifier_alnums > >(p))        ||
+                                identifier_alnums > >(p))          ||
            (q = peek< exactly<'&'> >(p))                           ||
            (q = peek< exactly<'%'> >(p))                           ||
            (q = peek< alternatives<exact_match,


### PR DESCRIPTION
Initial implementation for selector namespaces

Makes is (atm) pass these spec tests:

- extend-tests/021_test_universal_unification_with_simple_target
- extend-tests/023_test_universal_unification_with_simple_target
- extend-tests/026_test_universal_unification_with_namespaceless_universal_target
- extend-tests/028_test_universal_unification_with_namespaceless_universal_target
- extend-tests/031_test_universal_unification_with_namespaced_universal_target
- extend-tests/032_test_universal_unification_with_namespaced_universal_target
- extend-tests/033_test_universal_unification_with_namespaced_universal_target
- extend-tests/035_test_universal_unification_with_namespaceless_element_target
- extend-tests/037_test_universal_unification_with_namespaceless_element_target
- extend-tests/041_test_universal_unification_with_namespaced_element_target
- extend-tests/042_test_universal_unification_with_namespaced_element_target
- extend-tests/049_test_element_unification_with_namespaceless_universal_target
- extend-tests/050_test_element_unification_with_namespaceless_universal_target
- extend-tests/052_test_element_unification_with_namespaceless_universal_target
- extend-tests/055_test_element_unification_with_namespaced_universal_target
- extend-tests/057_test_element_unification_with_namespaceless_element_target
- extend-tests/062_test_element_unification_with_namespaced_element_target
- extend-tests/063_test_element_unification_with_namespaced_element_target

Needs more work to get extend working correctly with namespaces (selector unifying)!