### PR TITLE
Fix @elseif keyword not being parsed

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1630,12 +1630,13 @@ namespace Sass {
     if (!peek< exactly<'{'> >()) error("expected '{' after the predicate for @if", pstate);
     Block* consequent = parse_block();
     Block* alternative = 0;
-    if (lex< kwd_else_directive >()) {
-      if (peek< exactly<if_after_else_kwd> >()) {
-        alternative = new (ctx.mem) Block(pstate);
-        (*alternative) << parse_if_directive(true);
-      }
-      else if (!peek< exactly<'{'> >()) {
+
+    if (lex< elseif_directive >()) {
+      alternative = new (ctx.mem) Block(pstate);
+      (*alternative) << parse_if_directive(true);
+    }
+    else if (lex< kwd_else_directive >()) {
+      if (!peek< exactly<'{'> >()) {
         error("expected '{' after @else", pstate);
       }
       else {

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -262,9 +262,10 @@ namespace Sass {
       return word<else_kwd>(src);
     }
     const char* elseif_directive(const char* src) {
-      return sequence< kwd_else_directive,
-                       optional_css_whitespace,
-                       word< if_after_else_kwd > >(src);
+      return alternatives< word<else_kwd>,
+                           sequence< exactly< else_kwd >,
+                                     optional_css_whitespace,
+                                     word< if_after_else_kwd > > >(src);
     }
 
     const char* kwd_for_directive(const char* src) {


### PR DESCRIPTION
This PR fixes the `@elseif` keyword not being parsed.

Fixes https://github.com/sass/libsass/issues/1060. Specs added https://github.com/sass/sass-spec/pull/306.