### PR TITLE
Fix backslash multiline string with win linefeed

### DIFF
--- a/util.cpp
+++ b/util.cpp
@@ -88,7 +88,6 @@ namespace Sass {
       if (i == '\\') {
         esc = ! esc;
       } else if (esc && i == '\r') {
-        out.resize (out.size () - 1);
         continue;
       } else if (esc && i == '\n') {
         out.resize (out.size () - 1);


### PR DESCRIPTION
OK, that was a dumb coding error which I obviously did not test :cry:

Fixes https://github.com/sass/libsass/issues/1067