### PR TITLE
Fix interpolation with unary expressions

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -818,6 +818,9 @@ namespace Sass {
     } else if (Parent_Selector* var = dynamic_cast<Parent_Selector*>(s)) {
       Expression* ex = var->perform(this);
       return evacuate_quotes(interpolation(ex));
+    } else if (Unary_Expression* var = dynamic_cast<Unary_Expression*>(s)) {
+      Expression* ex = var->perform(this);
+      return evacuate_quotes(interpolation(ex));
     } else if (Selector* var = dynamic_cast<Selector*>(s)) {
       Expression* ex = var->perform(this);
       return evacuate_quotes(interpolation(ex));


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1074

Btw. we might be able to reduce or completely get rid of the interpolation function. It was mainly added to not "step on any toes" while doing the refactoring. For now it makes it easier to keep the code separated from the regular eval visitors. IMO it makes sense to revisit this once interpolation has proven to do the correct thing (I still know a few very esoteric edge-cases).