### PR TITLE
Fix a couple issue with random()

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -1079,8 +1079,8 @@ namespace Sass {
       }
       else {
         uniform_real_distribution<> distributor(0, 1);
-        uint_fast32_t distributed = static_cast<uint_fast32_t>(distributor(rand));
-        return new (ctx.mem) Number(pstate, trunc(distributed));
+        double distributed = static_cast<double>(distributor(rand));
+        return new (ctx.mem) Number(pstate, distributed);
      }
     }
 

--- a/functions.cpp
+++ b/functions.cpp
@@ -1071,8 +1071,8 @@ namespace Sass {
     BUILT_IN(random)
     {
       Number* l = dynamic_cast<Number*>(env["$limit"]);
-      if (l && trunc(l->value()) != l->value()) error("argument $limit of `" + string(sig) + "` must be an integer", pstate);
       if (l) {
+        if (trunc(l->value()) != l->value() || l->value() == 0) error("argument $limit of `" + string(sig) + "` must be a positive integer", pstate);
         uniform_real_distribution<> distributor(1, l->value() + 1);
         uint_fast32_t distributed = static_cast<uint_fast32_t>(distributor(rand));
         return new (ctx.mem) Number(pstate, (double)distributed);


### PR DESCRIPTION
This PR fixes a couple issues with `random()`
- `random()` without a limit was always returning 0
- `random(0)` should error

Updated specs https://github.com/sass/sass-spec/pull/328