### PR TITLE
Add a join us in slack button to the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@ by Aaron Leung ([@akhleung]) and Hampton Catlin ([@hcatlin])
 [![Windows CI](https://ci.appveyor.com/api/projects/status/github/sass/libsass?svg=true)](https://ci.appveyor.com/project/sass/libsass/branch/master)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=283068)](https://www.bountysource.com/trackers/283068-libsass?utm_source=283068&utm_medium=shield&utm_campaign=TRACKER_BADGE)
 [![Coverage Status](https://img.shields.io/coveralls/sass/libsass.svg)](https://coveralls.io/r/sass/libsass?branch=feature%2Ftest-travis-ci-3)
+[![Join us](https://still-ridge-9421.herokuapp.com/badge.svg)](https://still-ridge-9421.herokuapp.com/)
 
 https://github.com/sass/libsass
 


### PR DESCRIPTION
This PR adds a button to join us our Slack channel to the README.

![screen shot 2015-04-16 at 7 07 03 pm](https://cloud.githubusercontent.com/assets/579928/7177680/e4f053a0-e46b-11e4-8c08-1c9e0f68f6df.png)

This will in essence replace the gitter chat room which to this date has host 2 short conversations.

/cc @mgreter @hcatlin @chriseppstein 
