### PR TITLE
Fixes a regression in handling common IE property hacks

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1396,7 +1396,8 @@ namespace Sass {
     Token str(lexed);
     --str.end;
     --position;
-    String_Constant* str_node = new (ctx.mem) String_Constant(pstate, str);
+
+    String_Constant* str_node = new (ctx.mem) String_Constant(pstate, str.time_wspace());
     // str_node->is_delayed(true);
     return str_node;
   }

--- a/position.hpp
+++ b/position.hpp
@@ -89,6 +89,11 @@ namespace Sass {
     size_t length()    const { return end - begin; }
     string ws_before() const { return string(prefix, begin); }
     string to_string() const { return string(begin, end); }
+    string time_wspace() const {
+      string str(to_string());
+      string whitespaces(" \t\f\v\n\r");
+      return str.erase(str.find_last_not_of(whitespaces)+1);
+    }
 
     operator bool()   { return begin && end && begin >= end; }
     operator string() { return to_string(); }

--- a/prelexer.cpp
+++ b/prelexer.cpp
@@ -710,7 +710,10 @@ namespace Sass {
     }
 
     const char* static_value(const char* src) {
-      return sequence< static_component,
+      return sequence< sequence<
+                         static_component,
+                         zero_plus< identifier >
+                       >,
                        zero_plus < sequence<
                                    alternatives<
                                      sequence< optional_spaces, alternatives<
@@ -722,6 +725,7 @@ namespace Sass {
                                    >,
                                    static_component
                        > >,
+                       optional_css_whitespace,
                        alternatives< exactly<';'>, exactly<'}'> >
                       >(src);
     }


### PR DESCRIPTION
This PR fixes a regression in handling common IE property hacks.

Fixes https://github.com/sass/libsass/issues/1098. 
Specs added https://github.com/sass/sass-spec/issues/331