### PR TITLE
Unquoting null should return null

### DIFF
--- a/functions.cpp
+++ b/functions.cpp
@@ -760,6 +760,10 @@ namespace Sass {
     Signature unquote_sig = "unquote($string)";
     BUILT_IN(sass_unquote)
     {
+      if (dynamic_cast<Null*>(env["$string"])) {
+        return new (ctx.mem) Null(pstate);
+      }
+
       To_String to_string(&ctx);
       AST_Node* arg = env["$string"];
       if (String_Quoted* string_quoted = dynamic_cast<String_Quoted*>(arg)) {


### PR DESCRIPTION
This PR fixes `unquote(null)` ensuring it returns `null`.

Fixes https://github.com/sass/libsass/issues/1106, https://github.com/sass/libsass/issues/1124.
Specs added https://github.com/sass/sass-spec/pull/338, https://github.com/sass/sass-spec/pull/339.