### PR TITLE
Misc fixes for string handling regressions

### DIFF
--- a/debugger.hpp
+++ b/debugger.hpp
@@ -489,6 +489,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << " [" << prettyprint(expression->value()) << "]" <<
       (expression->is_delayed() ? " {delayed}" : "") <<
       (expression->sass_fix_1291() ? " {sass_fix_1291}" : "") <<
+      (expression->quote_mark() != 0 ? " {qm:" + string(1, expression->quote_mark()) + "}" : "") <<
       " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
   } else if (dynamic_cast<String_Schema*>(node)) {
     String_Schema* expression = dynamic_cast<String_Schema*>(node);

--- a/functions.cpp
+++ b/functions.cpp
@@ -771,7 +771,7 @@ namespace Sass {
         return result;
       }
       To_String to_string(&ctx);
-      return new (ctx.mem) String_Constant(pstate, string(arg->perform(&to_string)));
+      return new (ctx.mem) String_Constant(pstate, unquote(string(arg->perform(&to_string))));
     }
 
     Signature quote_sig = "quote($string)";

--- a/parser.cpp
+++ b/parser.cpp
@@ -1499,7 +1499,7 @@ namespace Sass {
         (*schema) << new (ctx.mem) Textual(pstate, Textual::HEX, unquote(lexed));
       }
       else if (lex< quoted_string >()) {
-        (*schema) << new (ctx.mem) String_Constant(pstate, lexed);
+        (*schema) << new (ctx.mem) String_Quoted(pstate, lexed);
       }
       else if (lex< variable >()) {
         (*schema) << new (ctx.mem) Variable(pstate, Util::normalize_underscores(lexed));

--- a/parser.cpp
+++ b/parser.cpp
@@ -1415,6 +1415,7 @@ namespace Sass {
     Token str(lexed);
     const char* i = str.begin;
     // see if there any interpolants
+    const char* q;
     const char* p = find_first_in_interval< exactly<hash_lbrace> >(str.begin, str.end);
     if (!p) {
       String_Constant* str_node = new (ctx.mem) String_Constant(pstate, normalize_wspace(string(str.begin, str.end)));
@@ -1424,8 +1425,16 @@ namespace Sass {
 
     String_Schema* schema = new (ctx.mem) String_Schema(pstate);
     while (i < str.end) {
+      q = find_first_in_interval< alternatives< exactly<'"'>, exactly<'\''> > >(i, str.end);
       p = find_first_in_interval< exactly<hash_lbrace> >(i, str.end);
-      if (p) {
+      if (q && (!p || p > q)) {
+        if (i < q) {
+          (*schema) << new (ctx.mem) String_Constant(pstate, string(i, q)); // accumulate the preceding segment if it's nonempty
+        }
+        (*schema) << new (ctx.mem) String_Constant(pstate, string(q, q+1)); // capture the quote mark separately
+        i = q+1;
+      }
+      else if (p) {
         if (i < p) {
           (*schema) << new (ctx.mem) String_Constant(pstate, string(i, p)); // accumulate the preceding segment if it's nonempty
         }

--- a/util.cpp
+++ b/util.cpp
@@ -327,12 +327,12 @@ namespace Sass {
       }
       // check for unexpected delimiter
       // be strict and throw error back
-      else if (!skipped && q == s[i]) {
-        // don't be that strict
-        return s;
-        // this basically always means an internal error and not users fault
-        error("Unescaped delimiter in string to unquote found. [" + s + "]", ParserState("[UNQUOTE]"));
-      }
+      // else if (!skipped && q == s[i]) {
+      //   // don't be that strict
+      //   return s;
+      //   // this basically always means an internal error and not users fault
+      //   error("Unescaped delimiter in string to unquote found. [" + s + "]", ParserState("[UNQUOTE]"));
+      // }
       else {
         skipped = false;
         unq.push_back(s[i]);


### PR DESCRIPTION
This is handles a handful for fixes for 3.2.0-beta regressions in string handling.

Most of the fixes involved ensuring if a string was quoted it was cast to a `String_Quoted` and never a `String_Constant`. Given this constraint the code generation handled output correctly almost always. I'm sure there are more place we can apply this constraint which I expect will solve some output bugs.

I'm the near future I'll add some debug logging for anytime a `String_Constant` is created with a quoted a string.

This PR also remove a bail out condition in `unquote` which didn't handle cases like `"["]"`. This is almost certainly a issue with how we escape strings internally, but for now this got all the specs passing.

Fixes #1127.
Fixes #1121 with help from #1137.

Specs added sass/sass-spec#331, sass/sass-spec#334, sass/sass-spec#341, sass/sass-spec#346, sass/sass-spec#352, https://github.com/sass/sass-spec/pull/354/