### PR TITLE
Fix comment_to_string edge case

### DIFF
--- a/util.cpp
+++ b/util.cpp
@@ -177,6 +177,7 @@ namespace Sass {
   {
     string str = "";
     size_t has = 0;
+    char prev = 0;
     bool clean = false;
     for (auto i : text) {
       if (clean) {
@@ -188,7 +189,8 @@ namespace Sass {
         else {
           clean = false;
           str += ' ';
-          str += i;
+          if (prev == '*' && i == '/') str += "*/";
+          else str += i;
         }
       } else if (i == '\n') {
         clean = true;
@@ -197,6 +199,7 @@ namespace Sass {
       } else {
         str += i;
       }
+      prev = i;
     }
     if (has) return str;
     else return text;


### PR DESCRIPTION
This PR fixes an edge in `comment_to_string` where it failed to correctly output cases where `*/` was on a new line.

```css
/*
 * This is comment
 */
```
Ruby Sass
```css
/* This is comment */
```
Libsass
```css
/* This is comment /
```

This is part of a larger fix for #1121.
Specs added sass/sass-spec#334.