### PR TITLE
Add missing header file to util.cpp

### DIFF
--- a/util.hpp
+++ b/util.hpp
@@ -1,6 +1,7 @@
 #ifndef SASS_UTIL_H
 #define SASS_UTIL_H
 
+#include <cstdio>
 #include <vector>
 #include <string>
 #include "ast_fwd_decl.hpp"


### PR DESCRIPTION
This PR adds the missing `<stdio.h>` header to util.cpp.

Fixes https://github.com/sass/libsass/issues/1144.
Partially fixes https://github.com/sass/node-sass/issues/892.

/cc @mgreter 