### PR TITLE
Remove all traces of compact once and for all

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -1619,9 +1619,6 @@ namespace Sass {
   {
     lex< identifier >();
     string name(lexed);
-    if (name == "compact") {
-      warn("`compact` has been removed from libsass because it's not part of the Sass spec", pstate);
-    }
 
     ParserState call_pos = pstate;
     Arguments* args = parse_arguments(name == "url");


### PR DESCRIPTION
This PR pulls the trigger on removing all traces of `compact`.

Fixes https://github.com/sass/libsass/issues/1155, https://github.com/sass/sass-spec/issues/360.