### PR TITLE
Add a max stack depth setting

### DIFF
--- a/constants.cpp
+++ b/constants.cpp
@@ -3,6 +3,8 @@
 namespace Sass {
   namespace Constants {
 
+    extern const unsigned long MaxCallStack = 1024;
+
     // https://github.com/sass/libsass/issues/592
     // https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity
     // https://github.com/sass/sass/issues/1495#issuecomment-61189114

--- a/constants.hpp
+++ b/constants.hpp
@@ -4,6 +4,9 @@
 namespace Sass {
   namespace Constants {
 
+    // The maximum call stack that can be created
+    extern const unsigned long MaxCallStack;
+
     // https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity
     // The following list of selectors is by increasing specificity:
     extern const unsigned long Specificity_Star;

--- a/eval.cpp
+++ b/eval.cpp
@@ -527,6 +527,9 @@ namespace Sass {
 
   Expression* Eval::operator()(Function_Call* c)
   {
+    if (backtrace->parent != NULL && backtrace->depth() > Constants::MaxCallStack) {
+        error("Stack depth exceeded max of " + to_string(Constants::MaxCallStack), c->pstate(), backtrace);
+    }
     string name(Util::normalize_underscores(c->name()));
     string full_name(name + "[f]");
     Arguments* args = c->arguments();


### PR DESCRIPTION
A segfault happens when a recursive function is created that never ends:

```
@function ex() { @return ex(); }
div { x: ex(); }
```

I've added a max stack depth setting and an error when that setting is exceeded.