### PR TITLE
Refactor `Sass_Value` implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,8 @@ SOURCES = \
 	to_string.cpp \
 	units.cpp \
 	utf8_string.cpp \
-	util.cpp
+	util.cpp \
+	values.cpp
 
 CSOURCES = cencode.c
 

--- a/context.cpp
+++ b/context.cpp
@@ -28,6 +28,7 @@
 #include "sass2scss.h"
 #include "prelexer.hpp"
 #include "emitter.hpp"
+#include "scalars.hpp"
 
 #include <string>
 #include <cstdlib>
@@ -49,6 +50,16 @@ namespace Sass {
     this->abs_path = abs_path;
     this->source = source;
   }
+
+  class Test {
+    Test(bool) {};
+    Test(const Test& a) {};
+    const Test& qwe(const Test& a) {
+    	Test q(false);
+    	return a; }
+    Test& operator=(const Test& a) { return *this; }
+    ~Test() {};
+  };
 
   inline bool sort_importers (const Sass_Importer_Entry& i, const Sass_Importer_Entry& j)
   { return sass_importer_get_priority(i) > sass_importer_get_priority(j); }
@@ -87,6 +98,70 @@ namespace Sass {
     plugins(),
     subset_map              (Subset_Map<string, pair<Complex_Selector*, Compound_Selector*> >())
   {
+/*
+cerr << "hello\n";
+Scalar::SassString asd("asd", false);
+Scalar::SassString qwe("qwe", false);
+const Scalar::SassString* a = asd + qwe;
+
+Scalar::SassNull na1;
+Scalar::SassNull na2;
+Scalar::SassScalar* na_1 = &na1;
+Scalar::SassScalar* na_2 = &na2;
+cerr << na_1->sass_type();
+const Scalar::SassScalar* b = na_1->addition(&na2);
+cerr << b->inspect();
+exit(33);
+*/
+
+
+Scalar::SassNull n1;
+Scalar::SassNull n2;
+
+Scalar::SassBool tr(true);
+Scalar::SassBool fa(false);
+
+auto _tr = tr;
+auto _fa = fa;
+auto _n1 = n1;
+auto _n2 = n2;
+
+// const Scalar::SassValue& val = _tr  + _n1;
+
+
+/*
+
+
+  auto val = _tr  + _n1;
+  auto val2 = val   + _n1;
+
+*/
+
+
+if (true) {
+  const Scalar::SassString v1("v1");
+  const Scalar::SassString v2("v2");
+  const Scalar::SassString v3("v3");
+
+  const Scalar::SassValue& val1 = v1;
+  const Scalar::SassValue& val2 = v2;
+
+  const Scalar::SassValue& val3 = val1;
+
+//  v1 = v2;
+
+  // const Scalar::SassValue& v99 = v1;
+
+  cerr << "v1: " << v1.stringify() << "\n";
+  cerr << "v2: " << v2.stringify() << "\n";
+  // cerr << "v3: " << v99.stringify() << "\n";
+}
+//Scalar::SassBool v2(true);
+
+//Scalar::SassValue& v3 = v2;
+//Scalar::SassBool v4 = v2;
+
+exit(32);
 
     cwd = get_cwd();
 

--- a/eval.cpp
+++ b/eval.cpp
@@ -1321,7 +1321,13 @@ namespace Sass {
         e = new (ctx.mem) Color(pstate, sass_color_get_r(v), sass_color_get_g(v), sass_color_get_b(v), sass_color_get_a(v));
       } break;
       case SASS_STRING: {
-        e = new (ctx.mem) String_Constant(pstate, sass_string_get_value(v));
+        if (sass_string_is_quoted(v)) {
+          e = new (ctx.mem) String_Quoted(pstate, "");
+          ((String_Quoted*)e)->value(sass_string_get_value(v));
+        } else {
+          e = new (ctx.mem) String_Constant(pstate, "");
+          ((String_Constant*)e)->value(sass_string_get_value(v));
+        }
       } break;
       case SASS_LIST: {
         List* l = new (ctx.mem) List(pstate, sass_list_get_length(v), sass_list_get_separator(v) == SASS_COMMA ? List::COMMA : List::SPACE);

--- a/sass_values.cpp
+++ b/sass_values.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <cstring>
 #include "util.hpp"
+#include "position.hpp"
 #include "sass_values.h"
 
 extern "C" {
@@ -15,6 +16,7 @@ extern "C" {
 
   struct Sass_Unknown {
     enum Sass_Tag tag;
+    ParserState   pstate;
   };
 
   struct Sass_Boolean {
@@ -26,6 +28,7 @@ extern "C" {
     enum Sass_Tag tag;
     double        value;
     char*         unit;
+    Number*       num;
   };
 
   struct Sass_Color {
@@ -258,6 +261,52 @@ extern "C" {
     if (v->warning.message == 0) { free(v); return 0; }
     return v;
   }
+
+//  inline exec_op(enum Sass_Op opt,
+
+  // Generic sass value operator function for concat, add, multiply etc
+  // Seems like we cannot easily re-use the high level c++ functions, since we
+  // would need to convert all sass values to AST_Nodes and furthermore pack
+  // them into Binary Expression for eval to evaluate the result (and convert back).
+  // So it seems easier (and more performant to implement on good op function here.
+  union Sass_Value* ADDCALL sass_value_op (union Sass_Value* a, union Sass_Value* b, enum Sass_Op op)
+  {
+    enum Sass_Tag t_a = a->unknown.tag;
+    enum Sass_Tag t_b = b->unknown.tag;
+    if (t_a == t_b) {
+        switch(a->unknown.tag) {
+            case SASS_NULL: {
+                    return sass_make_string("SASS_NULL");
+            }   break;
+            case SASS_BOOLEAN: {
+                    return sass_make_string("SASS_BOOLEAN");
+            }   break;
+            case SASS_NUMBER: {
+                    return sass_make_string("SASS_NUMBER");
+            }   break;
+            case SASS_COLOR: {
+                    return sass_make_string("SASS_COLOR");
+            }   break;
+            case SASS_STRING: {
+                    return sass_make_string("SASS_STRING");
+            }   break;
+            case SASS_LIST: {
+                    return sass_make_string("SASS_LIST");
+            }   break;
+            case SASS_MAP: {
+                    return sass_make_string("SASS_MAP");
+            }   break;
+            case SASS_ERROR: {
+                    return sass_make_string("SASS_ERROR");
+            }   break;
+            case SASS_WARNING: {
+                    return sass_make_string("SASS_WARNING");
+            }   break;
+        }
+    }
+    return sass_make_string("asd");
+  }
+
 
   // will free all associated sass values
   void ADDCALL sass_delete_value(union Sass_Value* val) {

--- a/sass_values.h
+++ b/sass_values.h
@@ -14,6 +14,16 @@ extern "C" {
 union Sass_Value;
 
 // Type for Sass values
+enum Sass_Op {
+  SASS_CONCAT,
+  SASS_MODULO,
+  SASS_SUBTRACT,
+  SASS_ADDITION,
+  SASS_DIVISION,
+  SASS_MULTIPLY
+};
+
+// Type for Sass values
 enum Sass_Tag {
   SASS_BOOLEAN,
   SASS_NUMBER,
@@ -110,6 +120,10 @@ ADDAPI union Sass_Value* ADDCALL sass_make_list    (size_t len, enum Sass_Separa
 ADDAPI union Sass_Value* ADDCALL sass_make_map     (size_t len);
 ADDAPI union Sass_Value* ADDCALL sass_make_error   (const char* msg);
 ADDAPI union Sass_Value* ADDCALL sass_make_warning (const char* msg);
+
+// Generic sass value operator function for concat, add, multiply etc
+ADDAPI union Sass_Value* ADDCALL sass_value_op (union Sass_Value* a, union Sass_Value* b, enum Sass_Op opt);
+
 
 // Generic destructor function for all types
 // Will release memory of all associated Sass_Values

--- a/scalars.cpp
+++ b/scalars.cpp
@@ -1,0 +1,398 @@
+#include "scalars.hpp"
+
+#include <sstream>
+#include <iostream>
+
+namespace Sass {
+  using namespace std;
+  namespace Scalar {
+
+    InvalidOp::InvalidOp(enum OP op, const SassValue& a, const SassValue& b)
+    : runtime_error("InvalidSassOp")
+    {
+      stringstream ss;
+      ss << a.sass_type() << " ";
+      ss << op_to_string(op);
+      ss << " " << b.sass_type();
+      this->msg = ss.str();
+    };
+
+    const char* InvalidOp::what() const throw()
+    {
+      return msg.c_str();
+    }
+
+    // SOME STATIC VALUES
+
+    static SassNull sass_null;
+    static SassBool sass_true(true);
+    static SassBool sass_false(false);
+
+    // IMPLEMENT TYPE QUERIES
+
+    const char* SassNull::sass_type() const { return "null"; }
+    const char* SassBool::sass_type() const { return "bool"; }
+    const char* SassNumber::sass_type() const { return "number"; }
+    const char* SassString::sass_type() const { return "string"; }
+    const char* SassColor::sass_type() const { return "color"; }
+
+    const string SassNull::stringify() const { return "null"; }
+    const string SassBool::stringify() const { return value ? "true" : "false"; }
+    const string SassNumber::stringify() const { return "number"; }
+    const string SassString::stringify() const { return value; }
+    const string SassColor::stringify() const { return "color"; }
+
+    // IMPLEMENT EQUAL
+
+    template < > const SassValue& sass_op < EQUAL > (const SassNull& a, const SassNull& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNull& a, const SassBool& b) { throw InvalidOp(EQUAL, a, b); return SassBool(false); }
+    template < > const SassValue& sass_op < EQUAL > (const SassNull& a, const SassString& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNull& a, const SassNumber& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNull& a, const SassColor& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNull& a, const SassValue& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+
+    template < > const SassValue& sass_op < EQUAL > (const SassBool& a, const SassNull& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassBool& a, const SassBool& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassBool& a, const SassString& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassBool& a, const SassNumber& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassBool& a, const SassColor& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassBool& a, const SassValue& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+
+    template < > const SassValue& sass_op < EQUAL > (const SassString& a, const SassNull& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassString& a, const SassBool& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassString& a, const SassString& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassString& a, const SassNumber& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassString& a, const SassColor& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassString& a, const SassValue& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+
+    template < > const SassValue& sass_op < EQUAL > (const SassNumber& a, const SassNull& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNumber& a, const SassBool& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNumber& a, const SassString& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNumber& a, const SassNumber& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNumber& a, const SassColor& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassNumber& a, const SassValue& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+
+    template < > const SassValue& sass_op < EQUAL > (const SassColor& a, const SassNull& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassColor& a, const SassBool& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassColor& a, const SassString& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassColor& a, const SassNumber& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassColor& a, const SassColor& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassColor& a, const SassValue& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+
+    template < > const SassValue& sass_op < EQUAL > (const SassValue& a, const SassNull& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassValue& a, const SassBool& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassValue& a, const SassString& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassValue& a, const SassNumber& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassValue& a, const SassColor& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+    template < > const SassValue& sass_op < EQUAL > (const SassValue& a, const SassValue& b) { throw InvalidOp(EQUAL, a, b); return sass_false; }
+
+    // IMPLEMENT CONCAT
+
+    template < > const SassValue& sass_op < CONCAT > (const SassNull& a, const SassNull& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNull& a, const SassBool& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNull& a, const SassString& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNull& a, const SassNumber& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNull& a, const SassColor& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNull& a, const SassValue& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < CONCAT > (const SassBool& a, const SassNull& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassBool& a, const SassBool& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassBool& a, const SassString& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassBool& a, const SassNumber& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassBool& a, const SassColor& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassBool& a, const SassValue& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < CONCAT > (const SassString& a, const SassNull& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassString& a, const SassBool& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassString& a, const SassString& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassString& a, const SassNumber& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassString& a, const SassColor& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassString& a, const SassValue& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < CONCAT > (const SassNumber& a, const SassNull& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNumber& a, const SassBool& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNumber& a, const SassString& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNumber& a, const SassNumber& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNumber& a, const SassColor& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassNumber& a, const SassValue& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < CONCAT > (const SassColor& a, const SassNull& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassColor& a, const SassBool& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassColor& a, const SassString& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassColor& a, const SassNumber& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassColor& a, const SassColor& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassColor& a, const SassValue& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < CONCAT > (const SassValue& a, const SassNull& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassValue& a, const SassBool& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassValue& a, const SassString& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassValue& a, const SassNumber& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassValue& a, const SassColor& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < CONCAT > (const SassValue& a, const SassValue& b) { throw InvalidOp(CONCAT, a, b); return sass_null; }
+
+    // IMPLEMENT ASSIGN
+
+    template < > const SassValue& sass_op < ASSIGN > (const SassNull& a, const SassNull& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNull& a, const SassBool& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNull& a, const SassString& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNull& a, const SassNumber& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNull& a, const SassColor& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNull& a, const SassValue& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ASSIGN > (const SassBool& a, const SassNull& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassBool& a, const SassBool& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassBool& a, const SassString& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassBool& a, const SassNumber& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassBool& a, const SassColor& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassBool& a, const SassValue& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ASSIGN > (const SassString& a, const SassNull& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassString& a, const SassBool& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassString& a, const SassString& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassString& a, const SassNumber& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassString& a, const SassColor& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassString& a, const SassValue& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ASSIGN > (const SassNumber& a, const SassNull& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNumber& a, const SassBool& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNumber& a, const SassString& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNumber& a, const SassNumber& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNumber& a, const SassColor& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassNumber& a, const SassValue& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ASSIGN > (const SassColor& a, const SassNull& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassColor& a, const SassBool& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassColor& a, const SassString& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassColor& a, const SassNumber& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassColor& a, const SassColor& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassColor& a, const SassValue& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ASSIGN > (const SassValue& a, const SassNull& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassValue& a, const SassBool& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassValue& a, const SassString& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassValue& a, const SassNumber& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassValue& a, const SassColor& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ASSIGN > (const SassValue& a, const SassValue& b) { throw InvalidOp(ASSIGN, a, b); return sass_null; }
+
+    // IMPLEMENT MODULO
+
+    template < > const SassValue& sass_op < MODULO > (const SassNull& a, const SassNull& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNull& a, const SassBool& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNull& a, const SassString& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNull& a, const SassNumber& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNull& a, const SassColor& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNull& a, const SassValue& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MODULO > (const SassBool& a, const SassNull& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassBool& a, const SassBool& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassBool& a, const SassString& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassBool& a, const SassNumber& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassBool& a, const SassColor& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassBool& a, const SassValue& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MODULO > (const SassString& a, const SassNull& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassString& a, const SassBool& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassString& a, const SassString& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassString& a, const SassNumber& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassString& a, const SassColor& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassString& a, const SassValue& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MODULO > (const SassNumber& a, const SassNull& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNumber& a, const SassBool& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNumber& a, const SassString& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNumber& a, const SassNumber& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNumber& a, const SassColor& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassNumber& a, const SassValue& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MODULO > (const SassColor& a, const SassNull& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassColor& a, const SassBool& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassColor& a, const SassString& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassColor& a, const SassNumber& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassColor& a, const SassColor& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassColor& a, const SassValue& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MODULO > (const SassValue& a, const SassNull& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassValue& a, const SassBool& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassValue& a, const SassString& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassValue& a, const SassNumber& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassValue& a, const SassColor& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MODULO > (const SassValue& a, const SassValue& b) { throw InvalidOp(MODULO, a, b); return sass_null; }
+
+    // IMPLEMENT ADDITION
+
+    template < > const SassValue& sass_op < ADDITION > (const SassNull& a, const SassNull& b) { return SassString("null null"); }
+    template < > const SassValue& sass_op < ADDITION > (const SassNull& a, const SassBool& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNull& a, const SassString& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNull& a, const SassNumber& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNull& a, const SassColor& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNull& a, const SassValue& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ADDITION > (const SassBool& a, const SassNull& b) { return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassBool& a, const SassBool& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassBool& a, const SassString& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassBool& a, const SassNumber& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassBool& a, const SassColor& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassBool& a, const SassValue& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ADDITION > (const SassString& a, const SassNull& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassString& a, const SassBool& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassString& a, const SassString& b) { return SassString(a.value + b.value, a.is_quoted); }
+    template < > const SassValue& sass_op < ADDITION > (const SassString& a, const SassNumber& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassString& a, const SassColor& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassString& a, const SassValue& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ADDITION > (const SassNumber& a, const SassNull& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNumber& a, const SassBool& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNumber& a, const SassString& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNumber& a, const SassNumber& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNumber& a, const SassColor& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassNumber& a, const SassValue& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ADDITION > (const SassColor& a, const SassNull& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassColor& a, const SassBool& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassColor& a, const SassString& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassColor& a, const SassNumber& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassColor& a, const SassColor& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassColor& a, const SassValue& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < ADDITION > (const SassValue& a, const SassNull& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassValue& a, const SassBool& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassValue& a, const SassString& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassValue& a, const SassNumber& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassValue& a, const SassColor& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < ADDITION > (const SassValue& a, const SassValue& b) { throw InvalidOp(ADDITION, a, b); return sass_null; }
+
+    // IMPLEMENT MULTIPLY
+
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNull& a, const SassNull& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNull& a, const SassBool& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNull& a, const SassString& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNull& a, const SassNumber& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNull& a, const SassColor& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNull& a, const SassValue& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MULTIPLY > (const SassBool& a, const SassNull& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassBool& a, const SassBool& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassBool& a, const SassString& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassBool& a, const SassNumber& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassBool& a, const SassColor& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassBool& a, const SassValue& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MULTIPLY > (const SassString& a, const SassNull& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassString& a, const SassBool& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassString& a, const SassString& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassString& a, const SassNumber& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassString& a, const SassColor& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassString& a, const SassValue& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNumber& a, const SassNull& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNumber& a, const SassBool& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNumber& a, const SassString& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNumber& a, const SassNumber& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNumber& a, const SassColor& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassNumber& a, const SassValue& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MULTIPLY > (const SassColor& a, const SassNull& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassColor& a, const SassBool& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassColor& a, const SassString& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassColor& a, const SassNumber& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassColor& a, const SassColor& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassColor& a, const SassValue& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < MULTIPLY > (const SassValue& a, const SassNull& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassValue& a, const SassBool& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassValue& a, const SassString& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassValue& a, const SassNumber& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassValue& a, const SassColor& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+    template < > const SassValue& sass_op < MULTIPLY > (const SassValue& a, const SassValue& b) { throw InvalidOp(MULTIPLY, a, b); return sass_null; }
+
+    // IMPLEMENT SUBTRACT
+
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNull& a, const SassNull& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNull& a, const SassBool& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNull& a, const SassString& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNull& a, const SassNumber& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNull& a, const SassColor& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNull& a, const SassValue& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < SUBTRACT > (const SassBool& a, const SassNull& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassBool& a, const SassBool& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassBool& a, const SassString& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassBool& a, const SassNumber& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassBool& a, const SassColor& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassBool& a, const SassValue& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < SUBTRACT > (const SassString& a, const SassNull& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassString& a, const SassBool& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassString& a, const SassString& b) { return SassString(a.value + b.value, a.is_quoted); }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassString& a, const SassNumber& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassString& a, const SassColor& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassString& a, const SassValue& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNumber& a, const SassNull& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNumber& a, const SassBool& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNumber& a, const SassString& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNumber& a, const SassNumber& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNumber& a, const SassColor& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassNumber& a, const SassValue& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < SUBTRACT > (const SassColor& a, const SassNull& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassColor& a, const SassBool& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassColor& a, const SassString& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassColor& a, const SassNumber& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassColor& a, const SassColor& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassColor& a, const SassValue& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < SUBTRACT > (const SassValue& a, const SassNull& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassValue& a, const SassBool& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassValue& a, const SassString& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassValue& a, const SassNumber& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassValue& a, const SassColor& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+    template < > const SassValue& sass_op < SUBTRACT > (const SassValue& a, const SassValue& b) { throw InvalidOp(SUBTRACT, a, b); return sass_null; }
+
+    // IMPLEMENT DIVISION
+
+    template < > const SassValue& sass_op < DIVISION > (const SassNull& a, const SassNull& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNull& a, const SassBool& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNull& a, const SassString& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNull& a, const SassNumber& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNull& a, const SassColor& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNull& a, const SassValue& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < DIVISION > (const SassBool& a, const SassNull& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassBool& a, const SassBool& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassBool& a, const SassString& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassBool& a, const SassNumber& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassBool& a, const SassColor& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassBool& a, const SassValue& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < DIVISION > (const SassString& a, const SassNull& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassString& a, const SassBool& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassString& a, const SassString& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassString& a, const SassNumber& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassString& a, const SassColor& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassString& a, const SassValue& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < DIVISION > (const SassNumber& a, const SassNull& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNumber& a, const SassBool& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNumber& a, const SassString& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNumber& a, const SassNumber& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNumber& a, const SassColor& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassNumber& a, const SassValue& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < DIVISION > (const SassColor& a, const SassNull& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassColor& a, const SassBool& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassColor& a, const SassString& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassColor& a, const SassNumber& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassColor& a, const SassColor& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassColor& a, const SassValue& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+
+    template < > const SassValue& sass_op < DIVISION > (const SassValue& a, const SassNull& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassValue& a, const SassBool& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassValue& a, const SassString& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassValue& a, const SassNumber& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassValue& a, const SassColor& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+    template < > const SassValue& sass_op < DIVISION > (const SassValue& a, const SassValue& b) { throw InvalidOp(DIVISION, a, b); return sass_null; }
+
+  }
+}

--- a/scalars.hpp
+++ b/scalars.hpp
@@ -1,0 +1,445 @@
+#ifndef SASS_SCALARS_H
+#define SASS_SCALARS_H
+
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <stdexcept>
+
+// This is highly familiar with how perl handles data structures.
+// There are certain basic data structures and native data types.
+// Basic data structures include arrays, hashes (maps) and scalars
+// Scalars are specific data types which attach certain semantics.
+
+// Perl also has a reference data types (which is just another
+// native scalar type) to store references to other data stores.
+// So a reference can point to arrays, hashes (maps) and scalars.
+
+namespace Sass {
+  using namespace std;
+  namespace Scalar {
+
+    enum OP {
+      EQUAL,
+      CONCAT,
+      MODULO,
+      ASSIGN,
+      ADDITION,
+      SUBTRACT,
+      MULTIPLY,
+      DIVISION
+    };
+
+    inline const char* op_to_string(enum OP op)
+    {
+      switch (op)
+      {
+        case EQUAL: return "eq"; break;
+        case CONCAT: return "cat"; break;
+        case MODULO: return "mod"; break;
+        case ASSIGN: return "assign"; break;
+        case ADDITION: return "plus"; break;
+        case SUBTRACT: return "minus"; break;
+        case MULTIPLY: return "times"; break;
+        case DIVISION: return "div"; break;
+      }
+      return 0;
+    }
+
+    class SassNull;
+    class SassBool;
+    class SassString;
+    class SassNumber;
+    class SassColor;
+    class SassValue;
+    template <typename>
+    class SassValue_CRTP;
+
+    template < enum OP T > const SassValue& sass_op(const SassValue& a, const SassNull& b);
+    template < enum OP T > const SassValue& sass_op(const SassValue& a, const SassBool& b);
+    template < enum OP T > const SassValue& sass_op(const SassValue& a, const SassString& b);
+    template < enum OP T > const SassValue& sass_op(const SassValue& a, const SassNumber& b);
+    template < enum OP T > const SassValue& sass_op(const SassValue& a, const SassColor& b);
+    template < enum OP T > const SassValue& sass_op(const SassValue& a, const SassValue& b);
+
+    template < enum OP T > const SassValue& sass_op(const SassNull& a, const SassNull& b);
+    template < enum OP T > const SassValue& sass_op(const SassNull& a, const SassBool& b);
+    template < enum OP T > const SassValue& sass_op(const SassNull& a, const SassString& b);
+    template < enum OP T > const SassValue& sass_op(const SassNull& a, const SassNumber& b);
+    template < enum OP T > const SassValue& sass_op(const SassNull& a, const SassColor& b);
+    template < enum OP T > const SassValue& sass_op(const SassNull& a, const SassValue& b);
+
+    template < enum OP T > const SassValue& sass_op(const SassBool& a, const SassNull& b);
+    template < enum OP T > const SassValue& sass_op(const SassBool& a, const SassBool& b);
+    template < enum OP T > const SassValue& sass_op(const SassBool& a, const SassString& b);
+    template < enum OP T > const SassValue& sass_op(const SassBool& a, const SassNumber& b);
+    template < enum OP T > const SassValue& sass_op(const SassBool& a, const SassColor& b);
+    template < enum OP T > const SassValue& sass_op(const SassBool& a, const SassValue& b);
+
+    template < enum OP T > const SassValue& sass_op(const SassString& a, const SassNull& b);
+    template < enum OP T > const SassValue& sass_op(const SassString& a, const SassBool& b);
+    template < enum OP T > const SassValue& sass_op(const SassString& a, const SassString& b);
+    template < enum OP T > const SassValue& sass_op(const SassString& a, const SassNumber& b);
+    template < enum OP T > const SassValue& sass_op(const SassString& a, const SassColor& b);
+    template < enum OP T > const SassValue& sass_op(const SassString& a, const SassValue& b);
+
+    template < enum OP T > const SassValue& sass_op(const SassNumber& a, const SassNull& b);
+    template < enum OP T > const SassValue& sass_op(const SassNumber& a, const SassBool& b);
+    template < enum OP T > const SassValue& sass_op(const SassNumber& a, const SassString& b);
+    template < enum OP T > const SassValue& sass_op(const SassNumber& a, const SassNumber& b);
+    template < enum OP T > const SassValue& sass_op(const SassNumber& a, const SassColor& b);
+    template < enum OP T > const SassValue& sass_op(const SassNumber& a, const SassValue& b);
+
+    template < enum OP T > const SassValue& sass_op(const SassColor& a, const SassNull& b);
+    template < enum OP T > const SassValue& sass_op(const SassColor& a, const SassBool& b);
+    template < enum OP T > const SassValue& sass_op(const SassColor& a, const SassString& b);
+    template < enum OP T > const SassValue& sass_op(const SassColor& a, const SassNumber& b);
+    template < enum OP T > const SassValue& sass_op(const SassColor& a, const SassColor& b);
+    template < enum OP T > const SassValue& sass_op(const SassColor& a, const SassValue& b);
+
+    // custom error (always use try catch for operations)
+    class InvalidOp : public runtime_error
+    {
+      public:
+        string msg;
+        virtual const char* what() const throw();
+        InvalidOp(enum OP op, const SassValue& a, const SassValue& b);
+    };
+
+    // abstract base class
+    class SassValue
+    {
+      friend class SassValue_CRTP < SassNull >;
+      friend class SassValue_CRTP < SassBool >;
+      friend class SassValue_CRTP < SassNumber >;
+      friend class SassValue_CRTP < SassString >;
+      friend class SassValue_CRTP < SassColor >;
+      public:
+        virtual ~SassValue() {};
+        virtual const SassValue& clone() const = 0;
+        virtual const char* sass_type() const = 0;
+        virtual const string stringify() const = 0;
+        virtual void operator=(const SassValue& value) = 0;
+        virtual const SassValue& operator+(const SassValue& value) const = 0;
+      protected:
+        // resolve right hand value also via virtual table call
+        // throw error if we have no specific implementation
+        virtual const SassValue& op_equal(const SassValue& value) const
+        { throw InvalidOp(EQUAL, value, *this); }
+        virtual const SassValue& op_concat(const SassValue& value) const
+        { throw InvalidOp(CONCAT, value, *this); }
+        virtual const SassValue& op_modulo(const SassValue& value) const
+        { throw InvalidOp(MODULO, value, *this); }
+        virtual const SassValue& op_addition(const SassValue& value) const
+        { throw InvalidOp(ADDITION, value, *this); }
+        virtual const SassValue& op_subtract(const SassValue& value) const
+        { throw InvalidOp(SUBTRACT, value, *this); }
+        virtual const SassValue& op_multiply(const SassValue& value) const
+        { throw InvalidOp(MULTIPLY, value, *this); }
+        virtual const SassValue& op_division(const SassValue& value) const
+        { throw InvalidOp(DIVISION, value, *this); }
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_equal(const SassNull& value) const = 0;
+        virtual const SassValue& op_equal(const SassBool& value) const = 0;
+        virtual const SassValue& op_equal(const SassString& value) const = 0;
+        virtual const SassValue& op_equal(const SassNumber& value) const = 0;
+        virtual const SassValue& op_equal(const SassColor& value) const = 0;
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_concat(const SassNull& value) const = 0;
+        virtual const SassValue& op_concat(const SassBool& value) const = 0;
+        virtual const SassValue& op_concat(const SassString& value) const = 0;
+        virtual const SassValue& op_concat(const SassNumber& value) const = 0;
+        virtual const SassValue& op_concat(const SassColor& value) const = 0;
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_assign(const SassNull& value) const = 0;
+        virtual const SassValue& op_assign(const SassBool& value) const = 0;
+        virtual const SassValue& op_assign(const SassString& value) const = 0;
+        virtual const SassValue& op_assign(const SassNumber& value) const = 0;
+        virtual const SassValue& op_assign(const SassColor& value) const = 0;
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_modulo(const SassNull& value) const = 0;
+        virtual const SassValue& op_modulo(const SassBool& value) const = 0;
+        virtual const SassValue& op_modulo(const SassString& value) const = 0;
+        virtual const SassValue& op_modulo(const SassNumber& value) const = 0;
+        virtual const SassValue& op_modulo(const SassColor& value) const = 0;
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_addition(const SassNull& value) const = 0;
+        virtual const SassValue& op_addition(const SassBool& value) const = 0;
+        virtual const SassValue& op_addition(const SassString& value) const = 0;
+        virtual const SassValue& op_addition(const SassNumber& value) const = 0;
+        virtual const SassValue& op_addition(const SassColor& value) const = 0;
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_subtract(const SassNull& value) const = 0;
+        virtual const SassValue& op_subtract(const SassBool& value) const = 0;
+        virtual const SassValue& op_subtract(const SassString& value) const = 0;
+        virtual const SassValue& op_subtract(const SassNumber& value) const = 0;
+        virtual const SassValue& op_subtract(const SassColor& value) const = 0;
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_multiply(const SassNull& value) const = 0;
+        virtual const SassValue& op_multiply(const SassBool& value) const = 0;
+        virtual const SassValue& op_multiply(const SassString& value) const = 0;
+        virtual const SassValue& op_multiply(const SassNumber& value) const = 0;
+        virtual const SassValue& op_multiply(const SassColor& value) const = 0;
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_division(const SassNull& value) const = 0;
+        virtual const SassValue& op_division(const SassBool& value) const = 0;
+        virtual const SassValue& op_division(const SassString& value) const = 0;
+        virtual const SassValue& op_division(const SassNumber& value) const = 0;
+        virtual const SassValue& op_division(const SassColor& value) const = 0;
+    };
+
+    template <typename Derived>
+    class SassValue_CRTP : public SassValue
+    {
+      public:
+        virtual const SassValue& clone() const
+        { return *(new Derived(static_cast<Derived const&>(*this))); }
+
+        virtual void operator=(const SassValue& value) {
+        	cerr << "assign op\n";
+        	 }
+        // resolve right hand value also via virtual table call
+        // throw error if we have no specific implementation
+        // virtual void operator=(const SassValue& value) const
+        // { return value.op_assign(static_cast<Derived const&>(*this)); }
+        virtual const SassValue& operator%(const SassValue& value) const
+        { return value.op_modulo(static_cast<Derived const&>(*this)); }
+        virtual const SassValue& operator+(const SassValue& value) const
+        { return value.op_addition(static_cast<Derived const&>(*this)); }
+        virtual const SassValue& operator-(const SassValue& value) const
+        { return value.op_subtract(static_cast<Derived const&>(*this)); }
+        virtual const SassValue& operator*(const SassValue& value) const
+        { return value.op_multiply(static_cast<Derived const&>(*this)); }
+        virtual const SassValue& operator/(const SassValue& value) const
+        { return value.op_division(static_cast<Derived const&>(*this)); }
+      protected:
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_equal(const SassNull& value) const
+        { return sass_op < EQUAL >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_equal(const SassBool& value) const
+        { return sass_op < EQUAL >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_equal(const SassString& value) const
+        { return sass_op < EQUAL >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_equal(const SassNumber& value) const
+        { return sass_op < EQUAL >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_equal(const SassColor& value) const
+        { return sass_op < EQUAL >(value, static_cast<Derived const&>(*this)); }
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_concat(const SassNull& value) const
+        { return sass_op < CONCAT >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_concat(const SassBool& value) const
+        { return sass_op < CONCAT >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_concat(const SassString& value) const
+        { return sass_op < CONCAT >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_concat(const SassNumber& value) const
+        { return sass_op < CONCAT >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_concat(const SassColor& value) const
+        { return sass_op < CONCAT >(value, static_cast<Derived const&>(*this)); }
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_assign(const SassNull& value) const
+        { return sass_op < ASSIGN >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_assign(const SassBool& value) const
+        { return sass_op < ASSIGN >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_assign(const SassString& value) const
+        { return sass_op < ASSIGN >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_assign(const SassNumber& value) const
+        { return sass_op < ASSIGN >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_assign(const SassColor& value) const
+        { return sass_op < ASSIGN >(value, static_cast<Derived const&>(*this)); }
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_modulo(const SassNull& value) const
+        { return sass_op < MODULO >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_modulo(const SassBool& value) const
+        { return sass_op < MODULO >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_modulo(const SassString& value) const
+        { return sass_op < MODULO >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_modulo(const SassNumber& value) const
+        { return sass_op < MODULO >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_modulo(const SassColor& value) const
+        { return sass_op < MODULO >(value, static_cast<Derived const&>(*this)); }
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_addition(const SassNull& value) const
+        { return sass_op < ADDITION >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_addition(const SassBool& value) const
+        { return sass_op < ADDITION >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_addition(const SassString& value) const
+        { return sass_op < ADDITION >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_addition(const SassNumber& value) const
+        { return sass_op < ADDITION >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_addition(const SassColor& value) const
+        { return sass_op < ADDITION >(value, static_cast<Derived const&>(*this)); }
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_subtract(const SassNull& value) const
+        { return sass_op < SUBTRACT >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_subtract(const SassBool& value) const
+        { return sass_op < SUBTRACT >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_subtract(const SassString& value) const
+        { return sass_op < SUBTRACT >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_subtract(const SassNumber& value) const
+        { return sass_op < SUBTRACT >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_subtract(const SassColor& value) const
+        { return sass_op < SUBTRACT >(value, static_cast<Derived const&>(*this)); }
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_multiply(const SassNull& value) const
+        { return sass_op < MULTIPLY >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_multiply(const SassBool& value) const
+        { return sass_op < MULTIPLY >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_multiply(const SassString& value) const
+        { return sass_op < MULTIPLY >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_multiply(const SassNumber& value) const
+        { return sass_op < MULTIPLY >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_multiply(const SassColor& value) const
+        { return sass_op < MULTIPLY >(value, static_cast<Derived const&>(*this)); }
+        // dispatch operations to the specific implementations
+        virtual const SassValue& op_division(const SassNull& value) const
+        { return sass_op < DIVISION >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_division(const SassBool& value) const
+        { return sass_op < DIVISION >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_division(const SassString& value) const
+        { return sass_op < DIVISION >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_division(const SassNumber& value) const
+        { return sass_op < DIVISION >(value, static_cast<Derived const&>(*this)); }
+        virtual const SassValue& op_division(const SassColor& value) const
+        { return sass_op < DIVISION >(value, static_cast<Derived const&>(*this)); }
+    };
+
+    class SassNull
+    : public SassValue_CRTP
+               < SassNull >
+    {
+      public:
+        SassNull() {
+        	cerr << "ctor null\n";
+        };
+        virtual const char* sass_type() const;
+        virtual const string stringify() const;
+        // virtual SassNull& operator=(const SassNull& value);
+        // virtual SassNull& operator=(const SassValue& value);
+        virtual ~SassNull() {
+        	cerr << "dtor null\n";
+        };
+    };
+
+
+    class SassBool
+    : public SassValue_CRTP
+               < SassBool >
+    {
+      private:
+        bool value;
+      public:
+        SassBool(bool value)
+        {
+        	cerr << "ctor bool\n";
+          this->value = value;
+        }
+        virtual const char* sass_type() const;
+        virtual const string stringify() const;
+        /*
+        SassBool operator=(SassBool value) {
+        	cout << "assign op\n";
+        	return SassBool(false); }
+        SassBool operator=(const SassBool& value) {
+        	cout << "assign op\n";
+        	return SassBool(false); }
+        */
+
+        // virtual SassBool& operator=(const SassBool& value);
+        // virtual SassBool& operator=(const SassValue& value);
+        virtual ~SassBool() {
+        	cerr << "dtor bool\n";
+        	};
+    };
+
+    class SassNumber
+    : public SassValue_CRTP
+               < SassNumber >
+    {
+      private:
+        double value;
+      public:
+        SassNumber(double value, const string& unit = "")
+        {
+          this->value = value;
+        }
+        virtual const char* sass_type() const;
+        virtual const string stringify() const;
+        // virtual SassNumber& operator=(const SassNumber& value);
+        // virtual SassNumber& operator=(const SassValue& value);
+        virtual ~SassNumber() {};
+    };
+
+    class SassString
+    : public SassValue_CRTP
+               < SassString >
+    {
+      public:
+        string value;
+        bool is_quoted;
+      public:
+
+        SassString(const SassString& rhs)
+        {
+        }
+
+        SassString(string value, bool is_quoted = false)
+        {
+        	cerr << "ctor string\n";
+          this->value = value;
+          this->is_quoted = is_quoted;
+        }
+/*
+        virtual SassString operator=(SassString value) {
+        	cout << "assign copy op\n";
+        	return SassString("test"); }
+*/
+/*
+        virtual const SassString& operator=(const SassValue& other) {
+          return *this;
+        }
+
+        virtual const SassString& operator=(const SassString& other) {
+        	cout << "assign move op\n";
+          SassString tmp(other);
+          std::swap(this->value, tmp.value);
+          std::swap(this->is_quoted, tmp.is_quoted);
+        	return *this; }
+*/
+
+        virtual const char* sass_type() const;
+        virtual const string stringify() const;
+        // virtual SassString& operator=(const SassString& value);
+        // virtual SassString& operator=(const SassValue& value);
+        virtual ~SassString() {
+        	cerr << "dtor string\n";
+        };
+    };
+
+    class SassColor
+    : public SassValue_CRTP
+               < SassColor >
+    {
+      private:
+        double r;
+        double g;
+        double b;
+        double a;
+      public:
+        SassColor(double r, double g, double b, double a = 1.0)
+        {
+          this->r = r;
+          this->g = g;
+          this->b = b;
+          this->a = a;
+        }
+        virtual const char* sass_type() const;
+        virtual const string stringify() const;
+        // virtual SassColor& operator=(const SassColor& value);
+        // virtual SassColor& operator=(const SassValue& value);
+        virtual ~SassColor() {};
+    };
+
+  }
+}
+
+#endif


### PR DESCRIPTION
This is a cry for help since I seem to be stuck with my c++ foo here!!

I am currently trying to refactor the `Sass_Value` handling. The C-API needs some more helper functions to support the full functional stack of Sass_Values, which includes operations like addition, multiplication or concatenation. Currently all the different parts are scatered mostly around AST_Node and eval implementation. This makes it very difficult for the C-API to re-use that logic. So it seems more practical to implement a de-coupled Sass_Value implementation, that can be used by C-API code and libsass (to replace the scatered code).

I implemented all SassValue types as native objects in c++ that inherit from an abstract base class (with a CRTP idiom). Seems to work quite well and the overloaded addition operator proved to work ok. But I'm now stuck with the assign operator. The code in the current state overloads the assign operator on the base class (`virtual void operator=(const SassValue& value)`), but it doesn't seem to be called. I can get it to work if I implement specific assign operators for each instance class, but I really wonder why it doesn't work for the assign operator in this case.

So I really hope that some with advanced c++ foo could take a look at `scalars.cpp/hpp` (//cc @QuLogic @akhleung). I know this is not very specific, but any pointers are welcome. In the mean time I will try to figure out why it doesn't do what I want it to do! Btw. this is only my second project I ever worked with c++, so I'm still learning a lot :)

Edit 1: Implementing in on the abstract class directly seems to solve the compile error. Maybe that's the right path to go, but at this point I have no idea what and why it is working.
