### PR TITLE
Implement correct String Schema parsing

### DIFF
--- a/context.cpp
+++ b/context.cpp
@@ -4,6 +4,13 @@
 #define PATH_SEP ':'
 #endif
 
+#include <string>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
+#include <iostream>
+
 #include "ast.hpp"
 #include "util.hpp"
 #include "sass.h"
@@ -28,13 +35,6 @@
 #include "sass2scss.h"
 #include "prelexer.hpp"
 #include "emitter.hpp"
-
-#include <string>
-#include <cstdlib>
-#include <cstring>
-#include <iomanip>
-#include <sstream>
-#include <iostream>
 
 namespace Sass {
   using namespace Constants;

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -383,9 +383,6 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << endl;
   } else if (dynamic_cast<Variable*>(node)) {
     Variable* expression = dynamic_cast<Variable*>(node);
-    cerr << ind << "Variable " << expression << " [" << expression->name() << "]";
-    if (expression->is_delayed()) cerr << " [delayed]";
-    cerr << endl;
     cerr << ind << "Variable " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << expression->name() << "]" << endl;
@@ -486,55 +483,37 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << " [" << expression->value() << expression->unit() << "]" << endl;
   } else if (dynamic_cast<String_Quoted*>(node)) {
     String_Quoted* expression = dynamic_cast<String_Quoted*>(node);
-    cerr << ind << "String_Quoted : " << expression << " [";
-    cerr << prettyprint(expression->value()) << "]";
+    cerr << ind << "String_Quoted " << expression;
+    cerr << " (" << pstate_source_position(node) << ")";
+    cerr << " [" << prettyprint(expression->value()) << "]";
     if (expression->is_delayed()) cerr << " [delayed]";
     if (expression->sass_fix_1291()) cerr << " [sass_fix_1291]";
-    if (expression->quote_mark()) cerr << " [quote_mark]";
+    if (expression->quote_mark()) cerr << " [quote_mark: " << expression->quote_mark() << "]";
     cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
-    cerr << ind << "String_Quoted : " << expression;
-    cerr << " (" << pstate_source_position(node) << ")";
-    cerr << " [" << prettyprint(expression->value()) << "]" <<
-      (expression->is_delayed() ? " {delayed}" : "") <<
-      (expression->sass_fix_1291() ? " {sass_fix_1291}" : "") <<
-      (expression->quote_mark() != 0 ? " {qm:" + string(1, expression->quote_mark()) + "}" : "") <<
-      " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
   } else if (dynamic_cast<String_Constant*>(node)) {
     String_Constant* expression = dynamic_cast<String_Constant*>(node);
-    cerr << ind << "String_Constant : " << expression;
+    cerr << ind << "String_Constant " << expression;
+    cerr << " " << expression->concrete_type() <<
+    cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [" << prettyprint(expression->value()) << "]";
     if (expression->is_delayed()) cerr << " [delayed]";
     if (expression->sass_fix_1291()) cerr << " [sass_fix_1291]";
     cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
-    cerr << ind << "String_Constant : " << expression;
-    cerr << " (" << pstate_source_position(node) << ")";
-    cerr << " [" << prettyprint(expression->value()) << "]" <<
-      (expression->is_delayed() ? " {delayed}" : "") <<
-      (expression->sass_fix_1291() ? " {sass_fix_1291}" : "") <<
-      (expression->quote_mark() != 0 ? " {qm:" + string(1, expression->quote_mark()) + "}" : "") <<
-      " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
   } else if (dynamic_cast<String_Schema*>(node)) {
     String_Schema* expression = dynamic_cast<String_Schema*>(node);
-    cerr << ind << "String_Schema " << expression << " [" << expression->concrete_type() << "]";
+    cerr << ind << "String_Schema " << expression;
+    cerr << " " << expression->concrete_type();
     if (expression->is_delayed()) cerr << " [delayed]";
     if (expression->has_interpolants()) cerr << " [has_interpolants]";
     cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
-    cerr << ind << "String_Schema " << expression;
-    cerr << " (" << pstate_source_position(node) << ")";
-    cerr << " " << expression->concrete_type() <<
-      (expression->has_interpolants() ? " {has_interpolants}" : "") <<
-      endl;
     for(auto i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<String*>(node)) {
     String* expression = dynamic_cast<String*>(node);
-    cerr << ind << "String " << expression << expression->concrete_type();
+    cerr << ind << "String " << expression;
+    cerr << " " << expression->concrete_type();
+    cerr << " (" << pstate_source_position(node) << ")";
     if (expression->sass_fix_1291()) cerr << " [sass_fix_1291]";
     cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << endl;
-    cerr << ind << "String " << expression;
-    cerr << " (" << pstate_source_position(node) << ")";
-    cerr << expression->concrete_type() <<
-      " " << (expression->sass_fix_1291() ? "{sass_fix_1291}" : "") <<
-      endl;
   } else if (dynamic_cast<Expression*>(node)) {
     Expression* expression = dynamic_cast<Expression*>(node);
     cerr << ind << "Expression " << expression;

--- a/eval.cpp
+++ b/eval.cpp
@@ -1,3 +1,9 @@
+#include <cstdlib>
+#include <cmath>
+#include <iostream>
+#include <iomanip>
+#include <typeinfo>
+
 #include "file.hpp"
 #include "eval.hpp"
 #include "ast.hpp"
@@ -10,12 +16,6 @@
 #include "backtrace.hpp"
 #include "prelexer.hpp"
 #include "parser.hpp"
-
-#include <cstdlib>
-#include <cmath>
-#include <iostream>
-#include <iomanip>
-#include <typeinfo>
 
 namespace Sass {
   using namespace std;

--- a/parser.hpp
+++ b/parser.hpp
@@ -270,6 +270,7 @@ namespace Sass {
 
     void parse_block_comments(Block* block);
 
+    Selector_Lookahead lookahead_for_value(const char* start = 0);
     Selector_Lookahead lookahead_for_selector(const char* start = 0);
     Selector_Lookahead lookahead_for_extension_target(const char* start = 0);
 


### PR DESCRIPTION
Declaration values should be parsed as a string-schema if
it contains any interpolations. To decide this we need to
look-ahead, as we already do with selectors and mixins.

Fixes https://github.com/sass/libsass/issues/1158