### PR TITLE
Improve selectors parsing for nth-child binomials

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -1359,21 +1359,22 @@ namespace Sass {
   ////////////////////////////////////////////////////////
   class String_Constant : public String {
     ADD_PROPERTY(char, quote_mark);
+    ADD_PROPERTY(bool, can_compress_whitespace);
     ADD_PROPERTY(string, value);
   protected:
     size_t hash_;
   public:
     String_Constant(ParserState pstate, string val)
-    : String(pstate), quote_mark_(0), value_(read_css_string(val)), hash_(0)
+    : String(pstate), quote_mark_(0), can_compress_whitespace_(false), value_(read_css_string(val)), hash_(0)
     { }
     String_Constant(ParserState pstate, const char* beg)
-    : String(pstate), quote_mark_(0), value_(read_css_string(string(beg))), hash_(0)
+    : String(pstate), quote_mark_(0), can_compress_whitespace_(false), value_(read_css_string(string(beg))), hash_(0)
     { }
     String_Constant(ParserState pstate, const char* beg, const char* end)
-    : String(pstate), quote_mark_(0), value_(read_css_string(string(beg, end-beg))), hash_(0)
+    : String(pstate), quote_mark_(0), can_compress_whitespace_(false), value_(read_css_string(string(beg, end-beg))), hash_(0)
     { }
     String_Constant(ParserState pstate, const Token& tok)
-    : String(pstate), quote_mark_(0), value_(read_css_string(string(tok.begin, tok.end))), hash_(0)
+    : String(pstate), quote_mark_(0), can_compress_whitespace_(false), value_(read_css_string(string(tok.begin, tok.end))), hash_(0)
     { }
     string type() { return "string"; }
     static string type_name() { return "string"; }

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -442,7 +442,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     Binary_Expression* expression = dynamic_cast<Binary_Expression*>(node);
     cerr << ind << "Binary_Expression " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
-    cerr << " [" << expression->type() << "]" << endl;
+    cerr << " [" << expression->type_name() << "]" << endl;
     debug_ast(expression->left(), ind + " left:  ", env);
     debug_ast(expression->right(), ind + " right: ", env);
   } else if (dynamic_cast<Map*>(node)) {

--- a/output.cpp
+++ b/output.cpp
@@ -385,10 +385,16 @@ namespace Sass {
   {
     if (String_Quoted* quoted = dynamic_cast<String_Quoted*>(s)) {
       return Output::operator()(quoted);
-    } else if (!in_comment) {
-      append_token(string_to_output(s->value()), s);
     } else {
-      append_token(s->value(), s);
+      string value(s->value());
+      if (s->can_compress_whitespace() && output_style() == COMPRESSED) {
+        value.erase(std::remove_if(value.begin(), value.end(), ::isspace), value.end());
+      }
+      if (!in_comment) {
+        append_token(string_to_output(value), s);
+      } else {
+        append_token(value, s);
+      }
     }
   }
 

--- a/parser.cpp
+++ b/parser.cpp
@@ -710,18 +710,9 @@ namespace Sass {
       if (lex< alternatives< even, odd > >()) {
         expr = new (ctx.mem) String_Quoted(p, lexed);
       }
-      else if (peek< binomial >(position)) {
-        lex< sequence< optional< coefficient >, exactly<'n'> > >();
-        String_Constant* var_coef = new (ctx.mem) String_Quoted(p, lexed);
-        lex< sign >();
-        String_Constant* op = new (ctx.mem) String_Quoted(p, lexed);
-        // Binary_Expression::Type op = (lexed == "+" ? Binary_Expression::ADD : Binary_Expression::SUB);
-        lex< one_plus < digit > >();
-        String_Constant* constant = new (ctx.mem) String_Quoted(p, lexed);
-        // expr = new (ctx.mem) Binary_Expression(p, op, var_coef, constant);
-        String_Schema* schema = new (ctx.mem) String_Schema(p, 3);
-        *schema << var_coef << op << constant;
-        expr = schema;
+      else if (lex< binomial >(position)) {
+        expr = new (ctx.mem) String_Constant(p, lexed);
+        ((String_Constant*)expr)->can_compress_whitespace(true);
       }
       else if (peek< sequence< optional<sign>,
                                zero_plus<digit>,


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/593

Implementation may not be the cleanest, but maybe we find more use cases where "compress" can be applied to String Constants. Then we may get a better picture how we can implement it better.