### PR TITLE
Properly capitalize LibSass

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-Libsass
+LibSass
 =======
 
 by Aaron Leung ([@akhleung]) and Hampton Catlin ([@hcatlin])
@@ -11,7 +11,7 @@ by Aaron Leung ([@akhleung]) and Hampton Catlin ([@hcatlin])
 
 https://github.com/sass/libsass
 
-Libsass is just a library, but if you want to RUN libsass,
+LibSass is just a library, but if you want to RUN LibSass,
 then go to https://github.com/sass/sassc or
 https://github.com/sass/ruby-libsass or
 [find your local implementer](https://github.com/sass/libsass/wiki/Implementations).
@@ -23,19 +23,19 @@ On Windows, you need MinGW with GCC 4.6+ or VS 2013 Update 4+. It is also possib
 About
 -----
 
-Libsass is a C/C++ port of the Sass CSS precompiler. The original version was written in Ruby, but this version is meant for efficiency and portability.
+LibSass is a C/C++ port of the Sass CSS precompiler. The original version was written in Ruby, but this version is meant for efficiency and portability.
 
 This library strives to be light, simple, and easy to build and integrate with a variety of platforms and languages.
 
 Developing
 ----------
 
-As you may have noticed, the libsass repo itself has
+As you may have noticed, the LibSass repo itself has
 no executables and no tests. Oh noes! How can you develop???
 
 Well, luckily, SassC is the official binary wrapper for
-libsass and is *always* kept in sync. SassC uses a git submodule
-to include libsass. When developing libsass, its best to actually
+LibSass and is *always* kept in sync. SassC uses a git submodule
+to include LibSass. When developing LibSass, its best to actually
 check out SassC and develop in that directory with the SassC spec
 and tests there.
 
@@ -44,21 +44,21 @@ We even run Travis tests for SassC!
 Tests
 -------
 
-Since libsass is a pure library, tests are run through the [SassSpec](https://github.com/sass/sass-spec) project using the [SassC](http://github.com/sass/sassc) driver.
+Since LibSass is a pure library, tests are run through the [SassSpec](https://github.com/sass/sass-spec) project using the [SassC](http://github.com/sass/sassc) driver.
 
-To run tests against libsass while developing, you can run `./script/spec`. This will clone SassC and Sass-Spec under the project folder and then run the Sass-Spec test suite. You may want to update the clones to ensure you have the latest version.
+To run tests against LibSass while developing, you can run `./script/spec`. This will clone SassC and Sass-Spec under the project folder and then run the Sass-Spec test suite. You may want to update the clones to ensure you have the latest version.
 
 Library Usage
 -------------
 
-While libsass is a library primarily written in C++, it provides a simple
-C interface which should be used by most implementers. Libsass does not do
+While LibSass is a library primarily written in C++, it provides a simple
+C interface which should be used by most implementers. LibSass does not do
 much on its own without an implementer. This can be a command line tool, like
 [sassc](https://github.com/sass/sassc) or a [binding](https://github.com/sass/libsass/wiki/Implementations)
 to your favorite programing language.
 
-If you want to build or interface with libsass, we recommend to check out the
-wiki pages about [building libsass](https://github.com/sass/libsass/wiki/Building-Libsass) and
+If you want to build or interface with LibSass, we recommend to check out the
+wiki pages about [building LibSass](https://github.com/sass/libsass/wiki/building-libsass) and
 the [C-API documentation](https://github.com/sass/libsass/wiki/API-Documentation).
 
 About Sass


### PR DESCRIPTION
Is LibSass the proper form of capitalization? I’ve assumed so for this PR. It’s the most common way I see it and the [LibSass website](http://libsass.org) has it that way for the `title`.

Any way, it’s a small detail, but consistency is nice.