### PR TITLE
Implement `is_superselector` sass function

### DIFF
--- a/ast.cpp
+++ b/ast.cpp
@@ -26,29 +26,29 @@ namespace Sass {
   }
 
   bool Complex_Selector::operator==(const Complex_Selector& rhs) const {
-  	// TODO: We have to access the tail directly using tail_ since ADD_PROPERTY doesn't provide a const version.
+    // TODO: We have to access the tail directly using tail_ since ADD_PROPERTY doesn't provide a const version.
 
-  	const Complex_Selector* pOne = this;
+    const Complex_Selector* pOne = this;
     const Complex_Selector* pTwo = &rhs;
 
     // Consume any empty references at the beginning of the Complex_Selector
     if (pOne->combinator() == Complex_Selector::ANCESTOR_OF && pOne->head()->is_empty_reference()) {
-    	pOne = pOne->tail_;
+      pOne = pOne->tail_;
     }
     if (pTwo->combinator() == Complex_Selector::ANCESTOR_OF && pTwo->head()->is_empty_reference()) {
-    	pTwo = pTwo->tail_;
+      pTwo = pTwo->tail_;
     }
 
     while (pOne && pTwo) {
-    	if (pOne->combinator() != pTwo->combinator()) {
-      	return false;
+      if (pOne->combinator() != pTwo->combinator()) {
+        return false;
       }
 
       if (*(pOne->head()) != *(pTwo->head())) {
-      	return false;
+        return false;
       }
 
-    	pOne = pOne->tail_;
+      pOne = pOne->tail_;
       pTwo = pTwo->tail_;
     }
 
@@ -68,10 +68,10 @@ namespace Sass {
 
   bool Simple_Selector::operator==(const Simple_Selector& rhs) const
   {
-  	// Compare the string representations for equality.
+    // Compare the string representations for equality.
 
-  	// Cast away const here. To_String should take a const object, but it doesn't.
-  	Simple_Selector* pLHS = const_cast<Simple_Selector*>(this);
+    // Cast away const here. To_String should take a const object, but it doesn't.
+    Simple_Selector* pLHS = const_cast<Simple_Selector*>(this);
     Simple_Selector* pRHS = const_cast<Simple_Selector*>(&rhs);
 
     To_String to_string;
@@ -79,10 +79,10 @@ namespace Sass {
   }
 
   bool Simple_Selector::operator<(const Simple_Selector& rhs) const {
-		// Use the string representation for ordering.
+    // Use the string representation for ordering.
 
-  	// Cast away const here. To_String should take a const object, but it doesn't.
-  	Simple_Selector* pLHS = const_cast<Simple_Selector*>(this);
+    // Cast away const here. To_String should take a const object, but it doesn't.
+    Simple_Selector* pLHS = const_cast<Simple_Selector*>(this);
     Simple_Selector* pRHS = const_cast<Simple_Selector*>(&rhs);
 
     To_String to_string;
@@ -217,25 +217,25 @@ namespace Sass {
     set<string> lpsuedoset, rpsuedoset;
     for (size_t i = 0, L = length(); i < L; ++i)
     {
-    	if ((*this)[i]->is_pseudo_element()) {
-      	string pseudo((*this)[i]->perform(&to_string));
+      if ((*this)[i]->is_pseudo_element()) {
+        string pseudo((*this)[i]->perform(&to_string));
         pseudo = pseudo.substr(pseudo.find_first_not_of(":")); // strip off colons to ensure :after matches ::after since ruby sass is forgiving
-      	lpsuedoset.insert(pseudo);
+        lpsuedoset.insert(pseudo);
       }
     }
     for (size_t i = 0, L = rhs->length(); i < L; ++i)
     {
-    	if ((*rhs)[i]->is_pseudo_element()) {
-      	string pseudo((*rhs)[i]->perform(&to_string));
+      if ((*rhs)[i]->is_pseudo_element()) {
+        string pseudo((*rhs)[i]->perform(&to_string));
         pseudo = pseudo.substr(pseudo.find_first_not_of(":")); // strip off colons to ensure :after matches ::after since ruby sass is forgiving
-	    	rpsuedoset.insert(pseudo);
+        rpsuedoset.insert(pseudo);
       }
     }
-  	if (lpsuedoset != rpsuedoset) {
+    if (lpsuedoset != rpsuedoset) {
       return false;
     }
 
-		// Check the Simple_Selectors
+    // Check the Simple_Selectors
 
     set<string> lset, rset;
 
@@ -244,19 +244,17 @@ namespace Sass {
       for (size_t i = 0, L = length(); i < L; ++i)
       {
         Selector* lhs = (*this)[i];
+        // very special case for wrapped matches selector
         if (Wrapped_Selector* wrapped = dynamic_cast<Wrapped_Selector*>(lhs)) {
-          if (
-            wrapped->name() == ":matches(" ||
-            wrapped->name() == ":-moz-any("
-          ) {
-          lhs = wrapped->selector();
-          if (Selector_List* list = dynamic_cast<Selector_List*>(lhs)) {
-            if (Compound_Selector* comp = dynamic_cast<Compound_Selector*>(rhs)) {
-              if (list->is_superselector_of(comp)) return true;
+          if (wrapped->name() == ":matches(" || wrapped->name() == ":-moz-any(") {
+            if (Selector_List* list = dynamic_cast<Selector_List*>(wrapped->selector())) {
+              if (Compound_Selector* comp = dynamic_cast<Compound_Selector*>(rhs)) {
+                if (list->is_superselector_of(comp)) return true;
+              }
             }
           }
-          }
         }
+        // match from here on as strings
         lset.insert(lhs->perform(&to_string));
       }
       for (size_t i = 0, L = rhs->length(); i < L; ++i)
@@ -290,33 +288,33 @@ namespace Sass {
     set<string> lpsuedoset, rpsuedoset;
     for (size_t i = 0, L = length(); i < L; ++i)
     {
-    	if ((*this)[i]->is_pseudo_element()) {
-      	string pseudo((*this)[i]->perform(&to_string));
+      if ((*this)[i]->is_pseudo_element()) {
+        string pseudo((*this)[i]->perform(&to_string));
         pseudo = pseudo.substr(pseudo.find_first_not_of(":")); // strip off colons to ensure :after matches ::after since ruby sass is forgiving
-      	lpsuedoset.insert(pseudo);
+        lpsuedoset.insert(pseudo);
       }
     }
     for (size_t i = 0, L = rhs.length(); i < L; ++i)
     {
-    	if (rhs[i]->is_pseudo_element()) {
-      	string pseudo(rhs[i]->perform(&to_string));
+      if (rhs[i]->is_pseudo_element()) {
+        string pseudo(rhs[i]->perform(&to_string));
         pseudo = pseudo.substr(pseudo.find_first_not_of(":")); // strip off colons to ensure :after matches ::after since ruby sass is forgiving
-	    	rpsuedoset.insert(pseudo);
+        rpsuedoset.insert(pseudo);
       }
     }
-  	if (lpsuedoset != rpsuedoset) {
+    if (lpsuedoset != rpsuedoset) {
       return false;
     }
 
-		// Check the base
+    // Check the base
 
     const Simple_Selector* const lbase = base();
     const Simple_Selector* const rbase = rhs.base();
 
     if ((lbase && !rbase) ||
-    	(!lbase && rbase) ||
+      (!lbase && rbase) ||
       ((lbase && rbase) && (*lbase != *rbase))) {
-			return false;
+      return false;
     }
 
 
@@ -482,7 +480,7 @@ namespace Sass {
     Complex_Selector* cpy = new (ctx.mem) Complex_Selector(*this);
 
     if (head()) {
-    	cpy->head(head()->clone(ctx));
+      cpy->head(head()->clone(ctx));
     }
 
     if (tail()) {

--- a/ast.hpp
+++ b/ast.hpp
@@ -1943,7 +1943,9 @@ namespace Sass {
         return (*this)[0];
       return 0;
     }
-    bool is_superselector_of(Compound_Selector* rhs);
+    bool is_superselector_of(Compound_Selector* sub);
+    // bool is_superselector_of(Complex_Selector* sub);
+    // bool is_superselector_of(Selector_List* sub);
     virtual unsigned long specificity()
     {
       int sum = 0;
@@ -2000,8 +2002,9 @@ namespace Sass {
     Complex_Selector* context(Context&);
     Complex_Selector* innermost();
     size_t length();
-    bool is_superselector_of(Compound_Selector*);
-    bool is_superselector_of(Complex_Selector*);
+    bool is_superselector_of(Compound_Selector* sub);
+    bool is_superselector_of(Complex_Selector* sub);
+    bool is_superselector_of(Selector_List* sub);
     // virtual Selector_Placeholder* find_placeholder();
     Combinator clear_innermost();
     void set_innermost(Complex_Selector*, Combinator);
@@ -2086,6 +2089,9 @@ namespace Sass {
     : Selector(pstate), Vectorized<Complex_Selector*>(s), wspace_(0)
     { }
     // virtual Selector_Placeholder* find_placeholder();
+    bool is_superselector_of(Compound_Selector* sub);
+    bool is_superselector_of(Complex_Selector* sub);
+    bool is_superselector_of(Selector_List* sub);
     virtual unsigned long specificity()
     {
       unsigned long sum = 0;

--- a/context.cpp
+++ b/context.cpp
@@ -539,6 +539,8 @@ namespace Sass {
     // Misc Functions
     register_function(ctx, inspect_sig, inspect, env);
     register_function(ctx, unique_id_sig, unique_id, env);
+    // Selector functions
+    register_function(ctx, is_superselector_sig, is_superselector, env);
   }
 
   void register_c_functions(Context& ctx, Env* env, Sass_Function_List descrs)

--- a/functions.cpp
+++ b/functions.cpp
@@ -1564,6 +1564,20 @@ namespace Sass {
       // return v;
     }
 
+    Signature is_superselector_sig = "is-superselector($super, $sub)";
+    BUILT_IN(is_superselector)
+    {
+      To_String to_string(&ctx, false);
+      Expression*  ex_sup = ARG("$super", Expression);
+      Expression*  ex_sub = ARG("$sub", Expression);
+      string sup_src = ex_sup->perform(&to_string) + "{";
+      string sub_src = ex_sub->perform(&to_string) + "{";
+      Selector_List* sel_sup = Parser::parse_selector(sup_src.c_str(), ctx);
+      Selector_List* sel_sub = Parser::parse_selector(sub_src.c_str(), ctx);
+      bool result = sel_sup->is_superselector_of(sel_sub);
+      return new (ctx.mem) Boolean(pstate, result);
+    }
+
     Signature unique_id_sig = "unique-id()";
     BUILT_IN(unique_id)
     {

--- a/functions.hpp
+++ b/functions.hpp
@@ -101,6 +101,7 @@ namespace Sass {
     extern Signature keywords_sig;
     extern Signature set_nth_sig;
     extern Signature unique_id_sig;
+    extern Signature is_superselector_sig;
 
     BUILT_IN(rgb);
     BUILT_IN(rgba_4);
@@ -175,6 +176,7 @@ namespace Sass {
     BUILT_IN(keywords);
     BUILT_IN(set_nth);
     BUILT_IN(unique_id);
+    BUILT_IN(is_superselector);
 
   }
 }

--- a/parser.cpp
+++ b/parser.cpp
@@ -40,6 +40,14 @@ namespace Sass {
     return p;
   }
 
+  Selector_List* Parser::parse_selector(const char* src, Context& ctx, ParserState pstate)
+  {
+    Parser p = Parser::from_c_str(src, ctx, pstate);
+    // ToDo: ruby sass errors on parent references
+    // ToDo: remap the source-map entries somehow
+    return p.parse_selector_group();
+  }
+
   bool Parser::peek_newline(const char* start)
   {
     return peek_linefeed(start ? start : position);

--- a/parser.hpp
+++ b/parser.hpp
@@ -57,6 +57,8 @@ namespace Sass {
     static Parser from_c_str(const char* src, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));
     static Parser from_c_str(const char* beg, const char* end, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));
     static Parser from_token(Token t, Context& ctx, ParserState pstate = ParserState("[TOKEN]"));
+    // special static parsers to convert strings into certain selectors
+    static Selector_List* parse_selector(const char* src, Context& ctx, ParserState pstate = ParserState("[SELECTOR]"));
 
 #ifdef __clang__
 


### PR DESCRIPTION
Based on https://github.com/sass/libsass/pull/1064

This is mainly for me to try out is superselector behavior which is one root problem of our selector deduping issues (which covers pretty much all of the currently still open confirmed bug issues).
It may also be a base to get the work done by @onedayitwillmake merged into master for 3.3.