### PR TITLE
Fix parsing of at-rules with variables as selectors

### DIFF
--- a/parser.cpp
+++ b/parser.cpp
@@ -2147,7 +2147,6 @@ namespace Sass {
            (q = peek< sequence< pseudo_prefix, identifier > >(p))  ||
            (q = peek< percentage >(p))                             ||
            (q = peek< dimension >(p))                              ||
-           (q = peek< variable >(p))                            ||
            (q = peek< quoted_string >(p))                          ||
            (q = peek< exactly<'*'> >(p))                           ||
            (q = peek< exactly<'('> >(p))                           ||


### PR DESCRIPTION
This PR fixes the parsing of at-rules with variables as selectors.

Fixes #1214
Spec PR https://github.com/sass/sass-spec/pull/388