### PR TITLE
Unquote media query expressions

### DIFF
--- a/debugger.hpp
+++ b/debugger.hpp
@@ -203,8 +203,8 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << (block->is_interpolated() ? " [is_interpolated]": " -")
     << endl;
-    debug_ast(block->feature(), ind + " f) ");
-    debug_ast(block->value(), ind + " v) ");
+    debug_ast(block->feature(), ind + " feature) ");
+    debug_ast(block->value(), ind + " value) ");
 
   } else if (dynamic_cast<Media_Query*>(node)) {
     Media_Query* block = dynamic_cast<Media_Query*>(node);

--- a/eval.cpp
+++ b/eval.cpp
@@ -997,8 +997,16 @@ namespace Sass {
   {
     Expression* feature = e->feature();
     feature = (feature ? feature->perform(this) : 0);
+    if (feature && dynamic_cast<String_Quoted*>(feature)) {
+      feature = new (ctx.mem) String_Constant(feature->pstate(),
+                                              dynamic_cast<String_Quoted*>(feature)->value());
+    }
     Expression* value = e->value();
     value = (value ? value->perform(this) : 0);
+    if (value && dynamic_cast<String_Quoted*>(value)) {
+      value = new (ctx.mem) String_Constant(value->pstate(),
+                                            dynamic_cast<String_Quoted*>(value)->value());
+    }
     return new (ctx.mem) Media_Query_Expression(e->pstate(),
                                                 feature,
                                                 value,


### PR DESCRIPTION
This PR fixes media query expressions that are just strings not being unquoted.

Fixes https://github.com/sass/libsass/issues/1218
Spec PR https://github.com/sass/sass-spec/pull/391