### PR TITLE
Add missing implementation of sass_importer_set_list_entry.

### DIFF
--- a/sass_functions.cpp
+++ b/sass_functions.cpp
@@ -88,6 +88,7 @@ extern "C" {
     return (Sass_Importer_List) calloc(length + 1, sizeof(Sass_Importer_Entry));
   }
 
+  Sass_Importer_Entry ADDCALL sass_importer_get_list_entry(Sass_Importer_List list, size_t idx) { return list[idx]; }
   void ADDCALL sass_importer_set_list_entry(Sass_Importer_List list, size_t idx, Sass_Importer_Entry cb) { list[idx] = cb; }
 
   // Creator for sass custom importer return argument list

--- a/sass_functions.cpp
+++ b/sass_functions.cpp
@@ -88,6 +88,8 @@ extern "C" {
     return (Sass_Importer_List) calloc(length + 1, sizeof(Sass_Importer_Entry));
   }
 
+  void ADDCALL sass_importer_set_list_entry(Sass_Importer_List list, size_t idx, Sass_Importer_Entry cb) { list[idx] = cb; }
+
   // Creator for sass custom importer return argument list
   Sass_Import_List ADDCALL sass_make_import_list(size_t length)
   {


### PR DESCRIPTION
@drewwells already mentioned in https://github.com/sass/libsass/pull/1000#issuecomment-87499756 that the implementation of `sass_importer_set_list_entry` is still missing. I need this function for my jsass (a java libsass integration) library, so I simply implemented it. :-)