### PR TITLE
Pass the compiler to custom functions instead of the options.

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -300,7 +300,7 @@ namespace Sass {
       To_C to_c;
       union Sass_Value* c_args = sass_make_list(1, SASS_COMMA);
       sass_list_set_value(c_args, 0, message->perform(&to_c));
-      Sass_Value* c_val = c_func(c_args, c_function, ctx.c_options);
+      Sass_Value* c_val = c_func(c_args, c_function, ctx.c_compiler);
       sass_delete_value(c_args);
       sass_delete_value(c_val);
       return 0;
@@ -332,7 +332,7 @@ namespace Sass {
       To_C to_c;
       union Sass_Value* c_args = sass_make_list(1, SASS_COMMA);
       sass_list_set_value(c_args, 0, message->perform(&to_c));
-      Sass_Value* c_val = c_func(c_args, c_function, ctx.c_options);
+      Sass_Value* c_val = c_func(c_args, c_function, ctx.c_compiler);
       sass_delete_value(c_args);
       sass_delete_value(c_val);
       return 0;
@@ -361,7 +361,7 @@ namespace Sass {
       To_C to_c;
       union Sass_Value* c_args = sass_make_list(1, SASS_COMMA);
       sass_list_set_value(c_args, 0, message->perform(&to_c));
-      Sass_Value* c_val = c_func(c_args, c_function, ctx.c_options);
+      Sass_Value* c_val = c_func(c_args, c_function, ctx.c_compiler);
       sass_delete_value(c_args);
       sass_delete_value(c_val);
       return 0;
@@ -646,7 +646,7 @@ namespace Sass {
         Expression* arg = static_cast<Expression*>(node);
         sass_list_set_value(c_args, i, arg->perform(&to_c));
       }
-      Sass_Value* c_val = c_func(c_args, c_function, ctx.c_options);
+      Sass_Value* c_val = c_func(c_args, c_function, ctx.c_compiler);
       if (sass_value_get_tag(c_val) == SASS_ERROR) {
         error("error in C function " + c->name() + ": " + sass_error_get_message(c_val), c->pstate(), backtrace);
       } else if (sass_value_get_tag(c_val) == SASS_WARNING) {

--- a/sass_functions.h
+++ b/sass_functions.h
@@ -32,7 +32,7 @@ typedef struct Sass_Function (*Sass_Function_Entry);
 typedef struct Sass_Function* (*Sass_Function_List);
 // Typedef defining function signature and return type
 typedef union Sass_Value* (*Sass_Function_Fn)
-  (const union Sass_Value*, Sass_Function_Entry cb, struct Sass_Options* options);
+  (const union Sass_Value*, Sass_Function_Entry cb, struct Sass_Compiler* compiler);
 
 
 // Creator for sass custom importer return argument list


### PR DESCRIPTION
For me it makes a lot more sense to pass the compiler to custom functions, so how is it done also in imports.
With the compiler I can not only access the options, I can access the context and the import stack.
Especially the import stack is very interesting, e.g. when you need to generate relative URLs in a custom function.