### PR TITLE
Convert wiki to markdown

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+Welcome to the libsass wiki!
+
+## First Off
+LibSass is just a library. To run the code locally (i.e. to compile your stylesheets), you need an implementer. SassC (get it?) is an implementer written in C. There are a number of other implementations of LibSass - for example Node. We encourage you to write your own port - the whole point of Libsass is that we want to bring Sass to many other languages, not just Ruby!
+
+We're working hard on moving to full parity with Ruby Sass... learn more at the [The-LibSass-Compatibility-Plan](compatibility-plan.md)!
+
+### Implementing libsass
+
+If you're interested in implementing libsass in your own project see the [API Documentation](api-doc.md) which now includes implementing 
+your own [Sass functions](api-function.md).  You may wish to [look at other implementations](implementations.md) for your language of choice. 
+Or make your own!
+
+### Contributing to libsass
+
+|   Issue Tracker   |            Issue Triage          |     Community Guidelines    |
+|-------------------|----------------------------------|-----------------------------|
+| We're always needing help, so checkout our issue tracker, help some people out, and read our article on [Contributing](contributing.md)! It's got all the details on what to do! | To help understand the process of triaging bugs, have a look at our [Issue-Triage](triage.md) document. | Oh, and don't forget we always follow [[Sass Community Guidelines|http://sass-lang.com/community-guidelines]]. Be nice and everyone else will be nice too! |
+
+Please refer to the steps on [Building Libsass](build.md)

--- a/docs/api-context-example.md
+++ b/docs/api-context-example.md
@@ -1,0 +1,45 @@
+## Example main.c
+
+```C
+#include <stdio.h>
+#include "sass_context.h"
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // configure some options ...
+  sass_option_set_precision(ctx_opt, 10);
+
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+### Compile main.c
+
+```bash
+gcc -c main.c -o main.o
+gcc -o sample main.o -lsass
+echo "foo { margin: 21px * 2; }" > foo.scss
+./sample foo.scss => "foo { margin: 42px }"
+```
+

--- a/docs/api-context-internal.md
+++ b/docs/api-context-internal.md
@@ -1,0 +1,151 @@
+```C
+// Input behaviours
+enum Sass_Input_Style {
+  SASS_CONTEXT_NULL,
+  SASS_CONTEXT_FILE,
+  SASS_CONTEXT_DATA,
+  SASS_CONTEXT_FOLDER
+};
+
+// simple linked list
+struct string_list {
+  string_list* next;
+  char* string;
+};
+
+// sass config options structure
+struct Sass_Options {
+
+  // Precision for fractional numbers
+  int precision;
+
+  // Output style for the generated css code
+  // A value from above SASS_STYLE_* constants
+  enum Sass_Output_Style output_style;
+
+  // Emit comments in the generated CSS indicating
+  // the corresponding source line.
+  bool source_comments;
+
+  // embed sourceMappingUrl as data uri
+  bool source_map_embed;
+
+  // embed include contents in maps
+  bool source_map_contents;
+
+  // Disable sourceMappingUrl in css output
+  bool omit_source_map_url;
+
+  // Treat source_string as sass (as opposed to scss)
+  bool is_indented_syntax_src;
+
+  // The input path is used for source map
+  // generation. It can be used to define
+  // something with string compilation or to
+  // overload the input file path. It is
+  // set to "stdin" for data contexts and
+  // to the input file on file contexts.
+  char* input_path;
+
+  // The output path is used for source map
+  // generation. Libsass will not write to
+  // this file, it is just used to create
+  // information in source-maps etc.
+  char* output_path;
+
+  // String to be used for indentation
+  const char* indent;
+  // String to be used to for line feeds
+  const char* linefeed;
+
+  // Colon-separated list of paths
+  // Semicolon-separated on Windows
+  // Maybe use array interface instead?
+  char* include_path;
+  char* plugin_path;
+
+  // Include paths (linked string list)
+  struct string_list* include_paths;
+  // Plugin paths (linked string list)
+  struct string_list* plugin_paths;
+
+  // Path to source map file
+  // Enables source map generation
+  // Used to create sourceMappingUrl
+  char* source_map_file;
+
+  // Directly inserted in source maps
+  char* source_map_root;
+
+  // Custom functions that can be called from sccs code
+  Sass_C_Function_List c_functions;
+
+  // Callback to overload imports
+  Sass_C_Import_Callback importer;
+
+};
+
+// base for all contexts
+struct Sass_Context : Sass_Options
+{
+
+  // store context type info
+  enum Sass_Input_Style type;
+
+  // generated output data
+  char* output_string;
+
+  // generated source map json
+  char* source_map_string;
+
+  // error status
+  int error_status;
+  char* error_json;
+  char* error_text;
+  char* error_message;
+  // error position
+  char* error_file;
+  size_t error_line;
+  size_t error_column;
+
+  // report imported files
+  char** included_files;
+
+};
+
+// struct for file compilation
+struct Sass_File_Context : Sass_Context {
+
+  // no additional fields required
+  // input_path is already on options
+
+};
+
+// struct for data compilation
+struct Sass_Data_Context : Sass_Context {
+
+  // provided source string
+  char* source_string;
+
+};
+
+// Compiler states
+enum Sass_Compiler_State {
+  SASS_COMPILER_CREATED,
+  SASS_COMPILER_PARSED,
+  SASS_COMPILER_EXECUTED
+};
+
+// link c and cpp context
+struct Sass_Compiler {
+  // progress status
+  Sass_Compiler_State state;
+  // original c context
+  Sass_Context* c_ctx;
+  // Sass::Context
+  void* cpp_ctx;
+  // Sass::Block
+  void* root;
+};
+```
+

--- a/docs/api-context.md
+++ b/docs/api-context.md
@@ -1,0 +1,268 @@
+Sass Contexts come in two flavors:
+
+- `Sass_File_Context`
+- `Sass_Data_Context`
+
+### Basic Usage
+
+```C
+#include "sass_context.h"
+```
+
+***Sass_Options***
+
+```C
+// Precision for fractional numbers
+int precision;
+```
+```C
+// Output style for the generated css code
+// A value from above SASS_STYLE_* constants
+int output_style;
+```
+```C
+// Emit comments in the generated CSS indicating
+// the corresponding source line.
+bool source_comments;
+```
+```C
+// embed sourceMappingUrl as data uri
+bool source_map_embed;
+```
+```C
+// embed include contents in maps
+bool source_map_contents;
+```
+```C
+// Disable sourceMappingUrl in css output
+bool omit_source_map_url;
+```
+```C
+// Treat source_string as sass (as opposed to scss)
+bool is_indented_syntax_src;
+```
+```C
+// The input path is used for source map
+// generating. It can be used to define
+// something with string compilation or to
+// overload the input file path. It is
+// set to "stdin" for data contexts and
+// to the input file on file contexts.
+char* input_path;
+```
+```C
+// The output path is used for source map
+// generating. Libsass will not write to
+// this file, it is just used to create
+// information in source-maps etc.
+char* output_path;
+```
+```C
+// String to be used for indentation
+const char* indent;
+```
+```C
+// String to be used to for line feeds
+const char* linefeed;
+```
+```C
+// Colon-separated list of paths
+// Semicolon-separated on Windows
+char* include_path;
+char* plugin_path;
+```
+```C
+// Additional include paths
+// Must be null delimited
+char** include_paths;
+char** plugin_paths;
+```
+```C
+// Path to source map file
+// Enables the source map generating
+// Used to create sourceMappingUrl
+char* source_map_file;
+```
+```C
+// Directly inserted in source maps
+char* source_map_root;
+```
+```C
+// Custom functions that can be called from sccs code
+Sass_C_Function_List c_functions;
+```
+```C
+// Callback to overload imports
+Sass_C_Import_Callback importer;
+```
+
+***Sass_Context***
+
+```C
+// store context type info
+enum Sass_Input_Style type;
+````
+```C
+// generated output data
+char* output_string;
+```
+```C
+// generated source map json
+char* source_map_string;
+```
+```C
+// error status
+int error_status;
+char* error_json;
+char* error_text;
+char* error_message;
+// error position
+char* error_file;
+size_t error_line;
+size_t error_column;
+```
+```C
+// report imported files
+char** included_files;
+```
+
+***Sass_File_Context***
+
+```C
+// no additional fields required
+// input_path is already on options
+```
+
+***Sass_Data_Context***
+
+```C
+// provided source string
+char* source_string;
+```
+
+### Sass Context API
+
+```C
+// Forward declaration
+struct Sass_Compiler;
+
+// Forward declaration
+struct Sass_Options;
+struct Sass_Context; // : Sass_Options
+struct Sass_File_Context; // : Sass_Context
+struct Sass_Data_Context; // : Sass_Context
+
+// Create and initialize an option struct
+struct Sass_Options* sass_make_options (void);
+// Create and initialize a specific context
+struct Sass_File_Context* sass_make_file_context (const char* input_path);
+struct Sass_Data_Context* sass_make_data_context (char* source_string);
+
+// Call the compilation step for the specific context
+int sass_compile_file_context (struct Sass_File_Context* ctx);
+int sass_compile_data_context (struct Sass_Data_Context* ctx);
+
+// Create a sass compiler instance for more control
+struct Sass_Compiler* sass_make_file_compiler (struct Sass_File_Context* file_ctx);
+struct Sass_Compiler* sass_make_data_compiler (struct Sass_Data_Context* data_ctx);
+
+// Execute the different compilation steps individually
+// Usefull if you only want to query the included files
+int sass_compiler_parse(struct Sass_Compiler* compiler);
+int sass_compiler_execute(struct Sass_Compiler* compiler);
+
+// Release all memory allocated with the compiler
+// This does _not_ include any contexts or options
+void sass_delete_compiler(struct Sass_Compiler* compiler);
+
+// Release all memory allocated and also ourself
+void sass_delete_file_context (struct Sass_File_Context* ctx);
+void sass_delete_data_context (struct Sass_Data_Context* ctx);
+
+// Getters for Context from specific implementation
+struct Sass_Context* sass_file_context_get_context (struct Sass_File_Context* file_ctx);
+struct Sass_Context* sass_data_context_get_context (struct Sass_Data_Context* data_ctx);
+
+// Getters for Context_Options from Sass_Context
+struct Sass_Options* sass_context_get_options (struct Sass_Context* ctx);
+struct Sass_Options* sass_file_context_get_options (struct Sass_File_Context* file_ctx);
+struct Sass_Options* sass_data_context_get_options (struct Sass_Data_Context* data_ctx);
+void sass_file_context_set_options (struct Sass_File_Context* file_ctx, struct Sass_Options* opt);
+void sass_data_context_set_options (struct Sass_Data_Context* data_ctx, struct Sass_Options* opt);
+
+// Getters for Sass_Context values
+const char* sass_context_get_output_string (struct Sass_Context* ctx);
+int sass_context_get_error_status (struct Sass_Context* ctx);
+const char* sass_context_get_error_json (struct Sass_Context* ctx);
+const char* sass_context_get_error_text (struct Sass_Context* ctx);
+const char* sass_context_get_error_message (struct Sass_Context* ctx);
+const char* sass_context_get_error_file (struct Sass_Context* ctx);
+size_t sass_context_get_error_line (struct Sass_Context* ctx);
+size_t sass_context_get_error_column (struct Sass_Context* ctx);
+const char* sass_context_get_source_map_string (struct Sass_Context* ctx);
+char** sass_context_get_included_files (struct Sass_Context* ctx);
+
+// Take ownership of memory (value on context is set to 0)
+char* sass_context_take_error_json (struct Sass_Context* ctx);
+char* sass_context_take_error_text (struct Sass_Context* ctx);
+char* sass_context_take_error_message (struct Sass_Context* ctx);
+char* sass_context_take_error_file (struct Sass_Context* ctx);
+char* sass_context_take_output_string (struct Sass_Context* ctx);
+char* sass_context_take_source_map_string (struct Sass_Context* ctx);
+
+// Push function for plugin/include paths (no manipulation support for now)
+void sass_option_push_plugin_path (struct Sass_Options* options, const char* path);
+void sass_option_push_include_path (struct Sass_Options* options, const char* path);
+```
+
+### Sass Options API
+
+```C
+// Getters for Context_Option values
+int sass_option_get_precision (struct Sass_Options* options);
+enum Sass_Output_Style sass_option_get_output_style (struct Sass_Options* options);
+bool sass_option_get_source_comments (struct Sass_Options* options);
+bool sass_option_get_source_map_embed (struct Sass_Options* options);
+bool sass_option_get_source_map_contents (struct Sass_Options* options);
+bool sass_option_get_omit_source_map_url (struct Sass_Options* options);
+bool sass_option_get_is_indented_syntax_src (struct Sass_Options* options);
+const char* sass_option_get_indent (struct Sass_Options* options);
+const char* sass_option_get_linefeed (struct Sass_Options* options);
+const char* sass_option_get_input_path (struct Sass_Options* options);
+const char* sass_option_get_output_path (struct Sass_Options* options);
+const char* sass_option_get_plugin_path (struct Sass_Options* options);
+const char* sass_option_get_include_path (struct Sass_Options* options);
+const char* sass_option_get_source_map_file (struct Sass_Options* options);
+const char* sass_option_get_source_map_root (struct Sass_Options* options);
+Sass_C_Function_List sass_option_get_c_functions (struct Sass_Options* options);
+Sass_C_Import_Callback sass_option_get_importer (struct Sass_Options* options);
+
+// Setters for Context_Option values
+void sass_option_set_precision (struct Sass_Options* options, int precision);
+void sass_option_set_output_style (struct Sass_Options* options, enum Sass_Output_Style output_style);
+void sass_option_set_source_comments (struct Sass_Options* options, bool source_comments);
+void sass_option_set_source_map_embed (struct Sass_Options* options, bool source_map_embed);
+void sass_option_set_source_map_contents (struct Sass_Options* options, bool source_map_contents);
+void sass_option_set_omit_source_map_url (struct Sass_Options* options, bool omit_source_map_url);
+void sass_option_set_is_indented_syntax_src (struct Sass_Options* options, bool is_indented_syntax_src);
+void sass_option_set_indent (struct Sass_Options* options, const char* indent);
+void sass_option_set_linefeed (struct Sass_Options* options, const char* linefeed);
+void sass_option_set_input_path (struct Sass_Options* options, const char* input_path);
+void sass_option_set_output_path (struct Sass_Options* options, const char* output_path);
+void sass_option_set_plugin_path (struct Sass_Options* options, const char* plugin_path);
+void sass_option_set_include_path (struct Sass_Options* options, const char* include_path);
+void sass_option_set_source_map_file (struct Sass_Options* options, const char* source_map_file);
+void sass_option_set_source_map_root (struct Sass_Options* options, const char* source_map_root);
+void sass_option_set_c_functions (struct Sass_Options* options, Sass_C_Function_List c_functions);
+void sass_option_set_importer (struct Sass_Options* options, Sass_C_Import_Callback importer);
+
+// Push function for paths (no manipulation support for now)
+void sass_option_push_plugin_path (struct Sass_Options* options, const char* path);
+void sass_option_push_include_path (struct Sass_Options* options, const char* path);
+```
+
+### More links
+
+- [Sass Context Example](api-context-example.md)
+- [Sass Context Internal](api-context-internal.md)
+

--- a/docs/api-doc.md
+++ b/docs/api-doc.md
@@ -1,0 +1,160 @@
+## Introduction
+
+Libsass wouldn't be much good without a way to interface with it. These interface documentations describe the various functions and data structures available to implementers. They are split up over three major components, which have all their own source files (plus some common functionality).
+
+- [Sass Context](api-context.md) - Trigger and handle the main Sass compilation
+- [Sass Value](api-value.md) - Exchange values and its format with libsass
+- [Sass Function](api-function.md) - Get invoked by libsass for function statments
+- [Sass Importer](api-importer.md) - Get invoked by libsass for @import statments
+
+### Basic usage
+
+First you will need to include the header file!  
+This will automatically load all other headers too!
+
+```C
+#include "sass/context.h"
+```
+
+### Deprecated usage
+
+The old API is kept in the source for backward compatibility.  
+It's deprecated and incompatible with this documentation, use `sass/context.h`!
+
+```C
+// deprecated interface
+#include "sass_interface.h"
+```
+
+## Basic C Example
+
+```C
+#include <stdio.h>
+#include "sass/context.h"
+
+int main() {
+  puts(libsass_version());
+  return 0;
+}
+```
+
+```bash
+gcc -Wall version.c -lsass -o version && ./version
+```
+
+## More C Examples
+
+- [Sample code for Sass Context](api-context-example.md)
+- [Sample code for Sass Value](api-value-example.md)
+- [Sample code for Sass Function](api-function-example.md)
+- [Sample code for Sass Importer](api-importer-example.md)
+
+## Compiling your code
+
+The most important is your sass file (or string of sass code).  With this, you will want to start a libsass compiler.  Here is some pseudocode describing the process.  The compiler has two different modes: direct input as a string with `Sass_Data_Context` or libsass will do file reading for you by using `Sass_File_Context`.  See the code for a list of options available [Sass_Options](https://github.com/sass/libsass/blob/36feef0/include/sass/interface.h#L18)
+
+**Building a file compiler**
+
+    context = sass_make_file_context("file.scss")
+    options = sass_file_context_get_options(context)
+    sass_option_set_precision(options, 1)
+    sass_option_set_source_comments(options, true)
+
+    sass_file_context_set_options(context, options)
+
+    compiler = sass_make_file_compiler(sass_context)
+    sass_compiler_parse(compiler)
+    sass_compiler_execute(compiler)
+
+    output = sass_context_get_output_string(context)
+    // Retrieve errors during compilation
+    error_status = sass_context_get_error_status(context)
+    json_error = sass_context_get_error_json(context)
+    // Release memory dedicated to the C compiler
+    sass_delete_compiler(compiler)
+
+**Building a data compiler**
+
+    context = sass_make_data_context("div { a { color: blue; } }")
+    options = sass_data_context_get_options(context)
+    sass_option_set_precision(options, 1)
+    sass_option_set_source_comments(options, true)
+
+    sass_data_context_set_options(context, options)
+
+    compiler = sass_make_data_compiler(context)
+    sass_compiler_parse(compiler)
+    sass_compiler_execute(compiler)
+
+    output = sass_context_get_output_string(context)
+    // div a { color: blue; }
+    // Retrieve errors during compilation
+    error_status = sass_context_get_error_status(context)
+    json_error = sass_context_get_error_json(context)
+    // Release memory dedicated to the C compiler
+    sass_delete_compiler(compiler)
+
+## Sass Context Internals
+
+Everything is stored in structs:
+
+```C
+struct Sass_Options;
+struct Sass_Context : Sass_Options;
+struct Sass_File_context : Sass_Context;
+struct Sass_Data_context : Sass_Context;
+```
+
+This mirrors very well how `libsass` uses these structures.
+
+- `Sass_Options` holds everything you feed in before the compilation. It also hosts `input_path` and `output_path` options, because they are used to generate/calculate relative links in source-maps. The `input_path` is shared with `Sass_File_Context`.
+- `Sass_Context` holds all the data returned by the compilation step. 
+- `Sass_File_Context` is a specific implementation that requires no additional fields
+- `Sass_Data_Context` is a specific implementation that adds the `input_source` field
+
+Structs can be down-casted to access `context` or `options`!
+
+## Common Pitfalls
+
+**input_path**
+
+The `input_path` is part of `Sass_Options`, but it also is the main option for `Sass_File_Context`. It is also used to generate relative file links in source-maps. Therefore it is pretty usefull to pass this information if you have a `Sass_Data_Context` and know the original path.
+
+**output_path**
+
+Be aware that `libsass` does not write the output file itself. This option merely exists to give `libsass` the proper information to generate links in source-maps. The file has to be written to the disk by the binding/implementation. If the `output_path` is omitted, `libsass` tries to extrapolate one from the `input_path` by replacing (or adding) the file ending with `.css`.
+
+## Error Codes
+
+The `error_code` is integer value which indicates the type of error that occurred inside the libsass process. Following is the list of error codes along with the short description:
+
+* 1: normal errors like parsing or `eval` errors
+* 2: bad allocation error (memory error)
+* 3: "untranslated" C++ exception (`throw std::exception`)
+* 4: legacy string exceptions ( `throw const char*` or `std::string` )
+* 5: Some other unknown exception
+
+Although for the API consumer, error codes do not offer much value except indicating whether *any* error occurred during the compilation, it helps debugging the libsass internal code paths.
+
+## Real-World Implementations
+
+The proof is in the pudding, so we have highlighted a few implementations that should be on par with the latest libsass interface version. Some of them may not have all features implemented!
+
+1. [Perl Example](https://github.com/sass/perl-libsass/blob/master/lib/CSS/Sass.xs)
+2. [Go Example](http://godoc.org/github.com/wellington/go-libsass#example-Context-Compile)
+3. [Node Example](https://github.com/sass/node-sass/blob/master/src/binding.cpp)
+
+## ABI forward compatibility
+
+We use a functional API to make dynamic linking more robust and future compatible. The API is not yet 100% stable, so we do not yet guarantee ABI forward compatibility. We will do so, once we increase the shared library version above 1.0.
+
+## Plugins (experimental)
+
+Libsass can load plugins from directories. Just define `plugin_path` on context options to load all plugins from the given directories. To implement plugins, please consult the [[Wiki-Page for plugins|API-Plugins]].
+
+## Internal Structs
+
+- [Sass Context Internals](api-context-internal.md)
+- [Sass Value Internals](api-value-internal.md)
+- [Sass Function Internals](api-function-internal.md)
+- [Sass Importer Internals](api-importer-internal.md)

--- a/docs/api-function-example.md
+++ b/docs/api-function-example.md
@@ -1,0 +1,58 @@
+## Example main.c
+
+```C
+#include <stdio.h>
+#include <stdint.h>
+#include "sass/context.h"
+
+union Sass_Value* call_fn_foo(const union Sass_Value* s_args, void* cookie)
+{
+  // we actually abuse the void* to store an "int"
+  return sass_make_number((intptr_t)cookie, "px");
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate a custom function caller
+  Sass_C_Function_Callback fn_foo =
+    sass_make_function("foo()", call_fn_foo, (void*)42);
+
+  // create list of all custom functions
+  Sass_C_Function_List fn_list = sass_make_function_list(1);
+  sass_function_set_list_entry(fn_list, 0, fn_foo);
+  sass_option_set_c_functions(ctx_opt, fn_list);
+
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+### Compile main.c
+
+```bash
+gcc -c main.c -o main.o
+gcc -o sample main.o -lsass
+echo "foo { margin: foo(); }" > foo.scss
+./sample foo.scss => "foo { margin: 42px }"
+```
+

--- a/docs/api-function-internal.md
+++ b/docs/api-function-internal.md
@@ -1,0 +1,8 @@
+```C
+// Struct to hold custom function callback
+struct Sass_C_Function_Descriptor {
+  const char*     signature;
+  Sass_C_Function function;
+  void*           cookie;
+};
+```

--- a/docs/api-function.md
+++ b/docs/api-function.md
@@ -1,0 +1,48 @@
+Sass functions are used to define new custom functions callable by Sass code. They are also used to overload debug or error statements. You can also define a fallback function, which is called for every unknown function found in the Sass code. Functions get passed zero or more `Sass_Values` (a `Sass_List` value) and they must also return a `Sass_Value`. Return a `Sass_Error` if you want to signal an error.
+
+## Special signatures
+
+- `*` - Fallback implementation
+- `@warn` - Overload warn statements
+- `@error` - Overload error statements
+- `@debug` - Overload debug statements
+
+Note: The fallback implementation will be given the name of the called function as the first argument, before all the original function arguments. These features are pretty new and should be considered experimental.
+
+### Basic Usage
+
+```C
+#include "sass/functions.h"
+```
+
+## Sass Function API
+
+```C
+// Forward declaration
+struct Sass_C_Function_Descriptor;
+
+// Typedef defining null terminated list of custom callbacks
+typedef struct Sass_C_Function_Descriptor* (*Sass_C_Function_List);
+typedef struct Sass_C_Function_Descriptor (*Sass_C_Function_Callback);
+// Typedef defining custom function prototype and its return value type
+typedef union Sass_Value*(*Sass_C_Function) (const union Sass_Value*, void* cookie);
+
+// Creators for sass function list and function descriptors
+Sass_C_Function_List sass_make_function_list (size_t length);
+Sass_C_Function_Callback sass_make_function (const char* signature, Sass_C_Function fn, void* cookie);
+
+// Setters and getters for callbacks on function lists
+Sass_C_Function_Callback sass_function_get_list_entry(Sass_C_Function_List list, size_t pos);
+void sass_function_set_list_entry(Sass_C_Function_List list, size_t pos, Sass_C_Function_Callback cb);
+
+// Getters for custom function descriptors
+const char* sass_function_get_signature (Sass_C_Function_Callback fn);
+Sass_C_Function sass_function_get_function (Sass_C_Function_Callback fn);
+void* sass_function_get_cookie (Sass_C_Function_Callback fn);
+```
+
+### More links
+
+- [Sass Function Example](api-function-example.md)
+- [Sass Function Internal](api-function-internal.md)
+

--- a/docs/api-importer-example.md
+++ b/docs/api-importer-example.md
@@ -1,0 +1,1345 @@
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+## Example importer.c
+
+```C
+#include <stdio.h>
+#include <string.h>
+#include "sass/context.h"
+
+Sass_Import_List sass_importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp)
+{
+  // get the cookie from importer descriptor
+  void* cookie = sass_importer_get_cookie(cb);
+  Sass_Import_List list = sass_make_import_list(2);
+  const char* local = "local { color: green; }";
+  const char* remote = "remote { color: red; }";
+  list[0] = sass_make_import_entry("/tmp/styles.scss", strdup(local), 0);
+  list[1] = sass_make_import_entry("http://www.example.com", strdup(remote), 0);
+  return list;
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate custom importer
+  Sass_Importer_Entry c_imp =
+    sass_make_importer(sass_importer, 0, 0);
+  // create list for all custom importers
+  Sass_Importer_List imp_list = sass_make_importer_list(1);
+  // put the only importer on to the list
+  sass_importer_set_list_entry(imp_list, 0, c_imp);
+  // register list on to the context options
+  sass_option_set_c_importers(ctx_opt, imp_list);
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+Compile importer.c
+
+```bash
+gcc -c importer.c -o importer.o
+gcc -o importer importer.o -lsass
+echo "@import 'foobar';" > importer.scss
+./importer importer.scss
+```
+
+## Importer Behavior Examples
+
+```C
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the import request
+  return NULL;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass handle the request
+  // swallows »@import "http://…"« pass-through
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(url, 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // return an error to halt execution
+  Sass_Import_List list = sass_make_import_list(1);
+  const char* message = "some error message";
+  list[0] = sass_make_import_entry(url, 0, 0);
+  sass_import_set_error(list[0], strdup(message), 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // let libsass load the file identifed by the importer
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry("/tmp/file.scss", 0, 0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(0);
+  return list;
+}
+
+Sass_Import_List importer(const char* path, Sass_Importer_Entry cb, struct Sass_Compiler* comp) {
+  // completely hide the import
+  // (arguably a bug)
+  Sass_Import_List list = sass_make_import_list(1);
+  list[0] = sass_make_import_entry(0, 0, 0);
+  return list;
+}
+```
+

--- a/docs/api-importer-internal.md
+++ b/docs/api-importer-internal.md
@@ -1,0 +1,15 @@
+```C
+// External import entry
+struct Sass_Import {
+  char* rel;
+  char* abs;
+  char* source;
+  char* srcmap;
+};
+
+// Struct to hold importer callback
+struct Sass_C_Import_Descriptor {
+  Sass_C_Import_Fn function;
+  void*            cookie;
+};
+```

--- a/docs/api-importer.md
+++ b/docs/api-importer.md
@@ -1,0 +1,84 @@
+Via custom importers you can implement any possible way to import sass stylesheets, like loading them from a remote server. This feature is experimental and is implemented differently than in ruby sass. Imports have to be relative from the parent import context. Therefore we need to pass this information to the importer callback. This is currently done by passing the complete import string/path of the previous import context.
+
+## Return Imports
+
+You actually have to return a list of imports, since some importers may want to import multiple files from one import statement (ie. a glob/star importer).  The memory you pass with source and srcmap is taken over by libsass and freed automatically when the import is done. You are also allowed to return `0` instead of a list, which will tell libsass to handle the import by itself (as if no custom importer was in use).
+
+```C
+struct Sass_Import** rv = sass_make_import_list(1);
+rv[0] = sass_make_import(rel, abs, source, srcmap);
+```
+
+Every import will then be included in libsass. You are allowed to only return a file path without any loaded source. This way you can ie. implement rewrite rules for import paths and leave the loading part for libsass.
+
+### Basic Usage
+
+```C
+#include "sass/functions.h"
+```
+
+## Sass Importer API
+
+```C
+// Forward declaration
+struct Sass_Import;
+
+// Forward declaration
+struct Sass_C_Import_Descriptor;
+
+// Typedef defining the custom importer callback
+typedef struct Sass_C_Import_Descriptor (*Sass_C_Import_Callback);
+// Typedef defining the importer c function prototype
+typedef struct Sass_Import** (*Sass_C_Import_Fn) (const char* url, const char* prev, void* cookie);
+
+// Creators for custom importer callback (with some additional pointer)
+// The pointer is mostly used to store the callback into the actual function
+Sass_C_Import_Callback sass_make_importer (Sass_C_Import_Fn, void* cookie);
+
+// Getters for import function descriptors
+Sass_C_Import_Fn sass_import_get_function (Sass_C_Import_Callback fn);
+void* sass_import_get_cookie (Sass_C_Import_Callback fn);
+
+// Deallocator for associated memory
+void sass_delete_importer (Sass_C_Import_Callback fn);
+
+// Creator for sass custom importer return argument list
+struct Sass_Import** sass_make_import_list (size_t length);
+// Creator for a single import entry returned by the custom importer inside the list
+struct Sass_Import* sass_make_import_entry (const char* path, char* source, char* srcmap);
+struct Sass_Import* sass_make_import (const char* rel, const char* abs, char* source, char* srcmap);
+
+// set error message to abort import and to print out a message (path from existing object is used in output)
+struct Sass_Import* sass_import_set_error(struct Sass_Import* import, const char* message, size_t line, size_t col);
+
+// Setters to insert an entry into the import list (you may also use [] access directly)
+// Since we are dealing with pointers they should have a guaranteed and fixed size
+void sass_import_set_list_entry (struct Sass_Import** list, size_t idx, struct Sass_Import* entry);
+struct Sass_Import* sass_import_get_list_entry (struct Sass_Import** list, size_t idx);
+
+// Getters for import entry
+const char* sass_import_get_rel_path (struct Sass_Import*);
+const char* sass_import_get_abs_path (struct Sass_Import*);
+const char* sass_import_get_source (struct Sass_Import*);
+const char* sass_import_get_srcmap (struct Sass_Import*);
+// Explicit functions to take ownership of these items
+// The property on our struct will be reset to NULL
+char* sass_import_take_source (struct Sass_Import*);
+char* sass_import_take_srcmap (struct Sass_Import*);
+
+// Getters for import error entries
+size_t sass_import_get_error_line (struct Sass_Import*);
+size_t sass_import_get_error_column (struct Sass_Import*);
+const char* sass_import_get_error_message (struct Sass_Import*);
+
+// Deallocator for associated memory (incl. entries)
+void sass_delete_import_list (struct Sass_Import**);
+// Just in case we have some stray import structs
+void sass_delete_import (struct Sass_Import*);
+```
+
+### More links
+
+- [Sass Importer Example](api-importer-example.md)
+- [Sass Importer Internal](api-importer-internal.md)
+

--- a/docs/api-value-internal.md
+++ b/docs/api-value-internal.md
@@ -1,0 +1,76 @@
+```C
+struct Sass_Unknown {
+  enum Sass_Tag tag;
+};
+
+struct Sass_Boolean {
+  enum Sass_Tag tag;
+  bool          value;
+};
+
+struct Sass_Number {
+  enum Sass_Tag tag;
+  double        value;
+  char*         unit;
+};
+
+struct Sass_Color {
+  enum Sass_Tag tag;
+  double        r;
+  double        g;
+  double        b;
+  double        a;
+};
+
+struct Sass_String {
+  enum Sass_Tag tag;
+  char*         value;
+};
+
+struct Sass_List {
+  enum Sass_Tag       tag;
+  enum Sass_Separator separator;
+  size_t              length;
+  // null terminated "array"
+  union Sass_Value**  values;
+};
+
+struct Sass_Map {
+  enum Sass_Tag        tag;
+  size_t               length;
+  struct Sass_MapPair* pairs;
+};
+
+struct Sass_Null {
+  enum Sass_Tag tag;
+};
+
+struct Sass_Error {
+  enum Sass_Tag tag;
+  char*         message;
+};
+
+struct Sass_Warning {
+  enum Sass_Tag tag;
+  char*         message;
+};
+
+union Sass_Value {
+  struct Sass_Unknown unknown;
+  struct Sass_Boolean boolean;
+  struct Sass_Number  number;
+  struct Sass_Color   color;
+  struct Sass_String  string;
+  struct Sass_List    list;
+  struct Sass_Map     map;
+  struct Sass_Null    null;
+  struct Sass_Error   error;
+  struct Sass_Warning   warning;
+};
+
+struct Sass_MapPair {
+  union Sass_Value* key;
+  union Sass_Value* value;
+};
+```
+

--- a/docs/api-value.md
+++ b/docs/api-value.md
@@ -1,0 +1,125 @@
+`Sass_Values` are used to pass values and their types between the implementer and libsass. Sass knows various different value types (including nested arrays and hash-maps). If you implement a binding to another programming language, you have to find a way to convert `Sass_Values` between the targeted language and C. `Sass_Values` are currently only used by custom functions.
+
+### Basic Usage
+
+```C
+#include "sass_values.h"
+```
+
+```C
+// Type for Sass values
+enum Sass_Tag {
+  SASS_BOOLEAN,
+  SASS_NUMBER,
+  SASS_COLOR,
+  SASS_STRING,
+  SASS_LIST,
+  SASS_MAP,
+  SASS_NULL,
+  SASS_ERROR,
+  SASS_WARNING
+};
+
+// Tags for denoting Sass list separators
+enum Sass_Separator {
+  SASS_COMMA,
+  SASS_SPACE
+};
+```
+
+### Sass Value API
+
+```C
+// Forward declaration
+union Sass_Value;
+
+// Return the sass tag for a generic sass value
+// Check is needed before accessing specific values!
+enum Sass_Tag sass_value_get_tag (const union Sass_Value* v);
+
+// Check value to be of a specific type
+// Can also be used before accessing properties!
+bool sass_value_is_null (const union Sass_Value* v);
+bool sass_value_is_number (const union Sass_Value* v);
+bool sass_value_is_string (const union Sass_Value* v);
+bool sass_value_is_boolean (const union Sass_Value* v);
+bool sass_value_is_color (const union Sass_Value* v);
+bool sass_value_is_list (const union Sass_Value* v);
+bool sass_value_is_map (const union Sass_Value* v);
+bool sass_value_is_error (const union Sass_Value* v);
+bool sass_value_is_warning (const union Sass_Value* v);
+
+// Getters and setters for Sass_Number
+double sass_number_get_value (const union Sass_Value* v);
+void sass_number_set_value (union Sass_Value* v, double value);
+const char* sass_number_get_unit (const union Sass_Value* v);
+void sass_number_set_unit (union Sass_Value* v, char* unit);
+
+// Getters and setters for Sass_String
+const char* sass_string_get_value (const union Sass_Value* v);
+void sass_string_set_value (union Sass_Value* v, char* value);
+
+// Getters and setters for Sass_Boolean
+bool sass_boolean_get_value (const union Sass_Value* v);
+void sass_boolean_set_value (union Sass_Value* v, bool value);
+
+// Getters and setters for Sass_Color
+double sass_color_get_r (const union Sass_Value* v);
+void sass_color_set_r (union Sass_Value* v, double r);
+double sass_color_get_g (const union Sass_Value* v);
+void sass_color_set_g (union Sass_Value* v, double g);
+double sass_color_get_b (const union Sass_Value* v);
+void sass_color_set_b (union Sass_Value* v, double b);
+double sass_color_get_a (const union Sass_Value* v);
+void sass_color_set_a (union Sass_Value* v, double a);
+
+// Getter for the number of items in list
+size_t sass_list_get_length (const union Sass_Value* v);
+// Getters and setters for Sass_List
+enum Sass_Separator sass_list_get_separator (const union Sass_Value* v);
+void sass_list_set_separator (union Sass_Value* v, enum Sass_Separator value);
+// Getters and setters for Sass_List values
+union Sass_Value* sass_list_get_value (const union Sass_Value* v, size_t i);
+void sass_list_set_value (union Sass_Value* v, size_t i, union Sass_Value* value);
+
+// Getter for the number of items in map
+size_t sass_map_get_length (const union Sass_Value* v);
+// Getters and setters for Sass_List keys and values
+union Sass_Value* sass_map_get_key (const union Sass_Value* v, size_t i);
+void sass_map_set_key (union Sass_Value* v, size_t i, union Sass_Value*);
+union Sass_Value* sass_map_get_value (const union Sass_Value* v, size_t i);
+void sass_map_set_value (union Sass_Value* v, size_t i, union Sass_Value*);
+
+// Getters and setters for Sass_Error
+char* sass_error_get_message (const union Sass_Value* v);
+void sass_error_set_message (union Sass_Value* v, char* msg);
+
+// Getters and setters for Sass_Warning
+char* sass_warning_get_message (const union Sass_Value* v);
+void sass_warning_set_message (union Sass_Value* v, char* msg);
+
+// Creator functions for all value types
+union Sass_Value* sass_make_null    (void);
+union Sass_Value* sass_make_boolean (bool val);
+union Sass_Value* sass_make_string  (const char* val);
+union Sass_Value* sass_make_number  (double val, const char* unit);
+union Sass_Value* sass_make_color   (double r, double g, double b, double a);
+union Sass_Value* sass_make_list    (size_t len, enum Sass_Separator sep);
+union Sass_Value* sass_make_map     (size_t len);
+union Sass_Value* sass_make_error   (const char* msg);
+union Sass_Value* sass_make_warning (const char* msg);
+
+// Generic destructor function for all types
+// Will release memory of all associated Sass_Values
+// Means we will delete recursively for lists and maps
+void sass_delete_value (union Sass_Value* val);
+
+// Make a deep cloned copy of the given sass value
+union Sass_Value* sass_clone_value (const union Sass_Value* val);
+```
+
+### More links
+
+- [Sass Value Example](api-value-example.md)
+- [Sass Value Internal](api-value-internal.md)
+

--- a/docs/build-on-darwin.md
+++ b/docs/build-on-darwin.md
@@ -1,0 +1,27 @@
+To install libsass, make sure the OS X build tools are installed:
+
+    xcode-select --install
+
+## Homebrew
+
+To install homebrew, see [http://brew.sh](http://brew.sh)
+
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+You can install the latest version of libsass quite easily with brew.
+
+    brew install --HEAD libsass
+
+To update this, do:
+
+    brew reinstall --HEAD libsass
+
+Brew will build static and shared libraries, and a `libsass.pc` file in `/usr/local/lib/pkgconfig`.
+
+To use `libsass.pc`, make sure this path is in your `PKG_CONFIG_PATH`
+
+    export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+## Manually
+
+See the linux instructions [Building-with-autotools](build-with-autotools.md) or [Building-with-makefiles](build-with-makefiles.md)

--- a/docs/build-on-gentoo.md
+++ b/docs/build-on-gentoo.md
@@ -1,0 +1,55 @@
+Here two ebuilds to compile libsass and sassc on gentoo linux. If you do not know how to use these ebuilds, you should probably read the gentoo wiki page about [portage overlays](http://wiki.gentoo.org/wiki/Overlay).
+
+## www-misc/libsass/libsass-9999.ebuild
+```ebuild
+EAPI=4
+
+inherit eutils git-2 autotools
+
+DESCRIPTION="A C/C++ implementation of a Sass compiler."
+HOMEPAGE="http://libsass.org/"
+EGIT_PROJECT='libsass'
+EGIT_REPO_URI="https://github.com/sass/libsass.git"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS=""
+IUSE=""
+DEPEND=""
+RDEPEND="${DEPEND}"
+DEPEND="${DEPEND}"
+
+pkg_pretend() {
+    # older gcc is not supported
+    local major=$(gcc-major-version)
+    local minor=$(gcc-minor-version)
+    [[ "${MERGE_TYPE}" != "binary" && ( $major > 4 || ( $major == 4 && $minor &lt; 5 ) ) ]] && \
+        die "Sorry, but gcc earlier than 4.5 will not work for libsass."
+}
+
+src_prepare() {
+   eautoreconf
+}
+```
+
+## www-misc/sassc/sassc-9999.ebuild
+```ebuild
+EAPI=4
+
+inherit eutils git-2 autotools
+
+DESCRIPTION="Command Line Tool for libsass."
+HOMEPAGE="http://libsass.org/"
+EGIT_PROJECT='sassc'
+EGIT_REPO_URI="https://github.com/sass/sassc.git"
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS=""
+IUSE=""
+DEPEND="www-misc/libsass"
+RDEPEND="${DEPEND}"
+DEPEND="${DEPEND}"
+
+src_prepare() {
+   eautoreconf
+}
+```

--- a/docs/build-on-windows.md
+++ b/docs/build-on-windows.md
@@ -1,0 +1,139 @@
+We support builds via MingGW and via Visual Studio Community 2013.
+Both should be considered experimental (MinGW was better tested)!
+
+## Building via MingGW (makefiles)
+
+First grab the latest [MinGW for windows] [1] installer. Once it is installed, you can click on continue or open the Installation Manager via `bin\mingw-get.exe`.
+
+You need to have the following components installed:
+![](https://cloud.githubusercontent.com/assets/282293/5525466/947bf396-89e6-11e4-841d-4aa916f14de1.png)
+
+Next we need to install [git for windows] [2]. You probably want to check the option to add it to the global path, but you do not need to install the unix tools.
+
+If you want to run the spec test-suite you also need [ruby] [3] and a few gems available. Grab the [latest installer] [3] and make sure to add it the global path. Then install the missing gems:
+
+```bash
+gem install minitest
+```
+
+### Mount the mingw root directory
+
+As mentioned in the [MinGW Getting Started](http://www.mingw.org/wiki/Getting_Started#toc5) guide, you should edit `C:\MinGW\msys\1.0\etc\fstab` to contain the following line:
+
+```
+C:\MinGW   /mingw
+```
+
+### Starting a "MingGW" console
+
+Create a batch file with this content:
+```bat
+@echo off
+set PATH=C:\MinGW\bin;%PATH%
+REM only needed if not already available
+set PATH=%PROGRAMFILES%\git\bin;%PATH%
+REM C:\MinGW\msys\1.0\msys.bat
+cmd
+```
+
+Execute it and make sure these commands can be called: `git`, `mingw32-make`, `rm` and `gcc`! Once this is all set, you should be ready to compile `libsass`!
+
+### Get the sources
+
+```bash
+# using git is preferred
+git clone https://github.com/sass/libsass.git
+# only needed for sassc and/or testsuite
+git clone https://github.com/sass/sassc.git libsass/sassc
+git clone https://github.com/sass/sass-spec.git libsass/sass-spec
+```
+
+### Decide for static or shared library
+
+`libsass` can be built and linked as a `static` or as a `shared` library. The default is `static`. To change it you can set the `BUILD` environment variable:
+
+```bat
+set BUILD="shared"
+```
+
+### Compile the library
+```bash
+mingw32-make -C libsass
+```
+
+### Results can be found in
+```bash
+$ ls libsass/lib
+libsass.a  libsass.dll  libsass.so
+```
+
+### Run the spec test-suite
+```bash
+mingw32-make -C libsass test_build
+```
+
+## Building via MingGW 64bit (makefiles)
+Building libass to dll on window 64bit.
+
++ downloads  [MinGW64 for windows7 64bit](http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.2/threads-win32/seh/x86_64-4.9.2-release-win32-seh-rt_v3-rev0.7z/download) , and unzip to "C:\mingw64".
+
++ Create a batch file with this content:
+
+```bat
+@echo off
+set PATH=C:\mingw64\bin;%PATH%
+set CC=gcc
+REM only needed if not already available
+set PATH=%PROGRAMFILES%\Git\bin;%PATH%
+REM C:\MinGW\msys\1.0\msys.bat
+cmd
+```
+
++ By default , mingw64 dll will depends on "​m​i​n​g​w​m​1​0​.​d​l​l​、​ ​l​i​b​g​c​c​_​s​_​d​w​2​-​1​.​d​l​l​" , we can modify Makefile to fix this:(add "-static")
+
+``` bash
+lib/libsass.dll: $(COBJECTS) $(OBJECTS) $(RCOBJECTS)
+	$(MKDIR) lib
+	$(CXX) -shared $(LDFLAGS) -o $@ $(COBJECTS) $(OBJECTS) $(RCOBJECTS) $(LDLIBS) -s -static -Wl,--subsystem,windows,--out-implib,lib/libsass.a
+```
+
++ Compile the library
+
+```bash
+mingw32-make -C libsass
+```
+
+By the way , if you are using java jna , [JNAerator](http://jnaerator.googlecode.com/) is a good tool.
+
+## Building via Visual Studio Community 2013
+
+Open a Visual Studio 2013 command prompt:
+- `VS2013 x86 Native Tools Command Prompt`
+
+Note: When I installed the community edition, I only got the 2012 command prompts. I copied them from the Startmenu to the Desktop and adjusted the paths from `Visual Studio 11.0` to `Visual Studio 12.0`. Since `libsass` uses some `C++11` features, you need at least a MSVC 2013 compiler (v120).
+
+### Get the source
+```bash
+# using git is preferred
+git clone https://github.com/sass/libsass.git
+git clone https://github.com/sass/sassc.git libsass/sassc
+# only needed if you want to run the testsuite
+git clone https://github.com/sass/sass-spec.git libsass/sass-spec
+```
+
+### Compile sassc
+
+Sometimes `msbuild` seems not available from the command prompt. Just search for it and add it to the global path. It seems to be included in the .net folders too.
+
+```bat
+cd libsass
+REM set PATH=%PATH%;%PROGRAMFILES%\MSBuild\12.0\Bin
+msbuild /m:4 /p:Configuration=Release win\libsass.sln
+REM running the spec test-suite manually (needs ruby and minitest gem)
+ruby sass-spec\sass-spec.rb -c win\bin\sassc.exe -s --ignore-todo sass-spec/spec
+cd ..
+```
+
+[1]: http://sourceforge.net/projects/mingw/files/latest/download?source=files
+[2]: https://msysgit.github.io/
+[3]: http://rubyinstaller.org/

--- a/docs/build-shared-library.md
+++ b/docs/build-shared-library.md
@@ -1,0 +1,35 @@
+This page is mostly intended for people that want to build a system library that gets distributed via RPMs or other means. This is currently in a experimental phase, as we currently do not really guarantee any ABI forward compatibility. The C API was rewritten to make this possible in the future, but we want to wait some more time till we can call this final and stable.
+
+Building via autotools
+--
+
+You want to build a system library only via autotools, since it will create the proper `libtool` files to make it loadable on multiple systems. We hope this works correctly, but nobody of the `libsass` core team has much knowledge in this area. Therefore we are open for comments or improvements by people that have more experience in that matter (like package maintainers from various linux distributions).
+
+```bash
+apt-get install autoconf libtool
+git clone https://github.com/sass/libsass.git
+cd libsass
+autoreconf --force --install
+./configure \
+  --disable-tests \
+  --disable-static \
+  --enable-shared \
+  --prefix=/usr
+make -j5 install
+cd ..
+```
+
+This should install these files
+```bash
+# $ ls -la /usr/lib/libsass.*
+/usr/lib/libsass.la
+/usr/lib/libsass.so -> libsass.so.0.0.9
+/usr/lib/libsass.so.0 -> libsass.so.0.0.9
+/usr/lib/libsass.so.0.0.9
+# $ ls -la /usr/include/sass*
+/usr/include/sass.h
+/usr/include/sass2scss.h
+/usr/include/sass_context.h
+/usr/include/sass_functions.h
+/usr/include/sass_values.h
+```

--- a/docs/build-with-autotools.md
+++ b/docs/build-with-autotools.md
@@ -1,0 +1,68 @@
+### Get the sources
+```bash
+# using git is preferred
+git clone https://github.com/sass/libsass.git
+# only needed for sassc and/or testsuite
+git clone https://github.com/sass/sassc.git libsass/sassc
+git clone https://github.com/sass/sass-spec.git libsass/sass-spec
+```
+
+### Create configure script
+```bash
+cd libsass
+autoreconf --force --install
+cd ..
+```
+
+### Create custom makefiles
+```bash
+cd libsass
+./configure \
+  --disable-tests \
+  --disable-shared \
+  --prefix=/usr
+cd ..
+```
+
+### Build the library
+```bash
+make -C libsass -j5
+```
+
+### Install the library
+The library will be installed to the location given as `prefix` to `configure`. This is standard behavior for autotools and not `libsass` specific.
+```bash
+make -C libsass -j5 install
+```
+
+### Configure options
+The `configure` script is created by autotools. To get an overview of available options you can call `./configure --help`. When you execute this script, it will create specific makefiles, which you then use via the regular make command.
+
+There are some `libsass` specific options:
+
+```
+Optional Features:
+  --enable-tests              enable testing the build
+  --enable-coverage           enable coverage report for test suite
+  --enable-shared             build shared libraries [default=yes]
+  --enable-static             build static libraries [default=yes]
+
+Optional Packages:
+  --with-sassc-dir=<dir>      specify directory of sassc sources for
+                              testing (default: sassc)
+  --with-sass-spec-dir=<dir>  specify directory of sass-spec for testing
+                              (default: sass-spec)
+```
+
+### Build sassc and run spec test-suite
+
+```bash
+cd libsass
+autoreconf --force --install
+./configure \
+  --enable-tests \
+  --enable-shared \
+  --prefix=/usr
+make -j5 test_build
+cd ..
+```

--- a/docs/build-with-makefiles.md
+++ b/docs/build-with-makefiles.md
@@ -1,0 +1,50 @@
+### Get the sources
+```bash
+# using git is preferred
+git clone https://github.com/sass/libsass.git
+# only needed for sassc and/or testsuite
+git clone https://github.com/sass/sassc.git libsass/sassc
+git clone https://github.com/sass/sass-spec.git libsass/sass-spec
+```
+
+### Decide for static or shared library
+
+`libsass` can be built and linked as a `static` or as a `shared` library. The default is `static`. To change it you can set the `BUILD` environment variable:
+
+```bash
+export BUILD="shared"
+```
+
+Alternatively you can also define it directly when calling make:
+
+```bash
+BUILD="shared" make ...
+```
+
+### Compile the library
+```bash
+make -C libsass -j5
+```
+
+### Results can be found in
+```bash
+$ ls libsass/lib
+libsass.a libsass.so
+```
+
+### Compling sassc
+
+```bash
+# Let build know library location
+export SASS_LIBSASS_PATH="`pwd`/libsass"
+# Invokes the sassc makefile
+make -C libsass -j5 sassc
+```
+
+### Run the spec test-suite
+
+```bash
+# needs ruby available
+# also gem install minitest
+make -C libsass -j5 test_build
+```

--- a/docs/build-with-mingw.md
+++ b/docs/build-with-mingw.md
@@ -1,0 +1,107 @@
+## Building LibSass with MingGW (makefiles)
+
+First grab the latest [MinGW for windows] [1] installer. Once it is installed, you can click on continue or open the Installation Manager via `bin\mingw-get.exe`.
+
+You need to have the following components installed:
+![](https://cloud.githubusercontent.com/assets/282293/5525466/947bf396-89e6-11e4-841d-4aa916f14de1.png)
+
+Next we need to install [git for windows] [2]. You probably want to check the option to add it to the global path, but you do not need to install the unix tools.
+
+If you want to run the spec test-suite you also need [ruby] [3] and a few gems available. Grab the [latest installer] [3] and make sure to add it the global path. Then install the missing gems:
+
+```bash
+gem install minitest
+```
+
+### Mount the mingw root directory
+
+As mentioned in the [MinGW Getting Started](http://www.mingw.org/wiki/Getting_Started#toc5) guide, you should edit `C:\MinGW\msys\1.0\etc\fstab` to contain the following line:
+
+```
+C:\MinGW   /mingw
+```
+
+### Starting a "MingGW" console
+
+Create a batch file with this content:
+```bat
+@echo off
+set PATH=C:\MinGW\bin;%PATH%
+REM only needed if not already available
+set PATH=%PROGRAMFILES%\git\bin;%PATH%
+REM C:\MinGW\msys\1.0\msys.bat
+cmd
+```
+
+Execute it and make sure these commands can be called: `git`, `mingw32-make`, `rm` and `gcc`! Once this is all set, you should be ready to compile `libsass`!
+
+### Get the sources
+
+```bash
+# using git is preferred
+git clone https://github.com/sass/libsass.git
+# only needed for sassc and/or testsuite
+git clone https://github.com/sass/sassc.git libsass/sassc
+git clone https://github.com/sass/sass-spec.git libsass/sass-spec
+```
+
+### Decide for static or shared library
+
+`libsass` can be built and linked as a `static` or as a `shared` library. The default is `static`. To change it you can set the `BUILD` environment variable:
+
+```bat
+set BUILD="shared"
+```
+
+### Compile the library
+```bash
+mingw32-make -C libsass
+```
+
+### Results can be found in
+```bash
+$ ls libsass/lib
+libsass.a  libsass.dll  libsass.so
+```
+
+### Run the spec test-suite
+```bash
+mingw32-make -C libsass test_build
+```
+
+## Building via MingGW 64bit (makefiles)
+Building libass to dll on window 64bit.
+
++ downloads  [MinGW64 for windows7 64bit](http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.2/threads-win32/seh/x86_64-4.9.2-release-win32-seh-rt_v3-rev0.7z/download) , and unzip to "C:\mingw64".
+
++ Create a batch file with this content:
+
+```bat
+@echo off
+set PATH=C:\mingw64\bin;%PATH%
+set CC=gcc
+REM only needed if not already available
+set PATH=%PROGRAMFILES%\Git\bin;%PATH%
+REM C:\MinGW\msys\1.0\msys.bat
+cmd
+```
+
++ By default , mingw64 dll will depends on "​m​i​n​g​w​m​1​0​.​d​l​l​、​ ​l​i​b​g​c​c​_​s​_​d​w​2​-​1​.​d​l​l​" , we can modify Makefile to fix this:(add "-static")
+
+``` bash
+lib/libsass.dll: $(COBJECTS) $(OBJECTS) $(RCOBJECTS)
+	$(MKDIR) lib
+	$(CXX) -shared $(LDFLAGS) -o $@ $(COBJECTS) $(OBJECTS) $(RCOBJECTS) $(LDLIBS) -s -static -Wl,--subsystem,windows,--out-implib,lib/libsass.a
+```
+
++ Compile the library
+
+```bash
+mingw32-make -C libsass
+```
+
+By the way , if you are using java jna , [JNAerator](http://jnaerator.googlecode.com/) is a good tool.
+
+[1]: http://sourceforge.net/projects/mingw/files/latest/download?source=files
+[2]: https://msysgit.github.io/
+[3]: http://rubyinstaller.org/

--- a/docs/build-with-visual-studio.md
+++ b/docs/build-with-visual-studio.md
@@ -1,0 +1,90 @@
+## Building LibSass with Visual Studio
+
+### Requirements:
+
+The minimum requirement to build LibSass with Visual Studio is "Visual Studio 2013 Express for Desktop".
+
+Additionally, it is recommended to have `git` installed and available in `PATH`, so to deduce the `libsass` version information. For instance, if GitHub for Windows (https://windows.github.com/) is installed, the `PATH` will have an entry resembling: `X:\Users\<YOUR_NAME>\AppData\Local\GitHub\PortableGit_<SOME_GUID>\cmd\` (where `X` is the drive letter of system drive). If `git` is not available, inquiring the LibSass version will result in `[NA]`.
+
+### Build Steps:
+
+#### From Visual Studio:
+
+On opening the `win\libsass.sln` solution and build (Ctrl+Shift+B) to build `libsass.dll`.
+
+To Build libsass as a static Library, it is recommended to set an environment variable `LIBSASS_STATIC_LIB` before launching the project:
+
+```cmd
+cd path\to\libsass
+SET LIBSASS_STATIC_LIB=1
+::
+:: or in PowerShell:
+:: $env:LIBSASS_STATIC_LIB=1
+::
+win\libsass.sln
+```
+
+Visual Studio will form the filtered source tree as shown below:
+
+![image](https://cloud.githubusercontent.com/assets/3840695/9298985/aae9e072-44bf-11e5-89eb-e7995c098085.png)
+
+`Header Files` contains the .h and .hpp files, while `Source Files` covers `.c` and `.cpp`. The other used headers/sources will appear under `External Dependencies`.
+
+If there is a libsass code file appearing under External Dependencies, it can be changed by altering the `win\libsass.vcxproj.filters` file or dragging in Solution Explorer.
+
+#### From Command Prompt:
+
+Notice that in the following commands:
+
+* If the platform is 32-bit Windows, replace `ProgramFiles(x86)` with `ProgramFiles`.
+* To build with Visual Studio 2015, replace `12.0` with `14.0` in the aforementioned command.
+
+Open a command prompt:
+
+To build dynamic/shared library (`libsass.dll`):
+
+```cmd
+:: debug build:
+"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\libsass.sln
+
+:: release build:
+"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\libsass.sln ^
+/p:Configuration=Release
+```
+
+To build static library (`libsass.lib`):
+
+```cmd
+:: debug build:
+"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\libsass.sln ^
+/p:LIBSASS_STATIC_LIB=1
+
+:: release build:
+"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\libsass.sln ^
+/p:LIBSASS_STATIC_LIB=1 /p:Configuration=Release
+```
+
+#### From PowerShell:
+
+To build dynamic/shared library (`libsass.dll`):
+
+```powershell
+# debug build:
+&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\libsass.sln
+
+# release build:
+&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\libsass.sln `
+/p:Configuration=Release
+```
+
+To build static library (`libsass.lib`):
+
+```powershell
+# build:
+&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\libsass.sln `
+/p:LIBSASS_STATIC_LIB=1
+
+# release build:
+&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\libsass.sln `
+/p:LIBSASS_STATIC_LIB=1 /p:Configuration=Release
+```

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,97 @@
+`libsass` is only a library and does not do much on its own. You need an implementation that you can use from the [command line] [6]. Or some [[bindings|Implementations]] to use it within your favorite programming language. You should be able to get [`sassc`] [6] running by following the instructions in this guide.
+
+Before starting, see [setup dev environment](setup-environment.md).
+
+Building on different Operating Systems
+--
+
+We try to keep the code as OS independent and standard compliant as possible. Reading files from the file-system has some OS depending code, but will ultimately fall back to a posix compatible implementation. We do use some `C++11` features, but are so far only committed to use `unordered_map`. This means you will need a pretty recent compiler on most systems (gcc 4.5 seems to be the minimum).
+
+### Building on Linux (and other *nix flavors)
+
+Linux is the main target for `libsass` and we support two ways to build `libsass` here. The old plain makefiles should still work on most systems (including MinGW), while the autotools build is preferred if you want to create a [system library] (experimental).
+
+- [Building with makefiles] [1]
+- [Building with autotools] [2]
+
+### Building on Windows (experimental)
+
+Windows build support was added very recently and should be considered experimental. Credits go to @darrenkopp and @am11 for their work on getting `libsass` and `sassc` to compile with visual studio!
+
+- [Building with MinGW] [3]
+- [Building with Visual Studio] [11]
+
+### Building on Max OS X (untested)
+
+Works the same as on linux, but you can also install libsass via `homebrew`.
+
+- [Building on Mac OS X] [10]
+
+### Building a system library (experimental)
+
+Since `libsass` is a library, it makes sense to install it as a shared library on your system. On linux this means creating a `.so` library via autotools. This should work pretty well already, but we are not yet committed to keep the ABI 100% stable. This should be the case once we increase the version number for the library to 1.0.0 or higher. On Windows you should be able get a `dll` by creating a shared build with MinGW. There is currently no target in the MSVC project files to do this.
+
+- [Building shared system library] [4]
+
+Compiling with clang instead of gcc
+--
+
+To use clang you just need to set the appropriate environment variables:
+
+```bash
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
+```
+
+Running the spec test-suite
+--
+
+We constantly and automatically test `libsass` against the official [spec test-suite] [5]. To do this we need to have a test-runner (which is written in ruby) and a command-line tool ([`sassc`] [6]) to run the tests. Therefore we need to additionally compile `sassc`. To do this, the build files of all three projects need to work together. This may not have the same quality for all build flavors. You definitely need to have ruby (2.1?) installed (version 1.9 seems to cause problems at least on windows). You also need some gems installed:
+
+```bash
+ruby -v
+gem install minitest
+# should be optional
+gem install minitap
+```
+
+Including the libsass version
+--
+
+There is a function in `libsass` to query the current version. This has to be defined at compile time. We use a C macro for this, which can be defined by calling `g++ -DLIBSASS_VERSION="\"x.y.z.\""`. The two quotes are necessary, since it needs to end up as a valid C string. Normally you do not need to do anything if you use the makefiles or autotools. They will try to fetch the version via git directly. If you only have the sources without the git repo, you can pass the version as an environment variable to `make` or `configure`:
+
+```
+export LIBSASS_VERSION="x.y.z."
+```
+
+Continuous Integration
+--
+
+We use two CI services to automatically test all commits against the latest [spec test-suite] [5].
+
+- [Libsass on Travis-CI (linux)][7]
+[![Build Status](https://travis-ci.org/sass/libsass.png?branch=master)](https://travis-ci.org/sass/libsass)
+- [Libsass on AppVeyor (windows)][8]
+[![Build status](https://ci.appveyor.com/api/projects/status/github/sass/libsass?svg=true)](https://ci.appveyor.com/project/mgreter/libsass-513/branch/master)
+
+Why not using CMake?
+--
+
+There were some efforts to get `libsass` to compile with CMake, which should make it easier to create build files for linux and windows. Unfortunately this was not completed. But we are certainly open for PRs!
+
+Miscellaneous
+--
+
+- [Ebuilds for Gentoo Linux](build-on-gentoo.md)
+
+[1]: build-with-makefiles.md
+[2]: build-with-autotools.md
+[3]: build-with-mingw.md
+[4]: build-shared-library.md
+[5]: https://github.com/sass/sass-spec
+[6]: https://github.com/sass/sassc
+[7]: https://github.com/sass/libsass/blob/master/.travis.yml
+[8]: https://github.com/sass/libsass/blob/master/appveyor.yml
+[9]: implementations.md
+[10]: build-on-darwin.md
+[11]: build-with-visual-studio.md

--- a/docs/compatibility-plan.md
+++ b/docs/compatibility-plan.md
@@ -1,0 +1,48 @@
+This document is to serve as a living, changing plan for getting libsass caught up with Ruby Sass.
+
+_Note: an "s" preceeding a version number is specifying a Ruby Sass version. Without an s, it's a version of libsass._
+
+# Goal
+**Our goal is to reach full s3.4 compatibility as soon as possible. LibSass version 3.4 will behave just like Ruby Sass 3.4**
+
+I highlight the goal, because there are some things that are *not* currently priorities. To be clear, they WILL be priorities, but they are not at the moment:
+
+* Performance Improvements
+* Extensibility
+
+The overriding goal is correctness.
+
+## Verifying Correctness
+Libsass uses the spec for its testing. The spec was originally based off s3.2 tests. Many things have changed in Ruby Sass since then and some of the tests need to be updated and changed in order to get them to match both libsass and Ruby Sass.
+
+Until this project is complete, the spec will be primarily a place to test libsass. By the time libsass reaches 3.4, it is our goal that sass-spec will be fully usable as an official testing source for ALL implementations of Sass.
+
+## Version Naming
+Until libsass reaches parity with Ruby Sass, we will be aggressively bumping versions, and libsass 3.4 will be the peer to Ruby Sass 3.4 in every way.
+
+# Release Plan
+
+## 3.0
+The goal of 3.0 is to introduce some of the most demanded features for libsass. That is, we are focusing on issues and features that have kept adoption down. This is a mongrel release wrt which version of Sass it's targeting. It's often a mixture of 3.2 / 3.3 / 3.4 behaviours. This is not ideal, but it's favourable to not existing. Targeting 3.4 strictly during this release would mean we never actually release.
+
+# 3.1
+The goal of 3.1 is to update all the passing specs to agree with 3.4. This will not be a complete representation of s3.4 (aka, there will me missing features), but the goal is to change existing features and implemented features to match 3.4 behaviour.
+
+By the end of this, the sass-spec must pass against 3.4.
+
+Major issues:
+* Variable Scoping
+* Color Handling
+* Precision
+
+# 3.2
+This version will focus on edge case fixes. There are a LOT of edge cases in the _todo_ tests and this is the release where we hunt those down like dogs (not that we want to hurt dogs, it's just a figure of speech in English).
+
+# 3.3
+Dress rehearsal. When we are 99% sure that we've fixed the main issues keeping us from saying we are compliant in s3.4 behaviour.
+
+# 3.4
+Compass Compatibility. We need to be able to work with Compass and all the other libraries out there. At this point, we are calling libsass "mature"
+
+# Beyond 3.4
+Obviously, there is matching Sass 3.5 behaviour. But, beyond that, we'll want to focus on performance, stability, and error handling. These can always be improved upon and are the life's work of an open source project. We'll have to work closely with Sass in the future.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,17 @@
+First of all, welcome! Thanks for even reading this page. If you're here, you're probably wondering what you can do to help make the libsass project even more awesome. And, even having that feeling means you are awesome!
+
+## I'm a programmer
+
+Awesome! We need your help. The best thing to do is go find issues that are tagged with both "bug" and "test written". We do spec driven development here and these issues have a test that's written already in the sass-spec project. Go find the test by going to sass-spec/spec/libsass-todo-issues/issue_XXX/ where XXX is the issue number. Write the code, and compile, and then issue a pull request referencing the issue. We'll quickly verify it and get it merged in!
+
+To get your dev environment setup, checkout our article on [Setup-Dev-Environment](setup-environment.md).
+
+## I'm not a backend programmer
+
+COOL! We also need your help. Doing [Issue-Triage](triage.md) is a big deal and something we need constant help with. That means helping to verify issues, write tests for them, and make sure they are getting fixed. It's being part of the smiling face of the project.
+
+Also, we need help with the Sass-Spec project itself. Just people to organize, refactor, and understand the tests in there.
+
+## I don't know what a computer is?
+
+Hmm.... well, it's the thing you are looking at right now. Ummm... checkout training courses! Then, come back and join us!

--- a/docs/custom-functions-internal.md
+++ b/docs/custom-functions-internal.md
@@ -1,0 +1,120 @@
+# Developer Documentation
+
+Custom functions are internally represented by `struct Sass_C_Function_Descriptor`.
+
+## Sass_C_Function_Descriptor
+
+```C
+struct Sass_C_Function_Descriptor {
+  const char*      signature;
+  Sass_C_Function  function;
+  void*            cookie;
+};
+```
+
+- `signature`: The function declaration, like `foo($bar, $baz:1)`
+- `function`:  Reference to the C function callback
+- `cookie`:    any pointer you want to attach
+
+### signature
+
+The signature defines how the function can be invoked. It also declares which arguments are required and which are optional.  Required arguments will be enforced by libsass and a SASS error is thrown in the event a call as missing an argument. Optional arguments only need to be present when you want to overwrite the default value.
+
+    foo($bar, $baz: 2)
+
+In this example, `$bar` is required and will error if not passed. `$baz` is optional and the default value of it is 2. A call like `foo(10)` is therefore equal to `foo(10, 2)`, while `foo()` will produce an error.
+
+### function
+
+The callback function needs to be of the following form:
+
+```C
+union Sass_Value* call_sass_function(
+    const union Sass_Value* s_args,
+    void*                   cookie
+) {
+  return sass_clone_value(s_args);
+}
+```
+
+### cookie
+
+The cookie can hold any pointer you want. In the `perl-libsass` implementation it holds the structure with the reference of the actual registered callback into the perl interpreter. Before that call `perl-libsass` will convert all `Sass_Values` to corresponding perl data types (so they can be used natively inside the perl interpretor). The callback can also return a `Sass_Value`. In `perl-libsass` the actual function returns a perl value, which has to be converted before `libsass` can work with it again!
+
+## Sass_Values
+
+```C
+// allocate memory (copies passed strings)
+union Sass_Value* make_sass_boolean (int val);
+union Sass_Value* make_sass_number  (double val, const char* unit);
+union Sass_Value* make_sass_color   (double r, double g, double b, double a);
+union Sass_Value* make_sass_string  (const char* val);
+union Sass_Value* make_sass_list    (size_t len, enum Sass_Separator sep);
+union Sass_Value* make_sass_map     (size_t len);
+union Sass_Value* make_sass_null    ();
+union Sass_Value* make_sass_error   (const char* msg);
+
+// Make a deep cloned copy of the given sass value
+union Sass_Value* sass_clone_value (const union Sass_Value* val);
+
+// deallocate memory (incl. all copied memory)
+void sass_delete_value (const union Sass_Value* val);
+```
+
+## Example main.c
+
+```C
+#include <stdio.h>
+#include <stdint.h>
+#include "sass_context.h"
+
+union Sass_Value* call_fn_foo(const union Sass_Value* s_args, void* cookie)
+{
+  // we actually abuse the void* to store an "int"
+  return sass_make_number((size_t)cookie, "px");
+}
+
+int main( int argc, const char* argv[] )
+{
+
+  // get the input file from first argument or use default
+  const char* input = argc > 1 ? argv[1] : "styles.scss";
+
+  // create the file context and get all related structs
+  struct Sass_File_Context* file_ctx = sass_make_file_context(input);
+  struct Sass_Context* ctx = sass_file_context_get_context(file_ctx);
+  struct Sass_Options* ctx_opt = sass_context_get_options(ctx);
+
+  // allocate a custom function caller
+  Sass_C_Function_Callback fn_foo =
+    sass_make_function("foo()", call_fn_foo, (void*)42);
+
+  // create list of all custom functions
+  Sass_C_Function_List fn_list = sass_make_function_list(1);
+  sass_function_set_list_entry(fn_list, 0, fn_foo);
+  sass_option_set_c_functions(ctx_opt, fn_list);
+
+  // context is set up, call the compile step now
+  int status = sass_compile_file_context(file_ctx);
+
+  // print the result or the error to the stdout
+  if (status == 0) puts(sass_context_get_output_string(ctx));
+  else puts(sass_context_get_error_message(ctx));
+
+  // release allocated memory
+  sass_delete_file_context(file_ctx);
+
+  // exit status
+  return status;
+
+}
+```
+
+## Compile main.c
+
+```bash
+gcc -c main.c -o main.o
+gcc -o sample main.o -lsass
+echo "foo { margin: foo(); }" > foo.scss
+./sample foo.scss => "foo { margin: 42px }"
+```

--- a/docs/implementations.md
+++ b/docs/implementations.md
@@ -1,0 +1,49 @@
+There are several implementations of `libsass` for a variety of languages. Here are just a few of them. Note, some implementations may or may not be up to date. We have not verified whether they work.
+
+### C
+* [sassc](https://github.com/hcatlin/sassc)
+
+### Go
+* [go-libsass](https://github.com/wellington/go-libsass)
+* [go_sass](https://github.com/suapapa/go_sass)
+* [go-sass](https://github.com/SamWhited/go-sass)
+
+### Lua
+* [lua-sass](https://github.com/craigbarnes/lua-sass)
+
+### .NET
+* [libsass-net](https://github.com/darrenkopp/libsass-net)
+* [NSass](https://github.com/TBAPI-0KA/NSass)
+* [Sass.Net](https://github.com/andyalm/Sass.Net)
+
+### node.js
+* [node-sass](https://github.com/andrew/node-sass)
+
+### Java
+* [libsass-maven-plugin](https://github.com/warmuuh/libsass-maven-plugin)
+* [jsass](https://github.com/bit3/jsass)
+
+### JavaScript
+* [sass.js](https://github.com/medialize/sass.js)
+
+### Perl
+* [CSS::Sass](https://github.com/caldwell/CSS-Sass)
+* [Text::Sass::XS](https://github.com/ysasaki/Text-Sass-XS)
+
+### PHP
+* [sassphp](https://github.com/sensational/sassphp)
+
+### Python
+* [libsass-python](https://github.com/dahlia/libsass-python)
+* [SassPython](https://github.com/marianoguerra/SassPython)
+* [pylibsass](https://github.com/rsenk330/pylibsass)
+* [python-scss](https://github.com/pistolero/python-scss)
+
+### Ruby
+* [sassruby](https://github.com/hcatlin/sassruby)
+
+### Scala
+* [Sass-Scala](https://github.com/kkung/Sass-Scala)
+
+### Tcl
+* [tclsass](https://github.com/flightaware/tclsass)

--- a/docs/plugins.go
+++ b/docs/plugins.go
@@ -1,0 +1,47 @@
+Plugins are shared object files (.so on *nix and .dll on win) that can be loaded by libsass on runtime. Currently we only provide a way to load internal/custom functions from plugins. In the future we probably will also add a way to provide custom importers via plugins (needs more refactoring to [support multiple importers with some kind of priority system](https://github.com/sass/libsass/issues/962)).
+
+## plugin.cpp
+
+```C++
+#include <cstring>
+#include <iostream>
+#include <stdint.h>
+#include "sass_values.h"
+
+union Sass_Value* ADDCALL call_fn_foo(const union Sass_Value* s_args, void* cookie)
+{
+  // we actually abuse the void* to store an "int"
+  return sass_make_number((intptr_t)cookie, "px");
+}
+
+extern "C" const char* ADDCALL libsass_get_version() {
+  return libsass_version();
+}
+
+extern "C" Sass_C_Function_List ADDCALL libsass_load_functions()
+{
+  // allocate a custom function caller
+  Sass_C_Function_Callback fn_foo =
+    sass_make_function("foo()", call_fn_foo, (void*)42);
+  // create list of all custom functions
+  Sass_C_Function_List fn_list = sass_make_function_list(1);
+  // put the only function in this plugin to the list
+  sass_function_set_list_entry(fn_list, 0, fn_foo);
+  // return the list
+  return fn_list;
+}
+```
+
+To compile the plugin you need to have libsass already built as a shared library (to link against it). The commands below expect the shared library in the `lib` sub-directory (`-Llib`). The plugin and the main libsass process should "consume" the same shared libsass library on runtime. It will propably also work if they use different libsass versions. In this case we check if the major versions are compatible (i.e. 3.1.3 and 3.1.1 would be considered compatible).
+
+## Compile with gcc on linux
+
+```bash
+g++ -O2 -shared plugin.cpp -o plugin.so -fPIC -Llib -lsass
+```
+
+## Compile with mingw on windows
+
+```bash
+g++ -O2 -shared plugin.cpp -o plugin.dll -Llib -lsass
+```

--- a/docs/setup-environment.md
+++ b/docs/setup-environment.md
@@ -1,0 +1,68 @@
+## Requirements
+In order to install and setup your local development environment, there are some prerequisites: 
+
+* git
+* gcc/clang/llvm (Linux: build tools, Mac OS X: XCode w/ Command Line Tools)
+* ruby w/ bundler
+
+OS X: 
+First you'll need to install XCode which you can now get from the AppStore installed on your mac. After you download that and run it, then run this on the command line:
+
+````
+xcode-select --install
+````
+
+## Cloning the Projects
+
+First, clone the project and then add a line to your `~/.bash_profile` that will let other programs know where the libsass dev files are.
+
+````
+git clone git@github.com:sass/libsass.git
+cd libsass
+echo "export SASS_LIBSASS_PATH=$(pwd)" >> ~/.bash_profile
+
+````
+
+Then, if you run the "bootstrap" script, it should clone all the other required projects.
+
+````
+./script/bootstrap
+````
+
+You should now have a `sass-spec` and `sassc` folder within the libsass folder. Both of these are clones of their respective git projects. If you want to do a pull request, remember to work in those folders. For instance, if you want to add a test (see other documentation for how to do that), make sure to commit it to your *fork* of the sass-spec github project. Also, whenever you are running tests, make sure to `pull` from the origin! We want to make sure we are testing against the newest libsass, sassc, and sass-spec!
+
+Now, try and see if you can build the project. We do that with the make command.
+
+````
+make
+````
+
+At this point, if you get an error, something is most likely wrong with your compiler installation. Yikes. It's hard to cover how to fix this in an article. Feel free to open an issue and we'll try and help! But, remember, before you do that, googling the error message is your friend! Many problems are solved quickly that way.
+
+## Running The Spec Against LibSass
+
+Then, to run the spec against libsass, just run:
+
+````
+./script/spec
+````
+
+If you get an error about `SASS_LIBSASS_PATH`, you may still need to set a variable pointing to the libsass folder, like this:
+
+````
+export SASS_LIBSASS_PATH=/Users/you/path/libsass
+````
+
+...where the latter part is to the `libsass` directory you've cloned. You can get this path by typing `pwd` in the Terminal
+
+## Running the Spec Against Ruby Sass
+
+Go into the sass-spec folder that should have been cloned earlier with the "bootstrap" command. Run the following.
+
+````
+bundle install
+./sass-spec.rb
+````
+
+Viola! Now you are testing against Sass too!
+

--- a/docs/source-map-internals.md
+++ b/docs/source-map-internals.md
@@ -1,0 +1,51 @@
+This document is mainly intended for developers!
+
+# Documenting some of the source map internals
+
+Since source maps are somewhat a black box to all libsass maintainers, [I](@mgreter) will try to document my findings with source maps in libsass, as I come across them. This document will also brievely explain how libsass parses the source and how it outputs the result.
+
+The main storage for SourceMap mappings is the `mappings` vector:
+
+```
+# in source_map.hpp
+vector<Mapping> mappings
+# in mappings.hpp
+struct Mapping ...
+  Position original_position;
+  Position generated_position;
+```
+
+## Every parsed token has its source associated
+
+Libsass uses a lexical parser. Whenever libsass finds a token of interest, it creates a specific `AST_Node`, which will hold a reference to the input source with line/column information. `AST_Node` is the base class for all parsed items. They are declared in `ast.hpp` and are used in `parser.hpp`. Here a simple example:
+
+```
+if (lex< custom_property_name >()) {
+  Sass::String* prop = new (ctx.mem) String_Constant(path, source_position, lexed);
+  return new (ctx.mem) Declaration(path, prop->position(), prop, ...);
+}
+```
+
+## How is the `source_position` calculated
+
+This is automatically done with `lex` in `parser.hpp`. Whenever something is lexed, the `source_position` is updated. But be aware that `source_position` points to the begining of the parsed text. If you need a mapping for the position where the parsing ended, you need to add another call to `lex` (to match nothing)!
+
+```
+lex< exactly < empty_str > >();
+end = new (ctx.mem) String_Constant(path, source_position, lexed);
+```
+
+## How are mappings for the output created
+
+So far we have collected all needed data for all tokens in the input stream. We can now use this information to create mappings when we put things into the output stream. Mappings are created via the `add_mappings` method:
+
+```
+# in source_map.hpp
+void add_mapping(AST_Node* node);
+```
+
+This method is called in two places:
+- `Inspect::append_to_buffer`
+- `Output_[Nested|Compressed]::append_to_buffer`
+
+Mappings can only be created for things that have been parsed into a `AST_Node`. Otherwise we do not have the information to create the mappings, which is the reason why libsass currently only maps the most important tokens in source maps.

--- a/docs/trace.md
+++ b/docs/trace.md
@@ -1,0 +1,26 @@
+## This is proposed interface in https://github.com/sass/libsass/pull/1288
+
+Additional debugging macros with low overhead are available, `TRACE()` and `TRACEINST()`.
+
+Both macros simulate a string stream, so they can be used like this:
+
+    TRACE() << "Reached.";
+
+produces:
+
+    [LIBSASS] parse_value parser.cpp:1384 Reached.
+
+`TRACE()`
+   logs function name, source filename, source file name to the standard error and the attached
+   stream to the standard error.
+
+`TRACEINST(obj)`
+   logs object instance address, function name, source filename, source file name to the standard error and the attached stream to the standard error, for example:
+
+    TRACEINST(this) << "String_Constant created " << this;
+
+produces:
+
+    [LIBSASS] 0x8031ba980:String_Constant ./ast.hpp:1371 String_Constant created (0,"auto")
+
+The macros generate output only of `LIBSASS_TRACE` is set in the environment.

--- a/docs/triage.md
+++ b/docs/triage.md
@@ -1,0 +1,17 @@
+This is an article about how to help with libsass issues. Issue triage is a fancy word for explaining how we deal with incoming issues and make sure that the right problems get worked on. The lifecycle of an issue goes like this:
+
+1. Issue is reported by a user.
+2. If the issue seems like a bug, then the "bug" tag is added. 
+3. If the reporting user didn't also create a spec test over at sass/sass-spec, the "needs test" tag is added.
+4. Verify that Ruby Sass *does not* have the same bug. LibSass strives to be an exact replica of how Ruby Sass works. If it's an issue that neither project has solved, please close the ticket with the "not in sass" label.
+5. The smallest possible breaking test is created in sass-spec. Cut away any extra information or non-breaking code until the core issue is made clear. 
+6. Again, verify that the expected output matches the latest Ruby Sass release. Do this by using your own tool OR by running ./sass-spec.rb in the spec folder and making sure that your test passes!
+7. Create the test cases in sass-spec with the name spec/libsass-todo-issues/issue_XXX/input.scss and expected_output.css where the XXX is the issue number here.
+8. Commit that test to sass-spec, making sure to reference the issue in the comment message like "Test to demonstrate sass/libsass#XXX".
+9. Once the spec test exists, remove the "needs test" tag and replace it with "test written".
+10. A C++ developer will then work on the issue and issue a pull request to fix the issue.
+11. A core member verifies that the fix does actually fix the spec tests.
+12. The fix is merged into the project.
+13. The spec is moved from the libsass-todo-issues folder into libsass-closed-issues
+14. The issue is closed
+15. Have a soda pop or enjoyable beverage of your choice

--- a/docs/unicode.md
+++ b/docs/unicode.md
@@ -1,0 +1,39 @@
+Libsass currently expects all input to be utf8 encoded (and outputs only utf8), if you actually have any unicode characters at all. We do not support conversion between encodings, even if you declare it with a `@charset` rule. The text below was originally posted as an [issue](https://github.com/sass/libsass/issues/381) on the libsass tracker.
+
+### [Declaring character encodings in CSS](http://www.w3.org/International/questions/qa-css-charset.en)
+
+This [explains](http://www.w3.org/International/questions/qa-css-charset.en) how the character encoding of a css file is determined. Since we are only dealing with local files, we never have a HTTP header. So the precedence should be 'charset' rule, byte-order mark (BOM) or auto-detection (finally falling back to system default/UTF-8). This may not sound too hard to implement, but what about import rules? The CSS specs do not forbid the mixing of different encodings! I solved that by converting all files to UTF-8 internally. On writing there is an option to tell the tool what encoding it should be (UTF-8 by default). One can also define if it should write a BOM or not and if it should add the charset declaration.
+
+Since my tool is written in perl, I have a lot of utilities at hand to deal with different unicode charsets. I'm pretty sure that most OSS uses [libiconv](https://www.gnu.org/software/libiconv/) to convert between different encodings. But I have now idea how easy/hard this would be to integrate platform independent (it seems doable).
+
+### Current status on libsass unicode support
+
+Currently libsass seems to handle the common UTF-8 case pretty well. I believe it should correctly support all ASCII compatible encodings (like UTF-8 or Latin-1). If all includes use the same encoding, the output should be correct (in the same encoding). It should also handle unicode chars in [selectors, variable names and other identifiers](https://github.com/hcatlin/libsass/issues/244#issuecomment-34681227). This is true for all ASCII compatible encodings. So the main incompatible encodings (I'm aware of) are UTF-16/UTF-32 (which could be converted to UTF-8 with libiconv).
+
+### Current encoding auto detection
+
+Libsass currently reads all kind of BOMs and will error out if it finds something it doesn't know how to handle! It seems that it throws away the optional UTF-8 BOM (if any is found). IMO it would be nice if users could configure that (also if a charset rule should be added to the output).
+
+### What is currently not supported
+
+- Using non ASCII compatible encodings (like UTF-16)
+- Using non ASCII characters in different encodings in different includes
+
+### What is missing to support the above cases
+
+- A way to convert between encodings (like libiconv)
+- Sniffing the charset inside the file (source is available)
+- Handling the conversion on import (and export)
+- Optional: Make output encoding configurable
+- Optional: Add optional/mandatory BOM (configurable)
+
+### Low priority feature
+
+I guess the current implementation should handle more than 99% of all real world use cases.
+A) Unicode characters are still seldomly seen (as they can be written escaped)
+B) It will still work if it's UTF-8 or in any of the most common known western ISO codepages.
+Although I'm not sure how this applies to asian and other "exotic" codepages!
+
+I guess the biggest Problem is to have libiconv (or some other) library as a dependency. Since it contains a lot of rules for the conversions, I see it as the only way to handle this correctly. Once that is sorted out it should be pretty much straight forward to implement the missing pieces (in parser.cpp - Parser::parse should return encoding and add Parser::sniff_charset, then convert the source byte stream to UTF-8).
+
+I hope the statements above all hold true. Unicode is really not the easiest topic to wrap your head around. But since I did all the above recently in Perl, I wanted to document it here. Feel free to extend or criticize.


### PR DESCRIPTION
Work in progress converting all the local wiki articles to markdown files and linking them appropriately.

After this is complete, the wiki will link to https://github.com/sass/libsass/tree/master/docs

Fixes #1226 

Check it out: https://github.com/drewwells/libsass/blob/feature/md/docs/README.md

- [x] Front page
- [x] API doc page
- [x] Build 
  - [x] win/darwin/linux
  - [x] autotools, makefile
  - [x] minGW
  - [x] Visual Studio
  - [x] Gentoo
- [x] Dev setup
- [x] Implementations
- [x] compat plan
- [x] unicode and charset support

Internals
- [x] Plugins
- [x] Context
- [x] Function
- [x] Importer
- [x] Custom function
- [x] Value
- [x] Trace
- [x] Source maps




