### PR TITLE
Don't output nested media queries that cannot be merged

### DIFF
--- a/cssize.cpp
+++ b/cssize.cpp
@@ -423,8 +423,10 @@ namespace Sass {
         else
         {
           List* mq = merge_media_queries(static_cast<Media_Block*>(b->node()), static_cast<Media_Block*>(parent));
-          static_cast<Media_Block*>(b->node())->media_queries(mq);
-          ss = b->node();
+          if (mq->length()) {
+            static_cast<Media_Block*>(b->node())->media_queries(mq);
+            ss = b->node();
+          }
         }
 
         if (!ss) continue;


### PR DESCRIPTION
This PR fixes incorrectly outputting nested media queries that cannot be merged.

Fixes https://github.com/sass/libsass/issues/1224
Spec PR https://github.com/sass/sass-spec/pull/396.