### PR TITLE
Always use shortest colour in compressed mode

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -790,6 +790,10 @@ namespace Sass {
                                       zero);
         break;
       case Textual::HEX: {
+        if (t->value().substr(0, 1) != "#") {
+          result = new (ctx.mem) String_Constant(t->pstate(), t->value());
+          break;
+        }
         string hext(t->value().substr(1)); // chop off the '#'
         if (hext.length() == 6) {
           string r(hext.substr(0,2));

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -582,6 +582,8 @@ namespace Sass {
       hexlet << hex << setw(2) << static_cast<unsigned long>(b);
     }
 
+    if (want_short && !c->is_delayed()) name = "";
+
     // retain the originally specified color definition if unchanged
     if (name != "") {
       ss << name;

--- a/parser.cpp
+++ b/parser.cpp
@@ -1003,6 +1003,7 @@ namespace Sass {
     }
     else if (lex< sequence< optional< exactly<'*'> >, identifier > >()) {
       prop = new (ctx.mem) String_Quoted(pstate, lexed);
+      prop->is_delayed(true);
     }
     else {
       error("invalid property name", pstate);
@@ -1487,7 +1488,7 @@ namespace Sass {
     --position;
 
     String_Constant* str_node = new (ctx.mem) String_Constant(pstate, str.time_wspace());
-    // str_node->is_delayed(true);
+    str_node->is_delayed(true);
     return str_node;
   }
 


### PR DESCRIPTION
This PR fixes an edge case with colour name shortening in compressed mode when using named colours.

Fixes https://github.com/sass/libsass/issues/1251.
Spec PR https://github.com/sass/sass-spec/pull/401.
Also fixes https://github.com/sass/sass-spec/tree/master/spec/libsass-todo-tests/libsass/test