### PR TITLE
Fix erroneous duplicate map key errors

### DIFF
--- a/debugger.hpp
+++ b/debugger.hpp
@@ -452,10 +452,10 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << ind << "Map " << expression;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " [Hashed]" << endl;
-    // for (auto i : expression->elements()) {
-    //   debug_ast(i.first, ind + " key: ");
-    //   debug_ast(i.second, ind + " val: ");
-    // }
+    for (auto i : expression->elements()) {
+      debug_ast(i.first, ind + " key: ");
+      debug_ast(i.second, ind + " val: ");
+    }
   } else if (dynamic_cast<List*>(node)) {
     List* expression = dynamic_cast<List*>(node);
     cerr << ind << "List " << expression;

--- a/parser.cpp
+++ b/parser.cpp
@@ -1105,12 +1105,6 @@ namespace Sass {
       (*map) << make_pair(key, value);
     }
 
-    // Check was moved to eval step
-    // if (map->has_duplicate_key()) {
-    //   To_String to_string(&ctx);
-    //   error("Duplicate key \"" + map->get_duplicate_key()->perform(&to_string) + "\" in map " + map->perform(&to_string) + ".", pstate);
-    // }
-
     ParserState ps = map->pstate();
     ps.offset = pstate - ps + pstate.offset;
     map->pstate(ps);


### PR DESCRIPTION
This PR fixes incorrect warning for duplicate map keys.

Fixes #1169.
Spec PR https://github.com/sass/sass-spec/pull/402.