### PR TITLE
Selector Functions

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -164,6 +164,7 @@ namespace Sass {
     size_t length() const   { return elements_.size(); }
     bool empty() const      { return elements_.empty(); }
     T last()                { return elements_.back(); }
+    T first()                { return elements_.front(); }
     T& operator[](size_t i) { return elements_[i]; }
     const T& operator[](size_t i) const { return elements_[i]; }
     Vectorized& operator<<(T element)
@@ -2006,6 +2007,9 @@ namespace Sass {
     bool is_superselector_of(Complex_Selector* sub);
     bool is_superselector_of(Selector_List* sub);
     // virtual Selector_Placeholder* find_placeholder();
+    
+    Selector_List* unify_with(Complex_Selector* rhs, Context& ctx);
+
     Combinator clear_innermost();
     void set_innermost(Complex_Selector*, Combinator);
     virtual unsigned long specificity() const
@@ -2074,6 +2078,8 @@ namespace Sass {
 
   typedef deque<Complex_Selector*> ComplexSelectorDeque;
 
+  typedef Subset_Map<string, pair<Complex_Selector*, Compound_Selector*> > ExtensionSubsetMap;
+
   ///////////////////////////////////
   // Comma-separated selector groups.
   ///////////////////////////////////
@@ -2092,6 +2098,10 @@ namespace Sass {
     bool is_superselector_of(Compound_Selector* sub);
     bool is_superselector_of(Complex_Selector* sub);
     bool is_superselector_of(Selector_List* sub);
+
+    Selector_List* unify_with(Selector_List*, Context&);
+    void populate_extends(Selector_List*, Context&, ExtensionSubsetMap&);
+    
     virtual unsigned long specificity()
     {
       unsigned long sum = 0;

--- a/context.cpp
+++ b/context.cpp
@@ -540,7 +540,14 @@ namespace Sass {
     register_function(ctx, inspect_sig, inspect, env);
     register_function(ctx, unique_id_sig, unique_id, env);
     // Selector functions
+    register_function(ctx, selector_nest_sig, selector_nest, env);
+    register_function(ctx, selector_append_sig, selector_append, env);
+    register_function(ctx, selector_extend_sig, selector_extend, env);
+    register_function(ctx, selector_replace_sig, selector_replace, env);
+    register_function(ctx, selector_unify_sig, selector_unify, env);
     register_function(ctx, is_superselector_sig, is_superselector, env);
+    register_function(ctx, simple_selectors_sig, simple_selectors, env);
+    register_function(ctx, selector_parse_sig, selector_parse, env);
   }
 
   void register_c_functions(Context& ctx, Env* env, Sass_Function_List descrs)

--- a/extend.cpp
+++ b/extend.cpp
@@ -1134,7 +1134,7 @@ namespace Sass {
         result
       end
   */
-  static Node subweave(Node& one, Node& two, Context& ctx) {
+  Node Extend::subweave(Node& one, Node& two, Context& ctx) {
     // Check for the simple cases
     if (one.collection()->size() == 0) {
       Node out = Node::createCollection();
@@ -1423,7 +1423,7 @@ namespace Sass {
       for (NodeDeque::iterator beforesIter = befores.collection()->begin(), beforesEndIter = befores.collection()->end(); beforesIter != beforesEndIter; beforesIter++) {
         Node& before = *beforesIter;
 
-        Node sub = subweave(before, current, ctx);
+        Node sub = Extend::subweave(before, current, ctx);
 
         DEBUG_PRINTLN(WEAVE, "SUB: " << sub)
 
@@ -1854,7 +1854,7 @@ namespace Sass {
   /*
    This is the equivalent of ruby's CommaSequence.do_extend.
   */
-  static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subsetMap, bool& extendedSomething) {
+  Selector_List* Extend::extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subsetMap, bool isReplace, bool& extendedSomething) {
 
     To_String to_string(&ctx);
 
@@ -1886,7 +1886,10 @@ namespace Sass {
         }
       }
 
-      for (NodeDeque::iterator iterator = extendedSelectors.collection()->begin(), iteratorEnd = extendedSelectors.collection()->end(); iterator != iteratorEnd; ++iterator) {
+      for (NodeDeque::iterator iterator = extendedSelectors.collection()->begin(), iteratorBegin = extendedSelectors.collection()->begin(), iteratorEnd = extendedSelectors.collection()->end(); iterator != iteratorEnd; ++iterator) {
+        // When it is a replace, skip the first one, unless there is only one
+        if(isReplace && iterator == iteratorBegin && extendedSelectors.collection()->size() > 1 ) continue;
+        
         Node& childNode = *iterator;
         *pNewSelectors << nodeToComplexSelector(childNode, ctx);
       }
@@ -1943,7 +1946,7 @@ namespace Sass {
     }
 
     bool extendedSomething = false;
-    Selector_List* pNewSelectorList = extendSelectorList(static_cast<Selector_List*>(pObject->selector()), ctx, subsetMap, extendedSomething);
+    Selector_List* pNewSelectorList = Extend::extendSelectorList(static_cast<Selector_List*>(pObject->selector()), ctx, subsetMap, false, extendedSomething);
 
     if (extendedSomething && pNewSelectorList) {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << static_cast<Selector_List*>(pObject->selector())->perform(&to_string))

--- a/extend.hpp
+++ b/extend.hpp
@@ -14,6 +14,7 @@ namespace Sass {
   using namespace std;
 
   class Context;
+  class Node;
 
   typedef Subset_Map<string, pair<Complex_Selector*, Compound_Selector*> > ExtensionSubsetMap;
 
@@ -38,6 +39,9 @@ namespace Sass {
 
     template <typename U>
     void fallback(U x) { return fallback_impl(x); }
+    
+    static Node subweave(Node& one, Node& two, Context& ctx);
+    static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subsetMap, bool isReplace, bool& extendedSomething);
   };
 
 }

--- a/functions.cpp
+++ b/functions.cpp
@@ -6,6 +6,7 @@
 #include "constants.hpp"
 #include "to_string.hpp"
 #include "inspect.hpp"
+#include "extend.hpp"
 #include "eval.hpp"
 #include "util.hpp"
 #include "utf8_string.hpp"
@@ -116,6 +117,38 @@ namespace Sass {
         error(msg.str(), pstate, backtrace);
       }
       return val;
+    }
+    
+#define ARGSEL(argname, seltype, contextualize) get_arg_sel<seltype>(argname, env, sig, pstate, backtrace, ctx)
+
+    template <typename T>
+    T* get_arg_sel(const string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx);
+    
+    template <>
+    Selector_List* get_arg_sel(const string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
+      To_String to_string(&ctx, false);
+      Expression* exp = ARG(argname, Expression);
+      string exp_src = exp->perform(&to_string) + "{";
+      return Parser::parse_selector(exp_src.c_str(), ctx);
+    }
+    
+    template <>
+    Complex_Selector* get_arg_sel(const string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
+      To_String to_string(&ctx, false);
+      Expression* exp = ARG(argname, Expression);
+      string exp_src = exp->perform(&to_string) + "{";
+      Selector_List* sel_list = Parser::parse_selector(exp_src.c_str(), ctx);
+      return (sel_list->length() > 0) ? sel_list->first() : 0;
+    }
+    
+    template <>
+    Compound_Selector* get_arg_sel(const string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
+      To_String to_string(&ctx, false);
+      Expression* exp = ARG(argname, Expression);
+      string exp_src = exp->perform(&to_string) + "{";
+      Selector_List* sel_list = Parser::parse_selector(exp_src.c_str(), ctx);
+      
+      return (sel_list->length() > 0) ? sel_list->first()->tail()->head() : 0;
     }
 
 #ifdef __MINGW32__
@@ -1563,6 +1596,196 @@ namespace Sass {
       }
       // return v;
     }
+    Signature selector_nest_sig = "selector-nest($selectors...)";
+    BUILT_IN(selector_nest)
+    {
+      To_String to_string;
+      List* arglist = ARG("$selectors", List);
+      
+      // Not enough parameters
+      if( arglist->length() == 0 )
+        error("$selectors: At least one selector must be passed", pstate);
+      
+      // Parse args into vector of selectors
+      vector<Selector_List*> parsedSelectors;
+      for (size_t i = 0, L = arglist->length(); i < L; ++i) {
+        Expression* exp = dynamic_cast<Expression*>(arglist->value_at_index(i));
+        string exp_src = exp->perform(&to_string) + "{";
+        Selector_List* sel = Parser::parse_selector(exp_src.c_str(), ctx);
+        parsedSelectors.push_back(sel);
+      }
+      
+      // Nothing to do
+      if( parsedSelectors.empty() ) {
+        return new (ctx.mem) Null(pstate);
+      }
+      
+      // Set the first element as the `result`, keep appending to as we go down the parsedSelector vector.
+      std::vector<Selector_List*>::iterator itr = parsedSelectors.begin();
+      Selector_List* result = *itr;
+      ++itr;
+      
+      for(;itr != parsedSelectors.end(); ++itr) {
+        Selector_List* child = *itr;
+        vector<Complex_Selector*> newElements;
+        
+        // For every COMPLEX_SELECTOR in `child`
+        // For every COMPLEX_SELECTOR in `result`
+            // let parentSeqClone equal a copy of result->elements[i]
+            // let childSeq equal child->elements[j]
+              // Set childSeq as the new innermost tail of parentSeqClone
+            // Add parentSeqClone to the newElements
+        // Replace result->elements with newElements
+        for (size_t i = 0, resultLen = result->length(); i < resultLen; ++i) {
+          for (size_t j = 0, childLen = child->length(); j < childLen; ++j) {
+            Complex_Selector* parentSeqClone = (*result)[i]->cloneFully(ctx);
+            Complex_Selector*  childSeq = (*child)[j];
+            
+            parentSeqClone->innermost()->tail(childSeq); // Set seq as the new tail of parentSeqClone
+            newElements.push_back(parentSeqClone);
+          }
+        }
+        
+        result->elements(newElements);
+      }
+      
+      
+      Listize listize(ctx);
+      return result->perform(&listize);
+    }
+    
+    Signature selector_append_sig = "selector-append($selectors...)";
+    BUILT_IN(selector_append)
+    {
+      To_String to_string;
+      List* arglist = ARG("$selectors", List);
+      
+      // Not enough parameters
+      if( arglist->length() == 0 )
+        error("$selectors: At least one selector must be passed", pstate);
+      
+      // Parse args into vector of selectors
+      vector<Selector_List*> parsedSelectors;
+      for (size_t i = 0, L = arglist->length(); i < L; ++i) {
+        Expression* exp = dynamic_cast<Expression*>(arglist->value_at_index(i));
+        string exp_src = exp->perform(&to_string) + "{";
+        Selector_List* sel = Parser::parse_selector(exp_src.c_str(), ctx);
+        parsedSelectors.push_back(sel);
+      }
+      
+      // Nothing to do
+      if( parsedSelectors.empty() ) {
+        return new (ctx.mem) Null(pstate);
+      }
+      
+      // Set the first element as the `result`, keep appending to as we go down the parsedSelector vector.
+      std::vector<Selector_List*>::iterator itr = parsedSelectors.begin();
+      Selector_List* result = *itr;
+      ++itr;
+      
+      for(;itr != parsedSelectors.end(); ++itr) {
+        Selector_List* child = *itr;
+        vector<Complex_Selector*> newElements;
+        
+        // For every COMPLEX_SELECTOR in `result`
+        // For every COMPLEX_SELECTOR in `child`
+          // let parentSeqClone equal a copy of result->elements[i]
+          // let childSeq equal child->elements[j]
+          // Append all of childSeq head elements into parentSeqClone
+          // Set the innermost tail of parentSeqClone, to childSeq's tail
+        // Replace result->elements with newElements
+        for (size_t i = 0, resultLen = result->length(); i < resultLen; ++i) {
+          for (size_t j = 0, childLen = child->length(); j < childLen; ++j) {
+            Complex_Selector* parentSeqClone = (*result)[i]->cloneFully(ctx);
+            Complex_Selector* childSeq = (*child)[j];
+            Complex_Selector* base = childSeq->tail();
+            
+            // Must be a simple sequence
+            if( childSeq->combinator() != Complex_Selector::Combinator::ANCESTOR_OF ) {
+              string msg("Can't append  `");
+              msg += childSeq->perform(&to_string);
+              msg += "` to `";
+              msg += parentSeqClone->perform(&to_string);;
+              msg += "`";
+              error(msg, pstate, backtrace);
+            }
+            
+            // Cannot be a Universal selector
+            Type_Selector* pType = dynamic_cast<Type_Selector*>(base->head()->first());
+            if(pType && pType->name() == "*") {
+              string msg("Can't append  `");
+              msg += childSeq->perform(&to_string);
+              msg += "` to `";
+              msg += parentSeqClone->perform(&to_string);;
+              msg += "`";
+              error(msg, pstate, backtrace);
+            }
+            
+            // TODO: Add check for namespace stuff
+            
+            // append any selectors in childSeq's head
+            *(parentSeqClone->innermost()->head()) += (base->head());
+            
+            // Set parentSeqClone new tail
+            parentSeqClone->innermost()->tail( base->tail() );
+            
+            newElements.push_back(parentSeqClone);
+          }
+        }
+        
+        result->elements(newElements);
+      }
+      
+      Listize listize(ctx);
+      return result->perform(&listize);
+    }
+    
+    Signature selector_extend_sig = "selector-extend($selector, $extendee, $extender)";
+    BUILT_IN(selector_extend)
+    {
+      To_String to_string;
+      
+      Selector_List*  selector = ARGSEL("$selector", Selector_List, p_contextualize);
+      Selector_List*  extendee = ARGSEL("$extendee", Selector_List, p_contextualize);
+      Selector_List*  extender = ARGSEL("$extender", Selector_List, p_contextualize);
+      
+      ExtensionSubsetMap subset_map;
+      extender->populate_extends(extendee, ctx, subset_map);
+      
+      bool extendedSomething;
+      Selector_List* result = Extend::extendSelectorList(selector, ctx, subset_map, false, extendedSomething);
+      
+      Listize listize(ctx);
+      return result->perform(&listize);
+    }
+    
+    Signature selector_replace_sig = "selector-replace($selector, $original, $replacement)";
+    BUILT_IN(selector_replace)
+    {
+      Selector_List*  selector = ARGSEL("$selector", Selector_List, p_contextualize);
+      Selector_List*  original = ARGSEL("$original", Selector_List, p_contextualize);
+      Selector_List*  replacement = ARGSEL("$replacement", Selector_List, p_contextualize);
+      
+      ExtensionSubsetMap subset_map;
+      replacement->populate_extends(original, ctx, subset_map);
+      
+      bool extendedSomething;
+      Selector_List* result = Extend::extendSelectorList(selector, ctx, subset_map, true, extendedSomething);
+      
+      Listize listize(ctx);
+      return result->perform(&listize);
+    }
+    
+    Signature selector_unify_sig = "selector-unify($selector1, $selector2)";
+    BUILT_IN(selector_unify)
+    {
+      Selector_List*  selector1 = ARGSEL("$selector1", Selector_List, p_contextualize);
+      Selector_List*  selector2 = ARGSEL("$selector2", Selector_List, p_contextualize);
+      
+      Selector_List* result = selector1->unify_with(selector2, ctx);
+      Listize listize(ctx);
+      return result->perform(&listize);
+    }
 
     Signature is_superselector_sig = "is-superselector($super, $sub)";
     BUILT_IN(is_superselector)
@@ -1576,6 +1799,37 @@ namespace Sass {
       Selector_List* sel_sub = Parser::parse_selector(sub_src.c_str(), ctx);
       bool result = sel_sup->is_superselector_of(sel_sub);
       return new (ctx.mem) Boolean(pstate, result);
+    }
+    
+    Signature simple_selectors_sig = "simple_selectors($selector)";
+    BUILT_IN(simple_selectors)
+    {
+      Compound_Selector* sel = ARGSEL("$selector", Compound_Selector, p_contextualize);
+      
+      To_String to_string;
+      List* l = new (ctx.mem) List(sel->pstate(), sel->length(), List::COMMA);
+      
+      for (size_t i = 0, L = sel->length(); i < L; ++i) {
+        Simple_Selector* ss = (*sel)[i];
+        string ss_string = ss->perform(&to_string) ;
+        
+        *l << new (ctx.mem) String_Constant(ss->pstate(), ss_string);
+      }
+      
+      
+      return l;
+    }
+    
+    Signature selector_parse_sig = "selector-parse($selector)";
+    BUILT_IN(selector_parse)
+    {
+      To_String to_string(&ctx, false);
+      Expression*  exp = ARG("$selector", Expression);
+      string sel_src = exp->perform(&to_string) + "{";
+      Selector_List* sel = Parser::parse_selector(sel_src.c_str(), ctx);
+      
+      Listize listize(ctx);
+      return sel->perform(&listize);
     }
 
     Signature unique_id_sig = "unique-id()";

--- a/functions.hpp
+++ b/functions.hpp
@@ -101,7 +101,14 @@ namespace Sass {
     extern Signature keywords_sig;
     extern Signature set_nth_sig;
     extern Signature unique_id_sig;
+    extern Signature selector_nest_sig;
+    extern Signature selector_append_sig;
+    extern Signature selector_extend_sig;
+    extern Signature selector_replace_sig;
+    extern Signature selector_unify_sig;
     extern Signature is_superselector_sig;
+    extern Signature simple_selectors_sig;
+    extern Signature selector_parse_sig;
 
     BUILT_IN(rgb);
     BUILT_IN(rgba_4);
@@ -176,7 +183,15 @@ namespace Sass {
     BUILT_IN(keywords);
     BUILT_IN(set_nth);
     BUILT_IN(unique_id);
+    BUILT_IN(selector_nest);
+    BUILT_IN(selector_append);
+    BUILT_IN(selector_extend);
+    BUILT_IN(selector_replace);
+    BUILT_IN(selector_unify);
     BUILT_IN(is_superselector);
+    BUILT_IN(simple_selectors);
+    BUILT_IN(selector_parse);
+    
 
   }
 }

--- a/node.cpp
+++ b/node.cpp
@@ -247,5 +247,33 @@ namespace Sass {
     return pFirst;
   }
 
+  // A very naive trim function, which removes duplicates in a node
+  // This is only used in Complex_Selector::unify_with for now, may need modifications to fit other needs
+  Node Node::naiveTrim(Node& seqses, Context& ctx) {
+    
+    Node result = Node::createCollection();
+    
+    To_String to_string;
+    std::set< Complex_Selector*, std::function< bool(Complex_Selector*, Complex_Selector*) > > sel_set([&] ( Complex_Selector* lhs, Complex_Selector* rhs ) {
+      bool result = lhs->perform(&to_string) < rhs->perform(&to_string);
+      return result;
+    } );
+    
+    // Add all selectors we don't already have, everything else just add it blindly
+    for (NodeDeque::iterator seqsesIter = seqses.collection()->begin(), seqsesIterEnd = seqses.collection()->end(); seqsesIter != seqsesIterEnd; ++seqsesIter) {
+      Node& seqs1 = *seqsesIter;
+      if( seqs1.isSelector() ) {
+        auto found = sel_set.find( seqs1.selector() );
+        if( found == sel_set.end() ) {
+          sel_set.insert(seqs1.selector());
+          result.collection()->push_back(seqs1);
+        }
+      } else {
+        result.collection()->push_back(seqs1);
+      }
+    }
+
+    return result;
+  }
 
 }

--- a/node.cpp
+++ b/node.cpp
@@ -254,10 +254,7 @@ namespace Sass {
     Node result = Node::createCollection();
     
     To_String to_string;
-    std::set< Complex_Selector*, std::function< bool(Complex_Selector*, Complex_Selector*) > > sel_set([&] ( Complex_Selector* lhs, Complex_Selector* rhs ) {
-      bool result = lhs->perform(&to_string) < rhs->perform(&to_string);
-      return result;
-    } );
+    std::set< Complex_Selector*, Complex_Selector_Pointer_Compare > sel_set;
     
     // Add all selectors we don't already have, everything else just add it blindly
     for (NodeDeque::iterator seqsesIter = seqses.collection()->begin(), seqsesIterEnd = seqses.collection()->end(); seqsesIter != seqsesIterEnd; ++seqsesIter) {

--- a/node.hpp
+++ b/node.hpp
@@ -69,6 +69,7 @@ namespace Sass {
     static Node createCollection(const NodeDeque& values);
 
     static Node createNil();
+    static Node naiveTrim(Node& seqses, Context& ctx);
 
     Node clone(Context& ctx) const;
 


### PR DESCRIPTION
#### Please note: The code in this pull request was written by myself, and is does not represent my employer. ####
Redoing https://github.com/sass/libsass/pull/1064.

This is a fresh checkout of master, and then manually went in and re-implemented the selector-functions.
This is a much simpler PR with less files modified, and only a single commit - hopefully that helps make everything more clear when merging 

Adds the selector functions:

- [x] selector-nest($selectors...)
- [x] selector-append($selectors...)
- [x] selector-extend($selector, $extendee, $extender)
- [x] selector-replace($selector, $original, $replacement)
- [x] selector-parse($selector)
- [x] simple-selectors($selector)
- [x] selector-unify($selector1, $selector2)

Regarding the sass-spec test, there are 2 issues when calling `selector-unify` and `selector-nest` and passing in a parent selector reference. 

I believe these are related to a couple of other issues cropping up around `&` - so I think it's safe to merge this in and tackle those as a new issue. 

###### Known Issues from sass-spec libsass issue_963 tests: ######
*selector-unify*
```
selector-unify(&, '.baz, .bang'); // never makes it passed the parser
Error: invalid selector after &
        on line 14 of test_selector_unify.scss
>>   content: selector-unify(&, '.baz, .bang');
   --------------------------^
```

*selector-nest*
```
selector-nest('.foo', '&.bar','baz &"); // '&' before .bar and after .baz are thrown out
```