### PR TITLE
Create quoted strings coming via API

### DIFF
--- a/eval.cpp
+++ b/eval.cpp
@@ -1358,7 +1358,11 @@ namespace Sass {
         e = new (ctx.mem) Color(pstate, sass_color_get_r(v), sass_color_get_g(v), sass_color_get_b(v), sass_color_get_a(v));
       } break;
       case SASS_STRING: {
-        e = new (ctx.mem) String_Constant(pstate, sass_string_get_value(v));
+        if (sass_string_is_quoted(v))
+          e = new (ctx.mem) String_Quoted(pstate, sass_string_get_value(v));
+        else {
+          e = new (ctx.mem) String_Constant(pstate, sass_string_get_value(v));
+        }
       } break;
       case SASS_LIST: {
         List* l = new (ctx.mem) List(pstate, sass_list_get_length(v), sass_list_get_separator(v) == SASS_COMMA ? List::COMMA : List::SPACE);

--- a/sass_values.cpp
+++ b/sass_values.cpp
@@ -322,7 +322,7 @@ extern "C" {
                 return sass_make_color(val->color.r, val->color.g, val->color.b, val->color.a);
         }   break;
         case SASS_STRING: {
-                return sass_make_string(val->string.value);
+                return sass_string_is_quoted(val) ? sass_make_qstring(val->string.value) : sass_make_string(val->string.value);
         }   break;
         case SASS_LIST: {
                 union Sass_Value* list = sass_make_list(val->list.length, val->list.separator);

--- a/to_c.cpp
+++ b/to_c.cpp
@@ -19,7 +19,16 @@ namespace Sass {
   { return sass_make_color(c->r(), c->g(), c->b(), c->a()); }
 
   Sass_Value* To_C::operator()(String_Constant* s)
-  { return sass_make_string(s->value().c_str()); }
+  { 
+    if (s->quote_mark()) {
+      return sass_make_qstring(s->value().c_str());
+    } else {
+	  return sass_make_string(s->value().c_str());
+    }
+  }
+
+  Sass_Value* To_C::operator()(String_Quoted* s)
+  { return sass_make_qstring(s->value().c_str()); }
 
   Sass_Value* To_C::operator()(List* l)
   {

--- a/to_c.hpp
+++ b/to_c.hpp
@@ -29,6 +29,7 @@ namespace Sass {
     Sass_Value* operator()(Number*);
     Sass_Value* operator()(Color*);
     Sass_Value* operator()(String_Constant*);
+    Sass_Value* operator()(String_Quoted*);
     Sass_Value* operator()(List*);
     Sass_Value* operator()(Map*);
     Sass_Value* operator()(Null*);


### PR DESCRIPTION
Make sure quoted strings coming via API
are created as a String_Quoted instance.
Adjust string "quoted" property sent
via API on output.