### PR TITLE
Better configurable sass-spec environment for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ env:
   - AUTOTOOLS=no COVERAGE=yes BUILD=static
   - AUTOTOOLS=yes COVERAGE=no BUILD=shared
 
-global:
-  - SASS_SPEC_REPO=https://github.com/sass/sass-spec.git
-  - SASS_SPEC_REPO_GITLOC=master
-
 # currenty there are various issues when
 # built with coverage, clang and autotools
 # - AUTOTOOLS=yes COVERAGE=yes BUILD=shared

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,10 +3,7 @@
 script/branding
 
 if [ ! -d "sass-spec" ]; then
-  if [ -z "$SASS_SPEC_REPO" ]; then
-    SASS_SPEC_REPO=https://github.com/sass/sass-spec.git
-  fi
-  git clone $SASS_SPEC_REPO
+  git clone https://github.com/sass/sass-spec.git
 fi
 if [ ! -d "sassc" ]; then
   git clone https://github.com/sass/sassc.git

--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -74,11 +74,55 @@ echo successfully compiled libsass
 echo AUTOTOOLS=$AUTOTOOLS COVERAGE=$COVERAGE BUILD=$BUILD
 
 if [ "x$PREFIX" == "x" ]; then
-	if [ "x$TRAVIS_BUILD_DIR" == "x" ]; then
-		PREFIX=/usr/local
-	else
-		PREFIX=$TRAVIS_BUILD_DIR
-	fi
+  if [ "x$TRAVIS_BUILD_DIR" == "x" ]; then
+    PREFIX=/usr/local
+  else
+    PREFIX=$TRAVIS_BUILD_DIR
+  fi
 fi
 
-LD_LIBRARY_PATH="$PREFIX/lib/" script/spec
+if [ "$CONTINUOUS_INTEGRATION" == "true" ] && [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_OS_NAME" == "linux" ];
+then
+  echo "Downloading jq"
+
+  curl http://stedolan.github.io/jq/download/linux64/jq > jq
+  chmod +x jq
+
+  echo "Fetching PR $TRAVIS_PULL_REQUEST"
+
+  JSON=$(curl -u xzyfer:882aeec2a5b847b7d67c61d7788c2721f011e2ea -sS https://api.github.com/repos/sass/libsass/pulls/$TRAVIS_PULL_REQUEST)
+
+  SPEC_PR=$(echo $JSON | jq -r .body)
+
+  BLAH="sass\/sass-spec(#|\/pull\/)([0-9]+)"
+
+  if [[ $SPEC_PR =~ $BLAH ]];
+  then
+    SPEC_PR="${BASH_REMATCH[2]}"
+
+    echo "Fetching Sass Spec PR $SPEC_PR"
+
+    JSON=$(curl -u xzyfer:882aeec2a5b847b7d67c61d7788c2721f011e2ea -sS https://api.github.com/repos/sass/sass-spec/pulls/$SPEC_PR)
+
+    SPEC_REMOTE=$(echo $JSON | jq -r .head.repo.clone_url)
+    SPEC_SHA=$(echo $JSON | jq -r .head.sha)
+
+    echo "Cloning $SPEC_REMOTE"
+
+    git clone $SPEC_REMOTE sass-spec-pr
+
+    echo "Checking out $SPEC_SHA"
+
+    cd sass-spec-pr
+    git checkout $SPEC_SHA
+
+    echo "Re-running Sass Spec"
+
+    cd ..
+    SASS_SPEC_PATH="sass-spec-pr" LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_build
+  else
+    LD_LIBRARY_PATH="$PREFIX/lib/" script/spec
+  fi
+else
+  LD_LIBRARY_PATH="$PREFIX/lib/" script/spec
+fi

--- a/script/spec
+++ b/script/spec
@@ -2,16 +2,4 @@
 
 script/bootstrap
 
-SASS_SPEC_REPO_GITLOC ?= master
-
-if [ -z "$SASS_SPEC_REPO_GITLOC" ]; then
-  SASS_SPEC_REPO_GITLOC=master
-fi
-
-echo "======================================================================"
-echo "Checking out sass-spec @ $SASS_SPEC_REPO_GITLOC"
-echo "======================================================================"
-
-(cd $SASS_SPEC_PATH; git checkout $SASS_SPEC_REPO_GITLOC)
-
 make $MAKE_OPTS test_build


### PR DESCRIPTION
This PR is a WIP for a better way to run CI against user defined sass-spec PRs.

I've reverted my `.travis.yml` hack from https://github.com/sass/libsass/pull/1300.

From now on if you have a link to a sass-spec PR well run against that PR in CI. We'll also continue to run against sass-spec master for the time being until we have confidence in this approach.

@mgreter thoughts?