### PR TITLE
Avoid global visibility of std:: in units

### DIFF
--- a/units.cpp
+++ b/units.cpp
@@ -61,7 +61,7 @@ namespace Sass {
     }
   };
 
-  SassUnit string_to_unit(const string& s)
+  SassUnit string_to_unit(const std::string& s)
   {
     // size units
     if      (s == "px") return PX;
@@ -120,7 +120,7 @@ namespace Sass {
   }
 
   // throws incompatibleUnits exceptions
-  double conversion_factor(const string& s1, const string& s2)
+  double conversion_factor(const std::string& s1, const std::string& s2)
   {
     // assert for same units
     if (s1 == s2) return 1;

--- a/units.hpp
+++ b/units.hpp
@@ -6,9 +6,8 @@
 #include <sstream>
 
 namespace Sass {
-  using namespace std;
 
-  const double PI = acos(-1);
+  const double PI = std::acos(-1);
 
   enum SassUnitType {
     SIZE = 0x000,
@@ -59,20 +58,20 @@ namespace Sass {
   extern const double frequency_conversion_factors[2][2];
   extern const double resolution_conversion_factors[3][3];
 
-  SassUnit string_to_unit(const string&);
+  SassUnit string_to_unit(const std::string&);
   const char* unit_to_string(SassUnit unit);
   SassUnitType get_unit_type(SassUnit unit);
   // throws incompatibleUnits exceptions
-  double conversion_factor(const string&, const string&);
+  double conversion_factor(const std::string&, const std::string&);
 
-  class incompatibleUnits: public exception
+  class incompatibleUnits: public std::exception
   {
     public:
       const char* msg;
       incompatibleUnits(SassUnit a, SassUnit b)
       : exception()
       {
-        stringstream ss;
+        std::stringstream ss;
         ss << "Incompatible units: ";
         ss << "'" << unit_to_string(a) << "' and ";
         ss << "'" << unit_to_string(b) << "'";


### PR DESCRIPTION
Solaris defines SEC in the global namespace

Fixes: https://github.com/sass/libsass/issues/1308