### PR TITLE
Fix hash collisions with complex values

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -53,6 +53,17 @@
 namespace Sass {
   using namespace std;
 
+  // from boost (functional/hash):
+  // http://www.boost.org/doc/libs/1_35_0/doc/html/hash/combine.html
+  // Boost Software License - Version 1.0
+  // http://www.boost.org/users/license.html
+  template <typename T>
+  void hash_combine (std::size_t& seed, const T& val)
+  {
+    seed ^= std::hash<T>()(val) + 0x9e3779b9
+             + (seed<<6) + (seed>>2);
+  }
+
   //////////////////////////////////////////////////////////
   // Abstract base class for all abstract syntax tree nodes.
   //////////////////////////////////////////////////////////
@@ -137,7 +148,7 @@ namespace std {
   {
     bool operator()( Sass::Expression* lhs,  Sass::Expression* rhs) const
     {
-      return *lhs == *rhs;
+      return lhs->hash() == rhs->hash();
     }
   };
 }
@@ -768,7 +779,7 @@ namespace Sass {
       hash_ = std::hash<string>()(separator() == COMMA ? "comma" : "space");
 
       for (size_t i = 0, L = length(); i < L; ++i)
-        hash_ ^= (elements()[i])->hash();
+        hash_combine(hash_, (elements()[i])->hash());
 
       return hash_;
     }
@@ -819,8 +830,10 @@ namespace Sass {
     {
       if (hash_ > 0) return hash_;
 
-      for (auto key : keys())
-        hash_ ^= key->hash() ^ at(key)->hash();
+      for (auto key : keys()) {
+        hash_combine(hash_, key->hash());
+        hash_combine(hash_, at(key)->hash());
+      }
 
       return hash_;
     }
@@ -1085,7 +1098,7 @@ namespace Sass {
 
       hash_ = std::hash<string>()(name());
       for (auto argument : arguments()->elements())
-        hash_ ^= argument->hash();
+        hash_combine(hash_, argument->hash());
 
       return hash_;
     }
@@ -1347,7 +1360,7 @@ namespace Sass {
       if (hash_ > 0) return hash_;
 
       for (auto string : elements())
-        hash_ ^= string->hash();
+        hash_combine(hash_, string->hash());
 
       return hash_;
     }

--- a/debugger.hpp
+++ b/debugger.hpp
@@ -465,6 +465,7 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
       " [delayed: " << expression->is_delayed() << "] " <<
       " [interpolant: " << expression->is_interpolant() << "] " <<
       " [arglist: " << expression->is_arglist() << "] " <<
+      " [hash: " << expression->hash() << "] " <<
       endl;
     for(auto i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Content*>(node)) {


### PR DESCRIPTION
Uses a copy of `hash_combine` from boost!

Fixes https://github.com/sass/libsass/issues/1283
Spec https://github.com/sass/sass-spec/pull/425

@mgreter I had to modify the original patch because we needed to define a custom `equal_to` function now that we have non-standard hashing algorithm. Also maps weren't being hashed correctly.