### PR TITLE
Implement static media_queries for imports

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -492,12 +492,15 @@ namespace Sass {
   class Import : public Statement {
     vector<string>         files_;
     vector<Expression*>    urls_;
+    ADD_PROPERTY(List*, media_queries);
   public:
     Import(ParserState pstate)
     : Statement(pstate),
-      files_(vector<string>()), urls_(vector<Expression*>())
+      files_(vector<string>()),
+      urls_(vector<Expression*>()),
+      media_queries_(0)
     { }
-    vector<string>&         files() { return files_; }
+    vector<string>&      files()    { return files_; }
     vector<Expression*>& urls()     { return urls_; }
     ATTACH_OPERATIONS()
   };

--- a/expand.cpp
+++ b/expand.cpp
@@ -275,6 +275,7 @@ namespace Sass {
   Statement* Expand::operator()(Import* imp)
   {
     Import* result = new (ctx.mem) Import(imp->pstate());
+    result->media_queries(imp->media_queries());
     for ( size_t i = 0, S = imp->urls().size(); i < S; ++i) {
       result->urls().push_back(imp->urls()[i]->perform(eval->with(env, backtrace)));
     }

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -157,6 +157,10 @@ namespace Sass {
       }
 
       import->urls().front()->perform(this);
+      if (import->media_queries()) {
+        append_mandatory_space();
+        import->media_queries()->perform(this);
+      }
       append_delimiter();
       for (size_t i = 1, S = import->urls().size(); i < S; ++i) {
         append_mandatory_linefeed();
@@ -168,6 +172,10 @@ namespace Sass {
         }
 
         import->urls()[i]->perform(this);
+        if (import->media_queries()) {
+          append_mandatory_space();
+          import->media_queries()->perform(this);
+        }
         append_delimiter();
       }
     }

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -129,5 +129,13 @@ namespace Sass {
       return *src == 0 || *src == '\n' || *src == '\r' ? src : 0;
     }
 
+    // Assert end_of_file boundary (/\z/)
+    // This is a zero-width positive lookahead
+    const char* end_of_file(const char* src)
+    {
+      // end of file or unix linefeed return here
+      return *src == 0 ? src : 0;
+    }
+
   }
 }

--- a/lexer.hpp
+++ b/lexer.hpp
@@ -65,7 +65,10 @@ namespace Sass {
     // Assert string boundaries (/\Z|\z|\A/)
     // There are zero-width positive lookaheads
     const char* end_of_line(const char* src);
-    // const char* end_of_string(const char* src);
+
+    // Assert end_of_file boundary (/\z/)
+    // This is a zero-width positive lookahead
+    const char* end_of_file(const char* src);
     // const char* start_of_string(const char* src);
 
     // Type definition for prelexer functions


### PR DESCRIPTION
This PR implements support for `@import`s with media queries.

Fixes https://github.com/sass/libsass/issues/1323
Spec https://github.com/sass/sass-spec/pull/432