### PR TITLE
Fix the output of Maps with falsey keys and/or values

### DIFF
--- a/ast.hpp
+++ b/ast.hpp
@@ -1598,7 +1598,7 @@ namespace Sass {
 
     virtual size_t hash()
     {
-      return 0;
+      return -1;
     }
 
     ATTACH_OPERATIONS()

--- a/inspect.cpp
+++ b/inspect.cpp
@@ -339,8 +339,6 @@ namespace Sass {
     bool items_output = false;
     append_string("(");
     for (auto key : map->keys()) {
-      if (key->is_invisible()) continue;
-      if (map->at(key)->is_invisible()) continue;
       if (items_output) append_comma_separator();
       key->perform(this);
       append_colon_separator();


### PR DESCRIPTION
This PR fix the debug output of maps to ensure all keys and values are outputted.

This also modifies the hash specialisation for `Null` to fix a hash collision between `False` and `Null` mentioned in https://github.com/sass/libsass/issues/1331#issuecomment-120813198. 

Fixes https://github.com/sass/libsass/issues/1331