### PR TITLE
[RFC] Change file fallback from `scss` to `sass` syntax

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -336,7 +336,7 @@ namespace Sass {
       }
       for(size_t i=0; i<extension.size();++i)
         extension[i] = tolower(extension[i]);
-      if (extension == ".sass" && contents != 0) {
+      if (extension != ".scss" && contents != 0) {
         char * converted = sass2scss(contents, SASS2SCSS_PRETTIFY_1 | SASS2SCSS_KEEP_COMMENT);
         free(contents); // free the indented contents
         return converted; // should be freed by caller


### PR DESCRIPTION
This is in response to https://github.com/sass/libsass/issues/1219.

Ruby sass seems to use indented syntax for all file types except `scss`. libsass currently does the opposite and recognises `sass` file as beeing indented syntax. This PR changes this behavior. It seems to be more inline with ruby sass, but I don't know the implications of this change. I also think we may need to change the force indented syntax flag in this case to force scss syntax.

So this is open for feedback and discussion!