### PR TITLE
Remove unused and bad `isPrintable(Expression)` function

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -582,10 +582,6 @@ namespace Sass {
       return true;
     }
 
-    bool isPrintable(Expression* e, Output_Style style) {
-      return isPrintable(e, style);
-    }
-
     bool isPrintable(Supports_Block* f, Output_Style style) {
       if (f == NULL) {
         return false;

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -46,7 +46,6 @@ namespace Sass {
     bool isPrintable(String_Constant* s, Output_Style style = NESTED);
     bool isPrintable(String_Quoted* s, Output_Style style = NESTED);
     bool isPrintable(Declaration* d, Output_Style style = NESTED);
-    bool isPrintable(Expression* e, Output_Style style = NESTED);
     bool isAscii(const char chr);
 
   }


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1361