### PR TITLE
[DEV] Add new selector functions to debug `unify` and `lt`

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -534,6 +534,8 @@ namespace Sass {
     register_function(ctx, selector_extend_sig, selector_extend, env);
     register_function(ctx, selector_replace_sig, selector_replace, env);
     register_function(ctx, selector_unify_sig, selector_unify, env);
+    register_function(ctx, selector_is_eq_sig, selector_is_eq, env);
+    register_function(ctx, selector_is_lt_sig, selector_is_lt, env);
     register_function(ctx, is_superselector_sig, is_superselector, env);
     register_function(ctx, simple_selectors_sig, simple_selectors, env);
     register_function(ctx, selector_parse_sig, selector_parse, env);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1738,6 +1738,24 @@ namespace Sass {
       return result->perform(&listize);
     }
 
+    Signature selector_is_eq_sig = "selector-is-eq($selector1, $selector2)";
+    BUILT_IN(selector_is_eq)
+    {
+      Listize listize(ctx);
+      Selector_List* selector1 = ARGSEL("$selector1", Selector_List, p_contextualize);
+      Selector_List* selector2 = ARGSEL("$selector2", Selector_List, p_contextualize);
+      return new (ctx.mem) Boolean(pstate, *selector1 == *selector2);
+    }
+
+    Signature selector_is_lt_sig = "selector-is-lt($selector1, $selector2)";
+    BUILT_IN(selector_is_lt)
+    {
+      Listize listize(ctx);
+      Selector_List* selector1 = ARGSEL("$selector1", Selector_List, p_contextualize);
+      Selector_List* selector2 = ARGSEL("$selector2", Selector_List, p_contextualize);
+      return new (ctx.mem) Boolean(pstate, *selector1 < *selector2);
+    }
+
     Signature simple_selectors_sig = "simple-selectors($selector)";
     BUILT_IN(simple_selectors)
     {

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -106,6 +106,8 @@ namespace Sass {
     extern Signature selector_extend_sig;
     extern Signature selector_replace_sig;
     extern Signature selector_unify_sig;
+    extern Signature selector_is_eq_sig;
+    extern Signature selector_is_lt_sig;
     extern Signature is_superselector_sig;
     extern Signature simple_selectors_sig;
     extern Signature selector_parse_sig;
@@ -188,6 +190,8 @@ namespace Sass {
     BUILT_IN(selector_extend);
     BUILT_IN(selector_replace);
     BUILT_IN(selector_unify);
+    BUILT_IN(selector_is_eq);
+    BUILT_IN(selector_is_lt);
     BUILT_IN(is_superselector);
     BUILT_IN(simple_selectors);
     BUILT_IN(selector_parse);


### PR DESCRIPTION
This is not really to be merged, but want to keep the code around since we probably need to test those functions better and it has proven to be very effective to be able to directly test the core selector functions. Maybe the equal function would even make sense for official ruby sass!?