### PR TITLE
Refactor C++ namespace usage

### DIFF
--- a/include/sass.h
+++ b/include/sass.h
@@ -1,5 +1,5 @@
-#ifndef SASS_H
-#define SASS_H
+#ifndef SASS_C_H
+#define SASS_C_H
 
 // #define DEBUG 1
 

--- a/include/sass2scss.h
+++ b/include/sass2scss.h
@@ -32,12 +32,13 @@
 #define SASS2SCSS_VERSION "1.0.3"
 #endif
 
-// using std::string
-using namespace std;
-
 // add namespace for c++
 namespace Sass
 {
+
+	using std::stack;
+	using std::string;
+	using std::stringstream;
 
 	// pretty print options
 	const int SASS2SCSS_PRETTIFY_0 = 0;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,4 +1,5 @@
 #include "ast.hpp"
+#include "sass.hpp"
 #include "context.hpp"
 #include "node.hpp"
 #include "extend.hpp"
@@ -10,7 +11,6 @@
 #include <iostream>
 
 namespace Sass {
-  using namespace std;
 
   static Null sass_null(Sass::Null(ParserState("null")));
 
@@ -1747,6 +1747,10 @@ namespace Sass {
 
   string Color::to_string(bool compressed, int precision) const
   {
+    using std::hex;
+    using std::setw;
+    using std::setfill;
+
     stringstream ss;
 
     // original color name
@@ -1846,8 +1850,8 @@ namespace Sass {
     // check if we got scientific notation in result
     if (ss.str().find_first_of("e") != string::npos) {
       ss.clear(); ss.str(string());
-      ss.precision(max(12, precision));
-      ss << fixed << value_;
+      ss.precision(std::max(12, precision));
+      ss << std::fixed << value_;
     }
 
     string tmp = ss.str();
@@ -1863,7 +1867,7 @@ namespace Sass {
     if (is_int)
     {
       ss.precision(0);
-      ss << fixed << value_;
+      ss << std::fixed << value_;
       res = string(ss.str());
     }
     // process floats
@@ -1874,7 +1878,7 @@ namespace Sass {
       { precision = pos_fract - pos_point; }
       // round value again
       ss.precision(precision);
-      ss << fixed << value_;
+      ss << std::fixed << value_;
       res = string(ss.str());
       // maybe we truncated up to decimal point
       size_t pos = res.find_last_not_of("0");

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -3,9 +3,6 @@
 
 #include <set>
 #include <deque>
-#include <vector>
-#include <string>
-#include <sstream>
 #include <iostream>
 #include <typeinfo>
 #include <algorithm>
@@ -30,6 +27,7 @@
 
 #endif
 
+#include "sass.hpp"
 #include "util.hpp"
 #include "units.hpp"
 #include "context.hpp"
@@ -52,7 +50,6 @@
 #include "sass_functions.h"
 
 namespace Sass {
-  using namespace std;
 
   // from boost (functional/hash):
   // http://www.boost.org/doc/libs/1_35_0/doc/html/hash/combine.html
@@ -173,7 +170,12 @@ namespace std {
 }
 
 namespace Sass {
-  using namespace std;
+
+  using std::deque;
+  using std::make_pair;
+  using std::istringstream;
+  using std::ostringstream;
+  using std::unordered_map;
 
   /////////////////////////////////////////////////////////////////////////////
   // Mixin class for AST nodes that should behave like vectors. Uses the

--- a/src/ast_factory.hpp
+++ b/src/ast_factory.hpp
@@ -6,7 +6,6 @@
 #include "ast.hpp"
 
 namespace Sass {
-  using namespace std;
 
   class AST_Factory {
     vector<AST_Node*> nodes;

--- a/src/backtrace.hpp
+++ b/src/backtrace.hpp
@@ -1,14 +1,11 @@
 #ifndef SASS_BACKTRACE_H
 #define SASS_BACKTRACE_H
 
-#include <sstream>
-
+#include "sass.hpp"
 #include "file.hpp"
 #include "position.hpp"
 
 namespace Sass {
-
-  using namespace std;
 
   struct Backtrace {
 

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -1,5 +1,6 @@
 #include "bind.hpp"
 #include "ast.hpp"
+#include "sass.hpp"
 #include "context.hpp"
 #include "eval.hpp"
 #include <map>
@@ -8,7 +9,6 @@
 #include "to_string.hpp"
 
 namespace Sass {
-  using namespace std;
 
   void bind(string callee, Parameters* ps, Arguments* as, Context& ctx, Env* env, Eval* eval)
   {

--- a/src/bind.hpp
+++ b/src/bind.hpp
@@ -1,7 +1,6 @@
 #ifndef SASS_BIND_H
 #define SASS_BIND_H
 
-#include <string>
 #include "environment.hpp"
 
 namespace Sass {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -34,11 +34,10 @@
 #include "emitter.hpp"
 
 namespace Sass {
-  using namespace Constants;
-  using namespace File;
-  using namespace Sass;
-  using std::cerr;
-  using std::endl;
+
+  using std::unordered_map;
+  using File::make_canonical_path;
+  using File::resolve_relative_path;
 
   Sass_Queued::Sass_Queued(const string& load_path, const string& abs_path, const char* source)
   {

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -1,13 +1,12 @@
 #ifndef SASS_CONTEXT_H
 #define SASS_CONTEXT_H
 
-#include <string>
-#include <vector>
 #include <map>
 
 #define BUFFERSIZE 255
 #include "b64/encode.h"
 
+#include "sass.hpp"
 #include "ast_fwd_decl.hpp"
 #include "kwd_arg_macros.hpp"
 #include "memory_manager.hpp"
@@ -21,7 +20,7 @@
 struct Sass_Function;
 
 namespace Sass {
-  using namespace std;
+
   struct Sass_Queued {
     string abs_path;
     string load_path;

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -10,7 +10,6 @@
 #include "environment.hpp"
 
 namespace Sass {
-  using namespace std;
 
   typedef Environment<AST_Node*> Env;
   struct Backtrace;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -1,13 +1,30 @@
 #ifndef SASS_DEBUGGER_H
 #define SASS_DEBUGGER_H
 
-#include <string>
-#include <sstream>
 #include "node.hpp"
 #include "ast_fwd_decl.hpp"
 
-using namespace std;
-using namespace Sass;
+/*
+inline void debug_extenstion_map(Sass::ExtensionSubsetMap* map, string ind = "")
+{
+  if (ind == "") cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
+  for(auto const &it : map->values()) {
+    debug_ast(it.first, ind + "first: ");
+    debug_ast(it.second, ind + "second: ");
+  }
+  if (ind == "") cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
+}
+
+inline void debug_subset_entries(SubsetMapEntries* entries, string ind = "")
+{
+  if (ind == "") cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
+  for(auto const &pair : *entries) {
+    debug_ast(pair.first, ind + "first: ");
+    debug_ast(pair.second, ind + "second: ");
+  }
+  if (ind == "") cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
+}
+*/
 
 inline string str_replace(std::string str, const std::string& oldStr, const std::string& newStr)
 {
@@ -46,6 +63,8 @@ inline string pstate_source_position(AST_Node* node)
 
 inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
 {
+  using std::string;
+  using namespace Sass;
   if (node == 0) return;
   if (ind == "") cerr << "####################################################################\n";
   if (dynamic_cast<Bubble*>(node)) {

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -5,7 +5,6 @@
 #include "utf8_string.hpp"
 
 namespace Sass {
-  using namespace std;
 
   Emitter::Emitter(Context* ctx)
   : wbuf(),

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -1,13 +1,13 @@
 #ifndef SASS_EMITTER_H
 #define SASS_EMITTER_H
 
-#include <string>
+#include "sass.hpp"
 #include "source_map.hpp"
 #include "ast_fwd_decl.hpp"
 
 namespace Sass {
+
   class Context;
-  using namespace std;
 
   class Emitter {
 

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -1,19 +1,17 @@
 #ifndef SASS_ENVIRONMENT_H
 #define SASS_ENVIRONMENT_H
 
-#include <string>
 #include <iostream>
 #include <map>
 
+#include "sass.hpp"
 #include "ast_fwd_decl.hpp"
 #include "ast_def_macros.hpp"
 #include "memory_manager.hpp"
 
 namespace Sass {
-  using std::string;
+
   using std::map;
-  using std::cerr;
-  using std::endl;
 
   template <typename T>
   class Environment {

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -1,12 +1,9 @@
 #ifndef SASS_ERROR_HANDLING_H
 #define SASS_ERROR_HANDLING_H
 
-#include <string>
-
 #include "position.hpp"
 
 namespace Sass {
-  using namespace std;
 
   struct Backtrace;
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -26,7 +26,6 @@
 #include "color_maps.hpp"
 
 namespace Sass {
-  using namespace std;
 
   inline double add(double x, double y) { return x + y; }
   inline double sub(double x, double y) { return x - y; }

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -2,12 +2,12 @@
 #define SASS_EVAL_H
 
 #include <iostream>
+#include "sass.hpp"
 #include "context.hpp"
 #include "listize.hpp"
 #include "operation.hpp"
 
 namespace Sass {
-  using namespace std;
 
   class Expand;
   class Context;

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -11,7 +11,6 @@
 #include "environment.hpp"
 
 namespace Sass {
-  using namespace std;
 
   class Listize;
   class Context;

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -376,7 +376,7 @@ namespace Sass {
         if (comparator(x[i], y[j], pCompareOut)) {
           c[i][j] = c[i - 1][j - 1] + 1;
         } else {
-          c[i][j] = max(c[i][j - 1], c[i - 1][j]);
+          c[i][j] = std::max(c[i][j - 1], c[i - 1][j]);
         }
       }
     }
@@ -529,7 +529,7 @@ namespace Sass {
 
         for (SourcesSet::iterator sourcesSetIterator = sources.begin(), sourcesSetIteratorEnd = sources.end(); sourcesSetIterator != sourcesSetIteratorEnd; ++sourcesSetIterator) {
           const Complex_Selector* const pCurrentSelector = *sourcesSetIterator;
-          maxSpecificity = max(maxSpecificity, pCurrentSelector->specificity());
+          maxSpecificity = std::max(maxSpecificity, pCurrentSelector->specificity());
         }
 
         DEBUG_PRINTLN(TRIM, "MAX SPECIFICITY: " << maxSpecificity)

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -11,7 +11,6 @@
 #include "subset_map.hpp"
 
 namespace Sass {
-  using namespace std;
 
   class Context;
   class Node;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -18,6 +18,9 @@
 #include "sass2scss.h"
 
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 
@@ -31,7 +34,8 @@
 
 namespace Sass {
   namespace File {
-    using namespace std;
+
+    using std::wstring;
 
     // return the current directory
     // always with forward slashes
@@ -84,7 +88,7 @@ namespace Sass {
         size_t pos_w = string::npos;
       #endif
       if (pos_p != string::npos && pos_w != string::npos) {
-        pos = max(pos_p, pos_w);
+        pos = std::max(pos_p, pos_w);
       }
       else if (pos_p != string::npos) {
         pos = pos_p;
@@ -188,7 +192,7 @@ namespace Sass {
       string stripped_base = "";
 
       size_t index = 0;
-      size_t minSize = min(absolute_uri.size(), absolute_base.size());
+      size_t minSize = std::min(absolute_uri.size(), absolute_base.size());
       for (size_t i = 0; i < minSize; ++i) {
         #ifdef FS_CASE_SENSITIVE
           if (absolute_uri[i] != absolute_base[i]) break;
@@ -299,6 +303,8 @@ namespace Sass {
     // will auto convert .sass files
     char* read_file(const string& path)
     {
+      using std::ios;
+      using std::ifstream;
       #ifdef _WIN32
         BYTE* pBuffer;
         DWORD dwBytes;

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -1,12 +1,12 @@
 #ifndef SASS_FILE_H
 #define SASS_FILE_H
 
-#include <string>
-#include <vector>
+#include "sass.hpp"
 
 namespace Sass {
-  using namespace std;
+
   class Context;
+
   namespace File {
 
     // return the current directory

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -25,6 +25,9 @@
 #include <set>
 
 #ifdef __MINGW32__
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include "windows.h"
 #include "wincrypt.h"
 #endif
@@ -34,8 +37,6 @@
 #define ARGM(argname, argtype, ctx) get_arg_m(argname, env, sig, pstate, backtrace, ctx)
 
 namespace Sass {
-  using std::stringstream;
-  using std::endl;
 
   Definition* make_native_function(Signature sig, Native_Function func, Context& ctx)
   {
@@ -184,7 +185,7 @@ namespace Sass {
       return seed;
     }
     #else
-    static random_device rd;
+    static std::random_device rd;
     uint64_t GetSeed()
     {
       return rd();
@@ -195,7 +196,7 @@ namespace Sass {
     // random_device degrades sharply once the entropy pool
     // is exhausted. For practical use, random_device is
     // generally only used to seed a PRNG such as mt19937.
-    static mt19937 rand(static_cast<unsigned int>(GetSeed()));
+    static std::mt19937 rand(static_cast<unsigned int>(GetSeed()));
 
     // features
     static set<string> features {
@@ -1104,12 +1105,12 @@ namespace Sass {
       Number* l = dynamic_cast<Number*>(env["$limit"]);
       if (l) {
         if (trunc(l->value()) != l->value() || l->value() == 0) error("argument $limit of `" + string(sig) + "` must be a positive integer", pstate);
-        uniform_real_distribution<> distributor(1, l->value() + 1);
+        std::uniform_real_distribution<> distributor(1, l->value() + 1);
         uint_fast32_t distributed = static_cast<uint_fast32_t>(distributor(rand));
         return new (ctx.mem) Number(pstate, (double)distributed);
       }
       else {
-        uniform_real_distribution<> distributor(0, 1);
+        std::uniform_real_distribution<> distributor(0, 1);
         double distributed = static_cast<double>(distributor(rand));
         return new (ctx.mem) Number(pstate, distributed);
      }
@@ -1822,9 +1823,9 @@ namespace Sass {
     BUILT_IN(unique_id)
     {
       std::stringstream ss;
-      uniform_real_distribution<> distributor(0, 4294967296); // 16^8
+      std::uniform_real_distribution<> distributor(0, 4294967296); // 16^8
       uint_fast32_t distributed = static_cast<uint_fast32_t>(distributor(rand));
-      ss << "u" << setfill('0') << setw(8) << std::hex << distributed;
+      ss << "u" << std::setfill('0') << std::setw(8) << std::hex << distributed;
       return new (ctx.mem) String_Quoted(pstate, ss.str());
     }
 

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -1,8 +1,6 @@
 #ifndef SASS_FUNCTIONS_H
 #define SASS_FUNCTIONS_H
 
-#include <string>
-
 #include "position.hpp"
 #include "environment.hpp"
 #include "sass_functions.h"

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -13,7 +13,6 @@
 #include "utf8/checked.h"
 
 namespace Sass {
-  using namespace std;
 
   Inspect::Inspect(Emitter emi)
   : Emitter(emi)

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -1,15 +1,13 @@
 #ifndef SASS_INSPECT_H
 #define SASS_INSPECT_H
 
-#include <string>
-
+#include "sass.hpp"
 #include "position.hpp"
 #include "operation.hpp"
 #include "emitter.hpp"
 
 namespace Sass {
   class Context;
-  using namespace std;
 
   class Inspect : public Operation_CRTP<void, Inspect>, public Emitter {
   protected:

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -825,7 +825,7 @@ failure:
 bool parse_string(const char **sp, char **out)
 {
   const char *s = *sp;
-  SB sb;
+  SB sb = {0};
   char throwaway_buffer[4];
     /* enough space for a UTF-8 character */
   char *b;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -2,12 +2,12 @@
 #include <cstddef>
 #include <iostream>
 #include <iomanip>
+#include "sass.hpp"
 #include "lexer.hpp"
 #include "constants.hpp"
 
 
 namespace Sass {
-  using namespace Constants;
 
   namespace Prelexer {
 

--- a/src/listize.hpp
+++ b/src/listize.hpp
@@ -10,7 +10,6 @@
 #include "environment.hpp"
 
 namespace Sass {
-  using namespace std;
 
   typedef Environment<AST_Node*> Env;
   struct Backtrace;

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -1,8 +1,8 @@
 #include "ast.hpp"
+#include "sass.hpp"
 #include "memory_manager.hpp"
 
 namespace Sass {
-  using namespace std;
 
   template <typename T>
   Memory_Manager<T>::Memory_Manager(size_t size)
@@ -18,7 +18,7 @@ namespace Sass {
   Memory_Manager<T>::~Memory_Manager()
   {
     // release memory for all controlled nodes
-    // avoid calling erase for every single node 
+    // avoid calling erase for every single node
     for (size_t i = 0, S = nodes.size(); i < S; ++i) {
       deallocate(nodes[i]);
     }

--- a/src/memory_manager.hpp
+++ b/src/memory_manager.hpp
@@ -1,11 +1,9 @@
 #ifndef SASS_MEMORY_MANAGER_H
 #define SASS_MEMORY_MANAGER_H
 
-#include <vector>
-#include <iostream>
+#include "sass.hpp"
 
 namespace Sass {
-  using namespace std;
   /////////////////////////////////////////////////////////////////////////////
   // A class for tracking allocations of AST_Node objects. The intended usage
   // is something like: Some_Node* n = new (mem_mgr) Some_Node(...);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -5,6 +5,7 @@
 
 namespace Sass {
 
+  using std::make_shared;
 
   Node Node::createCombinator(const Complex_Selector::Combinator& combinator) {
     NodeDequePtr null;

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -10,9 +10,7 @@
 
 namespace Sass {
 
-
-  using namespace std;
-
+  using std::shared_ptr;
 
   class Context;
 

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -4,10 +4,10 @@
 #include <iostream>
 #include <typeinfo>
 
+#include "sass.hpp"
 #include "ast_fwd_decl.hpp"
 
 namespace Sass {
-  using namespace std;
 
   template<typename T>
   class Operation {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -3,7 +3,6 @@
 #include "to_string.hpp"
 
 namespace Sass {
-  using namespace std;
 
   Output::Output(Context* ctx)
   : Inspect(Emitter(ctx)),

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -1,16 +1,13 @@
 #ifndef SASS_OUTPUT_H
 #define SASS_OUTPUT_H
 
-#include <string>
-#include <vector>
-
+#include "sass.hpp"
 #include "util.hpp"
 #include "inspect.hpp"
 #include "operation.hpp"
 
 namespace Sass {
   class Context;
-  using namespace std;
 
   // Refactor to make it generic to find linefeed (look behind)
   inline bool ends_with(std::string const & value, std::string const & ending)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <vector>
+#include "sass.hpp"
 #include "parser.hpp"
 #include "file.hpp"
 #include "inspect.hpp"
@@ -16,7 +17,7 @@
 #include <tuple>
 
 namespace Sass {
-  using namespace std;
+
   using namespace Constants;
 
   Parser Parser::from_c_str(const char* str, Context& ctx, ParserState pstate)

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -20,8 +20,7 @@ struct Lookahead {
 };
 
 namespace Sass {
-  using std::string;
-  using std::vector;
+
   using std::map;
   using namespace Prelexer;
 

--- a/src/paths.hpp
+++ b/src/paths.hpp
@@ -1,17 +1,13 @@
 #ifndef SASS_PATHS_H
 #define SASS_PATHS_H
 
-#include <string>
-#include <vector>
-#include <sstream>
 #include <iostream>
-
-using namespace std;
+#include "sass.hpp"
 
 template<typename T>
-string vector_to_string(vector<T> v)
+std::string vector_to_string(std::vector<T> v)
 {
-  stringstream buffer;
+  std::stringstream buffer;
   buffer << "[";
 
   if (!v.empty())
@@ -31,8 +27,6 @@ string vector_to_string(vector<T> v)
 }
 
 namespace Sass {
-
-  using namespace std;
 
   template<typename T>
   vector<vector<T> > paths(vector<vector<T> > strata, size_t from_end = 0)

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -1,4 +1,7 @@
 #ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #else
 #include <sys/types.h>
@@ -12,6 +15,8 @@
 #include "plugins.hpp"
 
 namespace Sass {
+
+  using std::wstring;
 
   Plugins::Plugins(void) { }
   Plugins::~Plugins(void) { }

--- a/src/plugins.hpp
+++ b/src/plugins.hpp
@@ -1,8 +1,7 @@
 #ifndef SASS_PLUGINS_H
 #define SASS_PLUGINS_H
 
-#include <string>
-#include <vector>
+#include "sass.hpp"
 #include "utf8_string.hpp"
 #include "sass_functions.h"
 
@@ -26,8 +25,6 @@
 #endif
 
 namespace Sass {
-
-  using namespace std;
 
   class Plugins {
 

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -2,8 +2,6 @@
 
 namespace Sass {
 
-  using namespace std;
-
   Offset::Offset(const char* string)
   : line(0), column(0)
   {

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -1,15 +1,12 @@
 #ifndef SASS_POSITION_H
 #define SASS_POSITION_H
 
-#include <string>
 #include <cstring>
 #include <cstdlib>
 #include <sstream>
-#include <iostream>
+#include "sass.hpp"
 
 namespace Sass {
-
-  using namespace std;
 
   class Offset {
 

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -9,7 +9,7 @@
 
 
 namespace Sass {
-  // using namespace Lexer;
+
   using namespace Constants;
 
   namespace Prelexer {

--- a/src/remove_placeholders.hpp
+++ b/src/remove_placeholders.hpp
@@ -10,8 +10,6 @@
 
 namespace Sass {
 
-    using namespace std;
-
     class Context;
 
     class Remove_Placeholders : public Operation_CRTP<void, Remove_Placeholders> {

--- a/src/sass.cpp
+++ b/src/sass.cpp
@@ -1,14 +1,13 @@
 #include <cstdlib>
 #include <cstring>
-#include <vector>
-#include <sstream>
 
 #include "sass.h"
 #include "file.hpp"
 #include "util.hpp"
+#include "sass.hpp"
 
 extern "C" {
-  using namespace std;
+
   using namespace Sass;
   using namespace File;
 

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -1,0 +1,26 @@
+#ifndef SASS_H
+#define SASS_H
+
+// #include <stack>
+#include <string>
+#include <vector>
+#include <sstream>
+#include <iostream>
+#include <stdexcept>
+
+namespace Sass {
+
+  // export only some symbols from std
+  // avoids to expose full std namespace
+  using std::cerr;
+  using std::endl;
+  // using std::stack;
+  using std::vector;
+  using std::string;
+  using std::stringstream;
+  using std::runtime_error;
+
+}
+
+
+#endif

--- a/src/sass2scss.cpp
+++ b/src/sass2scss.cpp
@@ -26,9 +26,6 @@
 // our own header
 #include "sass2scss.h"
 
-// using std::string
-using namespace std;
-
 // add namespace for c++
 namespace Sass
 {

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <stdexcept>
+#include "sass.hpp"
 #include "file.hpp"
 #include "json.hpp"
 #include "util.hpp"
@@ -18,8 +19,9 @@
 #include "error_handling.hpp"
 
 extern "C" {
-  using namespace std;
+
   using namespace Sass;
+  using std::bad_alloc;
 
   // Input behaviours
   enum Sass_Input_Style {

--- a/src/sass_functions.cpp
+++ b/src/sass_functions.cpp
@@ -5,12 +5,13 @@
 #endif
 
 #include <cstring>
+#include "sass.hpp"
 #include "util.hpp"
 #include "context.hpp"
 #include "sass_functions.h"
 
 extern "C" {
-  using namespace std;
+
   using namespace Sass;
 
   // Struct to hold custom function callback

--- a/src/sass_interface.cpp
+++ b/src/sass_interface.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <iostream>
 
+#include "sass.hpp"
 #include "util.hpp"
 #include "context.hpp"
 #include "inspect.hpp"
@@ -20,7 +21,9 @@
 
 
 extern "C" {
-  using namespace std;
+
+  using namespace Sass;
+  using std::bad_alloc;
 
   sass_context* sass_new_context()
   { return (sass_context*) calloc(1, sizeof(sass_context)); }
@@ -95,7 +98,6 @@ extern "C" {
 
   int sass_compile(sass_context* c_ctx)
   {
-    using namespace Sass;
     try {
       string input_path = safe_str(c_ctx->input_path);
       int lastindex = static_cast<int>(input_path.find_last_of("."));

--- a/src/sass_util.hpp
+++ b/src/sass_util.hpp
@@ -11,9 +11,6 @@
 namespace Sass {
 
 
-  using namespace std;
-
-
   /*
    This is for ports of functions in the Sass:Util module.
    */
@@ -119,7 +116,7 @@ namespace Sass {
         if (comparator(xChildren[i], yChildren[j], compareOut)) {
           c[i][j] = c[i - 1][j - 1] + 1;
         } else {
-          c[i][j] = max(c[i][j - 1], c[i - 1][j]);
+          c[i][j] = std::max(c[i][j - 1], c[i - 1][j]);
         }
       }
     }

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -6,13 +6,14 @@
 
 #include <cstdlib>
 #include <cstring>
+#include "sass.hpp"
 #include "util.hpp"
 #include "eval.hpp"
 #include "values.hpp"
 #include "sass_values.h"
 
 extern "C" {
-  using namespace std;
+
   using namespace Sass;
 
   struct Sass_Unknown {

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -11,7 +11,7 @@
 #include "source_map.hpp"
 
 namespace Sass {
-  using std::ptrdiff_t;
+
   SourceMap::SourceMap() : current_position(0, 0, 0), file("stdin") { }
   SourceMap::SourceMap(const string& file) : current_position(0, 0, 0), file(file) { }
 

--- a/src/source_map.hpp
+++ b/src/source_map.hpp
@@ -12,7 +12,6 @@
 #define VECTOR_UNSHIFT(vec, ins) vec.insert(vec.begin(), ins.begin(), ins.end())
 
 namespace Sass {
-  using std::vector;
 
   class Context;
   class OutputBuffer;

--- a/src/subset_map.hpp
+++ b/src/subset_map.hpp
@@ -3,13 +3,10 @@
 
 #include <map>
 #include <set>
-#include <vector>
 #include <algorithm>
 #include <iterator>
 #include <iostream>
-#include <sstream>
-
-// using namespace std;
+#include "sass.hpp"
 
 // template<typename T>
 // string vector_to_string(vector<T> v)
@@ -56,7 +53,9 @@
 // }
 
 namespace Sass {
-  using namespace std;
+
+  using std::set;
+  using std::pair;
 
   template<typename F, typename S, typename T>
   struct triple {

--- a/src/to_c.cpp
+++ b/src/to_c.cpp
@@ -1,10 +1,8 @@
-#include "to_c.hpp"
 #include "ast.hpp"
-
+#include "to_c.hpp"
 #include "sass_values.h"
 
 namespace Sass {
-  using namespace std;
 
   union Sass_Value* To_C::fallback_impl(AST_Node* n)
   { return sass_make_error("unknown type for C-API"); }

--- a/src/to_c.hpp
+++ b/src/to_c.hpp
@@ -1,12 +1,12 @@
 #ifndef SASS_TO_C_H
 #define SASS_TO_C_H
 
+#include "sass.hpp"
 #include "ast_fwd_decl.hpp"
 #include "operation.hpp"
 #include "sass_values.h"
 
 namespace Sass {
-  using namespace std;
 
   class To_C : public Operation_CRTP<union Sass_Value*, To_C> {
     // import all the class-specific methods and override as desired

--- a/src/to_string.cpp
+++ b/src/to_string.cpp
@@ -9,7 +9,6 @@
 #include "to_string.hpp"
 
 namespace Sass {
-  using namespace std;
 
   To_String::To_String(Context* ctx, bool in_declaration)
   : ctx(ctx), in_declaration(in_declaration) { }

--- a/src/to_string.hpp
+++ b/src/to_string.hpp
@@ -1,12 +1,10 @@
 #ifndef SASS_TO_STRING_H
 #define SASS_TO_STRING_H
 
-#include <string>
-
+#include "sass.hpp"
 #include "operation.hpp"
 
 namespace Sass {
-  using namespace std;
 
   class Context;
   class Null;

--- a/src/to_value.cpp
+++ b/src/to_value.cpp
@@ -1,10 +1,9 @@
 #include "ast.hpp"
-#include "sass_values.h"
 #include "to_value.hpp"
 #include "to_string.hpp"
+#include "sass_values.h"
 
 namespace Sass {
-  using namespace std;
 
   Value* To_Value::fallback_impl(AST_Node* n)
   {

--- a/src/to_value.hpp
+++ b/src/to_value.hpp
@@ -1,12 +1,12 @@
 #ifndef SASS_TO_VALUE_H
 #define SASS_TO_VALUE_H
 
+#include "sass.hpp"
 #include "operation.hpp"
 #include "sass_values.h"
 #include "ast_fwd_decl.hpp"
 
 namespace Sass {
-  using namespace std;
 
   class To_Value : public Operation_CRTP<Value*, To_Value> {
 

--- a/src/units.hpp
+++ b/src/units.hpp
@@ -2,15 +2,9 @@
 #define SASS_UNITS_H
 
 #include <cmath>
-#include <string>
-#include <sstream>
-
-#ifdef __sun
-#undef SEC
-#endif
+#include "sass.hpp"
 
 namespace Sass {
-  using namespace std;
 
   const double PI = acos(-1);
 
@@ -69,7 +63,7 @@ namespace Sass {
   // throws incompatibleUnits exceptions
   double conversion_factor(const string&, const string&);
 
-  class incompatibleUnits: public exception
+  class incompatibleUnits: public std::exception
   {
     public:
       const char* msg;

--- a/src/utf8_string.hpp
+++ b/src/utf8_string.hpp
@@ -7,6 +7,9 @@
 namespace Sass {
   namespace UTF_8 {
 
+    using std::wstring;
+
+
     // naming conventions:
     // offset: raw byte offset (0 based)
     // position: code point offset (0 based)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -485,7 +485,6 @@ namespace Sass {
   }
 
   namespace Util {
-    using std::string;
 
     string normalize_underscores(const string& str) {
       string normalized = str;

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -2,15 +2,13 @@
 #define SASS_UTIL_H
 
 #include <cstdio>
-#include <vector>
-#include <string>
+#include "sass.hpp"
 #include <assert.h>
 #include "ast_fwd_decl.hpp"
 
 #define SASS_ASSERT(cond, msg) assert(cond && msg)
 
 namespace Sass {
-  using namespace std;
 
   char* sass_strdup(const char* str);
   double sass_atof(const char* str);

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -1,10 +1,8 @@
-#include "sass.h"
 #include "values.hpp"
 
 #include <stdint.h>
 
 namespace Sass {
-  using namespace std;
 
   // convert value from C++ side to C-API
   union Sass_Value* ast_node_to_sass_value (const Expression* val)


### PR DESCRIPTION
Add new `sass.hpp` header for minimal std includes and exporting only specific symbols from std into our `Sass` namespace. Also removed some redundant includes! This is an alternative to @saper changes, which blindly adds `std::` to every symbol. I opted to only do this for more esoteric symbols and leave it as is for the more common ones.

Main fix is that I got rid of all `using namespace std` by explicitly saying:
```c++
namespace Sass {

  // export only some symbols from std
  // avoids to expose full std namespace
  using std::cerr;
  using std::endl;
  using std::stack;
  using std::vector;
  using std::string;
  using std::stringstream;
  using std::runtime_error;

}
```

Those are the only symbols imported into the `Sass` namespace. You can then import that namespace if you want. IMO this should solve the most important problem, which was that we were exporting all symbols in `std` into the global namespace in multiple headers!

I guess I don't have to emphasise that I like this solution much better than the approach in https://github.com/sass/libsass/pull/1310.
It should also keeps the git history much cleaner!