### PR TITLE
remove default argument from instantiation

### DIFF
--- a/src/sass_util.cpp
+++ b/src/sass_util.cpp
@@ -109,7 +109,7 @@ namespace Sass {
     return flattened
   end
   */
-  Node flatten(Node& arr, Context& ctx, int n = -1) {
+  Node flatten(Node& arr, Context& ctx, int n) {
     if (n != -1 && n == 0) {
       return arr;
     }


### PR DESCRIPTION
The default argument is in the definition https://github.com/sass/libsass/blob/bc802ba94/src/sass_util.cpp#L112 so the instantiation throws this error.

`error: redefinition of default argument`