### PR TITLE
Don't emit sourcesContent if empty

### DIFF
--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -50,8 +50,9 @@ namespace Sass {
         JsonNode *json_content = json_mkstring(content);
         json_append_element(json_contents, json_content);
       }
+      if (json_contents->children.head)
+        json_append_member(json_srcmap, "sourcesContent", json_contents);
     }
-    json_append_member(json_srcmap, "sourcesContent", json_contents);
 
     string mappings = serialize_mappings();
     JsonNode *json_mappings = json_mkstring(mappings.c_str());


### PR DESCRIPTION
An empty item might confuse some tools,
and it is not required by the spec.

See discussion at https://github.com/sass/node-sass/issues/1045