### PR TITLE
Fix memory manager not tracking memory

### DIFF
--- a/src/memory_manager.hpp
+++ b/src/memory_manager.hpp
@@ -33,7 +33,7 @@ namespace Sass {
 
 template <typename T>
 inline void* operator new(size_t size, Sass::Memory_Manager<T>& mem)
-{ return mem.allocate(size); }
+{ return mem(mem.allocate(size)); }
 
 template <typename T>
 inline void operator delete(void *np, Sass::Memory_Manager<T>& mem)


### PR DESCRIPTION
This is the alternative fix to https://github.com/sass/libsass/pull/1382 that keeps the allocation and adding "memory" to the "pool" separated. The bug got introduced in a [previous refactoring] [1] (I wrongly removed the call to `operator()`).

[1]: https://github.com/sass/libsass/commit/451980e52fdd11598cb2877f482698b049c3960e#diff-cb34a4b7c469c2c15b7102db29e0daf2L48