### PR TITLE
[DNM][WIP][Experimental] Manage dependent objects w/destructors

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1856,5 +1856,10 @@ namespace Sass {
     return message();
   }
 
+  Definition::~Definition()
+  {
+    delete parameters_;
+  }
+
 }
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1631,6 +1631,7 @@ namespace Sass {
       }
     }
     ATTACH_OPERATIONS()
+    ~Parameter() { if (default_value_) delete default_value_; }
   };
 
   /////////////////////////////////////////////////////////////////////////

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -225,7 +225,13 @@ namespace Sass {
 
   };
   template <typename T>
-  inline Vectorized<T>::~Vectorized() { }
+  Vectorized<T>::~Vectorized() {
+    typename vector<T>::const_iterator it = elements_.begin();
+    while(it != elements_.end()) {
+      T item = *it++;  
+      delete item;
+    }
+  }
 
   /////////////////////////////////////////////////////////////////////////////
   // Mixin class for AST nodes that should behave like a hash table. Uses an
@@ -763,6 +769,7 @@ namespace Sass {
       signature_(sig)
     { }
     ATTACH_OPERATIONS()
+    ~Definition();
   };
 
   //////////////////////////////////////

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1,6 +1,8 @@
 #include "ast.hpp"
 #include "environment.hpp"
 
+#include <stdio.h>
+
 namespace Sass {
 
   template <typename T>
@@ -9,6 +11,22 @@ namespace Sass {
   Environment<T>::Environment(Environment<T>* env) : local_frame_(map<string, T>()), parent_(env) { }
   template <typename T>
   Environment<T>::Environment(Environment<T>& env) : local_frame_(map<string, T>()), parent_(&env) { }
+
+  template <typename T>
+  Environment<T>::~Environment()
+  {
+     fprintf(stderr, "Environment(%p): removing: ", this); 
+     typename std::map<std::string, T>::iterator it = local_frame_.begin();
+     while(it != local_frame_.end()) {
+       std::string key = it->first;
+       T val = it->second;
+       ++it;
+       local_frame_.erase(key);
+       delete val;
+       fprintf(stderr, "X");
+     }
+     fprintf(stderr, " done.\n");
+  }
 
   // link parent to create a stack
   template <typename T>

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1,8 +1,6 @@
 #include "ast.hpp"
 #include "environment.hpp"
 
-#include <stdio.h>
-
 namespace Sass {
 
   template <typename T>
@@ -15,7 +13,6 @@ namespace Sass {
   template <typename T>
   Environment<T>::~Environment()
   {
-     fprintf(stderr, "Environment(%p): removing: ", this); 
      typename std::map<std::string, T>::iterator it = local_frame_.begin();
      while(it != local_frame_.end()) {
        std::string key = it->first;
@@ -23,9 +20,7 @@ namespace Sass {
        ++it;
        local_frame_.erase(key);
        delete val;
-       fprintf(stderr, "X");
      }
-     fprintf(stderr, " done.\n");
   }
 
   // link parent to create a stack

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -26,6 +26,7 @@ namespace Sass {
     Environment();
     Environment(Environment* env);
     Environment(Environment& env);
+    ~Environment();
 
     // link parent to create a stack
     void link(Environment& env);

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -20,7 +20,7 @@ namespace Sass {
     // release memory for all controlled nodes
     // avoid calling erase for every single node 
     for (size_t i = 0, S = nodes.size(); i < S; ++i) {
-      deallocate(nodes[i]);
+      // deallocate(nodes[i]);
     }
     // just in case
     nodes.clear();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -15,22 +15,17 @@
 #include <typeinfo>
 #include <tuple>
 
-#include <stdio.h>
-
 namespace Sass {
   using namespace std;
   using namespace Constants;
 
   Parser::~Parser()
   {
-    fprintf(stderr, "Parser(%p) goes out of scope: ", this);
     for(vector<Block*>::iterator i = block_stack.begin(); i != block_stack.end(); ) {
       Block *b = *i;
       ++i;
       ctx.mem.destroy(b);
-      fprintf(stderr, "X");
     }
-    fprintf(stderr, " done\n");
   }
 
   Parser Parser::from_c_str(const char* str, Context& ctx, ParserState pstate)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -15,9 +15,21 @@
 #include <typeinfo>
 #include <tuple>
 
+#include <stdio.h>
+
 namespace Sass {
   using namespace std;
   using namespace Constants;
+
+  Parser::~Parser()
+  {
+    fprintf(stderr, "Parser(%p) goes out of scope\n", this);
+    for(vector<Block*>::iterator i = block_stack.begin(); i != block_stack.end(); ) {
+      Block *b = *i;
+      ++i;
+      ctx.mem.destroy(b);
+    }
+  }
 
   Parser Parser::from_c_str(const char* str, Context& ctx, ParserState pstate)
   {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -23,12 +23,14 @@ namespace Sass {
 
   Parser::~Parser()
   {
-    fprintf(stderr, "Parser(%p) goes out of scope\n", this);
+    fprintf(stderr, "Parser(%p) goes out of scope: ", this);
     for(vector<Block*>::iterator i = block_stack.begin(); i != block_stack.end(); ) {
       Block *b = *i;
       ++i;
       ctx.mem.destroy(b);
+      fprintf(stderr, "X");
     }
+    fprintf(stderr, " done\n");
   }
 
   Parser Parser::from_c_str(const char* str, Context& ctx, ParserState pstate)

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -54,6 +54,8 @@ namespace Sass {
       source(0), position(0), end(0), before_token(pstate), after_token(pstate), pstate(pstate), indentation(0)
     { in_at_root = false; stack.push_back(nothing); }
 
+    ~Parser();
+
     // static Parser from_string(const string& src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
     static Parser from_c_str(const char* src, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));
     static Parser from_c_str(const char* beg, const char* end, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));


### PR DESCRIPTION
This is just a test for a better, more localized memory
management. Basically in the parse tree "parent" object
should "own" dependent objects. Locally scoped objects
should be attached to Environment (probably).

This series of commits frees 170+ object instances
created on startup of a very simple Sass script
with a custom importer. For example class Parser
instances used to prepare native functions are
freed after they are no longer needed.

This series "leaks memory" by not freeing the
objects attached to a global Context and
Memory Manager (so it is easier to detect, what
has not been destructed yet).

Parser frees its block_stack
Environment frees its local_frame_
Vectorized types free their elements_
Definitions free their parameters_ (which are
Vectorized). 
Each Parameter frees its default_value_ (if available).
