### PR TITLE
Fix a few MSVC warnings

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1711,7 +1711,7 @@ namespace Sass {
     }
     // otherwise get the possible resolved color name
     else {
-      int numval = r * 0x10000 + g * 0x100 + b;
+      double numval = r * 0x10000 + g * 0x100 + b;
       if (color_to_name(numval))
         res_name = color_to_name(numval);
     }

--- a/src/color_maps.cpp
+++ b/src/color_maps.cpp
@@ -627,11 +627,16 @@ namespace Sass {
     return 0;
   }
 
+  const char* color_to_name(const double key)
+  {
+    return color_to_name((int)key);
+  }
+
   const char* color_to_name(const Color& c)
   {
-    int key = c.r() * 0x10000
-              + c.g() * 0x100
-              + c.b();
+    double key = c.r() * 0x10000
+               + c.g() * 0x100
+               + c.b();
     return color_to_name(key);
   }
 

--- a/src/color_maps.hpp
+++ b/src/color_maps.hpp
@@ -326,6 +326,7 @@ namespace Sass {
   extern const Color* name_to_color(const std::string);
   extern const char* color_to_name(const int);
   extern const char* color_to_name(const Color&);
+  extern const char* color_to_name(const double);
 
 }
 

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -116,7 +116,7 @@
     <LinkIncremental>false</LinkIncremental>
     <TargetName>sassc</TargetName>
     <OutDir>$(SolutionDir)bin\</OutDir>
-    <IntDir>$(SolutionDir)bin\obj</IntDir>
+    <IntDir>$(SolutionDir)bin\obj\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>


### PR DESCRIPTION
Fixes the warnings about double to int conversion (allow double to be passed for color maps)!