### PR TITLE
Hotfix for block comment parsing (dirty)

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1381,8 +1381,8 @@ namespace Sass {
   protected:
     size_t hash_;
   public:
-    String_Constant(ParserState pstate, string val)
-    : String(pstate), quote_mark_(0), can_compress_whitespace_(false), value_(read_css_string(val)), hash_(0)
+    String_Constant(ParserState pstate, string val, bool norm = true)
+    : String(pstate), quote_mark_(0), can_compress_whitespace_(false), value_(norm ? read_css_string(val) : val), hash_(0)
     { }
     String_Constant(ParserState pstate, const char* beg)
     : String(pstate), quote_mark_(0), can_compress_whitespace_(false), value_(read_css_string(string(beg))), hash_(0)
@@ -1419,10 +1419,10 @@ namespace Sass {
   ////////////////////////////////////////////////////////
   class String_Quoted : public String_Constant {
   public:
-    String_Quoted(ParserState pstate, string val)
-    : String_Constant(pstate, val)
+    String_Quoted(ParserState pstate, string val, bool norm = true)
+    : String_Constant(pstate, val, norm)
     {
-      value_ = unquote(value_, &quote_mark_);
+      value_ = unquote(value_, &quote_mark_, norm);
     }
     virtual bool operator==(const Expression& rhs) const;
     virtual string to_string(bool compressed = false, int precision = 5) const;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -977,7 +977,7 @@ namespace Sass {
     Block* block = block_stack.back();
     while (lex< block_comment >()) {
       bool is_important = lexed.begin[2] == '!';
-      String*  contents = parse_interpolated_chunk(lexed);
+      String*  contents = parse_interpolated_chunk(lexed, true, false);
       (*block) << new (ctx.mem) Comment(pstate, contents, is_important);
     }
   }
@@ -1448,13 +1448,13 @@ namespace Sass {
 
   // this parses interpolation inside other strings
   // means the result should later be quoted again
-  String* Parser::parse_interpolated_chunk(Token chunk, bool constant)
+  String* Parser::parse_interpolated_chunk(Token chunk, bool constant, bool norm)
   {
     const char* i = chunk.begin;
     // see if there any interpolants
     const char* p = find_first_in_interval< exactly<hash_lbrace> >(i, chunk.end);
     if (!p) {
-      String_Quoted* str_quoted = new (ctx.mem) String_Quoted(pstate, string(i, chunk.end));
+      String_Quoted* str_quoted = new (ctx.mem) String_Quoted(pstate, string(i, chunk.end), norm);
       if (!constant && str_quoted->quote_mark()) str_quoted->quote_mark('*');
       str_quoted->is_delayed(true);
       return str_quoted;
@@ -1466,7 +1466,7 @@ namespace Sass {
       if (p) {
         if (i < p) {
           // accumulate the preceding segment if it's nonempty
-          (*schema) << new (ctx.mem) String_Constant(pstate, string(i, p));
+          (*schema) << new (ctx.mem) String_Constant(pstate, string(i, p), norm);
         }
         // we need to skip anything inside strings
         // create a new target in parser/prelexer
@@ -1488,7 +1488,7 @@ namespace Sass {
       }
       else { // no interpolants left; add the last segment if nonempty
         // check if we need quotes here (was not sure after merge)
-        if (i < chunk.end) (*schema) << new (ctx.mem) String_Constant(pstate, string(i, chunk.end));
+        if (i < chunk.end) (*schema) << new (ctx.mem) String_Constant(pstate, string(i, chunk.end), norm);
         break;
       }
       ++ i;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -245,7 +245,7 @@ namespace Sass {
     Function_Call* parse_calc_function();
     Function_Call* parse_function_call();
     Function_Call_Schema* parse_function_call_schema();
-    String* parse_interpolated_chunk(Token, bool constant = false);
+    String* parse_interpolated_chunk(Token, bool constant = false, bool norm = true);
     String* parse_string();
     String_Constant* parse_static_expression();
     // String_Constant* parse_static_property();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -317,7 +317,7 @@ namespace Sass {
     return quote_mark;
   }
 
-  string unquote(const string& s, char* qd)
+  string unquote(const string& s, char* qd, bool norm)
   {
 
     // not enough room for quotes

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -25,7 +25,7 @@ namespace Sass {
   string normalize_wspace(const string& str);
 
   string quote(const string&, char q = 0, bool keep_linefeed_whitespace = false);
-  string unquote(const string&, char* q = 0);
+  string unquote(const string&, char* q = 0, bool norm = true);
   char detect_best_quotemark(const char* s, char qm = '"');
 
   bool is_hex_doublet(double n);


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1294

To fix this proberly a String refactoring is needed and this PR should show why. IMHO we need to find the places where we have to apply which behavior. I guess we're getting closer, but still have some basics wrong. Nut sure if we want to ship this PR, as it's a pretty dirty hack. But maybe it helps us identify which strings need what behavior. Since the issue it fixes is not critical, I leave this open for comments. 