### PR TITLE
fix build errors on windows

### DIFF
--- a/src/units.cpp
+++ b/src/units.cpp
@@ -1,6 +1,10 @@
 #include <stdexcept>
 #include "units.hpp"
 
+#ifdef IN
+#undef IN
+#endif
+
 namespace Sass {
 
   /* the conversion matrix can be readed the following way */


### PR DESCRIPTION
This addresses a build error occurring on Windows. 

```
units.cpp: In function 'Sass::SassUnit Sass::string_to_unit(const string&)':
units.cpp:87:25: error: return-statement with no value, in function returning 'Sass::SassUnit' [-fpermissive]
     else if (s == "in") return IN;
                         ^
units.cpp: In function 'const char* Sass::unit_to_string(Sass::SassUnit)':
units.cpp:116:14: error: expected primary-expression before ':' token
       case IN: return "in"; break;
              ^
```