### PR TITLE
Rename DEBUG->DEBUGSTMT

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -316,7 +316,7 @@ namespace Sass {
       RETURN,
       EXTEND,
       ERROR,
-      DEBUG,
+      DEBUGSTMT,
       WHILE,
       EACH,
       FOR,
@@ -593,7 +593,7 @@ namespace Sass {
   public:
     Debug(ParserState pstate, Expression* val)
     : Statement(pstate), value_(val)
-    { statement_type(DEBUG); }
+    { statement_type(DEBUGSTMT); }
     ATTACH_OPERATIONS()
   };
 


### PR DESCRIPTION
gmake BUILD=debug-shared fails because
DEBUG symbol defined for debugging
overwrites DEBUG statement type
and libsass fails to compile.

````
m> gmake CC=cc CXX=c++ BUILD=debug-shared
c++ -g -DDEBUG -DDEBUG_LVL="NONE" -Wall -DLIBSASS_VERSION="\"3.2.5-151-g9b4e4-dirty\"" -std=c++0x -I /home/saper/sw/libsass/include -fPIC -fPIC -c -o src/ast.o src/ast.cpp
In file included from src/ast.cpp:1:
src/ast.hpp:319:7: error: expected '}'
      DEBUG,
      ^
<command line>:1:15: note: expanded from here
              ^
src/ast.hpp:301:25: note: to match this '{'
    enum Statement_Type {
                        ^
src/ast.hpp:596:7: error: no matching member function for call to 'statement_type'
    { statement_type(DEBUG); }
      ^~~~~~~~~~~~~~
src/ast.hpp:327:34: note: candidate function not viable: no known conversion from 'int' to 'Sass::Statement::Statement_Type' for 1st argument
    ADD_PROPERTY(Statement_Type, statement_type)
                                 ^
src/ast_def_macros.hpp:44:8: note: expanded from macro 'ADD_PROPERTY'
  type name(type name##__) { return name##_ = name##__; }\
       ^
src/ast.hpp:327:34: note: candidate function not viable: requires 0 arguments, but 1 was provided
src/ast_def_macros.hpp:43:8: note: expanded from macro 'ADD_PROPERTY'
  type name() const        { return name##_; }\
       ^
In file included from src/ast.cpp:1:
src/ast.hpp:622:22: error: use of undeclared identifier 'IF'
    { statement_type(IF); }
                     ^
src/ast.hpp:639:22: error: use of undeclared identifier 'FOR'; did you mean 'OR'?
    { statement_type(FOR); }
                     ^~~
                     OR
/home/saper/sw/libsass/include/sass_values.h:37:8: note: 'OR' declared here
  AND, OR,                   // logical connectives
       ^
In file included from src/ast.cpp:1:
src/ast.hpp:639:7: error: no matching member function for call to 'statement_type'
    { statement_type(FOR); }
      ^~~~~~~~~~~~~~
src/ast.hpp:327:34: note: candidate function not viable: no known conversion from 'Sass_OP' to 'Sass::Statement::Statement_Type' for 1st argument
    ADD_PROPERTY(Statement_Type, statement_type)
                                 ^
src/ast_def_macros.hpp:44:8: note: expanded from macro 'ADD_PROPERTY'
  type name(type name##__) { return name##_ = name##__; }\
       ^
src/ast.hpp:327:34: note: candidate function not viable: requires 0 arguments, but 1 was provided
src/ast_def_macros.hpp:43:8: note: expanded from macro 'ADD_PROPERTY'
  type name() const        { return name##_; }\
       ^
In file included from src/ast.cpp:1:
src/ast.hpp:652:22: error: use of undeclared identifier 'EACH'
    { statement_type(EACH); }
                     ^
src/ast.hpp:664:22: error: use of undeclared identifier 'WHILE'
    { statement_type(WHILE); }
                     ^
7 errors generated.
Makefile:230: recipe for target 'src/ast.o' failed
````