### PR TITLE
Refactor feature query support to better match the reference impl

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -14,6 +14,17 @@ namespace Sass {
 
   static Null sass_null(Sass::Null(ParserState("null")));
 
+  const bool Supports_Operator::needs_parens(Supports_Condition* cond) {
+    return dynamic_cast<Supports_Negation*>(cond) ||
+          (dynamic_cast<Supports_Operator*>(cond) &&
+           dynamic_cast<Supports_Operator*>(cond)->operand() != operand());
+  }
+
+  const bool Supports_Negation::needs_parens(Supports_Condition* cond) {
+    return dynamic_cast<Supports_Negation*>(cond) ||
+          dynamic_cast<Supports_Operator*>(cond);
+  }
+
   void AST_Node::update_pstate(const ParserState& pstate)
   {
     pstate_.offset += pstate - pstate_ + pstate.offset;

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -59,8 +59,11 @@ namespace Sass {
   class String_Quoted;
   class Media_Query;
   class Media_Query_Expression;
-  class Supports_Query;
   class Supports_Condition;
+  class Supports_Operator;
+  class Supports_Negation;
+  class Supports_Declaration;
+  class Supports_Interpolation;
   class At_Root_Expression;
   class Null;
   class Parent_Selector;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -32,6 +32,7 @@
 #include "sass2scss.h"
 #include "prelexer.hpp"
 #include "emitter.hpp"
+#include "debugger.hpp"
 
 namespace Sass {
   using namespace Constants;

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -167,7 +167,7 @@ namespace Sass {
     p_stack.push_back(m);
 
     Supports_Block* mm = new (ctx.mem) Supports_Block(m->pstate(),
-                                                    m->queries(),
+                                                    m->condition(),
                                                     m->block()->perform(this)->block());
     mm->tabs(m->tabs());
 
@@ -264,7 +264,7 @@ namespace Sass {
     Block* wrapper_block = new (ctx.mem) Block(m->block()->pstate());
     *wrapper_block << new_rule;
     Supports_Block* mm = new (ctx.mem) Supports_Block(m->pstate(),
-                                                    m->queries(),
+                                                    m->condition(),
                                                     wrapper_block);
 
     mm->tabs(m->tabs());

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -225,7 +225,27 @@ inline void debug_ast(AST_Node* node, string ind = "", Env* env = 0)
     cerr << ind << "Supports_Block " << block;
     cerr << " (" << pstate_source_position(node) << ")";
     cerr << " " << block->tabs() << endl;
-    if (block->block()) for(auto i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
+    debug_ast(block->condition(), ind + " =@ ");
+  } else if (dynamic_cast<Supports_Operator*>(node)) {
+    Supports_Operator* block = dynamic_cast<Supports_Operator*>(node);
+    cerr << ind << "Supports_Operator " << block;
+    cerr << " (" << pstate_source_position(node) << ")"
+    << endl;
+    debug_ast(block->left(), ind + " left) ");
+    debug_ast(block->right(), ind + " right) ");
+  } else if (dynamic_cast<Supports_Negation*>(node)) {
+    Supports_Negation* block = dynamic_cast<Supports_Negation*>(node);
+    cerr << ind << "Supports_Negation " << block;
+    cerr << " (" << pstate_source_position(node) << ")"
+    << endl;
+    debug_ast(block->condition(), ind + " condition) ");
+  } else if (dynamic_cast<Supports_Declaration*>(node)) {
+    Supports_Declaration* block = dynamic_cast<Supports_Declaration*>(node);
+    cerr << ind << "Supports_Declaration " << block;
+    cerr << " (" << pstate_source_position(node) << ")"
+    << endl;
+    debug_ast(block->feature(), ind + " feature) ");
+    debug_ast(block->value(), ind + " value) ");
   } else if (dynamic_cast<Block*>(node)) {
     Block* root_block = dynamic_cast<Block*>(node);
     cerr << ind << "Block " << root_block;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -959,30 +959,40 @@ namespace Sass {
     return s;
   }
 
-  Expression* Eval::operator()(Supports_Query* q)
+  Expression* Eval::operator()(Supports_Operator* c)
   {
-    Supports_Query* qq = new (ctx.mem) Supports_Query(q->pstate(),
-                                                    q->length());
-    for (size_t i = 0, L = q->length(); i < L; ++i) {
-      *qq << static_cast<Supports_Condition*>((*q)[i]->perform(this));
-    }
-    return qq;
+    Expression* left = c->left()->perform(this);
+    Expression* right = c->right()->perform(this);
+    Supports_Operator* cc = new (ctx.mem) Supports_Operator(c->pstate(),
+                                                 static_cast<Supports_Condition*>(left),
+                                                 static_cast<Supports_Condition*>(right),
+                                                 c->operand());
+    return cc;
   }
 
-  Expression* Eval::operator()(Supports_Condition* c)
+  Expression* Eval::operator()(Supports_Negation* c)
   {
-    String* feature = c->feature();
-    Expression* value = c->value();
-    value = (value ? value->perform(this) : 0);
-    Supports_Condition* cc = new (ctx.mem) Supports_Condition(c->pstate(),
-                                                 c->length(),
+    Expression* condition = c->condition()->perform(this);
+    Supports_Negation* cc = new (ctx.mem) Supports_Negation(c->pstate(),
+                                                 static_cast<Supports_Condition*>(condition));
+    return cc;
+  }
+
+  Expression* Eval::operator()(Supports_Declaration* c)
+  {
+    Expression* feature = c->feature()->perform(this);
+    Expression* value = c->value()->perform(this);
+    Supports_Declaration* cc = new (ctx.mem) Supports_Declaration(c->pstate(),
                                                  feature,
-                                                 value,
-                                                 c->operand(),
-                                                 c->is_root());
-    for (size_t i = 0, L = c->length(); i < L; ++i) {
-      *cc << static_cast<Supports_Condition*>((*c)[i]->perform(this));
-    }
+                                                 value);
+    return cc;
+  }
+
+  Expression* Eval::operator()(Supports_Interpolation* c)
+  {
+    Expression* value = c->value()->perform(this);
+    Supports_Interpolation* cc = new (ctx.mem) Supports_Interpolation(c->pstate(),
+                                                 value);
     return cc;
   }
 

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -61,8 +61,10 @@ namespace Sass {
     Expression* operator()(Media_Query*);
     Expression* operator()(Media_Query_Expression*);
     Expression* operator()(At_Root_Expression*);
-    Expression* operator()(Supports_Query*);
-    Expression* operator()(Supports_Condition*);
+    Expression* operator()(Supports_Operator*);
+    Expression* operator()(Supports_Negation*);
+    Expression* operator()(Supports_Declaration*);
+    Expression* operator()(Supports_Interpolation*);
     Expression* operator()(Null*);
     Expression* operator()(Argument*);
     Expression* operator()(Arguments*);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -146,11 +146,10 @@ namespace Sass {
 
   Statement* Expand::operator()(Supports_Block* f)
   {
-    Expression* queries = f->queries()->perform(&eval);
+    Expression* condition = f->condition()->perform(&eval);
     Supports_Block* ff = new (ctx.mem) Supports_Block(f->pstate(),
-                                                    static_cast<Supports_Query*>(queries),
+                                                    static_cast<Supports_Condition*>(condition),
                                                     f->block()->perform(this)->block());
-    // ff->selector(selector());
     return ff;
   }
 

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -67,8 +67,10 @@ namespace Sass {
     virtual void operator()(String_Schema*);
     virtual void operator()(String_Constant*);
     virtual void operator()(String_Quoted*);
-    virtual void operator()(Supports_Query*);
-    virtual void operator()(Supports_Condition*);
+    virtual void operator()(Supports_Operator*);
+    virtual void operator()(Supports_Negation*);
+    virtual void operator()(Supports_Declaration*);
+    virtual void operator()(Supports_Interpolation*);
     virtual void operator()(Media_Query*);
     virtual void operator()(Media_Query_Expression*);
     virtual void operator()(At_Root_Expression*);

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -58,8 +58,11 @@ namespace Sass {
     virtual T operator()(String_Schema* x)          = 0;
     virtual T operator()(String_Quoted* x)          = 0;
     virtual T operator()(String_Constant* x)        = 0;
-    virtual T operator()(Supports_Query* x)          = 0;
-    virtual T operator()(Supports_Condition* x)= 0;
+    virtual T operator()(Supports_Condition* x)     = 0;
+    virtual T operator()(Supports_Operator* x)      = 0;
+    virtual T operator()(Supports_Negation* x)      = 0;
+    virtual T operator()(Supports_Declaration* x)   = 0;
+    virtual T operator()(Supports_Interpolation* x) = 0;
     virtual T operator()(Media_Query* x)            = 0;
     virtual T operator()(Media_Query_Expression* x) = 0;
     virtual T operator()(At_Root_Expression* x)     = 0;
@@ -135,8 +138,11 @@ namespace Sass {
     virtual T operator()(String_Schema* x)          { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(String_Constant* x)        { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(String_Quoted* x)          { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Supports_Query* x)         { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Supports_Condition* x)     { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Supports_Operator* x)      { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Supports_Negation* x)      { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Supports_Declaration* x)   { return static_cast<D*>(this)->fallback(x); }
+    virtual T operator()(Supports_Interpolation* x) { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Query* x)            { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(Media_Query_Expression* x) { return static_cast<D*>(this)->fallback(x); }
     virtual T operator()(At_Root_Expression* x)     { return static_cast<D*>(this)->fallback(x); }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -225,8 +225,8 @@ namespace Sass {
   {
     if (f->is_invisible()) return;
 
-    Supports_Query* q    = f->queries();
-    Block* b            = f->block();
+    Supports_Condition* c = f->condition();
+    Block* b              = f->block();
 
     // Filter out feature blocks that aren't printable (process its children though)
     if (!Util::isPrintable(f, output_style())) {
@@ -243,7 +243,7 @@ namespace Sass {
     append_indentation();
     append_token("@supports", f);
     append_mandatory_space();
-    q->perform(this);
+    c->perform(this);
     append_scope_opener();
 
     if (b->has_non_hoistable()) {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -267,13 +267,12 @@ namespace Sass {
     Media_Query* parse_media_query();
     Media_Query_Expression* parse_media_expression();
     Supports_Block* parse_supports_directive();
-    Supports_Query* parse_supports_queries();
     Supports_Condition* parse_supports_condition();
     Supports_Condition* parse_supports_negation();
-    Supports_Condition* parse_supports_conjunction();
-    Supports_Condition* parse_supports_disjunction();
+    Supports_Condition* parse_supports_operator();
+    Supports_Condition* parse_supports_interpolation();
     Supports_Condition* parse_supports_declaration();
-    Supports_Condition* parse_supports_declaration_in_parens();
+    Supports_Condition* parse_supports_condition_in_parens();
     At_Root_Block* parse_at_root_block();
     At_Root_Expression* parse_at_root_expression();
     At_Rule* parse_at_rule();


### PR DESCRIPTION
The aim of this refactor is simple to bring the code and AST more inline with the Ruby Sass implementation to help us better address difference between how we handle feature queries. As an intended side affect this fixes some issues.

Fixes #1425 
Spec https://github.com/sass/sass-spec/pull/461