### PR TITLE
Return Null value for & if selector stack is empty

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1517,10 +1517,14 @@ namespace Sass {
   Expression* Eval::operator()(Parent_Selector* p)
   {
     Selector_List* pr = selector();
-    exp.selector_stack.pop_back();
-    if (pr) pr = operator()(pr);
-    exp.selector_stack.push_back(pr);
-    return pr;
+    if (pr) {
+      exp.selector_stack.pop_back();
+      pr = operator()(pr);
+      exp.selector_stack.push_back(pr);
+      return pr;
+    } else {
+      return new (ctx.mem) Null(p->pstate());
+    }
   }
 
 }


### PR DESCRIPTION
A quick'n'dirty "fix" for https://github.com/sass/libsass/issues/1415

Fixes #1415