### PR TITLE
Better mirror Ruby Sass errors for null params to selector functions

### DIFF
--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -23,6 +23,8 @@ namespace Sass {
   Definition* make_native_function(Signature, Native_Function, Context& ctx);
   Definition* make_c_function(Sass_Function_Entry c_func, Context& ctx);
 
+  std::string function_name(Signature);
+
   namespace Functions {
 
     extern Signature rgb_sig;


### PR DESCRIPTION
This PR updates the selector functions to throw errors if a `null` argument is supplied.

Originally mentioned in https://github.com/sass/libsass/pull/1430#issuecomment-129283759

Fixes https://github.com/sass/libsass/issues/1432

/cc @saper 