### PR TITLE
MemoryManager: Use free instead of delete.

### DIFF
--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -67,7 +67,7 @@ namespace Sass {
     // remove from pool
     remove(np);
     // release memory
-    delete np;
+    free(np);
   }
 
   // compile implementation for AST_Node


### PR DESCRIPTION
On instantiating `Color` at src/functions.cpp (`BUILT_IN(rgba_4)` body)
, `Memory_Manager`'s `operator new()` is called which after explicitly
calling the underlying `operator new(size_t)`, `static_cast` the
allocated memory for `void*` -> `AST_Node*` conversion.

The `delete` operator in `Memory_Manager` is called when an exception
is thrown during the construction of the object (right after the `new`)
. When calling underlying `delete` from custom `delete` implementation,
it throws access violation probably because it tries to `delete` all
continents of objects which weren't initialised properly, as in case of
invalid rgba value, `error_handling` layer throws.

Therefore, more rawer `free()` is used to avoid `bad_alloc`<->`delete`
panics. :)

Note that this is the quick fix to the problem. The actual fix would be
to implement a custom exception-tolerant `New`.

Read more on this subject:
http://www.scs.stanford.edu/~dm/home/papers/c++-new.html.

Fixes #1443.