### PR TITLE
MSVC: Removes unnecessary NOMINMAX macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ bin/*
 .deps/
 .libs/
 win/bin
+*.user
 
 # Final results
 

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,6 +1,3 @@
-#if defined(_MSC_VER)
-#define NOMINMAX
-#endif
 #include "ast.hpp"
 #include "context.hpp"
 #include "node.hpp"

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1,6 +1,5 @@
 #ifdef _MSC_VER
 #pragma warning(disable : 4503)
-#define NOMINMAX
 #endif
 
 #include "extend.hpp"

--- a/src/sass_util.hpp
+++ b/src/sass_util.hpp
@@ -1,9 +1,6 @@
 #ifndef SASS_SASS_UTIL_H
 #define SASS_SASS_UTIL_H
 
-#if defined(_MSC_VER)
-#define NOMINMAX
-#endif
 #include "ast.hpp"
 #include "node.hpp"
 #include "debug.hpp"


### PR DESCRIPTION
* `NOMINMAX` macro is only required where we include `<windows>` header
  because it has `min` and `max` defined as macros; and we need it in
  one file: `src/file.cpp`.
* Also adds .user (VS user file) to `.gitignore`.