### PR TITLE
rename SIZE to LENGTH to avoid conflict with windows headers

### DIFF
--- a/src/units.cpp
+++ b/src/units.cpp
@@ -56,7 +56,7 @@ namespace Sass {
   {
     switch (unit & 0xFF00)
     {
-      case SassUnitType::SIZE:        return SassUnitType::SIZE; break;
+      case SassUnitType::LENGTH:      return SassUnitType::LENGTH; break;
       case SassUnitType::ANGLE:       return SassUnitType::ANGLE; break;
       case SassUnitType::TIME:        return SassUnitType::TIME; break;
       case SassUnitType::FREQUENCY:   return SassUnitType::FREQUENCY; break;
@@ -144,7 +144,7 @@ namespace Sass {
     // only process known units
     if (u1 != UNKNOWN && u2 != UNKNOWN) {
       switch (t1) {
-        case SassUnitType::SIZE:              return size_conversion_factors[i1][i2]; break;
+        case SassUnitType::LENGTH:              return size_conversion_factors[i1][i2]; break;
         case SassUnitType::ANGLE:             return angle_conversion_factors[i1][i2]; break;
         case SassUnitType::TIME:              return time_conversion_factors[i1][i2]; break;
         case SassUnitType::FREQUENCY:         return frequency_conversion_factors[i1][i2]; break;

--- a/src/units.hpp
+++ b/src/units.hpp
@@ -10,7 +10,7 @@ namespace Sass {
   const double PI = acos(-1);
 
   enum SassUnitType {
-    SIZE = 0x000,
+    LENGTH = 0x000,
     ANGLE = 0x100,
     TIME = 0x200,
     FREQUENCY = 0x300,
@@ -21,7 +21,7 @@ namespace Sass {
   enum SassUnit {
 
     // size units
-    IN = SIZE,
+    IN = SassUnitType::LENGTH,
     CM,
     PC,
     MM,


### PR DESCRIPTION
The use of `SIZE` in units.cpp/hpp conflicts with the mingw32 windows header definition of SIZE: http://sourceforge.net/u/earnie/winapi/winapi/ci/f9fa22a4ecce88ad12a8371a40f00ef702ec3e1b/tree/include/windef.h#l322

Rather than messing with this definition, SIZE has been renamed to LENGTH which actually is a more accurate name. https://developer.mozilla.org/en-US/docs/Web/CSS/length Every now and then things work out like that!
