### PR TITLE
Fix memory manager for MSVC

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -287,11 +287,11 @@ namespace Sass {
     }
     if (!found)
     {
-      Compound_Selector* cpy = new (ctx.mem) Compound_Selector(*rhs);
+      Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *rhs);
       (*cpy) << this;
       return cpy;
     }
-    Compound_Selector* cpy = new (ctx.mem) Compound_Selector(rhs->pstate());
+    Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, rhs->pstate());
     for (size_t j = 0; j < i; ++j)
     { (*cpy) << (*rhs)[j]; }
     (*cpy) << this;
@@ -311,7 +311,7 @@ namespace Sass {
       if (!rhs->is_universal_ns())
       {
         // creaty the copy inside (avoid unnecessary copies)
-        Type_Selector* ts = new (ctx.mem) Type_Selector(*this);
+        Type_Selector* ts = SASS_MEMORY_NEW(ctx.mem, Type_Selector, *this);
         // overwrite the name if star is given as name
         if (ts->name() == "*") { ts->name(rhs->name()); }
         // now overwrite the namespace name and flag
@@ -325,7 +325,7 @@ namespace Sass {
     if (name() == "*" && rhs->name() != "*")
     {
       // creaty the copy inside (avoid unnecessary copies)
-      Type_Selector* ts = new (ctx.mem) Type_Selector(*this);
+      Type_Selector* ts = SASS_MEMORY_NEW(ctx.mem, Type_Selector, *this);
       // simply set the new name
       ts->name(rhs->name());
       // return copy
@@ -341,7 +341,7 @@ namespace Sass {
 
     // if the rhs is empty, just return a copy of this
     if (rhs->length() == 0) {
-      Compound_Selector* cpy = new (ctx.mem) Compound_Selector(rhs->pstate());
+      Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, rhs->pstate());
       (*cpy) << this;
       return cpy;
     }
@@ -353,14 +353,14 @@ namespace Sass {
       if (typeid(*rhs_0) == typeid(Type_Selector))
       {
         // if rhs is universal, just return this tagname + rhs's qualifiers
-        Compound_Selector* cpy = new (ctx.mem) Compound_Selector(*rhs);
+        Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *rhs);
         Type_Selector* ts = static_cast<Type_Selector*>(rhs_0);
         (*cpy)[0] = this->unify_with(ts, ctx);
         return cpy;
       }
       else if (dynamic_cast<Selector_Qualifier*>(rhs_0)) {
         // qualifier is `.class`, so we can prefix with `ns|*.class`
-        Compound_Selector* cpy = new (ctx.mem) Compound_Selector(rhs->pstate());
+        Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, rhs->pstate());
         if (has_ns() && !rhs_0->has_ns()) {
           if (ns() != "*") (*cpy) << this;
         }
@@ -378,13 +378,13 @@ namespace Sass {
       // if rhs is universal, just return this tagname + rhs's qualifiers
       if (rhs_0->name() != "*" && rhs_0->ns() != "*" && rhs_0->name() != name()) return 0;
       // otherwise create new compound and unify first simple selector
-      Compound_Selector* copy = new (ctx.mem) Compound_Selector(*rhs);
+      Compound_Selector* copy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *rhs);
       (*copy)[0] = this->unify_with(rhs_0, ctx);
       return copy;
 
     }
     // else it's a tag name and a bunch of qualifiers -- just append them
-    Compound_Selector* cpy = new (ctx.mem) Compound_Selector(rhs->pstate());
+    Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, rhs->pstate());
     if (name() != "*") (*cpy) << this;
     (*cpy) += rhs;
     return cpy;
@@ -588,10 +588,11 @@ namespace Sass {
   Complex_Selector* Compound_Selector::to_complex(Memory_Manager<AST_Node>& mem)
   {
     // create an intermediate complex selector
-    return new (mem) Complex_Selector(pstate(),
-                                      Complex_Selector::ANCESTOR_OF,
-                                      this,
-                                      0);
+    return SASS_MEMORY_NEW(mem, Complex_Selector,
+                           pstate(),
+                           Complex_Selector::ANCESTOR_OF,
+                           this,
+                           0);
   }
 
   Selector_List* Complex_Selector::unify_with(Complex_Selector* other, Context& ctx)
@@ -652,7 +653,7 @@ namespace Sass {
 
     // do some magic we inherit from node and extend
     Node node = Extend::subweave(lhsNode, rhsNode, ctx);
-    Selector_List* result = new (ctx.mem) Selector_List(pstate());
+    Selector_List* result = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
     NodeDequePtr col = node.collection(); // move from collection to list
     for (NodeDeque::iterator it = col->begin(), end = col->end(); it != end; it++)
     { (*result) << nodeToComplexSelector(Node::naiveTrim(*it, ctx), ctx); }
@@ -796,7 +797,7 @@ namespace Sass {
   {
     if (!tail()) return 0;
     if (!head()) return tail()->context(ctx);
-    Complex_Selector* cpy = new (ctx.mem) Complex_Selector(pstate(), combinator(), head(), tail()->context(ctx));
+    Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pstate(), combinator(), head(), tail()->context(ctx));
     cpy->media_block(media_block());
     return cpy;
   }
@@ -829,7 +830,7 @@ namespace Sass {
 
     if (last()) {
       if (last()->combinator() != ANCESTOR_OF && c != ANCESTOR_OF) {
-        Complex_Selector* inter = new (ctx.mem) Complex_Selector(pstate());
+        Complex_Selector* inter = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pstate());
         inter->reference(r);
         inter->combinator(c);
         inter->tail(t);
@@ -848,9 +849,9 @@ namespace Sass {
 
   Selector_List* Selector_List::parentize(Selector_List* ps, Context& ctx)
   {
-    Selector_List* ss = new (ctx.mem) Selector_List(pstate());
+    Selector_List* ss = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
     for (size_t pi = 0, pL = ps->length(); pi < pL; ++pi) {
-      Selector_List* list = new (ctx.mem) Selector_List(pstate());
+      Selector_List* list = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
       *list << (*ps)[pi];
       for (size_t si = 0, sL = this->length(); si < sL; ++si) {
         *ss += (*this)[si]->parentize(list, ctx);
@@ -874,7 +875,7 @@ namespace Sass {
       // mix parent complex selector into the compound list
       if (dynamic_cast<Parent_Selector*>((*head)[0])) {
         if (parents && parents->length()) {
-          Selector_List* retval = new (ctx.mem) Selector_List(pstate());
+          Selector_List* retval = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
           if (tails && tails->length() > 0) {
             for (size_t n = 0, nL = tails->length(); n < nL; ++n) {
               for (size_t i = 0, iL = parents->length(); i < iL; ++i) {
@@ -912,12 +913,12 @@ namespace Sass {
         }
         // have no parent but some tails
         else {
-          Selector_List* retval = new (ctx.mem) Selector_List(pstate());
+          Selector_List* retval = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
           if (tails && tails->length() > 0) {
             for (size_t n = 0, nL = tails->length(); n < nL; ++n) {
               Complex_Selector* cpy = this->clone(ctx);
               cpy->tail((*tails)[n]->cloneFully(ctx));
-              cpy->head(new (ctx.mem) Compound_Selector(head->pstate()));
+              cpy->head(SASS_MEMORY_NEW(ctx.mem, Compound_Selector, head->pstate()));
               for (size_t i = 1, L = this->head()->length(); i < L; ++i)
                 *cpy->head() << (*this->head())[i];
               if (!cpy->head()->length()) cpy->head(0);
@@ -927,7 +928,7 @@ namespace Sass {
           // have no parent and not tails
           else {
             Complex_Selector* cpy = this->clone(ctx);
-            cpy->head(new (ctx.mem) Compound_Selector(head->pstate()));
+            cpy->head(SASS_MEMORY_NEW(ctx.mem, Compound_Selector, head->pstate()));
             for (size_t i = 1, L = this->head()->length(); i < L; ++i)
               *cpy->head() << (*this->head())[i];
             if (!cpy->head()->length()) cpy->head(0);
@@ -953,7 +954,7 @@ namespace Sass {
 
   Selector_List* Complex_Selector::tails(Context& ctx, Selector_List* tails)
   {
-    Selector_List* rv = new (ctx.mem) Selector_List(pstate_);
+    Selector_List* rv = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate_);
     if (tails && tails->length()) {
       for (size_t i = 0, iL = tails->length(); i < iL; ++i) {
         Complex_Selector* pr = this->clone(ctx);
@@ -1050,14 +1051,14 @@ namespace Sass {
 
   Complex_Selector* Complex_Selector::clone(Context& ctx) const
   {
-    Complex_Selector* cpy = new (ctx.mem) Complex_Selector(*this);
+    Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, *this);
     if (tail()) cpy->tail(tail()->clone(ctx));
     return cpy;
   }
 
   Complex_Selector* Complex_Selector::cloneFully(Context& ctx) const
   {
-    Complex_Selector* cpy = new (ctx.mem) Complex_Selector(*this);
+    Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, *this);
 
     if (head()) {
       cpy->head(head()->clone(ctx));
@@ -1072,19 +1073,19 @@ namespace Sass {
 
   Compound_Selector* Compound_Selector::clone(Context& ctx) const
   {
-    Compound_Selector* cpy = new (ctx.mem) Compound_Selector(*this);
+    Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *this);
     return cpy;
   }
 
   Selector_List* Selector_List::clone(Context& ctx) const
   {
-    Selector_List* cpy = new (ctx.mem) Selector_List(*this);
+    Selector_List* cpy = SASS_MEMORY_NEW(ctx.mem, Selector_List, *this);
     return cpy;
   }
 
   Selector_List* Selector_List::cloneFully(Context& ctx) const
   {
-    Selector_List* cpy = new (ctx.mem) Selector_List(pstate());
+    Selector_List* cpy = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
     for (size_t i = 0, L = length(); i < L; ++i) {
       *cpy << (*this)[i]->cloneFully(ctx);
     }
@@ -1182,7 +1183,7 @@ namespace Sass {
     }
 
     // Creates the final Selector_List by combining all the complex selectors
-    Selector_List* final_result = new (ctx.mem) Selector_List(pstate());
+    Selector_List* final_result = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
     for (auto itr = unified_complex_selectors.begin(); itr != unified_complex_selectors.end(); ++itr) {
       *final_result << *itr;
     }
@@ -1235,7 +1236,7 @@ namespace Sass {
   Compound_Selector* Compound_Selector::minus(Compound_Selector* rhs, Context& ctx)
   {
     To_String to_string(&ctx);
-    Compound_Selector* result = new (ctx.mem) Compound_Selector(pstate());
+    Compound_Selector* result = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pstate());
     // result->has_parent_reference(has_parent_reference());
 
     // not very efficient because it needs to preserve order

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -74,17 +74,19 @@ namespace Sass {
             // otherwise we will not be able to fetch it again
             else {
               // create a new list object for wrapped items
-              List* arglist = new (ctx.mem) List(p->pstate(),
-                                                 0,
-                                                 rest->separator(),
-                                                 true);
+              List* arglist = SASS_MEMORY_NEW(ctx.mem, List,
+                                              p->pstate(),
+                                              0,
+                                              rest->separator(),
+                                              true);
               // wrap each item from list as an argument
               for (Expression* item : rest->elements()) {
-                (*arglist) << new (ctx.mem) Argument(item->pstate(),
-                                                     item,
-                                                     "",
-                                                     false,
-                                                     false);
+                (*arglist) << SASS_MEMORY_NEW(ctx.mem, Argument,
+                                              item->pstate(),
+                                              item,
+                                              "",
+                                              false,
+                                              false);
               }
               // assign new arglist to environment
               env->local_frame()[p->name()] = arglist;
@@ -97,25 +99,27 @@ namespace Sass {
         } else if (a->is_keyword_argument()) {
 
           // expand keyword arguments into their parameters
-          List* arglist = new (ctx.mem) List(p->pstate(), 0, SASS_COMMA, true);
+          List* arglist = SASS_MEMORY_NEW(ctx.mem, List, p->pstate(), 0, SASS_COMMA, true);
           env->local_frame()[p->name()] = arglist;
           Map* argmap = static_cast<Map*>(a->value());
           for (auto key : argmap->keys()) {
             std::string name = unquote(static_cast<String_Constant*>(key)->value());
-            (*arglist) << new (ctx.mem) Argument(key->pstate(),
-                                                 argmap->at(key),
-                                                 name,
-                                                 false,
-                                                 false);
+            (*arglist) << SASS_MEMORY_NEW(ctx.mem, Argument,
+                                          key->pstate(),
+                                          argmap->at(key),
+                                          name,
+                                          false,
+                                          false);
           }
 
         } else {
 
           // create a new list object for wrapped items
-          List* arglist = new (ctx.mem) List(p->pstate(),
-                                             0,
-                                             SASS_COMMA,
-                                             true);
+          List* arglist = SASS_MEMORY_NEW(ctx.mem, List,
+                                          p->pstate(),
+                                          0,
+                                          SASS_COMMA,
+                                          true);
           // consume the next args
           while (ia < LA) {
             // get and post inc
@@ -125,11 +129,12 @@ namespace Sass {
             // skip any list completely if empty
             if (ls && ls->empty()) continue;
             // check if we have rest argument
-            (*arglist) << new (ctx.mem) Argument(a->pstate(),
-                                                 a->value(),
-                                                 a->name(),
-                                                 false,
-                                                 false);
+            (*arglist) << SASS_MEMORY_NEW(ctx.mem, Argument,
+                                          a->pstate(),
+                                          a->value(),
+                                          a->name(),
+                                          false,
+                                          false);
             // check if we have rest argument
             if (a->is_rest_argument()) {
               // preserve the list separator from rest args
@@ -160,11 +165,12 @@ namespace Sass {
         // otherwise move one of the rest args into the param, converting to argument if necessary
         if (!(a = dynamic_cast<Argument*>((*arglist)[0]))) {
           Expression* a_to_convert = (*arglist)[0];
-          a = new (ctx.mem) Argument(a_to_convert->pstate(),
-                                     a_to_convert,
-                                     "",
-                                     false,
-                                     false);
+          a = SASS_MEMORY_NEW(ctx.mem, Argument,
+                              a_to_convert->pstate(),
+                              a_to_convert,
+                              "",
+                              false,
+                              false);
         }
         arglist->elements().erase(arglist->elements().begin());
         if (!arglist->length() || (!arglist->is_arglist() && ip + 1 == LP)) {
@@ -235,10 +241,11 @@ namespace Sass {
       // cerr << "********" << endl;
       if (!env->has_local(leftover->name())) {
         if (leftover->is_rest_parameter()) {
-          env->local_frame()[leftover->name()] = new (ctx.mem) List(leftover->pstate(),
-                                                                      0,
-                                                                      SASS_COMMA,
-                                                                      true);
+          env->local_frame()[leftover->name()] = SASS_MEMORY_NEW(ctx.mem, List,
+                                                                   leftover->pstate(),
+                                                                   0,
+                                                                   SASS_COMMA,
+                                                                   true);
         }
         else if (leftover->default_value()) {
           Expression* dv = leftover->default_value()->perform(eval);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -438,12 +438,13 @@ namespace Sass {
 
   void register_overload_stub(Context& ctx, std::string name, Env* env)
   {
-    Definition* stub = new (ctx.mem) Definition(ParserState("[built-in function]"),
-                                                0,
-                                                name,
-                                                0,
-                                                0,
-                                                true);
+    Definition* stub = SASS_MEMORY_NEW(ctx.mem, Definition,
+                                       ParserState("[built-in function]"),
+                                       0,
+                                       name,
+                                       0,
+                                       0,
+                                       true);
     (*env)[name + "[f]"] = stub;
   }
 

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -23,7 +23,7 @@ namespace Sass {
 
   Statement* Cssize::operator()(Block* b)
   {
-    Block* bb = new (ctx.mem) Block(b->pstate(), b->length(), b->is_root());
+    Block* bb = SASS_MEMORY_NEW(ctx.mem, Block, b->pstate(), b->length(), b->is_root());
     // bb->tabs(b->tabs());
     block_stack.push_back(bb);
     append_block(b);
@@ -37,14 +37,15 @@ namespace Sass {
 
     if (parent()->statement_type() == Statement::RULESET)
     {
-      return (r->is_keyframes()) ? new (ctx.mem) Bubble(r->pstate(), r) : bubble(r);
+      return (r->is_keyframes()) ? SASS_MEMORY_NEW(ctx.mem, Bubble, r->pstate(), r) : bubble(r);
     }
 
     p_stack.push_back(r);
-    At_Rule* rr = new (ctx.mem) At_Rule(r->pstate(),
-                                        r->keyword(),
-                                        r->selector(),
-                                        r->block() ? r->block()->perform(this)->block() : 0);
+    At_Rule* rr = SASS_MEMORY_NEW(ctx.mem, At_Rule,
+                                  r->pstate(),
+                                  r->keyword(),
+                                  r->selector(),
+                                  r->block() ? r->block()->perform(this)->block() : 0);
     if (r->value()) rr->value(r->value());
     p_stack.pop_back();
 
@@ -61,15 +62,15 @@ namespace Sass {
 
     }
 
-    Block* result = new (ctx.mem) Block(rr->pstate());
+    Block* result = SASS_MEMORY_NEW(ctx.mem, Block, rr->pstate());
     if (!(directive_exists || rr->is_keyframes()))
     {
       At_Rule* empty_node = static_cast<At_Rule*>(rr);
-      empty_node->block(new (ctx.mem) Block(rr->block() ? rr->block()->pstate() : rr->pstate()));
+      empty_node->block(SASS_MEMORY_NEW(ctx.mem, Block, rr->block() ? rr->block()->pstate() : rr->pstate()));
       *result << empty_node;
     }
 
-    Statement* ss = debubble(rr->block() ? rr->block() : new (ctx.mem) Block(rr->pstate()), rr);
+    Statement* ss = debubble(rr->block() ? rr->block() : SASS_MEMORY_NEW(ctx.mem, Block, rr->pstate()), rr);
     for (size_t i = 0, L = ss->block()->length(); i < L; ++i) {
       *result << (*ss->block())[i];
     }
@@ -81,8 +82,9 @@ namespace Sass {
   {
     if (!r->block() || !r->block()->length()) return r;
 
-    Keyframe_Rule* rr = new (ctx.mem) Keyframe_Rule(r->pstate(),
-                                                    r->block()->perform(this)->block());
+    Keyframe_Rule* rr = SASS_MEMORY_NEW(ctx.mem, Keyframe_Rule,
+                                        r->pstate(),
+                                        r->block()->perform(this)->block());
     if (r->selector()) rr->selector(r->selector());
 
     return debubble(rr->block(), rr)->block();
@@ -91,14 +93,15 @@ namespace Sass {
   Statement* Cssize::operator()(Ruleset* r)
   {
     p_stack.push_back(r);
-    Ruleset* rr = new (ctx.mem) Ruleset(r->pstate(),
-                                        r->selector(),
-                                        r->block()->perform(this)->block());
+    Ruleset* rr = SASS_MEMORY_NEW(ctx.mem, Ruleset,
+                                  r->pstate(),
+                                  r->selector(),
+                                  r->block()->perform(this)->block());
     // rr->tabs(r->block()->tabs());
     p_stack.pop_back();
 
-    Block* props = new (ctx.mem) Block(rr->block()->pstate());
-    Block* rules = new (ctx.mem) Block(rr->block()->pstate());
+    Block* props = SASS_MEMORY_NEW(ctx.mem, Block, rr->block()->pstate());
+    Block* rules = SASS_MEMORY_NEW(ctx.mem, Block, rr->block()->pstate());
     for (size_t i = 0, L = rr->block()->length(); i < L; i++)
     {
       Statement* s = (*rr->block())[i];
@@ -108,7 +111,7 @@ namespace Sass {
 
     if (props->length())
     {
-      Block* bb = new (ctx.mem) Block(rr->block()->pstate());
+      Block* bb = SASS_MEMORY_NEW(ctx.mem, Block, rr->block()->pstate());
       *bb += props;
       rr->block(bb);
 
@@ -143,13 +146,14 @@ namespace Sass {
     { return bubble(m); }
 
     if (parent()->statement_type() == Statement::MEDIA)
-    { return new (ctx.mem) Bubble(m->pstate(), m); }
+    { return SASS_MEMORY_NEW(ctx.mem, Bubble, m->pstate(), m); }
 
     p_stack.push_back(m);
 
-    Media_Block* mm = new (ctx.mem) Media_Block(m->pstate(),
-                                                m->media_queries(),
-                                                m->block()->perform(this)->block());
+    Media_Block* mm = SASS_MEMORY_NEW(ctx.mem, Media_Block,
+                                      m->pstate(),
+                                      m->media_queries(),
+                                      m->block()->perform(this)->block());
     mm->tabs(m->tabs());
 
     p_stack.pop_back();
@@ -167,9 +171,10 @@ namespace Sass {
 
     p_stack.push_back(m);
 
-    Supports_Block* mm = new (ctx.mem) Supports_Block(m->pstate(),
-                                                    m->condition(),
-                                                    m->block()->perform(this)->block());
+    Supports_Block* mm = SASS_MEMORY_NEW(ctx.mem, Supports_Block,
+                                       m->pstate(),
+                                       m->condition(),
+                                       m->block()->perform(this)->block());
     mm->tabs(m->tabs());
 
     p_stack.pop_back();
@@ -198,7 +203,7 @@ namespace Sass {
 
     if (m->exclude_node(parent()))
     {
-      return new (ctx.mem) Bubble(m->pstate(), m);
+      return SASS_MEMORY_NEW(ctx.mem, Bubble, m->pstate(), m);
     }
 
     return bubble(m);
@@ -206,7 +211,7 @@ namespace Sass {
 
   Statement* Cssize::bubble(At_Rule* m)
   {
-    Block* bb = new (ctx.mem) Block(this->parent()->pstate());
+    Block* bb = SASS_MEMORY_NEW(ctx.mem, Block, this->parent()->pstate());
     Has_Block* new_rule = static_cast<Has_Block*>(shallow_copy(this->parent()));
     new_rule->block(bb);
     new_rule->tabs(this->parent()->tabs());
@@ -216,21 +221,22 @@ namespace Sass {
       *new_rule->block() << (*m->block())[i];
     }
 
-    Block* wrapper_block = new (ctx.mem) Block(m->block() ? m->block()->pstate() : m->pstate());
+    Block* wrapper_block = SASS_MEMORY_NEW(ctx.mem, Block, m->block() ? m->block()->pstate() : m->pstate());
     *wrapper_block << new_rule;
-    At_Rule* mm = new (ctx.mem) At_Rule(m->pstate(),
-                                        m->keyword(),
-                                        m->selector(),
-                                        wrapper_block);
+    At_Rule* mm = SASS_MEMORY_NEW(ctx.mem, At_Rule,
+                                  m->pstate(),
+                                  m->keyword(),
+                                  m->selector(),
+                                  wrapper_block);
     if (m->value()) mm->value(m->value());
 
-    Bubble* bubble = new (ctx.mem) Bubble(mm->pstate(), mm);
+    Bubble* bubble = SASS_MEMORY_NEW(ctx.mem, Bubble, mm->pstate(), mm);
     return bubble;
   }
 
   Statement* Cssize::bubble(At_Root_Block* m)
   {
-    Block* bb = new (ctx.mem) Block(this->parent()->pstate());
+    Block* bb = SASS_MEMORY_NEW(ctx.mem, Block, this->parent()->pstate());
     Has_Block* new_rule = static_cast<Has_Block*>(shallow_copy(this->parent()));
     new_rule->block(bb);
     new_rule->tabs(this->parent()->tabs());
@@ -239,12 +245,13 @@ namespace Sass {
       *new_rule->block() << (*m->block())[i];
     }
 
-    Block* wrapper_block = new (ctx.mem) Block(m->block()->pstate());
+    Block* wrapper_block = SASS_MEMORY_NEW(ctx.mem, Block, m->block()->pstate());
     *wrapper_block << new_rule;
-    At_Root_Block* mm = new (ctx.mem) At_Root_Block(m->pstate(),
-                                                    wrapper_block,
-                                                    m->expression());
-    Bubble* bubble = new (ctx.mem) Bubble(mm->pstate(), mm);
+    At_Root_Block* mm = SASS_MEMORY_NEW(ctx.mem, At_Root_Block,
+                                        m->pstate(),
+                                        wrapper_block,
+                                        m->expression());
+    Bubble* bubble = SASS_MEMORY_NEW(ctx.mem, Bubble, mm->pstate(), mm);
     return bubble;
   }
 
@@ -252,25 +259,27 @@ namespace Sass {
   {
     Ruleset* parent = static_cast<Ruleset*>(shallow_copy(this->parent()));
 
-    Block* bb = new (ctx.mem) Block(parent->block()->pstate());
-    Ruleset* new_rule = new (ctx.mem) Ruleset(parent->pstate(),
-                                              parent->selector(),
-                                              bb);
+    Block* bb = SASS_MEMORY_NEW(ctx.mem, Block, parent->block()->pstate());
+    Ruleset* new_rule = SASS_MEMORY_NEW(ctx.mem, Ruleset,
+                                        parent->pstate(),
+                                        parent->selector(),
+                                        bb);
     new_rule->tabs(parent->tabs());
 
     for (size_t i = 0, L = m->block()->length(); i < L; ++i) {
       *new_rule->block() << (*m->block())[i];
     }
 
-    Block* wrapper_block = new (ctx.mem) Block(m->block()->pstate());
+    Block* wrapper_block = SASS_MEMORY_NEW(ctx.mem, Block, m->block()->pstate());
     *wrapper_block << new_rule;
-    Supports_Block* mm = new (ctx.mem) Supports_Block(m->pstate(),
-                                                    m->condition(),
-                                                    wrapper_block);
+    Supports_Block* mm = SASS_MEMORY_NEW(ctx.mem, Supports_Block,
+                                       m->pstate(),
+                                       m->condition(),
+                                       wrapper_block);
 
     mm->tabs(m->tabs());
 
-    Bubble* bubble = new (ctx.mem) Bubble(mm->pstate(), mm);
+    Bubble* bubble = SASS_MEMORY_NEW(ctx.mem, Bubble, mm->pstate(), mm);
     return bubble;
   }
 
@@ -278,26 +287,28 @@ namespace Sass {
   {
     Ruleset* parent = static_cast<Ruleset*>(shallow_copy(this->parent()));
 
-    Block* bb = new (ctx.mem) Block(parent->block()->pstate());
-    Ruleset* new_rule = new (ctx.mem) Ruleset(parent->pstate(),
-                                              parent->selector(),
-                                              bb);
+    Block* bb = SASS_MEMORY_NEW(ctx.mem, Block, parent->block()->pstate());
+    Ruleset* new_rule = SASS_MEMORY_NEW(ctx.mem, Ruleset,
+                                        parent->pstate(),
+                                        parent->selector(),
+                                        bb);
     new_rule->tabs(parent->tabs());
 
     for (size_t i = 0, L = m->block()->length(); i < L; ++i) {
       *new_rule->block() << (*m->block())[i];
     }
 
-    Block* wrapper_block = new (ctx.mem) Block(m->block()->pstate());
+    Block* wrapper_block = SASS_MEMORY_NEW(ctx.mem, Block, m->block()->pstate());
     *wrapper_block << new_rule;
-    Media_Block* mm = new (ctx.mem) Media_Block(m->pstate(),
-                                                m->media_queries(),
-                                                wrapper_block,
-                                                0);
+    Media_Block* mm = SASS_MEMORY_NEW(ctx.mem, Media_Block,
+                                      m->pstate(),
+                                      m->media_queries(),
+                                      wrapper_block,
+                                      0);
 
     mm->tabs(m->tabs());
 
-    Bubble* bubble = new (ctx.mem) Bubble(mm->pstate(), mm);
+    Bubble* bubble = SASS_MEMORY_NEW(ctx.mem, Bubble, mm->pstate(), mm);
 
     return bubble;
   }
@@ -310,7 +321,7 @@ namespace Sass {
   Statement* Cssize::flatten(Statement* s)
   {
     Block* bb = s->block();
-    Block* result = new (ctx.mem) Block(bb->pstate(), 0, bb->is_root());
+    Block* result = SASS_MEMORY_NEW(ctx.mem, Block, bb->pstate(), 0, bb->is_root());
     for (size_t i = 0, L = bb->length(); i < L; ++i) {
       Statement* ss = (*bb)[i];
       if (ss->block()) {
@@ -340,7 +351,7 @@ namespace Sass {
       }
       else
       {
-        Block* wrapper_block = new (ctx.mem) Block(value->pstate());
+        Block* wrapper_block = SASS_MEMORY_NEW(ctx.mem, Block, value->pstate());
         *wrapper_block << value;
         results.push_back(std::make_pair(key, wrapper_block));
       }
@@ -353,24 +364,24 @@ namespace Sass {
     switch (s->statement_type())
     {
       case Statement::RULESET:
-        return new (ctx.mem) Ruleset(*static_cast<Ruleset*>(s));
+        return SASS_MEMORY_NEW(ctx.mem, Ruleset, *static_cast<Ruleset*>(s));
       case Statement::MEDIA:
-        return new (ctx.mem) Media_Block(*static_cast<Media_Block*>(s));
+        return SASS_MEMORY_NEW(ctx.mem, Media_Block, *static_cast<Media_Block*>(s));
       case Statement::BUBBLE:
-        return new (ctx.mem) Bubble(*static_cast<Bubble*>(s));
+        return SASS_MEMORY_NEW(ctx.mem, Bubble, *static_cast<Bubble*>(s));
       case Statement::DIRECTIVE:
-        return new (ctx.mem) At_Rule(*static_cast<At_Rule*>(s));
+        return SASS_MEMORY_NEW(ctx.mem, At_Rule, *static_cast<At_Rule*>(s));
       case Statement::SUPPORTS:
-        return new (ctx.mem) Supports_Block(*static_cast<Supports_Block*>(s));
+        return SASS_MEMORY_NEW(ctx.mem, Supports_Block, *static_cast<Supports_Block*>(s));
       case Statement::ATROOT:
-        return new (ctx.mem) At_Root_Block(*static_cast<At_Root_Block*>(s));
+        return SASS_MEMORY_NEW(ctx.mem, At_Root_Block, *static_cast<At_Root_Block*>(s));
       case Statement::KEYFRAMERULE:
-        return new (ctx.mem) Keyframe_Rule(*static_cast<Keyframe_Rule*>(s));
+        return SASS_MEMORY_NEW(ctx.mem, Keyframe_Rule, *static_cast<Keyframe_Rule*>(s));
       case Statement::NONE:
       default:
         error("unknown internal error; please contact the LibSass maintainers", s->pstate(), backtrace);
-        String_Quoted* msg = new (ctx.mem) String_Quoted(ParserState("[WARN]"), std::string("`CSSize` can't clone ") + typeid(*s).name());
-        return new (ctx.mem) Warning(ParserState("[WARN]"), msg);
+        String_Quoted* msg = SASS_MEMORY_NEW(ctx.mem, String_Quoted, ParserState("[WARN]"), std::string("`CSSize` can't clone ") + typeid(*s).name());
+        return SASS_MEMORY_NEW(ctx.mem, Warning, ParserState("[WARN]"), msg);
     }
   }
 
@@ -378,7 +389,7 @@ namespace Sass {
   {
     Has_Block* previous_parent = 0;
     std::vector<std::pair<bool, Block*>> baz = slice_by_bubble(children);
-    Block* result = new (ctx.mem) Block(children->pstate());
+    Block* result = SASS_MEMORY_NEW(ctx.mem, Block, children->pstate());
 
     for (size_t i = 0, L = baz.size(); i < L; ++i) {
       bool is_bubble = baz[i].first;
@@ -404,9 +415,10 @@ namespace Sass {
         continue;
       }
 
-      Block* wrapper_block = new (ctx.mem) Block(children->block()->pstate(),
-                                                 children->block()->length(),
-                                                 children->block()->is_root());
+      Block* wrapper_block = SASS_MEMORY_NEW(ctx.mem, Block,
+                                             children->block()->pstate(),
+                                             children->block()->length(),
+                                             children->block()->is_root());
 
       for (size_t j = 0, K = slice->length(); j < K; ++j)
       {
@@ -435,9 +447,10 @@ namespace Sass {
 
         if (!ss) continue;
 
-        Block* bb = new (ctx.mem) Block(children->block()->pstate(),
-                                        children->block()->length(),
-                                        children->block()->is_root());
+        Block* bb = SASS_MEMORY_NEW(ctx.mem, Block,
+                                    children->block()->pstate(),
+                                    children->block()->length(),
+                                    children->block()->is_root());
         *bb << ss->perform(this);
         Statement* wrapper = flatten(bb);
         *wrapper_block << wrapper;
@@ -479,9 +492,10 @@ namespace Sass {
 
   List* Cssize::merge_media_queries(Media_Block* m1, Media_Block* m2)
   {
-    List* qq = new (ctx.mem) List(m1->media_queries()->pstate(),
-                                  m1->media_queries()->length(),
-                                  SASS_COMMA);
+    List* qq = SASS_MEMORY_NEW(ctx.mem, List,
+                               m1->media_queries()->pstate(),
+                               m1->media_queries()->length(),
+                               SASS_COMMA);
 
     for (size_t i = 0, L = m1->media_queries()->length(); i < L; i++) {
       for (size_t j = 0, K = m2->media_queries()->length(); j < K; j++) {
@@ -534,13 +548,14 @@ namespace Sass {
       mod = m1.empty() ? m2 : m1;
     }
 
-    Media_Query* mm = new (ctx.mem) Media_Query(
-      mq1->pstate(), 0,
-      mq1->length() + mq2->length(), mod == "not", mod == "only"
-    );
+    Media_Query* mm = SASS_MEMORY_NEW(ctx.mem, Media_Query,
+
+mq1->pstate(), 0,
+mq1->length() + mq2->length(), mod == "not", mod == "only"
+);
 
     if (!type.empty()) {
-      mm->media_type(new (ctx.mem) String_Quoted(mq1->pstate(), type));
+      mm->media_type(SASS_MEMORY_NEW(ctx.mem, String_Quoted, mq1->pstate(), type));
     }
 
     *mm += mq2;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -179,7 +179,7 @@ namespace Sass {
     double end = sass_end->value();
     // only create iterator once in this environment
     Env* env = exp.environment();
-    Number* it = new (env->mem) Number(low->pstate(), start, sass_end->unit());
+    Number* it = SASS_MEMORY_NEW(env->mem, Number, low->pstate(), start, sass_end->unit());
     AST_Node* old_var = env->has_local(variable) ? env->get_local(variable) : 0;
     env->set_local(variable, it);
     Block* body = f->block();
@@ -224,7 +224,7 @@ namespace Sass {
       map = static_cast<Map*>(expr);
     }
     else if (expr->concrete_type() != Expression::LIST) {
-      list = new (ctx.mem) List(expr->pstate(), 1, SASS_COMMA);
+      list = SASS_MEMORY_NEW(ctx.mem, List, expr->pstate(), 1, SASS_COMMA);
       *list << expr;
     }
     else {
@@ -244,7 +244,7 @@ namespace Sass {
         Expression* value = map->at(key);
 
         if (variables.size() == 1) {
-          List* variable = new (ctx.mem) List(map->pstate(), 2, SASS_SPACE);
+          List* variable = SASS_MEMORY_NEW(ctx.mem, List, map->pstate(), 2, SASS_SPACE);
           *variable << key;
           *variable << value;
           env->set_local(variables[0], variable);
@@ -272,7 +272,7 @@ namespace Sass {
           } else {
             for (size_t j = 0, K = variables.size(); j < K; ++j) {
               Expression* res = j >= scalars->length()
-                ? new (ctx.mem) Null(expr->pstate())
+                ? SASS_MEMORY_NEW(ctx.mem, Null, expr->pstate())
                 : (*scalars)[j];
               env->set_local(variables[j], res);
             }
@@ -281,7 +281,7 @@ namespace Sass {
           if (variables.size() > 0) {
             env->set_local(variables[0], e);
             for (size_t j = 1, K = variables.size(); j < K; ++j) {
-              Expression* res = new (ctx.mem) Null(expr->pstate());
+              Expression* res = SASS_MEMORY_NEW(ctx.mem, Null, expr->pstate());
               env->set_local(variables[j], res);
             }
           }
@@ -413,10 +413,11 @@ namespace Sass {
   Expression* Eval::operator()(List* l)
   {
     if (l->is_expanded()) return l;
-    List* ll = new (ctx.mem) List(l->pstate(),
-                                  l->length(),
-                                  l->separator(),
-                                  l->is_arglist());
+    List* ll = SASS_MEMORY_NEW(ctx.mem, List,
+                               l->pstate(),
+                               l->length(),
+                               l->separator(),
+                               l->is_arglist());
     for (size_t i = 0, L = l->length(); i < L; ++i) {
       *ll << (*l)[i]->perform(this);
     }
@@ -435,8 +436,9 @@ namespace Sass {
       error("Duplicate key \"" + m->get_duplicate_key()->perform(&to_string) + "\" in map " + m->perform(&to_string) + ".", m->pstate());
     }
 
-    Map* mm = new (ctx.mem) Map(m->pstate(),
-                                  m->length());
+    Map* mm = SASS_MEMORY_NEW(ctx.mem, Map,
+                                m->pstate(),
+                                m->length());
     for (auto key : m->keys()) {
       Expression* ex_key = key->perform(this);
       Expression* ex_val = m->at(key)->perform(this);
@@ -502,7 +504,7 @@ namespace Sass {
         std::string value(str->value());
         const char* start = value.c_str();
         if (Prelexer::sequence < Prelexer::number >(start) != 0) {
-          rhs = new (ctx.mem) Textual(rhs->pstate(), Textual::DIMENSION, str->value());
+          rhs = SASS_MEMORY_NEW(ctx.mem, Textual, rhs->pstate(), Textual::DIMENSION, str->value());
           rhs->is_delayed(false); rhs = rhs->perform(this);
         }
       }
@@ -510,12 +512,12 @@ namespace Sass {
 
     // see if it's a relational expression
     switch(op_type) {
-      case Sass_OP::EQ:  return new (ctx.mem) Boolean(b->pstate(), eq(lhs, rhs));
-      case Sass_OP::NEQ: return new (ctx.mem) Boolean(b->pstate(), !eq(lhs, rhs));
-      case Sass_OP::GT:  return new (ctx.mem) Boolean(b->pstate(), !lt(lhs, rhs) && !eq(lhs, rhs));
-      case Sass_OP::GTE: return new (ctx.mem) Boolean(b->pstate(), !lt(lhs, rhs));
-      case Sass_OP::LT:  return new (ctx.mem) Boolean(b->pstate(), lt(lhs, rhs));
-      case Sass_OP::LTE: return new (ctx.mem) Boolean(b->pstate(), lt(lhs, rhs) || eq(lhs, rhs));
+      case Sass_OP::EQ:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), eq(lhs, rhs));
+      case Sass_OP::NEQ: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !eq(lhs, rhs));
+      case Sass_OP::GT:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !lt(lhs, rhs) && !eq(lhs, rhs));
+      case Sass_OP::GTE: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !lt(lhs, rhs));
+      case Sass_OP::LT:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), lt(lhs, rhs));
+      case Sass_OP::LTE: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), lt(lhs, rhs) || eq(lhs, rhs));
 
       default:                     break;
     }
@@ -566,12 +568,12 @@ namespace Sass {
   {
     Expression* operand = u->operand()->perform(this);
     if (u->type() == Unary_Expression::NOT) {
-      Boolean* result = new (ctx.mem) Boolean(u->pstate(), (bool)*operand);
+      Boolean* result = SASS_MEMORY_NEW(ctx.mem, Boolean, u->pstate(), (bool)*operand);
       result->value(!result->value());
       return result;
     }
     else if (operand->concrete_type() == Expression::NUMBER) {
-      Number* result = new (ctx.mem) Number(*static_cast<Number*>(operand));
+      Number* result = SASS_MEMORY_NEW(ctx.mem, Number, *static_cast<Number*>(operand));
       result->value(u->type() == Unary_Expression::MINUS
                     ? -result->value()
                     :  result->value());
@@ -582,11 +584,12 @@ namespace Sass {
       // Special cases: +/- variables which evaluate to null ouput just +/-,
       // but +/- null itself outputs the string
       if (operand->concrete_type() == Expression::NULL_VAL && typeid(*(u->operand())) == typeid(Variable)) {
-        u->operand(new (ctx.mem) String_Quoted(u->pstate(), ""));
+        u->operand(SASS_MEMORY_NEW(ctx.mem, String_Quoted, u->pstate(), ""));
       }
       else u->operand(operand);
-      String_Constant* result = new (ctx.mem) String_Quoted(u->pstate(),
-                                                              u->perform(&to_string));
+      String_Constant* result = SASS_MEMORY_NEW(ctx.mem, String_Quoted,
+                                                  u->pstate(),
+                                                  u->perform(&to_string));
       return result;
     }
     // unreachable
@@ -611,15 +614,17 @@ namespace Sass {
     if (!env->has(full_name)) {
       if (!env->has("*[f]")) {
         // just pass it through as a literal
-        Function_Call* lit = new (ctx.mem) Function_Call(c->pstate(),
-                                                         c->name(),
-                                                         args);
+        Function_Call* lit = SASS_MEMORY_NEW(ctx.mem, Function_Call,
+                                             c->pstate(),
+                                             c->name(),
+                                             args);
         To_String to_string(&ctx);
         if (args->has_named_arguments()) {
           error("Function " + c->name() + " doesn't support keyword arguments", c->pstate());
         }
-        return new (ctx.mem) String_Quoted(c->pstate(),
-                                           lit->perform(&to_string));
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted,
+                               c->pstate(),
+                               lit->perform(&to_string));
       } else {
         // call generic function
         full_name = "*[f]";
@@ -664,9 +669,9 @@ namespace Sass {
     else if (c_function) {
       Sass_Function_Fn c_func = sass_function_get_function(c_function);
       if (full_name == "*[f]") {
-        String_Quoted *str = new (ctx.mem) String_Quoted(c->pstate(), c->name());
-        Arguments* new_args = new (ctx.mem) Arguments(c->pstate());
-        *new_args << new (ctx.mem) Argument(c->pstate(), str);
+        String_Quoted *str = SASS_MEMORY_NEW(ctx.mem, String_Quoted, c->pstate(), c->name());
+        Arguments* new_args = SASS_MEMORY_NEW(ctx.mem, Arguments, c->pstate());
+        *new_args << SASS_MEMORY_NEW(ctx.mem, Argument, c->pstate(), str);
         *new_args += args;
         args = new_args;
       }
@@ -714,7 +719,7 @@ namespace Sass {
   {
     Expression* evaluated_name = s->name()->perform(this);
     Expression* evaluated_args = s->arguments()->perform(this);
-    String_Schema* ss = new (ctx.mem) String_Schema(s->pstate(), 2);
+    String_Schema* ss = SASS_MEMORY_NEW(ctx.mem, String_Schema, s->pstate(), 2);
     (*ss) << evaluated_name << evaluated_args;
     return ss->perform(this);
   }
@@ -732,30 +737,30 @@ namespace Sass {
 
     // behave according to as ruby sass (add leading zero)
     if (value->concrete_type() == Expression::NUMBER) {
-      value = new (ctx.mem) Number(*static_cast<Number*>(value));
+      value = SASS_MEMORY_NEW(ctx.mem, Number, *static_cast<Number*>(value));
       static_cast<Number*>(value)->zero(true);
     }
     else if (value->concrete_type() == Expression::STRING) {
       if (auto str = dynamic_cast<String_Quoted*>(value)) {
-        value = new (ctx.mem) String_Quoted(*str);
+        value = SASS_MEMORY_NEW(ctx.mem, String_Quoted, *str);
       } else if (auto str = dynamic_cast<String_Constant*>(value)) {
-        value = new (ctx.mem) String_Quoted(str->pstate(), str->perform(&to_string));
+        value = SASS_MEMORY_NEW(ctx.mem, String_Quoted, str->pstate(), str->perform(&to_string));
       }
     }
     else if (value->concrete_type() == Expression::LIST) {
-      value = new (ctx.mem) List(*static_cast<List*>(value));
+      value = SASS_MEMORY_NEW(ctx.mem, List, *static_cast<List*>(value));
     }
     else if (value->concrete_type() == Expression::MAP) {
-      value = new (ctx.mem) Map(*static_cast<Map*>(value));
+      value = SASS_MEMORY_NEW(ctx.mem, Map, *static_cast<Map*>(value));
     }
     else if (value->concrete_type() == Expression::BOOLEAN) {
-      value = new (ctx.mem) Boolean(*static_cast<Boolean*>(value));
+      value = SASS_MEMORY_NEW(ctx.mem, Boolean, *static_cast<Boolean*>(value));
     }
     else if (value->concrete_type() == Expression::COLOR) {
-      value = new (ctx.mem) Color(*static_cast<Color*>(value));
+      value = SASS_MEMORY_NEW(ctx.mem, Color, *static_cast<Color*>(value));
     }
     else if (value->concrete_type() == Expression::NULL_VAL) {
-      value = new (ctx.mem) Null(value->pstate());
+      value = SASS_MEMORY_NEW(ctx.mem, Null, value->pstate());
     }
     else if (value->concrete_type() == Expression::SELECTOR) {
       value = value->perform(this)->perform(&listize);
@@ -782,26 +787,29 @@ namespace Sass {
     switch (t->type())
     {
       case Textual::NUMBER:
-        result = new (ctx.mem) Number(t->pstate(),
-                                      sass_atof(num.c_str()),
-                                      "",
-                                      zero);
+        result = SASS_MEMORY_NEW(ctx.mem, Number,
+                                 t->pstate(),
+                                 sass_atof(num.c_str()),
+                                 "",
+                                 zero);
         break;
       case Textual::PERCENTAGE:
-        result = new (ctx.mem) Number(t->pstate(),
-                                      sass_atof(num.c_str()),
-                                      "%",
-                                      zero);
+        result = SASS_MEMORY_NEW(ctx.mem, Number,
+                                 t->pstate(),
+                                 sass_atof(num.c_str()),
+                                 "%",
+                                 zero);
         break;
       case Textual::DIMENSION:
-        result = new (ctx.mem) Number(t->pstate(),
-                                      sass_atof(num.c_str()),
-                                      Token(number(text.c_str())),
-                                      zero);
+        result = SASS_MEMORY_NEW(ctx.mem, Number,
+                                 t->pstate(),
+                                 sass_atof(num.c_str()),
+                                 Token(number(text.c_str())),
+                                 zero);
         break;
       case Textual::HEX: {
         if (t->value().substr(0, 1) != "#") {
-          result = new (ctx.mem) String_Quoted(t->pstate(), t->value());
+          result = SASS_MEMORY_NEW(ctx.mem, String_Quoted, t->pstate(), t->value());
           break;
         }
         std::string hext(t->value().substr(1)); // chop off the '#'
@@ -809,20 +817,22 @@ namespace Sass {
           std::string r(hext.substr(0,2));
           std::string g(hext.substr(2,2));
           std::string b(hext.substr(4,2));
-          result = new (ctx.mem) Color(t->pstate(),
-                                       static_cast<double>(strtol(r.c_str(), NULL, 16)),
-                                       static_cast<double>(strtol(g.c_str(), NULL, 16)),
-                                       static_cast<double>(strtol(b.c_str(), NULL, 16)),
-                                       1, true,
-                                       t->value());
+          result = SASS_MEMORY_NEW(ctx.mem, Color,
+                                   t->pstate(),
+                                   static_cast<double>(strtol(r.c_str(), NULL, 16)),
+                                   static_cast<double>(strtol(g.c_str(), NULL, 16)),
+                                   static_cast<double>(strtol(b.c_str(), NULL, 16)),
+                                   1, true,
+                                   t->value());
         }
         else {
-          result = new (ctx.mem) Color(t->pstate(),
-                                       static_cast<double>(strtol(std::string(2,hext[0]).c_str(), NULL, 16)),
-                                       static_cast<double>(strtol(std::string(2,hext[1]).c_str(), NULL, 16)),
-                                       static_cast<double>(strtol(std::string(2,hext[2]).c_str(), NULL, 16)),
-                                       1, false,
-                                       t->value());
+          result = SASS_MEMORY_NEW(ctx.mem, Color,
+                                   t->pstate(),
+                                   static_cast<double>(strtol(std::string(2,hext[0]).c_str(), NULL, 16)),
+                                   static_cast<double>(strtol(std::string(2,hext[1]).c_str(), NULL, 16)),
+                                   static_cast<double>(strtol(std::string(2,hext[2]).c_str(), NULL, 16)),
+                                   1, false,
+                                   t->value());
         }
       } break;
     }
@@ -945,7 +955,7 @@ namespace Sass {
         acc += interpolation((*s)[i]);
       }
     }
-    String_Quoted* str = new (ctx.mem) String_Quoted(s->pstate(), acc);
+    String_Quoted* str = SASS_MEMORY_NEW(ctx.mem, String_Quoted, s->pstate(), acc);
     if (!str->quote_mark()) {
       str->value(string_unescape(str->value()));
     } else if (str->quote_mark()) {
@@ -958,7 +968,7 @@ namespace Sass {
   Expression* Eval::operator()(String_Constant* s)
   {
     if (!s->is_delayed() && name_to_color(s->value())) {
-      Color* c = new (ctx.mem) Color(*name_to_color(s->value()));
+      Color* c = SASS_MEMORY_NEW(ctx.mem, Color, *name_to_color(s->value()));
       c->pstate(s->pstate());
       c->disp(s->value());
       return c;
@@ -975,18 +985,20 @@ namespace Sass {
   {
     Expression* left = c->left()->perform(this);
     Expression* right = c->right()->perform(this);
-    Supports_Operator* cc = new (ctx.mem) Supports_Operator(c->pstate(),
-                                                 static_cast<Supports_Condition*>(left),
-                                                 static_cast<Supports_Condition*>(right),
-                                                 c->operand());
+    Supports_Operator* cc = SASS_MEMORY_NEW(ctx.mem, Supports_Operator,
+                                 c->pstate(),
+                                 static_cast<Supports_Condition*>(left),
+                                 static_cast<Supports_Condition*>(right),
+                                 c->operand());
     return cc;
   }
 
   Expression* Eval::operator()(Supports_Negation* c)
   {
     Expression* condition = c->condition()->perform(this);
-    Supports_Negation* cc = new (ctx.mem) Supports_Negation(c->pstate(),
-                                                 static_cast<Supports_Condition*>(condition));
+    Supports_Negation* cc = SASS_MEMORY_NEW(ctx.mem, Supports_Negation,
+                                 c->pstate(),
+                                 static_cast<Supports_Condition*>(condition));
     return cc;
   }
 
@@ -994,17 +1006,19 @@ namespace Sass {
   {
     Expression* feature = c->feature()->perform(this);
     Expression* value = c->value()->perform(this);
-    Supports_Declaration* cc = new (ctx.mem) Supports_Declaration(c->pstate(),
-                                                 feature,
-                                                 value);
+    Supports_Declaration* cc = SASS_MEMORY_NEW(ctx.mem, Supports_Declaration,
+                              c->pstate(),
+                              feature,
+                              value);
     return cc;
   }
 
   Expression* Eval::operator()(Supports_Interpolation* c)
   {
     Expression* value = c->value()->perform(this);
-    Supports_Interpolation* cc = new (ctx.mem) Supports_Interpolation(c->pstate(),
-                                                 value);
+    Supports_Interpolation* cc = SASS_MEMORY_NEW(ctx.mem, Supports_Interpolation,
+                            c->pstate(),
+                            value);
     return cc;
   }
 
@@ -1014,10 +1028,11 @@ namespace Sass {
     feature = (feature ? feature->perform(this) : 0);
     Expression* value = e->value();
     value = (value ? value->perform(this) : 0);
-    Expression* ee = new (ctx.mem) At_Root_Expression(e->pstate(),
-                                                      static_cast<String*>(feature),
-                                                      value,
-                                                      e->is_interpolated());
+    Expression* ee = SASS_MEMORY_NEW(ctx.mem, At_Root_Expression,
+                                     e->pstate(),
+                                     static_cast<String*>(feature),
+                                     value,
+                                     e->is_interpolated());
     return ee;
   }
 
@@ -1026,11 +1041,12 @@ namespace Sass {
     To_String to_string(&ctx);
     String* t = q->media_type();
     t = static_cast<String*>(t ? t->perform(this) : 0);
-    Media_Query* qq = new (ctx.mem) Media_Query(q->pstate(),
-                                                t,
-                                                q->length(),
-                                                q->is_negated(),
-                                                q->is_restricted());
+    Media_Query* qq = SASS_MEMORY_NEW(ctx.mem, Media_Query,
+                                      q->pstate(),
+                                      t,
+                                      q->length(),
+                                      q->is_negated(),
+                                      q->is_restricted());
     for (size_t i = 0, L = q->length(); i < L; ++i) {
       *qq << static_cast<Media_Query_Expression*>((*q)[i]->perform(this));
     }
@@ -1042,19 +1058,22 @@ namespace Sass {
     Expression* feature = e->feature();
     feature = (feature ? feature->perform(this) : 0);
     if (feature && dynamic_cast<String_Quoted*>(feature)) {
-      feature = new (ctx.mem) String_Quoted(feature->pstate(),
-                                              dynamic_cast<String_Quoted*>(feature)->value());
+      feature = SASS_MEMORY_NEW(ctx.mem, String_Quoted,
+                                  feature->pstate(),
+                                  dynamic_cast<String_Quoted*>(feature)->value());
     }
     Expression* value = e->value();
     value = (value ? value->perform(this) : 0);
     if (value && dynamic_cast<String_Quoted*>(value)) {
-      value = new (ctx.mem) String_Quoted(value->pstate(),
-                                            dynamic_cast<String_Quoted*>(value)->value());
+      value = SASS_MEMORY_NEW(ctx.mem, String_Quoted,
+                                value->pstate(),
+                                dynamic_cast<String_Quoted*>(value)->value());
     }
-    return new (ctx.mem) Media_Query_Expression(e->pstate(),
-                                                feature,
-                                                value,
-                                                e->is_interpolated());
+    return SASS_MEMORY_NEW(ctx.mem, Media_Query_Expression,
+                           e->pstate(),
+                           feature,
+                           value,
+                           e->is_interpolated());
   }
 
   Expression* Eval::operator()(Null* n)
@@ -1078,24 +1097,26 @@ namespace Sass {
         is_keyword_argument = true;
       }
       else if(val->concrete_type() != Expression::LIST) {
-        List* wrapper = new (ctx.mem) List(val->pstate(),
-                                           0,
-                                           SASS_COMMA,
-                                           true);
+        List* wrapper = SASS_MEMORY_NEW(ctx.mem, List,
+                                        val->pstate(),
+                                        0,
+                                        SASS_COMMA,
+                                        true);
         *wrapper << val;
         val = wrapper;
       }
     }
-    return new (ctx.mem) Argument(a->pstate(),
-                                  val,
-                                  a->name(),
-                                  is_rest_argument,
-                                  is_keyword_argument);
+    return SASS_MEMORY_NEW(ctx.mem, Argument,
+                           a->pstate(),
+                           val,
+                           a->name(),
+                           is_rest_argument,
+                           is_keyword_argument);
   }
 
   Expression* Eval::operator()(Arguments* a)
   {
-    Arguments* aa = new (ctx.mem) Arguments(a->pstate());
+    Arguments* aa = SASS_MEMORY_NEW(ctx.mem, Arguments, a->pstate());
     for (size_t i = 0, L = a->length(); i < L; ++i) {
       *aa << static_cast<Argument*>((*a)[i]->perform(this));
     }
@@ -1135,7 +1156,7 @@ namespace Sass {
     double lv = l.value();
     double rv = r.value();
     if (op == Sass_OP::DIV && !rv) {
-      return new (mem) String_Quoted(l.pstate(), "Infinity");
+      return SASS_MEMORY_NEW(mem, String_Quoted, l.pstate(), "Infinity");
     }
     if (op == Sass_OP::MOD && !rv) {
       error("division by zero", r.pstate());
@@ -1150,7 +1171,7 @@ namespace Sass {
         (op == Sass_OP::ADD || op == Sass_OP::SUB)) {
       error("Incompatible units: '"+r_unit+"' and '"+l_unit+"'.", l.pstate());
     }
-    Number* v = new (mem) Number(l);
+    Number* v = SASS_MEMORY_NEW(mem, Number, l);
     v->pstate(l.pstate());
     if (l_unit.empty() && (op == Sass_OP::ADD || op == Sass_OP::SUB || op == Sass_OP::MOD)) {
       v->numerator_units() = r.numerator_units();
@@ -1189,7 +1210,8 @@ namespace Sass {
     switch (op) {
       case Sass_OP::ADD:
       case Sass_OP::MUL: {
-        return new (mem) Color(l.pstate(),
+        return SASS_MEMORY_NEW(mem, Color,
+                               l.pstate(),
                                ops[op](lv, r.r()),
                                ops[op](lv, r.g()),
                                ops[op](lv, r.b()),
@@ -1199,10 +1221,11 @@ namespace Sass {
       case Sass_OP::DIV: {
         std::string sep(op == Sass_OP::SUB ? "-" : "/");
         std::string color(r.to_string(compressed||!r.sixtuplet(), precision));
-        return new (mem) String_Quoted(l.pstate(),
-                                       l.to_string(compressed, precision)
-                                       + sep
-                                       + color);
+        return SASS_MEMORY_NEW(mem, String_Quoted,
+                               l.pstate(),
+                               l.to_string(compressed, precision)
+                               + sep
+                               + color);
       } break;
       case Sass_OP::MOD: {
         error("cannot divide a number by a color", r.pstate());
@@ -1210,14 +1233,15 @@ namespace Sass {
       default: break; // caller should ensure that we don't get here
     }
     // unreachable
-    return new (mem) Color(rh);
+    return SASS_MEMORY_NEW(mem, Color, rh);
   }
 
   Value* Eval::op_color_number(Memory_Manager<AST_Node>& mem, enum Sass_OP op, const Color& l, const Number& r, bool compressed, int precision)
   {
     double rv = r.value();
     if (op == Sass_OP::DIV && !rv) error("division by zero", r.pstate());
-    return new (mem) Color(l.pstate(),
+    return SASS_MEMORY_NEW(mem, Color,
+                           l.pstate(),
                            ops[op](l.r(), rv),
                            ops[op](l.g(), rv),
                            ops[op](l.b(), rv),
@@ -1232,7 +1256,8 @@ namespace Sass {
     if (op == Sass_OP::DIV && (!r.r() || !r.g() ||!r.b())) {
       error("division by zero", r.pstate());
     }
-    return new (mem) Color(l.pstate(),
+    return SASS_MEMORY_NEW(mem, Color,
+                           l.pstate(),
                            ops[op](l.r(), r.r()),
                            ops[op](l.g(), r.g()),
                            ops[op](l.b(), r.b()),
@@ -1292,8 +1317,8 @@ namespace Sass {
     if (rtype == Expression::NULL_VAL) error("invalid null operation: \""+quote(unquote(lstr), '"')+" plus null\".", rhs.pstate());
 
     String_Constant* str = ltype == Expression::STRING || sep == ""
-      ? new (mem) String_Quoted(lhs.pstate(), (lstr) + sep + (rstr))
-      : new (mem) String_Constant(lhs.pstate(), (lstr) + sep + quote(rstr));
+      ? SASS_MEMORY_NEW(mem, String_Quoted, lhs.pstate(), (lstr) + sep + (rstr))
+      : SASS_MEMORY_NEW(mem, String_Constant, lhs.pstate(), (lstr) + sep + quote(rstr));
     str->quote_mark(0);
     return str;
   }
@@ -1305,30 +1330,30 @@ namespace Sass {
     Expression* e = 0;
     switch (sass_value_get_tag(v)) {
       case SASS_BOOLEAN: {
-        e = new (mem) Boolean(pstate, !!sass_boolean_get_value(v));
+        e = SASS_MEMORY_NEW(mem, Boolean, pstate, !!sass_boolean_get_value(v));
       } break;
       case SASS_NUMBER: {
-        e = new (mem) Number(pstate, sass_number_get_value(v), sass_number_get_unit(v));
+        e = SASS_MEMORY_NEW(mem, Number, pstate, sass_number_get_value(v), sass_number_get_unit(v));
       } break;
       case SASS_COLOR: {
-        e = new (mem) Color(pstate, sass_color_get_r(v), sass_color_get_g(v), sass_color_get_b(v), sass_color_get_a(v));
+        e = SASS_MEMORY_NEW(mem, Color, pstate, sass_color_get_r(v), sass_color_get_g(v), sass_color_get_b(v), sass_color_get_a(v));
       } break;
       case SASS_STRING: {
         if (sass_string_is_quoted(v))
-          e = new (mem) String_Quoted(pstate, sass_string_get_value(v));
+          e = SASS_MEMORY_NEW(mem, String_Quoted, pstate, sass_string_get_value(v));
         else {
-          e = new (mem) String_Constant(pstate, sass_string_get_value(v));
+          e = SASS_MEMORY_NEW(mem, String_Constant, pstate, sass_string_get_value(v));
         }
       } break;
       case SASS_LIST: {
-        List* l = new (mem) List(pstate, sass_list_get_length(v), sass_list_get_separator(v));
+        List* l = SASS_MEMORY_NEW(mem, List, pstate, sass_list_get_length(v), sass_list_get_separator(v));
         for (size_t i = 0, L = sass_list_get_length(v); i < L; ++i) {
           *l << cval_to_astnode(mem, sass_list_get_value(v, i), ctx, backtrace, pstate);
         }
         e = l;
       } break;
       case SASS_MAP: {
-        Map* m = new (mem) Map(pstate);
+        Map* m = SASS_MEMORY_NEW(mem, Map, pstate);
         for (size_t i = 0, L = sass_map_get_length(v); i < L; ++i) {
           *m << std::make_pair(
             cval_to_astnode(mem, sass_map_get_key(v, i), ctx, backtrace, pstate),
@@ -1337,7 +1362,7 @@ namespace Sass {
         e = m;
       } break;
       case SASS_NULL: {
-        e = new (mem) Null(pstate);
+        e = SASS_MEMORY_NEW(mem, Null, pstate);
       } break;
       case SASS_ERROR: {
         error("Error in C function: " + std::string(sass_error_get_message(v)), pstate, backtrace);
@@ -1352,7 +1377,7 @@ namespace Sass {
   Selector_List* Eval::operator()(Selector_List* s)
   {
     std::vector<Selector_List*> rv;
-    Selector_List* sl = new (ctx.mem) Selector_List(s->pstate());
+    Selector_List* sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, s->pstate());
     for (size_t i = 0, iL = s->length(); i < iL; ++i) {
       rv.push_back(operator()((*s)[i]));
     }
@@ -1389,7 +1414,7 @@ namespace Sass {
   {
     String* attr = s->value();
     if (attr) { attr = static_cast<String*>(attr->perform(this)); }
-    Attribute_Selector* ss = new (ctx.mem) Attribute_Selector(*s);
+    Attribute_Selector* ss = SASS_MEMORY_NEW(ctx.mem, Attribute_Selector, *s);
     ss->value(attr);
     return ss;
   }
@@ -1412,7 +1437,7 @@ namespace Sass {
       exp.selector_stack.push_back(pr);
       return pr;
     } else {
-      return new (ctx.mem) Null(p->pstate());
+      return SASS_MEMORY_NEW(ctx.mem, Null, p->pstate());
     }
   }
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -67,9 +67,10 @@ namespace Sass {
     // set the current env as parent
     Env env(environment());
     // copy the block object (add items later)
-    Block* bb = new (ctx.mem) Block(b->pstate(),
-                                    b->length(),
-                                    b->is_root());
+    Block* bb = SASS_MEMORY_NEW(ctx.mem, Block,
+                                b->pstate(),
+                                b->length(),
+                                b->is_root());
     // setup block and env stack
     this->block_stack.push_back(bb);
     this->env_stack.push_back(&env);
@@ -87,7 +88,7 @@ namespace Sass {
     // reset when leaving scope
 
     if (in_keyframes) {
-      Keyframe_Rule* k = new (ctx.mem) Keyframe_Rule(r->pstate(), r->block()->perform(this)->block());
+      Keyframe_Rule* k = SASS_MEMORY_NEW(ctx.mem, Keyframe_Rule, r->pstate(), r->block()->perform(this)->block());
       if (r->selector()) {
         selector_stack.push_back(0);
         k->selector(static_cast<Selector_List*>(r->selector()->perform(&eval)));
@@ -102,9 +103,10 @@ namespace Sass {
 
     selector_stack.push_back(sel);
     Block* blk = r->block()->perform(this)->block();
-    Ruleset* rr = new (ctx.mem) Ruleset(r->pstate(),
-                                        sel,
-                                        blk);
+    Ruleset* rr = SASS_MEMORY_NEW(ctx.mem, Ruleset,
+                                  r->pstate(),
+                                  sel,
+                                  blk);
     selector_stack.pop_back();
     rr->tabs(r->tabs());
 
@@ -119,11 +121,12 @@ namespace Sass {
     for (size_t i = 0, L = expanded_block->length(); i < L; ++i) {
       Statement* stm = (*expanded_block)[i];
       if (Declaration* dec = static_cast<Declaration*>(stm)) {
-        String_Schema* combined_prop = new (ctx.mem) String_Schema(p->pstate());
+        String_Schema* combined_prop = SASS_MEMORY_NEW(ctx.mem, String_Schema, p->pstate());
         if (!property_stack.empty()) {
           *combined_prop << property_stack.back()->perform(&eval)
-                         << new (ctx.mem) String_Quoted(p->pstate(), "-")
-                         << dec->property(); // TODO: eval the prop into a string constant
+                         << SASS_MEMORY_NEW(ctx.mem, String_Quoted,
+             p->pstate(), "-")
+             << dec->property(); // TODO: eval the prop into a string constant
         }
         else {
           *combined_prop << dec->property();
@@ -147,9 +150,10 @@ namespace Sass {
   Statement* Expand::operator()(Supports_Block* f)
   {
     Expression* condition = f->condition()->perform(&eval);
-    Supports_Block* ff = new (ctx.mem) Supports_Block(f->pstate(),
-                                                    static_cast<Supports_Condition*>(condition),
-                                                    f->block()->perform(this)->block());
+    Supports_Block* ff = SASS_MEMORY_NEW(ctx.mem, Supports_Block,
+                                       f->pstate(),
+                                       static_cast<Supports_Condition*>(condition),
+                                       f->block()->perform(this)->block());
     return ff;
   }
 
@@ -158,10 +162,11 @@ namespace Sass {
     To_String to_string(&ctx);
     Expression* mq = m->media_queries()->perform(&eval);
     mq = Parser::from_c_str(mq->perform(&to_string).c_str(), ctx, mq->pstate()).parse_media_queries();
-    Media_Block* mm = new (ctx.mem) Media_Block(m->pstate(),
-                                                static_cast<List*>(mq),
-                                                m->block()->perform(this)->block(),
-                                                0);
+    Media_Block* mm = SASS_MEMORY_NEW(ctx.mem, Media_Block,
+                                      m->pstate(),
+                                      static_cast<List*>(mq),
+                                      m->block()->perform(this)->block(),
+                                      0);
     mm->tabs(m->tabs());
     return mm;
   }
@@ -172,11 +177,12 @@ namespace Sass {
     // if (ab) ab->is_root(true);
     Expression* ae = a->expression();
     if (ae) ae = ae->perform(&eval);
-    else ae = new (ctx.mem) At_Root_Expression(a->pstate());
+    else ae = SASS_MEMORY_NEW(ctx.mem, At_Root_Expression, a->pstate());
     Block* bb = ab ? ab->perform(this)->block() : 0;
-    At_Root_Block* aa = new (ctx.mem) At_Root_Block(a->pstate(),
-                                                    bb,
-                                                    static_cast<At_Root_Expression*>(ae));
+    At_Root_Block* aa = SASS_MEMORY_NEW(ctx.mem, At_Root_Block,
+                                        a->pstate(),
+                                        bb,
+                                        static_cast<At_Root_Expression*>(ae));
     // aa->block()->is_root(true);
     return aa;
   }
@@ -192,11 +198,12 @@ namespace Sass {
     if (as) as = dynamic_cast<Selector*>(as->perform(&eval));
     selector_stack.pop_back();
     Block* bb = ab ? ab->perform(this)->block() : 0;
-    At_Rule* aa = new (ctx.mem) At_Rule(a->pstate(),
-                                        a->keyword(),
-                                        as,
-                                        bb,
-                                        av);
+    At_Rule* aa = SASS_MEMORY_NEW(ctx.mem, At_Rule,
+                                  a->pstate(),
+                                  a->keyword(),
+                                  as,
+                                  bb,
+                                  av);
     return aa;
   }
 
@@ -206,10 +213,11 @@ namespace Sass {
     String* new_p = static_cast<String*>(old_p->perform(&eval));
     Expression* value = d->value()->perform(&eval);
     if (!value || (value->is_invisible() && !d->is_important())) return 0;
-    Declaration* decl = new (ctx.mem) Declaration(d->pstate(),
-                                                  new_p,
-                                                  value,
-                                                  d->is_important());
+    Declaration* decl = SASS_MEMORY_NEW(ctx.mem, Declaration,
+                                        d->pstate(),
+                                        new_p,
+                                        value,
+                                        d->is_important());
     decl->tabs(d->tabs());
     return decl;
   }
@@ -277,7 +285,7 @@ namespace Sass {
 
   Statement* Expand::operator()(Import* imp)
   {
-    Import* result = new (ctx.mem) Import(imp->pstate());
+    Import* result = SASS_MEMORY_NEW(ctx.mem, Import, imp->pstate());
     if (imp->media_queries()) {
       Expression* ex = imp->media_queries()->perform(&eval);
       result->media_queries(dynamic_cast<List*>(ex));
@@ -318,7 +326,7 @@ namespace Sass {
   Statement* Expand::operator()(Comment* c)
   {
     // TODO: eval the text, once we're parsing/storing it as a String_Schema
-    return new (ctx.mem) Comment(c->pstate(), static_cast<String*>(c->text()->perform(&eval)), c->is_important());
+    return SASS_MEMORY_NEW(ctx.mem, Comment, c->pstate(), static_cast<String*>(c->text()->perform(&eval)), c->is_important());
   }
 
   Statement* Expand::operator()(If* i)
@@ -359,7 +367,7 @@ namespace Sass {
     double end = sass_end->value();
     // only create iterator once in this environment
     Env* env = environment();
-    Number* it = new (env->mem) Number(low->pstate(), start, sass_end->unit());
+    Number* it = SASS_MEMORY_NEW(env->mem, Number, low->pstate(), start, sass_end->unit());
     AST_Node* old_var = env->has_local(variable) ? env->get_local(variable) : 0;
     env->set_local(variable, it);
     Block* body = f->block();
@@ -400,7 +408,7 @@ namespace Sass {
       map = static_cast<Map*>(expr);
     }
     else if (expr->concrete_type() != Expression::LIST) {
-      list = new (ctx.mem) List(expr->pstate(), 1, SASS_COMMA);
+      list = SASS_MEMORY_NEW(ctx.mem, List, expr->pstate(), 1, SASS_COMMA);
       *list << expr;
     }
     else {
@@ -421,7 +429,7 @@ namespace Sass {
         Expression* v = map->at(key)->perform(&eval);
 
         if (variables.size() == 1) {
-          List* variable = new (ctx.mem) List(map->pstate(), 2, SASS_SPACE);
+          List* variable = SASS_MEMORY_NEW(ctx.mem, List, map->pstate(), 2, SASS_SPACE);
           *variable << k;
           *variable << v;
           env->set_local(variables[0], variable);
@@ -447,7 +455,7 @@ namespace Sass {
           } else {
             for (size_t j = 0, K = variables.size(); j < K; ++j) {
               Expression* res = j >= scalars->length()
-                ? new (ctx.mem) Null(expr->pstate())
+                ? SASS_MEMORY_NEW(ctx.mem, Null, expr->pstate())
                 : (*scalars)[j]->perform(&eval);
               env->set_local(variables[j], res);
             }
@@ -456,7 +464,7 @@ namespace Sass {
           if (variables.size() > 0) {
             env->set_local(variables[0], e);
             for (size_t j = 1, K = variables.size(); j < K; ++j) {
-              Expression* res = new (ctx.mem) Null(expr->pstate());
+              Expression* res = SASS_MEMORY_NEW(ctx.mem, Null, expr->pstate());
               env->set_local(variables[j], res);
             }
           }
@@ -511,10 +519,10 @@ namespace Sass {
         if (!(sel->head() && sel->head()->length() > 0 &&
             dynamic_cast<Parent_Selector*>((*sel->head())[0])))
         {
-          Compound_Selector* hh = new (ctx.mem) Compound_Selector((*extender)[i]->pstate());
-          Complex_Selector* ssel = new (ctx.mem) Complex_Selector((*extender)[i]->pstate());
+          Compound_Selector* hh = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, (*extender)[i]->pstate());
+          Complex_Selector* ssel = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, (*extender)[i]->pstate());
           if (sel->has_line_feed()) ssel->has_line_feed(true);
-          *hh << new (ctx.mem) Parent_Selector((*extender)[i]->pstate());
+          *hh << SASS_MEMORY_NEW(ctx.mem, Parent_Selector, (*extender)[i]->pstate());
           ssel->tail(sel);
           ssel->head(hh);
           sel = ssel;
@@ -531,7 +539,7 @@ namespace Sass {
   Statement* Expand::operator()(Definition* d)
   {
     Env* env = environment();
-    Definition* dd = new (ctx.mem) Definition(*d);
+    Definition* dd = SASS_MEMORY_NEW(ctx.mem, Definition, *d);
     env->local_frame()[d->name() +
                         (d->type() == Definition::MIXIN ? "[m]" : "[f]")] = dd;
     // set the static link so we can have lexical scoping
@@ -558,11 +566,12 @@ namespace Sass {
     env_stack.push_back(&new_env);
     if (c->block()) {
       // represent mixin content blocks as thunks/closures
-      Definition* thunk = new (ctx.mem) Definition(c->pstate(),
-                                                   "@content",
-                                                   new (ctx.mem) Parameters(c->pstate()),
-                                                   c->block(),
-                                                   Definition::MIXIN);
+      Definition* thunk = SASS_MEMORY_NEW(ctx.mem, Definition,
+                                          c->pstate(),
+                                          "@content",
+                                          SASS_MEMORY_NEW(ctx.mem, Parameters, c->pstate()),
+                                          c->block(),
+                                          Definition::MIXIN);
       thunk->environment(env);
       new_env.local_frame()["@content[m]"] = thunk;
     }
@@ -578,9 +587,10 @@ namespace Sass {
     Env* env = environment();
     // convert @content directives into mixin calls to the underlying thunk
     if (!env->has("@content[m]")) return 0;
-    Mixin_Call* call = new (ctx.mem) Mixin_Call(c->pstate(),
-                                                "@content",
-                                                new (ctx.mem) Arguments(c->pstate()));
+    Mixin_Call* call = SASS_MEMORY_NEW(ctx.mem, Mixin_Call,
+                                       c->pstate(),
+                                       "@content",
+                                       SASS_MEMORY_NEW(ctx.mem, Arguments, c->pstate()));
     return call->perform(this);
   }
 
@@ -588,9 +598,9 @@ namespace Sass {
   inline Statement* Expand::fallback_impl(AST_Node* n)
   {
     std::string err =std:: string("`Expand` doesn't handle ") + typeid(*n).name();
-    String_Quoted* msg = new (ctx.mem) String_Quoted(ParserState("[WARN]"), err);
+    String_Quoted* msg = SASS_MEMORY_NEW(ctx.mem, String_Quoted, ParserState("[WARN]"), err);
     error("unknown internal error; please contact the LibSass maintainers", n->pstate(), backtrace());
-    return new (ctx.mem) Warning(ParserState("[WARN]"), msg);
+    return SASS_MEMORY_NEW(ctx.mem, Warning, ParserState("[WARN]"), msg);
   }
 
   // process and add to last block on stack

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1525,7 +1525,7 @@ namespace Sass {
       DEBUG_EXEC(EXTEND_COMPOUND, printComplexSelector(&seq, "SEQ: "))
 
 
-      Compound_Selector* pSels = new (ctx.mem) Compound_Selector(pSelector->pstate());
+      Compound_Selector* pSels = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pSelector->pstate());
       for (std::vector<ExtensionPair>::iterator groupIter = group.begin(), groupIterEnd = group.end(); groupIter != groupIterEnd; groupIter++) {
         ExtensionPair& pair = *groupIter;
         Compound_Selector* pCompound = pair.second;
@@ -1550,7 +1550,7 @@ namespace Sass {
       Compound_Selector* pUnifiedSelector = NULL;
 
       if (!pInnermostCompoundSelector) {
-        pInnermostCompoundSelector = new (ctx.mem) Compound_Selector(pSelector->pstate());
+        pInnermostCompoundSelector = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pSelector->pstate());
       }
 
       pUnifiedSelector = pInnermostCompoundSelector->unify_with(pSelectorWithoutExtendSelectors, ctx);
@@ -1573,7 +1573,7 @@ namespace Sass {
       // out and aren't operated on.
       Complex_Selector* pNewSelector = pExtComplexSelector->cloneFully(ctx); // ->first();
 
-      Complex_Selector* pNewInnerMost = new (ctx.mem) Complex_Selector(pSelector->pstate(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, NULL);
+      Complex_Selector* pNewInnerMost = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pSelector->pstate(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, NULL);
 
       Complex_Selector::Combinator combinator = pNewSelector->clear_innermost();
       pNewSelector->set_innermost(pNewInnerMost, combinator);
@@ -1853,7 +1853,7 @@ namespace Sass {
 
     To_String to_string(&ctx);
 
-    Selector_List* pNewSelectors = new (ctx.mem) Selector_List(pSelectorList->pstate(), pSelectorList->length());
+    Selector_List* pNewSelectors = SASS_MEMORY_NEW(ctx.mem, Selector_List, pSelectorList->pstate(), pSelectorList->length());
 
     extendedSomething = false;
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -43,12 +43,13 @@ namespace Sass {
     sig_parser.lex<Prelexer::identifier>();
     std::string name(Util::normalize_underscores(sig_parser.lexed));
     Parameters* params = sig_parser.parse_parameters();
-    return new (ctx.mem) Definition(ParserState("[built-in function]"),
-                                    sig,
-                                    name,
-                                    params,
-                                    func,
-                                    false);
+    return SASS_MEMORY_NEW(ctx.mem, Definition,
+                           ParserState("[built-in function]"),
+                           sig,
+                           name,
+                           params,
+                           func,
+                           false);
   }
 
   Definition* make_c_function(Sass_Function_Entry c_func, Context& ctx)
@@ -65,12 +66,13 @@ namespace Sass {
                    >              >();
     std::string name(Util::normalize_underscores(sig_parser.lexed));
     Parameters* params = sig_parser.parse_parameters();
-    return new (ctx.mem) Definition(ParserState("[c function]"),
-                                    sig,
-                                    name,
-                                    params,
-                                    c_func,
-                                    false, true);
+    return SASS_MEMORY_NEW(ctx.mem, Definition,
+                           ParserState("[c function]"),
+                           sig,
+                           name,
+                           params,
+                           c_func,
+                           false, true);
   }
 
   std::string function_name(Signature sig)
@@ -125,7 +127,7 @@ namespace Sass {
       if (val) return val;
 
       List* lval = dynamic_cast<List*>(env[argname]);
-      if (lval && lval->length() == 0) return new (ctx.mem) Map(pstate, 0);
+      if (lval && lval->length() == 0) return SASS_MEMORY_NEW(ctx.mem, Map, pstate, 0);
 
       // fallback on get_arg for error handling
       val = get_arg<Map>(argname, env, sig, pstate, backtrace);
@@ -253,27 +255,29 @@ namespace Sass {
     Signature rgb_sig = "rgb($red, $green, $blue)";
     BUILT_IN(rgb)
     {
-      return new (ctx.mem) Color(pstate,
-                                 color_num(ARG("$red",   Number)),
-                                 color_num(ARG("$green", Number)),
-                                 color_num(ARG("$blue",  Number)));
+      return SASS_MEMORY_NEW(ctx.mem, Color,
+                             pstate,
+                             color_num(ARG("$red",   Number)),
+                             color_num(ARG("$green", Number)),
+                             color_num(ARG("$blue",  Number)));
     }
 
     Signature rgba_4_sig = "rgba($red, $green, $blue, $alpha)";
     BUILT_IN(rgba_4)
     {
-      return new (ctx.mem) Color(pstate,
-                                 color_num(ARG("$red",   Number)),
-                                 color_num(ARG("$green", Number)),
-                                 color_num(ARG("$blue",  Number)),
-                                 alpha_num(ARG("$alpha", Number)));
+      return SASS_MEMORY_NEW(ctx.mem, Color,
+                             pstate,
+                             color_num(ARG("$red",   Number)),
+                             color_num(ARG("$green", Number)),
+                             color_num(ARG("$blue",  Number)),
+                             alpha_num(ARG("$alpha", Number)));
     }
 
     Signature rgba_2_sig = "rgba($color, $alpha)";
     BUILT_IN(rgba_2)
     {
       Color* c_arg = ARG("$color", Color);
-      Color* new_c = new (ctx.mem) Color(*c_arg);
+      Color* new_c = SASS_MEMORY_NEW(ctx.mem, Color, *c_arg);
       new_c->a(alpha_num(ARG("$alpha", Number)));
       new_c->disp("");
       return new_c;
@@ -281,15 +285,15 @@ namespace Sass {
 
     Signature red_sig = "red($color)";
     BUILT_IN(red)
-    { return new (ctx.mem) Number(pstate, ARG("$color", Color)->r()); }
+    { return SASS_MEMORY_NEW(ctx.mem, Number, pstate, ARG("$color", Color)->r()); }
 
     Signature green_sig = "green($color)";
     BUILT_IN(green)
-    { return new (ctx.mem) Number(pstate, ARG("$color", Color)->g()); }
+    { return SASS_MEMORY_NEW(ctx.mem, Number, pstate, ARG("$color", Color)->g()); }
 
     Signature blue_sig = "blue($color)";
     BUILT_IN(blue)
-    { return new (ctx.mem) Number(pstate, ARG("$color", Color)->b()); }
+    { return SASS_MEMORY_NEW(ctx.mem, Number, pstate, ARG("$color", Color)->b()); }
 
     Signature mix_sig = "mix($color-1, $color-2, $weight: 50%)";
     BUILT_IN(mix)
@@ -305,11 +309,12 @@ namespace Sass {
       double w1 = (((w * a == -1) ? w : (w + a)/(1 + w*a)) + 1)/2.0;
       double w2 = 1 - w1;
 
-      return new (ctx.mem) Color(pstate,
-                                 std::round(w1*color1->r() + w2*color2->r()),
-                                 std::round(w1*color1->g() + w2*color2->g()),
-                                 std::round(w1*color1->b() + w2*color2->b()),
-                                 color1->a()*p + color2->a()*(1-p));
+      return SASS_MEMORY_NEW(ctx.mem, Color,
+                             pstate,
+                             std::round(w1*color1->r() + w2*color2->r()),
+                             std::round(w1*color1->g() + w2*color2->g()),
+                             std::round(w1*color1->b() + w2*color2->b()),
+                             color1->a()*p + color2->a()*(1-p));
     }
 
     ////////////////
@@ -383,7 +388,7 @@ namespace Sass {
       double g = (h_to_rgb(m1, m2, h) * 255.0);
       double b = (h_to_rgb(m1, m2, h-1.0/3.0) * 255.0);
 
-      return new (ctx.mem) Color(pstate, r, g, b, a);
+      return SASS_MEMORY_NEW(ctx.mem, Color, pstate, r, g, b, a);
     }
 
     Signature hsl_sig = "hsl($hue, $saturation, $lightness)";
@@ -415,7 +420,7 @@ namespace Sass {
       HSL hsl_color = rgb_to_hsl(rgb_color->r(),
                                  rgb_color->g(),
                                  rgb_color->b());
-      return new (ctx.mem) Number(pstate, hsl_color.h, "deg");
+      return SASS_MEMORY_NEW(ctx.mem, Number, pstate, hsl_color.h, "deg");
     }
 
     Signature saturation_sig = "saturation($color)";
@@ -425,7 +430,7 @@ namespace Sass {
       HSL hsl_color = rgb_to_hsl(rgb_color->r(),
                                  rgb_color->g(),
                                  rgb_color->b());
-      return new (ctx.mem) Number(pstate, hsl_color.s, "%");
+      return SASS_MEMORY_NEW(ctx.mem, Number, pstate, hsl_color.s, "%");
     }
 
     Signature lightness_sig = "lightness($color)";
@@ -435,7 +440,7 @@ namespace Sass {
       HSL hsl_color = rgb_to_hsl(rgb_color->r(),
                                  rgb_color->g(),
                                  rgb_color->b());
-      return new (ctx.mem) Number(pstate, hsl_color.l, "%");
+      return SASS_MEMORY_NEW(ctx.mem, Number, pstate, hsl_color.l, "%");
     }
 
     Signature adjust_hue_sig = "adjust-hue($color, $degrees)";
@@ -506,7 +511,7 @@ namespace Sass {
       Number* amount = dynamic_cast<Number*>(env["$amount"]);
       if (!amount) {
         To_String to_string(&ctx);
-        return new (ctx.mem) String_Quoted(pstate, "saturate(" + env["$color"]->perform(&to_string) + ")");
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "saturate(" + env["$color"]->perform(&to_string) + ")");
       }
 
       ARGR("$amount", Number, 0, 100);
@@ -567,7 +572,7 @@ namespace Sass {
       Number* amount = dynamic_cast<Number*>(env["$color"]);
       if (amount) {
         To_String to_string(&ctx);
-        return new (ctx.mem) String_Quoted(pstate, "grayscale(" + amount->perform(&to_string) + ")");
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "grayscale(" + amount->perform(&to_string) + ")");
       }
 
       Color* rgb_color = ARG("$color", Color);
@@ -604,15 +609,16 @@ namespace Sass {
       Number* amount = dynamic_cast<Number*>(env["$color"]);
       if (amount) {
         To_String to_string(&ctx);
-        return new (ctx.mem) String_Quoted(pstate, "invert(" + amount->perform(&to_string) + ")");
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "invert(" + amount->perform(&to_string) + ")");
       }
 
       Color* rgb_color = ARG("$color", Color);
-      return new (ctx.mem) Color(pstate,
-                                 255 - rgb_color->r(),
-                                 255 - rgb_color->g(),
-                                 255 - rgb_color->b(),
-                                 rgb_color->a());
+      return SASS_MEMORY_NEW(ctx.mem, Color,
+                             pstate,
+                             255 - rgb_color->r(),
+                             255 - rgb_color->g(),
+                             255 - rgb_color->b(),
+                             rgb_color->a());
     }
 
     ////////////////////
@@ -624,17 +630,17 @@ namespace Sass {
     {
       String_Constant* ie_kwd = dynamic_cast<String_Constant*>(env["$color"]);
       if (ie_kwd) {
-        return new (ctx.mem) String_Quoted(pstate, "alpha(" + ie_kwd->value() + ")");
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "alpha(" + ie_kwd->value() + ")");
       }
 
       // CSS3 filter function overload: pass literal through directly
       Number* amount = dynamic_cast<Number*>(env["$color"]);
       if (amount) {
         To_String to_string(&ctx);
-        return new (ctx.mem) String_Quoted(pstate, "opacity(" + amount->perform(&to_string) + ")");
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "opacity(" + amount->perform(&to_string) + ")");
       }
 
-      return new (ctx.mem) Number(pstate, ARG("$color", Color)->a());
+      return SASS_MEMORY_NEW(ctx.mem, Number, pstate, ARG("$color", Color)->a());
     }
 
     Signature opacify_sig = "opacify($color, $amount)";
@@ -644,11 +650,12 @@ namespace Sass {
       Color* color = ARG("$color", Color);
       double amount = ARGR("$amount", Number, 0, 1)->value();
       double alpha = std::min(color->a() + amount, 1.0);
-      return new (ctx.mem) Color(pstate,
-                                 color->r(),
-                                 color->g(),
-                                 color->b(),
-                                 alpha);
+      return SASS_MEMORY_NEW(ctx.mem, Color,
+                             pstate,
+                             color->r(),
+                             color->g(),
+                             color->b(),
+                             alpha);
     }
 
     Signature transparentize_sig = "transparentize($color, $amount)";
@@ -658,11 +665,12 @@ namespace Sass {
       Color* color = ARG("$color", Color);
       double amount = ARGR("$amount", Number, 0, 1)->value();
       double alpha = std::max(color->a() - amount, 0.0);
-      return new (ctx.mem) Color(pstate,
-                                 color->r(),
-                                 color->g(),
-                                 color->b(),
-                                 alpha);
+      return SASS_MEMORY_NEW(ctx.mem, Color,
+                             pstate,
+                             color->r(),
+                             color->g(),
+                             color->b(),
+                             alpha);
     }
 
     ////////////////////////
@@ -692,11 +700,12 @@ namespace Sass {
         double gg = g ? ARGR("$green", Number, -255, 255)->value() : 0;
         double bb = b ? ARGR("$blue",  Number, -255, 255)->value() : 0;
         double aa = a ? ARGR("$alpha", Number, -1, 1)->value() : 0;
-        return new (ctx.mem) Color(pstate,
-                                   color->r() + rr,
-                                   color->g() + gg,
-                                   color->b() + bb,
-                                   color->a() + aa);
+        return SASS_MEMORY_NEW(ctx.mem, Color,
+                               pstate,
+                               color->r() + rr,
+                               color->g() + gg,
+                               color->b() + bb,
+                               color->a() + aa);
       }
       if (hsl) {
         HSL hsl_struct = rgb_to_hsl(color->r(), color->g(), color->b());
@@ -711,11 +720,12 @@ namespace Sass {
                          pstate);
       }
       if (a) {
-        return new (ctx.mem) Color(pstate,
-                                   color->r(),
-                                   color->g(),
-                                   color->b(),
-                                   color->a() + (a ? a->value() : 0));
+        return SASS_MEMORY_NEW(ctx.mem, Color,
+                               pstate,
+                               color->r(),
+                               color->g(),
+                               color->b(),
+                               color->a() + (a ? a->value() : 0));
       }
       error("not enough arguments for `adjust-color`", pstate);
       // unreachable
@@ -745,11 +755,12 @@ namespace Sass {
         double gscale = (g ? ARGR("$green", Number, -100.0, 100.0)->value() : 0.0) / 100.0;
         double bscale = (b ? ARGR("$blue",  Number, -100.0, 100.0)->value() : 0.0) / 100.0;
         double ascale = (a ? ARGR("$alpha", Number, -100.0, 100.0)->value() : 0.0) / 100.0;
-        return new (ctx.mem) Color(pstate,
-                                   color->r() + rscale * (rscale > 0.0 ? 255 - color->r() : color->r()),
-                                   color->g() + gscale * (gscale > 0.0 ? 255 - color->g() : color->g()),
-                                   color->b() + bscale * (bscale > 0.0 ? 255 - color->b() : color->b()),
-                                   color->a() + ascale * (ascale > 0.0 ? 1.0 - color->a() : color->a()));
+        return SASS_MEMORY_NEW(ctx.mem, Color,
+                               pstate,
+                               color->r() + rscale * (rscale > 0.0 ? 255 - color->r() : color->r()),
+                               color->g() + gscale * (gscale > 0.0 ? 255 - color->g() : color->g()),
+                               color->b() + bscale * (bscale > 0.0 ? 255 - color->b() : color->b()),
+                               color->a() + ascale * (ascale > 0.0 ? 1.0 - color->a() : color->a()));
       }
       if (hsl) {
         double hscale = (h ? ARGR("$hue",        Number, -100.0, 100.0)->value() : 0.0) / 100.0;
@@ -765,11 +776,12 @@ namespace Sass {
       }
       if (a) {
         double ascale = (a ? ARGR("$alpha", Number, -100.0, 100.0)->value() : 0.0) / 100.0;
-        return new (ctx.mem) Color(pstate,
-                                   color->r(),
-                                   color->g(),
-                                   color->b(),
-                                   color->a() + ascale * (ascale > 0.0 ? 1.0 - color->a() : color->a()));
+        return SASS_MEMORY_NEW(ctx.mem, Color,
+                               pstate,
+                               color->r(),
+                               color->g(),
+                               color->b(),
+                               color->a() + ascale * (ascale > 0.0 ? 1.0 - color->a() : color->a()));
       }
       error("not enough arguments for `scale-color`", pstate);
       // unreachable
@@ -795,11 +807,12 @@ namespace Sass {
         error("cannot specify both RGB and HSL values for `change-color`", pstate);
       }
       if (rgb) {
-        return new (ctx.mem) Color(pstate,
-                                   r ? ARGR("$red",   Number, 0, 255)->value() : color->r(),
-                                   g ? ARGR("$green", Number, 0, 255)->value() : color->g(),
-                                   b ? ARGR("$blue",  Number, 0, 255)->value() : color->b(),
-                                   a ? ARGR("$alpha", Number, 0, 255)->value() : color->a());
+        return SASS_MEMORY_NEW(ctx.mem, Color,
+                               pstate,
+                               r ? ARGR("$red",   Number, 0, 255)->value() : color->r(),
+                               g ? ARGR("$green", Number, 0, 255)->value() : color->g(),
+                               b ? ARGR("$blue",  Number, 0, 255)->value() : color->b(),
+                               a ? ARGR("$alpha", Number, 0, 255)->value() : color->a());
       }
       if (hsl) {
         HSL hsl_struct = rgb_to_hsl(color->r(), color->g(), color->b());
@@ -811,11 +824,12 @@ namespace Sass {
       }
       if (a) {
         double alpha = a ? ARGR("$alpha", Number, 0, 1.0)->value() : color->a();
-        return new (ctx.mem) Color(pstate,
-                                   color->r(),
-                                   color->g(),
-                                   color->b(),
-                                   alpha);
+        return SASS_MEMORY_NEW(ctx.mem, Color,
+                               pstate,
+                               color->r(),
+                               color->g(),
+                               color->b(),
+                               alpha);
       }
       error("not enough arguments for `change-color`", pstate);
       // unreachable
@@ -849,7 +863,7 @@ namespace Sass {
       for (size_t i = 0, L = result.length(); i < L; ++i) {
         result[i] = std::toupper(result[i]);
       }
-      return new (ctx.mem) String_Quoted(pstate, result);
+      return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, result);
     }
 
     ///////////////////
@@ -861,10 +875,10 @@ namespace Sass {
     {
       AST_Node* arg = env["$string"];
       if (dynamic_cast<Null*>(arg)) {
-        return new (ctx.mem) Null(pstate);
+        return SASS_MEMORY_NEW(ctx.mem, Null, pstate);
       }
       else if (String_Quoted* string_quoted = dynamic_cast<String_Quoted*>(arg)) {
-        String_Quoted* result = new (ctx.mem) String_Quoted(pstate, string_quoted->value());
+        String_Quoted* result = SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, string_quoted->value());
         // remember if the string was quoted (color tokens)
         result->sass_fix_1291(string_quoted->quote_mark() != 0);
         return result;
@@ -886,7 +900,7 @@ namespace Sass {
       To_String to_string(&ctx);
       AST_Node* arg = env["$string"];
       std::string str(quote(arg->perform(&to_string), String_Constant::double_quote()));
-      String_Quoted* result = new (ctx.mem) String_Quoted(pstate, str);
+      String_Quoted* result = SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, str);
       result->is_delayed(true);
       return result;
     }
@@ -905,7 +919,7 @@ namespace Sass {
       // other errors will be re-thrown
       catch (...) { handle_utf8_error(pstate, backtrace); }
       // return something even if we had an error (-1)
-      return new (ctx.mem) Number(pstate, (double)len);
+      return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)len);
     }
 
     Signature str_insert_sig = "str-insert($string, $insert, $index)";
@@ -951,7 +965,7 @@ namespace Sass {
       // handle any invalid utf8 errors
       // other errors will be re-thrown
       catch (...) { handle_utf8_error(pstate, backtrace); }
-      return new (ctx.mem) String_Quoted(pstate, str);
+      return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, str);
     }
 
     Signature str_index_sig = "str-index($string, $substring)";
@@ -968,7 +982,7 @@ namespace Sass {
 
         size_t c_index = str.find(substr);
         if(c_index == std::string::npos) {
-          return new (ctx.mem) Null(pstate);
+          return SASS_MEMORY_NEW(ctx.mem, Null, pstate);
         }
         index = UTF_8::code_point_count(str, 0, c_index) + 1;
       }
@@ -976,7 +990,7 @@ namespace Sass {
       // other errors will be re-thrown
       catch (...) { handle_utf8_error(pstate, backtrace); }
       // return something even if we had an error (-1)
-      return new (ctx.mem) Number(pstate, (double)index);
+      return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)index);
     }
 
     Signature str_slice_sig = "str-slice($string, $start-at, $end-at:-1)";
@@ -1012,7 +1026,7 @@ namespace Sass {
       // handle any invalid utf8 errors
       // other errors will be re-thrown
       catch (...) { handle_utf8_error(pstate, backtrace); }
-      return new (ctx.mem) String_Quoted(pstate, newstr);
+      return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, newstr);
     }
 
     Signature to_upper_case_sig = "to-upper-case($string)";
@@ -1028,11 +1042,11 @@ namespace Sass {
       }
 
       if (String_Quoted* ss = dynamic_cast<String_Quoted*>(s)) {
-        String_Quoted* cpy = new (ctx.mem) String_Quoted(*ss);
+        String_Quoted* cpy = SASS_MEMORY_NEW(ctx.mem, String_Quoted, *ss);
         cpy->value(str);
         return cpy;
       } else {
-        return new (ctx.mem) String_Quoted(pstate, str);
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, str);
       }
     }
 
@@ -1049,11 +1063,11 @@ namespace Sass {
       }
 
       if (String_Quoted* ss = dynamic_cast<String_Quoted*>(s)) {
-        String_Quoted* cpy = new (ctx.mem) String_Quoted(*ss);
+        String_Quoted* cpy = SASS_MEMORY_NEW(ctx.mem, String_Quoted, *ss);
         cpy->value(str);
         return cpy;
       } else {
-        return new (ctx.mem) String_Quoted(pstate, str);
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, str);
       }
     }
 
@@ -1066,14 +1080,14 @@ namespace Sass {
     {
       Number* n = ARG("$number", Number);
       if (!n->is_unitless()) error("argument $number of `" + std::string(sig) + "` must be unitless", pstate);
-      return new (ctx.mem) Number(pstate, n->value() * 100, "%");
+      return SASS_MEMORY_NEW(ctx.mem, Number, pstate, n->value() * 100, "%");
     }
 
     Signature round_sig = "round($number)";
     BUILT_IN(round)
     {
       Number* n = ARG("$number", Number);
-      Number* r = new (ctx.mem) Number(*n);
+      Number* r = SASS_MEMORY_NEW(ctx.mem, Number, *n);
       r->pstate(pstate);
       r->value(std::floor(r->value() + 0.5));
       return r;
@@ -1083,7 +1097,7 @@ namespace Sass {
     BUILT_IN(ceil)
     {
       Number* n = ARG("$number", Number);
-      Number* r = new (ctx.mem) Number(*n);
+      Number* r = SASS_MEMORY_NEW(ctx.mem, Number, *n);
       r->pstate(pstate);
       r->value(std::ceil(r->value()));
       return r;
@@ -1093,7 +1107,7 @@ namespace Sass {
     BUILT_IN(floor)
     {
       Number* n = ARG("$number", Number);
-      Number* r = new (ctx.mem) Number(*n);
+      Number* r = SASS_MEMORY_NEW(ctx.mem, Number, *n);
       r->pstate(pstate);
       r->value(std::floor(r->value()));
       return r;
@@ -1103,7 +1117,7 @@ namespace Sass {
     BUILT_IN(abs)
     {
       Number* n = ARG("$number", Number);
-      Number* r = new (ctx.mem) Number(*n);
+      Number* r = SASS_MEMORY_NEW(ctx.mem, Number, *n);
       r->pstate(pstate);
       r->value(std::abs(r->value()));
       return r;
@@ -1147,12 +1161,12 @@ namespace Sass {
         if (trunc(l->value()) != l->value() || l->value() == 0) error("argument $limit of `" + std::string(sig) + "` must be a positive integer", pstate);
         std::uniform_real_distribution<> distributor(1, l->value() + 1);
         uint_fast32_t distributed = static_cast<uint_fast32_t>(distributor(rand));
-        return new (ctx.mem) Number(pstate, (double)distributed);
+        return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)distributed);
       }
       else {
         std::uniform_real_distribution<> distributor(0, 1);
         double distributed = static_cast<double>(distributor(rand));
-        return new (ctx.mem) Number(pstate, distributed);
+        return SASS_MEMORY_NEW(ctx.mem, Number, pstate, distributed);
      }
     }
 
@@ -1166,22 +1180,24 @@ namespace Sass {
       Expression* v = ARG("$list", Expression);
       if (v->concrete_type() == Expression::MAP) {
         Map* map = dynamic_cast<Map*>(env["$list"]);
-        return new (ctx.mem) Number(pstate,
-										(double)(map ? map->length() : 1));
+        return SASS_MEMORY_NEW(ctx.mem, Number,
+     pstate,
+     (double)(map ? map->length() : 1));
       }
       if (v->concrete_type() == Expression::SELECTOR) {
         if (Compound_Selector* h = dynamic_cast<Compound_Selector*>(v)) {
-          return new (ctx.mem) Number(pstate, (double)h->length());
+          return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)h->length());
         } else if (Selector_List* ls = dynamic_cast<Selector_List*>(v)) {
-          return new (ctx.mem) Number(pstate, (double)ls->length());
+          return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)ls->length());
         } else {
-          return new (ctx.mem) Number(pstate, 1);
+          return SASS_MEMORY_NEW(ctx.mem, Number, pstate, 1);
         }
       }
 
       List* list = dynamic_cast<List*>(env["$list"]);
-      return new (ctx.mem) Number(pstate,
-                                  (double)(list ? list->size() : 1));
+      return SASS_MEMORY_NEW(ctx.mem, Number,
+                             pstate,
+                             (double)(list ? list->size() : 1));
     }
 
     Signature nth_sig = "nth($list, $n)";
@@ -1193,7 +1209,7 @@ namespace Sass {
       if (n->value() == 0) error("argument `$n` of `" + std::string(sig) + "` must be non-zero", pstate);
       // if the argument isn't a list, then wrap it in a singleton list
       if (!m && !l) {
-        l = new (ctx.mem) List(pstate, 1);
+        l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << ARG("$list", Expression);
       }
       size_t len = m ? m->length() : l->length();
@@ -1203,7 +1219,7 @@ namespace Sass {
       if (index < 0 || index > len - 1) error("index out of bounds for `" + std::string(sig) + "`", pstate);
 
       if (m) {
-        l = new (ctx.mem) List(pstate, 1);
+        l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << m->keys()[static_cast<unsigned int>(index)];
         *l << m->at(m->keys()[static_cast<unsigned int>(index)]);
         return l;
@@ -1220,13 +1236,13 @@ namespace Sass {
       Number* n = ARG("$n", Number);
       Expression* v = ARG("$value", Expression);
       if (!l) {
-        l = new (ctx.mem) List(pstate, 1);
+        l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << ARG("$list", Expression);
       }
       if (l->empty()) error("argument `$list` of `" + std::string(sig) + "` must not be empty", pstate);
       double index = std::floor(n->value() < 0 ? l->length() + n->value() : n->value() - 1);
       if (index < 0 || index > l->length() - 1) error("index out of bounds for `" + std::string(sig) + "`", pstate);
-      List* result = new (ctx.mem) List(pstate, l->length(), l->separator());
+      List* result = SASS_MEMORY_NEW(ctx.mem, List, pstate, l->length(), l->separator());
       for (size_t i = 0, L = l->length(); i < L; ++i) {
         *result << ((i == index) ? v : (*l)[i]);
       }
@@ -1239,13 +1255,13 @@ namespace Sass {
       List* l = dynamic_cast<List*>(env["$list"]);
       Expression* v = ARG("$value", Expression);
       if (!l) {
-        l = new (ctx.mem) List(pstate, 1);
+        l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << ARG("$list", Expression);
       }
       for (size_t i = 0, L = l->length(); i < L; ++i) {
-        if (Eval::eq(l->value_at_index(i), v)) return new (ctx.mem) Number(pstate, (double)(i+1));
+        if (Eval::eq(l->value_at_index(i), v)) return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)(i+1));
       }
-      return new (ctx.mem) Null(pstate);
+      return SASS_MEMORY_NEW(ctx.mem, Null, pstate);
     }
 
     Signature join_sig = "join($list1, $list2, $separator: auto)";
@@ -1256,12 +1272,12 @@ namespace Sass {
       String_Constant* sep = ARG("$separator", String_Constant);
       enum Sass_Separator sep_val = (l1 ? l1->separator() : SASS_SPACE);
       if (!l1) {
-        l1 = new (ctx.mem) List(pstate, 1);
+        l1 = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l1 << ARG("$list1", Expression);
         sep_val = (l2 ? l2->separator() : SASS_SPACE);
       }
       if (!l2) {
-        l2 = new (ctx.mem) List(pstate, 1);
+        l2 = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l2 << ARG("$list2", Expression);
       }
       size_t len = l1->length() + l2->length();
@@ -1269,7 +1285,7 @@ namespace Sass {
       if (sep_str == "space") sep_val = SASS_SPACE;
       else if (sep_str == "comma") sep_val = SASS_COMMA;
       else if (sep_str != "auto") error("argument `$separator` of `" + std::string(sig) + "` must be `space`, `comma`, or `auto`", pstate);
-      List* result = new (ctx.mem) List(pstate, len, sep_val);
+      List* result = SASS_MEMORY_NEW(ctx.mem, List, pstate, len, sep_val);
       *result += l1;
       *result += l2;
       return result;
@@ -1282,10 +1298,10 @@ namespace Sass {
       Expression* v = ARG("$val", Expression);
       String_Constant* sep = ARG("$separator", String_Constant);
       if (!l) {
-        l = new (ctx.mem) List(pstate, 1);
+        l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << ARG("$list", Expression);
       }
-      List* result = new (ctx.mem) List(pstate, l->length() + 1, l->separator());
+      List* result = SASS_MEMORY_NEW(ctx.mem, List, pstate, l->length() + 1, l->separator());
       std::string sep_str(unquote(sep->value()));
       if (sep_str == "space") result->separator(SASS_SPACE);
       else if (sep_str == "comma") result->separator(SASS_COMMA);
@@ -1294,11 +1310,12 @@ namespace Sass {
       bool is_arglist = l->is_arglist();
       result->is_arglist(is_arglist);
       if (is_arglist) {
-        *result << new (ctx.mem) Argument(v->pstate(),
-                                          v,
-                                          "",
-                                          false,
-                                          false);
+        *result << SASS_MEMORY_NEW(ctx.mem, Argument,
+                                   v->pstate(),
+                                   v,
+                                   "",
+                                   false,
+                                   false);
 
       } else {
         *result << v;
@@ -1309,12 +1326,12 @@ namespace Sass {
     Signature zip_sig = "zip($lists...)";
     BUILT_IN(zip)
     {
-      List* arglist = new (ctx.mem) List(*ARG("$lists", List));
+      List* arglist = SASS_MEMORY_NEW(ctx.mem, List, *ARG("$lists", List));
       size_t shortest = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         List* ith = dynamic_cast<List*>(arglist->value_at_index(i));
         if (!ith) {
-          ith = new (ctx.mem) List(pstate, 1);
+          ith = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
           *ith << arglist->value_at_index(i);
           if (arglist->is_arglist()) {
             ((Argument*)(*arglist)[i])->value(ith);
@@ -1324,10 +1341,10 @@ namespace Sass {
         }
         shortest = (i ? std::min(shortest, ith->length()) : ith->length());
       }
-      List* zippers = new (ctx.mem) List(pstate, shortest, SASS_COMMA);
+      List* zippers = SASS_MEMORY_NEW(ctx.mem, List, pstate, shortest, SASS_COMMA);
       size_t L = arglist->length();
       for (size_t i = 0; i < shortest; ++i) {
-        List* zipper = new (ctx.mem) List(pstate, L);
+        List* zipper = SASS_MEMORY_NEW(ctx.mem, List, pstate, L);
         for (size_t j = 0; j < L; ++j) {
           *zipper << (*static_cast<List*>(arglist->value_at_index(j)))[i];
         }
@@ -1341,11 +1358,12 @@ namespace Sass {
     {
       List* l = dynamic_cast<List*>(env["$list"]);
       if (!l) {
-        l = new (ctx.mem) List(pstate, 1);
+        l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << ARG("$list", Expression);
       }
-      return new (ctx.mem) String_Quoted(pstate,
-                                           l->separator() == SASS_COMMA ? "comma" : "space");
+      return SASS_MEMORY_NEW(ctx.mem, String_Quoted,
+                               pstate,
+                               l->separator() == SASS_COMMA ? "comma" : "space");
     }
 
     /////////////////
@@ -1360,7 +1378,7 @@ namespace Sass {
       try {
         return m->at(v);
       } catch (const std::out_of_range&) {
-        return new (ctx.mem) Null(pstate);
+        return SASS_MEMORY_NEW(ctx.mem, Null, pstate);
       }
       catch (...) { throw; }
     }
@@ -1370,14 +1388,14 @@ namespace Sass {
     {
       Map* m = ARGM("$map", Map, ctx);
       Expression* v = ARG("$key", Expression);
-      return new (ctx.mem) Boolean(pstate, m->has(v));
+      return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, m->has(v));
     }
 
     Signature map_keys_sig = "map-keys($map)";
     BUILT_IN(map_keys)
     {
       Map* m = ARGM("$map", Map, ctx);
-      List* result = new (ctx.mem) List(pstate, m->length(), SASS_COMMA);
+      List* result = SASS_MEMORY_NEW(ctx.mem, List, pstate, m->length(), SASS_COMMA);
       for ( auto key : m->keys()) {
         *result << key;
       }
@@ -1388,7 +1406,7 @@ namespace Sass {
     BUILT_IN(map_values)
     {
       Map* m = ARGM("$map", Map, ctx);
-      List* result = new (ctx.mem) List(pstate, m->length(), SASS_COMMA);
+      List* result = SASS_MEMORY_NEW(ctx.mem, List, pstate, m->length(), SASS_COMMA);
       for ( auto key : m->keys()) {
         *result << m->at(key);
       }
@@ -1402,7 +1420,7 @@ namespace Sass {
       Map* m2 = ARGM("$map2", Map, ctx);
 
       size_t len = m1->length() + m2->length();
-      Map* result = new (ctx.mem) Map(pstate, len);
+      Map* result = SASS_MEMORY_NEW(ctx.mem, Map, pstate, len);
       *result += m1;
       *result += m2;
       return result;
@@ -1414,7 +1432,7 @@ namespace Sass {
       bool remove;
       Map* m = ARGM("$map", Map, ctx);
       List* arglist = ARG("$keys", List);
-      Map* result = new (ctx.mem) Map(pstate, 1);
+      Map* result = SASS_MEMORY_NEW(ctx.mem, Map, pstate, 1);
       for (auto key : m->keys()) {
         remove = false;
         for (size_t j = 0, K = arglist->length(); j < K && !remove; ++j) {
@@ -1428,13 +1446,14 @@ namespace Sass {
     Signature keywords_sig = "keywords($args)";
     BUILT_IN(keywords)
     {
-      List* arglist = new (ctx.mem) List(*ARG("$args", List));
-      Map* result = new (ctx.mem) Map(pstate, 1);
+      List* arglist = SASS_MEMORY_NEW(ctx.mem, List, *ARG("$args", List));
+      Map* result = SASS_MEMORY_NEW(ctx.mem, Map, pstate, 1);
       for (size_t i = arglist->size(), L = arglist->length(); i < L; ++i) {
         std::string name = std::string(((Argument*)(*arglist)[i])->name());
         name = name.erase(0, 1); // sanitize name (remove dollar sign)
-        *result << std::make_pair(new (ctx.mem) String_Quoted(pstate, name),
-                             ((Argument*)(*arglist)[i])->value());
+        *result << std::make_pair(SASS_MEMORY_NEW(ctx.mem, String_Quoted,
+                 pstate, name),
+                 ((Argument*)(*arglist)[i])->value());
       }
       return result;
     }
@@ -1447,16 +1466,16 @@ namespace Sass {
     BUILT_IN(type_of)
     {
       Expression* v = ARG("$value", Expression);
-      return new (ctx.mem) String_Quoted(pstate, v->type());
+      return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, v->type());
     }
 
     Signature unit_sig = "unit($number)";
     BUILT_IN(unit)
-    { return new (ctx.mem) String_Quoted(pstate, quote(ARG("$number", Number)->unit(), '"')); }
+    { return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, quote(ARG("$number", Number)->unit(), '"')); }
 
     Signature unitless_sig = "unitless($number)";
     BUILT_IN(unitless)
-    { return new (ctx.mem) Boolean(pstate, ARG("$number", Number)->is_unitless()); }
+    { return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, ARG("$number", Number)->is_unitless()); }
 
     Signature comparable_sig = "comparable($number-1, $number-2)";
     BUILT_IN(comparable)
@@ -1464,11 +1483,11 @@ namespace Sass {
       Number* n1 = ARG("$number-1", Number);
       Number* n2 = ARG("$number-2", Number);
       if (n1->is_unitless() || n2->is_unitless()) {
-        return new (ctx.mem) Boolean(pstate, true);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, true);
       }
       Number tmp_n2(*n2);
       tmp_n2.normalize(n1->find_convertible_unit());
-      return new (ctx.mem) Boolean(pstate, n1->unit() == tmp_n2.unit());
+      return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, n1->unit() == tmp_n2.unit());
     }
 
     Signature variable_exists_sig = "variable-exists($name)";
@@ -1477,10 +1496,10 @@ namespace Sass {
       std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
 
       if(d_env.has("$"+s)) {
-        return new (ctx.mem) Boolean(pstate, true);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, true);
       }
       else {
-        return new (ctx.mem) Boolean(pstate, false);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, false);
       }
     }
 
@@ -1490,10 +1509,10 @@ namespace Sass {
       std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
 
       if(d_env.has_global("$"+s)) {
-        return new (ctx.mem) Boolean(pstate, true);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, true);
       }
       else {
-        return new (ctx.mem) Boolean(pstate, false);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, false);
       }
     }
 
@@ -1503,10 +1522,10 @@ namespace Sass {
       std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
 
       if(d_env.has_global(s+"[f]")) {
-        return new (ctx.mem) Boolean(pstate, true);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, true);
       }
       else {
-        return new (ctx.mem) Boolean(pstate, false);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, false);
       }
     }
 
@@ -1516,10 +1535,10 @@ namespace Sass {
       std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
 
       if(d_env.has_global(s+"[m]")) {
-        return new (ctx.mem) Boolean(pstate, true);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, true);
       }
       else {
-        return new (ctx.mem) Boolean(pstate, false);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, false);
       }
     }
 
@@ -1529,10 +1548,10 @@ namespace Sass {
       std::string s = unquote(ARG("$name", String_Constant)->value());
 
       if(features.find(s) == features.end()) {
-        return new (ctx.mem) Boolean(pstate, false);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, false);
       }
       else {
-        return new (ctx.mem) Boolean(pstate, true);
+        return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, true);
       }
     }
 
@@ -1540,23 +1559,24 @@ namespace Sass {
     BUILT_IN(call)
     {
       std::string name = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
-      List* arglist = new (ctx.mem) List(*ARG("$args", List));
+      List* arglist = SASS_MEMORY_NEW(ctx.mem, List, *ARG("$args", List));
 
-      Arguments* args = new (ctx.mem) Arguments(pstate);
+      Arguments* args = SASS_MEMORY_NEW(ctx.mem, Arguments, pstate);
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression* expr = arglist->value_at_index(i);
         if (arglist->is_arglist()) {
           Argument* arg = static_cast<Argument*>((*arglist)[i]);
-          *args << new (ctx.mem) Argument(pstate,
-                                          expr,
-                                          "",
-                                          arg->is_rest_argument(),
-                                          arg->is_keyword_argument());
+          *args << SASS_MEMORY_NEW(ctx.mem, Argument,
+                                   pstate,
+                                   expr,
+                                   "",
+                                   arg->is_rest_argument(),
+                                   arg->is_keyword_argument());
         } else {
-          *args << new (ctx.mem) Argument(pstate, expr);
+          *args << SASS_MEMORY_NEW(ctx.mem, Argument, pstate, expr);
         }
       }
-      Function_Call* func = new (ctx.mem) Function_Call(pstate, name, args);
+      Function_Call* func = SASS_MEMORY_NEW(ctx.mem, Function_Call, pstate, name, args);
       Expand expand(ctx, &d_env, backtrace);
       return func->perform(&expand.eval);
 
@@ -1568,7 +1588,7 @@ namespace Sass {
 
     Signature not_sig = "not($value)";
     BUILT_IN(sass_not)
-    { return new (ctx.mem) Boolean(pstate, ARG("$value", Expression)->is_false()); }
+    { return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, ARG("$value", Expression)->is_false()); }
 
     Signature if_sig = "if($condition, $if-true, $if-false)";
     // BUILT_IN(sass_if)
@@ -1605,9 +1625,9 @@ namespace Sass {
     {
       Expression* v = ARG("$value", Expression);
       if (v->concrete_type() == Expression::NULL_VAL) {
-        return new (ctx.mem) String_Quoted(pstate, "null");
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "null");
       } else if (v->concrete_type() == Expression::BOOLEAN && *v == 0) {
-        return new (ctx.mem) String_Quoted(pstate, "false");
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "false");
       } else if (v->concrete_type() == Expression::STRING) {
         return v;
       } else {
@@ -1620,7 +1640,7 @@ namespace Sass {
         std::string inspect = v->perform(&to_string);
         if (inspect.empty() && parentheses) inspect = "()";
         ctx.output_style = old_style;
-        return new (ctx.mem) String_Quoted(pstate, inspect);
+        return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, inspect);
       }
       // return v;
     }
@@ -1651,7 +1671,7 @@ namespace Sass {
 
       // Nothing to do
       if( parsedSelectors.empty() ) {
-        return new (ctx.mem) Null(pstate);
+        return SASS_MEMORY_NEW(ctx.mem, Null, pstate);
       }
 
       // Set the first element as the `result`, keep appending to as we go down the parsedSelector vector.
@@ -1700,7 +1720,7 @@ namespace Sass {
 
       // Nothing to do
       if( parsedSelectors.empty() ) {
-        return new (ctx.mem) Null(pstate);
+        return SASS_MEMORY_NEW(ctx.mem, Null, pstate);
       }
 
       // Set the first element as the `result`, keep appending to as we go down the parsedSelector vector.
@@ -1782,13 +1802,13 @@ namespace Sass {
       Compound_Selector* sel = ARGSEL("$selector", Compound_Selector, p_contextualize);
 
       To_String to_string;
-      List* l = new (ctx.mem) List(sel->pstate(), sel->length(), SASS_COMMA);
+      List* l = SASS_MEMORY_NEW(ctx.mem, List, sel->pstate(), sel->length(), SASS_COMMA);
 
       for (size_t i = 0, L = sel->length(); i < L; ++i) {
         Simple_Selector* ss = (*sel)[i];
         std::string ss_string = ss->perform(&to_string) ;
 
-        *l << new (ctx.mem) String_Quoted(ss->pstate(), ss_string);
+        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, ss->pstate(), ss_string);
       }
 
       return l;
@@ -1848,7 +1868,7 @@ namespace Sass {
       Selector_List* sel_sup = Parser::parse_selector(sup_src.c_str(), ctx);
       Selector_List* sel_sub = Parser::parse_selector(sub_src.c_str(), ctx);
       bool result = sel_sup->is_superselector_of(sel_sub);
-      return new (ctx.mem) Boolean(pstate, result);
+      return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, result);
     }
 
     Signature unique_id_sig = "unique-id()";
@@ -1858,7 +1878,7 @@ namespace Sass {
       std::uniform_real_distribution<> distributor(0, 4294967296); // 16^8
       uint_fast32_t distributed = static_cast<uint_fast32_t>(distributor(rand));
       ss << "u" << std::setfill('0') << std::setw(8) << std::hex << distributed;
-      return new (ctx.mem) String_Quoted(pstate, ss.str());
+      return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, ss.str());
     }
 
   }

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -16,7 +16,7 @@ namespace Sass {
 
   Expression* Listize::operator()(Selector_List* sel)
   {
-    List* l = new (ctx.mem) List(sel->pstate(), sel->length(), SASS_COMMA);
+    List* l = SASS_MEMORY_NEW(ctx.mem, List, sel->pstate(), sel->length(), SASS_COMMA);
     for (size_t i = 0, L = sel->length(); i < L; ++i) {
       if (!(*sel)[i]) continue;
       *l << (*sel)[i]->perform(this);
@@ -32,12 +32,12 @@ namespace Sass {
       Expression* e = (*sel)[i]->perform(this);
       if (e) str += e->perform(&to_string);
     }
-    return new (ctx.mem) String_Quoted(sel->pstate(), str);
+    return SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), str);
   }
 
   Expression* Listize::operator()(Complex_Selector* sel)
   {
-    List* l = new (ctx.mem) List(sel->pstate(), 2);
+    List* l = SASS_MEMORY_NEW(ctx.mem, List, sel->pstate(), 2);
 
     Compound_Selector* head = sel->head();
     if (head && !head->is_empty_reference())
@@ -52,16 +52,16 @@ namespace Sass {
     switch(sel->combinator())
     {
       case Complex_Selector::PARENT_OF:
-        *l << new (ctx.mem) String_Quoted(sel->pstate(), ">");
+        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), ">");
       break;
       case Complex_Selector::ADJACENT_TO:
-        *l << new (ctx.mem) String_Quoted(sel->pstate(), "+");
+        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), "+");
       break;
       case Complex_Selector::REFERENCE:
-        *l << new (ctx.mem) String_Quoted(sel->pstate(), "/" + reference + "/");
+        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), "/" + reference + "/");
       break;
       case Complex_Selector::PRECEDES:
-        *l << new (ctx.mem) String_Quoted(sel->pstate(), "~");
+        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), "~");
       break;
       case Complex_Selector::ANCESTOR_OF:
       break;

--- a/src/memory_manager.hpp
+++ b/src/memory_manager.hpp
@@ -24,17 +24,25 @@ namespace Sass {
     void deallocate(T* np);
     void remove(T* np);
     void destroy(T* np);
-    T* operator()(T* np);
+    T* add(T* np);
 
   };
 }
 
 template <typename T>
 inline void* operator new(size_t size, Sass::Memory_Manager<T>& mem)
-{ return mem(mem.allocate(size)); }
+{ return mem.add(mem.allocate(size)); }
 
 template <typename T>
 inline void operator delete(void *np, Sass::Memory_Manager<T>& mem)
 { mem.destroy(reinterpret_cast<T*>(np)); }
+
+///////////////////////////////////////////////////////////////////////////////
+// Use macros for the allocation task, since overloading operator `new`
+// has been proven to be flaky under certain compilers (see comment below).
+///////////////////////////////////////////////////////////////////////////////
+
+#define SASS_MEMORY_NEW(mgr, Class, ...)                                                 \
+  (static_cast<Class*>(mgr.add(new (mgr.allocate(sizeof(Class))) Class(__VA_ARGS__))))   \
 
 #endif

--- a/src/memory_manager.hpp
+++ b/src/memory_manager.hpp
@@ -29,14 +29,6 @@ namespace Sass {
   };
 }
 
-template <typename T>
-inline void* operator new(size_t size, Sass::Memory_Manager<T>& mem)
-{ return mem.add(mem.allocate(size)); }
-
-template <typename T>
-inline void operator delete(void *np, Sass::Memory_Manager<T>& mem)
-{ mem.destroy(reinterpret_cast<T*>(np)); }
-
 ///////////////////////////////////////////////////////////////////////////////
 // Use macros for the allocation task, since overloading operator `new`
 // has been proven to be flaky under certain compilers (see comment below).

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -239,7 +239,7 @@ namespace Sass {
 
     std::string noPath("");
     Position noPosition(-1, -1, -1);
-    Complex_Selector* pFirst = new (ctx.mem) Complex_Selector(ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL);
+    Complex_Selector* pFirst = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL);
 
     Complex_Selector* pCurrent = pFirst;
 
@@ -262,7 +262,7 @@ namespace Sass {
         if (childIter+1 != childIterEnd) {
           Node& nextNode = *(childIter+1);
           if (nextNode.isCombinator()) {
-            pCurrent->tail(new (ctx.mem) Complex_Selector(ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL));
+            pCurrent->tail(SASS_MEMORY_NEW(ctx.mem, Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL));
             if (nextNode.got_line_feed) pCurrent->tail()->has_line_feed(nextNode.got_line_feed);
             pCurrent = pCurrent->tail();
           }
@@ -273,8 +273,8 @@ namespace Sass {
     }
 
     // Put the dummy Compound_Selector in the first position, for consistency with the rest of libsass
-    Compound_Selector* fakeHead = new (ctx.mem) Compound_Selector(ParserState("[NODE]"), 1);
-    Parent_Selector* selectorRef = new (ctx.mem) Parent_Selector(ParserState("[NODE]"));
+    Compound_Selector* fakeHead = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, ParserState("[NODE]"), 1);
+    Parent_Selector* selectorRef = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, ParserState("[NODE]"));
     fakeHead->elements().push_back(selectorRef);
     if (toConvert.got_line_feed) pFirst->has_line_feed(toConvert.got_line_feed);
     // pFirst->has_line_feed(pFirst->has_line_feed() || pFirst->tail()->has_line_feed() || toConvert.got_line_feed);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -25,7 +25,7 @@ namespace Sass {
     p.source   = str;
     p.position = p.source;
     p.end      = str + strlen(str);
-    Block* root = new (ctx.mem) Block(pstate);
+    Block* root = SASS_MEMORY_NEW(ctx.mem, Block, pstate);
     p.block_stack.push_back(root);
     root->is_root(true);
     return p;
@@ -37,7 +37,7 @@ namespace Sass {
     p.source   = beg;
     p.position = p.source;
     p.end      = end;
-    Block* root = new (ctx.mem) Block(pstate);
+    Block* root = SASS_MEMORY_NEW(ctx.mem, Block, pstate);
     p.block_stack.push_back(root);
     root->is_root(true);
     return p;
@@ -63,7 +63,7 @@ namespace Sass {
     p.source   = t.begin;
     p.position = p.source;
     p.end      = t.end;
-    Block* root = new (ctx.mem) Block(pstate);
+    Block* root = SASS_MEMORY_NEW(ctx.mem, Block, pstate);
     p.block_stack.push_back(root);
     root->is_root(true);
     return p;
@@ -72,18 +72,18 @@ namespace Sass {
   /* main entry point to parse root block */
   Block* Parser::parse()
   {
-    Block* root = new (ctx.mem) Block(pstate, 0, true);
+    Block* root = SASS_MEMORY_NEW(ctx.mem, Block, pstate, 0, true);
     read_bom();
 
     if (ctx.queue.size() == 1) {
-      Import* pre = new (ctx.mem) Import(pstate);
+      Import* pre = SASS_MEMORY_NEW(ctx.mem, Import, pstate);
       std::string load_path(ctx.queue[0].load_path);
       do_import(load_path, pre, ctx.c_headers, false);
       ctx.head_imports = ctx.queue.size() - 1;
       if (!pre->urls().empty()) (*root) << pre;
       if (!pre->files().empty()) {
         for (size_t i = 0, S = pre->files().size(); i < S; ++i) {
-          (*root) << new (ctx.mem) Import_Stub(pstate, pre->files()[i]);
+          (*root) << SASS_MEMORY_NEW(ctx.mem, Import_Stub, pstate, pre->files()[i]);
         }
       }
     }
@@ -116,7 +116,7 @@ namespace Sass {
       css_error("Invalid CSS", " after ", ": expected \"{\", was ");
     }
     // create new block and push to the selector stack
-    Block* block = new (ctx.mem) Block(pstate, 0, is_root);
+    Block* block = SASS_MEMORY_NEW(ctx.mem, Block, pstate, 0, is_root);
     block_stack.push_back(block);
 
     if (!parse_block_nodes()) css_error("Invalid CSS", " after ", ": expected \"}\", was ");;
@@ -185,7 +185,7 @@ namespace Sass {
     while (lex< block_comment >()) {
       bool is_important = lexed.begin[2] == '!';
       String*  contents = parse_interpolated_chunk(lexed);
-      (*block) << new (ctx.mem) Comment(pstate, contents, is_important);
+      (*block) << SASS_MEMORY_NEW(ctx.mem, Comment, pstate, contents, is_important);
     }
 
     // throw away white-space
@@ -223,7 +223,7 @@ namespace Sass {
       // if it is a file(s), we should process them
       if (!imp->files().empty()) {
         for (size_t i = 0, S = imp->files().size(); i < S; ++i) {
-          (*block) << new (ctx.mem) Import_Stub(pstate, imp->files()[i]);
+          (*block) << SASS_MEMORY_NEW(ctx.mem, Import_Stub, pstate, imp->files()[i]);
         }
       }
     }
@@ -238,7 +238,7 @@ namespace Sass {
       Selector* target;
       if (lookahead.has_interpolants) target = parse_selector_schema(lookahead.found);
       else                            target = parse_selector_list();
-      (*block) << new (ctx.mem) Extension(pstate, target);
+      (*block) << SASS_MEMORY_NEW(ctx.mem, Extension, pstate, target);
     }
 
     // selector may contain interpolations which need delayed evaluation
@@ -277,7 +277,7 @@ namespace Sass {
       if (peek< exactly<'{'> >()) {
         if (decl->is_indented()) ++ indentation;
         // parse a propset that rides on the declaration's property
-        (*block) << new (ctx.mem) Propset(pstate, decl->property(), parse_block());
+        (*block) << SASS_MEMORY_NEW(ctx.mem, Propset, pstate, decl->property(), parse_block());
         if (decl->is_indented()) -- indentation;
       }
     }
@@ -296,11 +296,11 @@ namespace Sass {
     }
 
     if (extension == ".css") {
-      String_Constant* loc = new (ctx.mem) String_Constant(pstate, unquote(import_path));
-      Argument* loc_arg = new (ctx.mem) Argument(pstate, loc);
-      Arguments* loc_args = new (ctx.mem) Arguments(pstate);
+      String_Constant* loc = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, unquote(import_path));
+      Argument* loc_arg = SASS_MEMORY_NEW(ctx.mem, Argument, pstate, loc);
+      Arguments* loc_args = SASS_MEMORY_NEW(ctx.mem, Arguments, pstate);
       (*loc_args) << loc_arg;
-      Function_Call* new_url = new (ctx.mem) Function_Call(pstate, "url", loc_args);
+      Function_Call* new_url = SASS_MEMORY_NEW(ctx.mem, Function_Call, pstate, "url", loc_args);
       imp->urls().push_back(new_url);
     }
     else {
@@ -319,7 +319,7 @@ namespace Sass {
         !unquote(import_path).substr(0, 8).compare("https://") ||
         !unquote(import_path).substr(0, 2).compare("//"))
     {
-      imp->urls().push_back(new (ctx.mem) String_Quoted(pstate, import_path));
+      imp->urls().push_back(SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, import_path));
     }
     else {
       add_single_file(imp, import_path);
@@ -375,7 +375,7 @@ namespace Sass {
 
   Import* Parser::parse_import()
   {
-    Import* imp = new (ctx.mem) Import(pstate);
+    Import* imp = SASS_MEMORY_NEW(ctx.mem, Import, pstate);
     std::vector<std::pair<std::string,Function_Call*>> to_import;
     bool first = true;
     do {
@@ -389,19 +389,19 @@ namespace Sass {
         }
       }
       else if (lex< uri_prefix >()) {
-        Arguments* args = new (ctx.mem) Arguments(pstate);
-        Function_Call* result = new (ctx.mem) Function_Call(pstate, "url", args);
+        Arguments* args = SASS_MEMORY_NEW(ctx.mem, Arguments, pstate);
+        Function_Call* result = SASS_MEMORY_NEW(ctx.mem, Function_Call, pstate, "url", args);
         if (lex< quoted_string >()) {
           Expression* the_url = parse_string();
-          *args << new (ctx.mem) Argument(the_url->pstate(), the_url);
+          *args << SASS_MEMORY_NEW(ctx.mem, Argument, the_url->pstate(), the_url);
         }
         else if (lex < uri_value >(false)) { // don't skip comments
           String* the_url = parse_interpolated_chunk(lexed);
-          *args << new (ctx.mem) Argument(the_url->pstate(), the_url);
+          *args << SASS_MEMORY_NEW(ctx.mem, Argument, the_url->pstate(), the_url);
         }
         else if (peek < skip_over_scopes < exactly < '(' >, exactly < ')' > > >(position)) {
           Expression* the_url = parse_list(); // parse_interpolated_chunk(lexed);
-          *args << new (ctx.mem) Argument(the_url->pstate(), the_url);
+          *args << SASS_MEMORY_NEW(ctx.mem, Argument, the_url->pstate(), the_url);
         }
         else {
           error("malformed URL", pstate);
@@ -446,7 +446,7 @@ namespace Sass {
     else stack.push_back(function_def);
     Block* body = parse_block();
     stack.pop_back();
-    Definition* def = new (ctx.mem) Definition(source_position_of_def, name, params, body, which_type);
+    Definition* def = SASS_MEMORY_NEW(ctx.mem, Definition, source_position_of_def, name, params, body, which_type);
     return def;
   }
 
@@ -454,7 +454,7 @@ namespace Sass {
   {
     std::string name(lexed);
     Position position = after_token;
-    Parameters* params = new (ctx.mem) Parameters(pstate);
+    Parameters* params = SASS_MEMORY_NEW(ctx.mem, Parameters, pstate);
     if (lex_css< exactly<'('> >()) {
       // if there's anything there at all
       if (!peek_css< exactly<')'> >()) {
@@ -483,7 +483,7 @@ namespace Sass {
     else if (lex< exactly< ellipsis > >()) {
       is_rest = true;
     }
-    Parameter* p = new (ctx.mem) Parameter(pos, name, val, is_rest);
+    Parameter* p = SASS_MEMORY_NEW(ctx.mem, Parameter, pos, name, val, is_rest);
     return p;
   }
 
@@ -491,7 +491,7 @@ namespace Sass {
   {
     std::string name(lexed);
     Position position = after_token;
-    Arguments* args = new (ctx.mem) Arguments(pstate);
+    Arguments* args = SASS_MEMORY_NEW(ctx.mem, Arguments, pstate);
     if (lex_css< exactly<'('> >()) {
       // if there's anything there at all
       if (!peek_css< exactly<')'> >()) {
@@ -510,7 +510,7 @@ namespace Sass {
     // some urls can look like line comments (parse literally - chunk would not work)
     if (has_url && lex< sequence < uri_value, lookahead < loosely<')'> > > >(false)) {
       String* the_url = parse_interpolated_chunk(lexed);
-      arg = new (ctx.mem) Argument(the_url->pstate(), the_url);
+      arg = SASS_MEMORY_NEW(ctx.mem, Argument, the_url->pstate(), the_url);
     }
     else if (peek_css< sequence < variable, optional_css_comments, exactly<':'> > >()) {
       lex_css< variable >();
@@ -519,7 +519,7 @@ namespace Sass {
       lex_css< exactly<':'> >();
       Expression* val = parse_space_list();
       val->is_delayed(false);
-      arg = new (ctx.mem) Argument(p, val, name);
+      arg = SASS_MEMORY_NEW(ctx.mem, Argument, p, val, name);
     }
     else {
       bool is_arglist = false;
@@ -530,7 +530,7 @@ namespace Sass {
         if (val->concrete_type() == Expression::MAP) is_keyword = true;
         else is_arglist = true;
       }
-      arg = new (ctx.mem) Argument(pstate, val, "", is_arglist, is_keyword);
+      arg = SASS_MEMORY_NEW(ctx.mem, Argument, pstate, val, "", is_arglist, is_keyword);
     }
     return arg;
   }
@@ -554,7 +554,7 @@ namespace Sass {
       if (lex< default_flag >()) is_default = true;
       else if (lex< global_flag >()) is_global = true;
     }
-    Assignment* var = new (ctx.mem) Assignment(var_source_position, name, val, is_default, is_global);
+    Assignment* var = SASS_MEMORY_NEW(ctx.mem, Assignment, var_source_position, name, val, is_default, is_global);
     return var;
   }
 
@@ -562,7 +562,7 @@ namespace Sass {
   Ruleset* Parser::parse_ruleset(Lookahead lookahead)
   {
     // create the connector object (add parts later)
-    Ruleset* ruleset = new (ctx.mem) Ruleset(pstate);
+    Ruleset* ruleset = SASS_MEMORY_NEW(ctx.mem, Ruleset, pstate);
     // parse selector static or as schema to be evaluated later
     if (lookahead.parsable) ruleset->selector(parse_selector_list());
     else ruleset->selector(parse_selector_schema(lookahead.found));
@@ -583,16 +583,16 @@ namespace Sass {
     lex< optional_spaces >();
     const char* i = position;
     // selector schema re-uses string schema implementation
-    String_Schema* schema = new (ctx.mem) String_Schema(pstate);
+    String_Schema* schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate);
     // the selector schema is pretty much just a wrapper for the string schema
-    Selector_Schema* selector_schema = new (ctx.mem) Selector_Schema(pstate, schema);
+    Selector_Schema* selector_schema = SASS_MEMORY_NEW(ctx.mem, Selector_Schema, pstate, schema);
 
     // process until end
     while (i < end_of_selector) {
       // try to parse mutliple interpolants
       if (const char* p = find_first_in_interval< exactly<hash_lbrace> >(i, end_of_selector)) {
         // accumulate the preceding segment if the position has advanced
-        if (i < p) (*schema) << new (ctx.mem) String_Constant(pstate, std::string(i, p));
+        if (i < p) (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, std::string(i, p));
         // check if the interpolation only contains white-space (error out)
         if (peek < sequence < optional_spaces, exactly<rbrace> > >(p+2)) { position = p+2;
           css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
@@ -612,7 +612,7 @@ namespace Sass {
       // add the last segment if there is one
       else {
         // make sure to add the last bits of the string up to the end (if any)
-        if (i < end_of_selector) (*schema) << new (ctx.mem) String_Constant(pstate, std::string(i, end_of_selector));
+        if (i < end_of_selector) (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, std::string(i, end_of_selector));
         // exit loop
         i = end_of_selector;
       }
@@ -649,7 +649,7 @@ namespace Sass {
     // normalize underscores to hyphens
     std::string name(Util::normalize_underscores(lexed));
     // create the initial mixin call object
-    Mixin_Call* call = new (ctx.mem) Mixin_Call(pstate, name, 0, 0);
+    Mixin_Call* call = SASS_MEMORY_NEW(ctx.mem, Mixin_Call, pstate, name, 0, 0);
     // parse mandatory arguments
     call->arguments(parse_arguments());
     // parse optional block
@@ -669,7 +669,7 @@ namespace Sass {
     bool had_linefeed = false;
     Complex_Selector* sel = 0;
     To_String to_string(&ctx);
-    Selector_List* group = new (ctx.mem) Selector_List(pstate);
+    Selector_List* group = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate);
 
     do {
       reloop = false;
@@ -741,7 +741,7 @@ namespace Sass {
       // comments are allowed, but not spaces?
       combinator = Complex_Selector::REFERENCE;
       if (!lex < re_reference_combinator >()) return 0;
-      reference = new (ctx.mem) String_Constant(pstate, lexed);
+      reference = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
       if (!lex < exactly < '/' > >()) return 0; // ToDo: error msg?
     }
     else /* if (lex< zero >()) */   combinator = Complex_Selector::ANCESTOR_OF;
@@ -751,7 +751,7 @@ namespace Sass {
     // lex < block_comment >();
     // source position of a complex selector points to the combinator
     // ToDo: make sure we update pstate for ancestor of (lex < zero >());
-    Complex_Selector* sel = new (ctx.mem) Complex_Selector(pstate, combinator, lhs);
+    Complex_Selector* sel = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pstate, combinator, lhs);
     if (combinator == Complex_Selector::REFERENCE) sel->reference(reference);
     // has linfeed after combinator?
     sel->has_line_break(peek_newline());
@@ -772,14 +772,14 @@ namespace Sass {
     // also skip adding parent ref if we only have refs
     if (!sel->has_reference() && !in_at_root && !in_root) {
       // create the objects to wrap parent selector reference
-      Parent_Selector* parent = new (ctx.mem) Parent_Selector(pstate);
-      Compound_Selector* head = new (ctx.mem) Compound_Selector(pstate);
+      Parent_Selector* parent = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate);
+      Compound_Selector* head = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pstate);
       // add simple selector
       (*head) << parent;
       // selector may not have any head yet
       if (!sel->head()) { sel->head(head); }
       // otherwise we need to create a new complex selector and set the old one as its tail
-      else { sel = new (ctx.mem) Complex_Selector(pstate, Complex_Selector::ANCESTOR_OF, head, sel); }
+      else { sel = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pstate, Complex_Selector::ANCESTOR_OF, head, sel); }
       // peek for linefeed and remember result on head
       // if (peek_newline()) head->has_line_break(true);
     }
@@ -795,7 +795,7 @@ namespace Sass {
   Compound_Selector* Parser::parse_compound_selector()
   {
     // init an empty compound selector wrapper
-    Compound_Selector* seq = new (ctx.mem) Compound_Selector(pstate);
+    Compound_Selector* seq = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pstate);
 
     // skip initial white-space
     lex< css_whitespace >();
@@ -815,12 +815,12 @@ namespace Sass {
       {
         // this produces a linefeed!?
         seq->has_parent_reference(true);
-        (*seq) << new (ctx.mem) Parent_Selector(pstate);
+        (*seq) << SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate);
       }
       // parse type selector
       else if (lex< re_type_selector >(false))
       {
-        (*seq) << new (ctx.mem) Type_Selector(pstate, lexed);
+        (*seq) << SASS_MEMORY_NEW(ctx.mem, Type_Selector, pstate, lexed);
       }
       // peek for abort conditions
       else if (peek< spaces >()) break;
@@ -849,13 +849,13 @@ namespace Sass {
   {
     lex < css_comments >();
     if (lex< alternatives < id_name, class_name > >()) {
-      return new (ctx.mem) Selector_Qualifier(pstate, lexed);
+      return SASS_MEMORY_NEW(ctx.mem, Selector_Qualifier, pstate, lexed);
     }
     else if (lex< quoted_string >()) {
-      return new (ctx.mem) Type_Selector(pstate, unquote(lexed));
+      return SASS_MEMORY_NEW(ctx.mem, Type_Selector, pstate, unquote(lexed));
     }
     else if (lex< alternatives < variable, number, static_reference_combinator > >()) {
-      return new (ctx.mem) Type_Selector(pstate, lexed);
+      return SASS_MEMORY_NEW(ctx.mem, Type_Selector, pstate, lexed);
     }
     else if (peek< pseudo_not >()) {
       return parse_negated_selector();
@@ -870,7 +870,7 @@ namespace Sass {
       return parse_attribute_selector();
     }
     else if (lex< placeholder >()) {
-      return new (ctx.mem) Selector_Placeholder(pstate, lexed);
+      return SASS_MEMORY_NEW(ctx.mem, Selector_Placeholder, pstate, lexed);
     }
     // failed
     return 0;
@@ -886,7 +886,7 @@ namespace Sass {
       error("negated selector is missing ')'", pstate);
     }
     name.erase(name.size() - 1);
-    return new (ctx.mem) Wrapped_Selector(nsource_position, name, negated);
+    return SASS_MEMORY_NEW(ctx.mem, Wrapped_Selector, nsource_position, name, negated);
   }
 
   // a pseudo selector often starts with one or two colons
@@ -919,15 +919,15 @@ namespace Sass {
           >()
       ) {
         lex_css< alternatives < static_value, binomial > >();
-        String_Constant* expr = new (ctx.mem) String_Constant(pstate, lexed);
+        String_Constant* expr = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
         if (expr && lex_css< exactly<')'> >()) {
           expr->can_compress_whitespace(true);
-          return new (ctx.mem) Pseudo_Selector(p, name, expr);
+          return SASS_MEMORY_NEW(ctx.mem, Pseudo_Selector, p, name, expr);
         }
       }
       else if (Selector* wrapped = parse_selector_list()) {
         if (wrapped && lex_css< exactly<')'> >()) {
-          return new (ctx.mem) Wrapped_Selector(p, name, wrapped);
+          return SASS_MEMORY_NEW(ctx.mem, Wrapped_Selector, p, name, wrapped);
         }
       }
 
@@ -935,7 +935,7 @@ namespace Sass {
     // EO if pseudo selector
 
     else if (lex < sequence< optional < pseudo_prefix >, identifier > >()) {
-      return new (ctx.mem) Pseudo_Selector(pstate, lexed);
+      return SASS_MEMORY_NEW(ctx.mem, Pseudo_Selector, pstate, lexed);
     }
     else if(lex < pseudo_prefix >()) {
       css_error("Invalid CSS", " after ", ": expected pseudoclass or pseudoelement, was ");
@@ -952,7 +952,7 @@ namespace Sass {
     ParserState p = pstate;
     if (!lex_css< attribute_name >()) error("invalid attribute name in attribute selector", pstate);
     std::string name(lexed);
-    if (lex_css< alternatives < exactly<']'>, exactly<'/'> > >()) return new (ctx.mem) Attribute_Selector(p, name, "", 0);
+    if (lex_css< alternatives < exactly<']'>, exactly<'/'> > >()) return SASS_MEMORY_NEW(ctx.mem, Attribute_Selector, p, name, "", 0);
     if (!lex_css< alternatives< exact_match, class_match, dash_match,
                                 prefix_match, suffix_match, substring_match > >()) {
       error("invalid operator in attribute selector for " + name, pstate);
@@ -961,7 +961,7 @@ namespace Sass {
 
     String* value = 0;
     if (lex_css< identifier >()) {
-      value = new (ctx.mem) String_Constant(p, lexed);
+      value = SASS_MEMORY_NEW(ctx.mem, String_Constant, p, lexed);
     }
     else if (lex_css< quoted_string >()) {
       value = parse_interpolated_chunk(lexed, true); // needed!
@@ -971,7 +971,7 @@ namespace Sass {
     }
 
     if (!lex_css< alternatives < exactly<']'>, exactly<'/'> > >()) error("unterminated attribute selector for " + name, pstate);
-    return new (ctx.mem) Attribute_Selector(p, name, matcher, value);
+    return SASS_MEMORY_NEW(ctx.mem, Attribute_Selector, p, name, matcher, value);
   }
 
   /* parse block comment and add to block */
@@ -981,7 +981,7 @@ namespace Sass {
     while (lex< block_comment >()) {
       bool is_important = lexed.begin[2] == '!';
       String*  contents = parse_interpolated_chunk(lexed);
-      (*block) << new (ctx.mem) Comment(pstate, contents, is_important);
+      (*block) << SASS_MEMORY_NEW(ctx.mem, Comment, pstate, contents, is_important);
     }
   }
 
@@ -991,7 +991,7 @@ namespace Sass {
       prop = parse_identifier_schema();
     }
     else if (lex< sequence< optional< exactly<'*'> >, identifier, zero_plus< block_comment > > >()) {
-      prop = new (ctx.mem) String_Constant(pstate, lexed);
+      prop = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
       prop->is_delayed(true);
     }
     else {
@@ -1004,7 +1004,7 @@ namespace Sass {
     if (peek_css< exactly<';'> >()) error("style declaration must contain a value", pstate);
     if (peek_css< exactly<'{'> >()) is_indented = false; // don't indent if value is empty
     if (peek_css< static_value >()) {
-      return new (ctx.mem) Declaration(prop->pstate(), prop, parse_static_value()/*, lex<kwd_important>()*/);
+      return SASS_MEMORY_NEW(ctx.mem, Declaration, prop->pstate(), prop, parse_static_value()/*, lex<kwd_important>()*/);
     }
     else {
       Expression* value;
@@ -1025,7 +1025,7 @@ namespace Sass {
         }
       }
 
-      auto decl = new (ctx.mem) Declaration(prop->pstate(), prop, value/*, lex<kwd_important>()*/);
+      auto decl = SASS_MEMORY_NEW(ctx.mem, Declaration, prop->pstate(), prop, value/*, lex<kwd_important>()*/);
       decl->is_indented(is_indented);
       return decl;
     }
@@ -1050,11 +1050,11 @@ namespace Sass {
   Expression* Parser::parse_map()
   {
     Expression* key = parse_list();
-    Map* map = new (ctx.mem) Map(pstate, 1);
+    Map* map = SASS_MEMORY_NEW(ctx.mem, Map, pstate, 1);
     if (String_Quoted* str = dynamic_cast<String_Quoted*>(key)) {
       if (!str->quote_mark() && !str->is_delayed()) {
         if (const Color* col = name_to_color(str->value())) {
-          Color* c = new (ctx.mem) Color(*col);
+          Color* c = SASS_MEMORY_NEW(ctx.mem, Color, *col);
           c->pstate(str->pstate());
           c->disp(str->value());
           key = c;
@@ -1082,7 +1082,7 @@ namespace Sass {
       if (String_Quoted* str = dynamic_cast<String_Quoted*>(key)) {
         if (!str->quote_mark() && !str->is_delayed()) {
           if (const Color* col = name_to_color(str->value())) {
-            Color* c = new (ctx.mem) Color(*col);
+            Color* c = SASS_MEMORY_NEW(ctx.mem, Color, *col);
             c->pstate(str->pstate());
             c->disp(str->value());
             key = c;
@@ -1130,7 +1130,7 @@ namespace Sass {
           default_flag,
           global_flag
         > >(position))
-    { return new (ctx.mem) List(pstate, 0); }
+    { return SASS_MEMORY_NEW(ctx.mem, List, pstate, 0); }
 
     // now try to parse a space list
     Expression* list = parse_space_list();
@@ -1138,7 +1138,7 @@ namespace Sass {
     if (!peek_css< exactly<','> >(position)) return list;
 
     // if we got so far, we actually do have a comma list
-    List* comma_list = new (ctx.mem) List(pstate, 2, SASS_COMMA);
+    List* comma_list = SASS_MEMORY_NEW(ctx.mem, List, pstate, 2, SASS_COMMA);
     // wrap the first expression
     (*comma_list) << list;
 
@@ -1183,7 +1183,7 @@ namespace Sass {
         > >(position)
     ) { return disj1; }
 
-    List* space_list = new (ctx.mem) List(pstate, 2, SASS_SPACE);
+    List* space_list = SASS_MEMORY_NEW(ctx.mem, List, pstate, 2, SASS_SPACE);
     (*space_list) << disj1;
 
     while (!(peek_css< alternatives <
@@ -1267,7 +1267,7 @@ namespace Sass {
     // parse the right hand side expression
     Expression* rhs = parse_expression();
     // return binary expression with a left and a right hand side
-    return new (ctx.mem) Binary_Expression(lhs->pstate(), op, lhs, rhs);
+    return SASS_MEMORY_NEW(ctx.mem, Binary_Expression, lhs->pstate(), op, lhs, rhs);
   }
   // parse_relation
 
@@ -1379,17 +1379,17 @@ namespace Sass {
       return parse_function_call();
     }
     else if (lex< exactly<'+'> >()) {
-      return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::PLUS, parse_factor());
+      return SASS_MEMORY_NEW(ctx.mem, Unary_Expression, pstate, Unary_Expression::PLUS, parse_factor());
     }
     else if (lex< exactly<'-'> >()) {
-      return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::MINUS, parse_factor());
+      return SASS_MEMORY_NEW(ctx.mem, Unary_Expression, pstate, Unary_Expression::MINUS, parse_factor());
     }
     else if (lex< sequence< kwd_not > >()) {
-      return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::NOT, parse_factor());
+      return SASS_MEMORY_NEW(ctx.mem, Unary_Expression, pstate, Unary_Expression::NOT, parse_factor());
     }
     else if (peek < sequence < one_plus < alternatives < css_whitespace, exactly<'-'>, exactly<'+'> > >, number > >()) {
       if (parse_number_prefix()) return parse_value(); // prefix is positive
-      return new (ctx.mem) Unary_Expression(pstate, Unary_Expression::MINUS, parse_value());
+      return SASS_MEMORY_NEW(ctx.mem, Unary_Expression, pstate, Unary_Expression::MINUS, parse_value());
     }
     else {
       return parse_value();
@@ -1402,10 +1402,10 @@ namespace Sass {
     lex< css_comments >();
     if (lex< ampersand >())
     {
-      return new (ctx.mem) Parent_Selector(pstate); }
+      return SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate); }
 
     if (lex< kwd_important >())
-    { return new (ctx.mem) String_Constant(pstate, "!important"); }
+    { return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, "!important"); }
 
     if (const char* stop = peek< value_schema >())
     { return parse_value_schema(stop); }
@@ -1415,44 +1415,44 @@ namespace Sass {
     { return parse_string(); }
 
     if (lex< kwd_true >())
-    { return new (ctx.mem) Boolean(pstate, true); }
+    { return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, true); }
 
     if (lex< kwd_false >())
-    { return new (ctx.mem) Boolean(pstate, false); }
+    { return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, false); }
 
     if (lex< kwd_null >())
-    { return new (ctx.mem) Null(pstate); }
+    { return SASS_MEMORY_NEW(ctx.mem, Null, pstate); }
 
     if (lex< identifier >()) {
-      return new (ctx.mem) String_Constant(pstate, lexed);
+      return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
     }
 
     if (lex< percentage >())
-    { return new (ctx.mem) Textual(pstate, Textual::PERCENTAGE, lexed); }
+    { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::PERCENTAGE, lexed); }
 
     // match hex number first because 0x000 looks like a number followed by an indentifier
     if (lex< sequence < alternatives< hex, hex0 >, negate < exactly<'-'> > > >())
-    { return new (ctx.mem) Textual(pstate, Textual::HEX, lexed); }
+    { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::HEX, lexed); }
 
     if (lex< sequence < exactly <'#'>, identifier > >())
-    { return new (ctx.mem) String_Quoted(pstate, lexed); }
+    { return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, lexed); }
 
     // also handle the 10em- foo special case
     if (lex< sequence< dimension, optional< sequence< exactly<'-'>, negate< digit > > > > >())
-    { return new (ctx.mem) Textual(pstate, Textual::DIMENSION, lexed); }
+    { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::DIMENSION, lexed); }
 
     if (lex< sequence< static_component, one_plus< identifier > > >())
-    { return new (ctx.mem) String_Constant(pstate, lexed); }
+    { return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed); }
 
     if (lex< number >())
-    { return new (ctx.mem) Textual(pstate, Textual::NUMBER, lexed); }
+    { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::NUMBER, lexed); }
 
     if (lex< variable >())
-    { return new (ctx.mem) Variable(pstate, Util::normalize_underscores(lexed)); }
+    { return SASS_MEMORY_NEW(ctx.mem, Variable, pstate, Util::normalize_underscores(lexed)); }
 
     // Special case handling for `%` proceeding an interpolant.
     if (lex< sequence< exactly<'%'>, optional< percentage > > >())
-    { return new (ctx.mem) String_Constant(pstate, lexed); }
+    { return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed); }
 
     error("error reading values after " + lexed.to_string(), pstate);
 
@@ -1468,19 +1468,19 @@ namespace Sass {
     // see if there any interpolants
     const char* p = find_first_in_interval< exactly<hash_lbrace> >(i, chunk.end);
     if (!p) {
-      String_Quoted* str_quoted = new (ctx.mem) String_Quoted(pstate, std::string(i, chunk.end));
+      String_Quoted* str_quoted = SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, std::string(i, chunk.end));
       if (!constant && str_quoted->quote_mark()) str_quoted->quote_mark('*');
       str_quoted->is_delayed(true);
       return str_quoted;
     }
 
-    String_Schema* schema = new (ctx.mem) String_Schema(pstate);
+    String_Schema* schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate);
     while (i < chunk.end) {
       p = find_first_in_interval< exactly<hash_lbrace> >(i, chunk.end);
       if (p) {
         if (i < p) {
           // accumulate the preceding segment if it's nonempty
-          (*schema) << new (ctx.mem) String_Constant(pstate, std::string(i, p));
+          (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, std::string(i, p));
         }
         // we need to skip anything inside strings
         // create a new target in parser/prelexer
@@ -1502,7 +1502,7 @@ namespace Sass {
       }
       else { // no interpolants left; add the last segment if nonempty
         // check if we need quotes here (was not sure after merge)
-        if (i < chunk.end) (*schema) << new (ctx.mem) String_Constant(pstate, std::string(i, chunk.end));
+        if (i < chunk.end) (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, std::string(i, chunk.end));
         break;
       }
       ++ i;
@@ -1526,7 +1526,7 @@ namespace Sass {
     --str.end;
     --position;
 
-    String_Constant* str_node = new (ctx.mem) String_Constant(pstate, str.time_wspace());
+    String_Constant* str_node = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, str.time_wspace());
     str_node->is_delayed(true);
     return str_node;
   }
@@ -1544,15 +1544,15 @@ namespace Sass {
     // see if there any interpolants
     const char* p = find_first_in_interval< exactly<hash_lbrace> >(str.begin, str.end);
     if (!p) {
-      return new (ctx.mem) String_Quoted(pstate, std::string(str.begin, str.end));
+      return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, std::string(str.begin, str.end));
     }
 
-    String_Schema* schema = new (ctx.mem) String_Schema(pstate);
+    String_Schema* schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate);
     while (i < str.end) {
       p = find_first_in_interval< exactly<hash_lbrace> >(i, str.end);
       if (p) {
         if (i < p) {
-          (*schema) << new (ctx.mem) String_Constant(pstate, std::string(i, p)); // accumulate the preceding segment if it's nonempty
+          (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, std::string(i, p)); // accumulate the preceding segment if it's nonempty
         }
         if (peek < sequence < optional_spaces, exactly<rbrace> > >(p+2)) { position = p+2;
           css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
@@ -1572,7 +1572,7 @@ namespace Sass {
       }
       else { // no interpolants left; add the last segment if nonempty
         if (i < str.end) {
-          (*schema) << new (ctx.mem) String_Constant(pstate, std::string(i, str.end));
+          (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, std::string(i, str.end));
         }
         break;
       }
@@ -1582,17 +1582,17 @@ namespace Sass {
 
   String* Parser::parse_ie_keyword_arg()
   {
-    String_Schema* kwd_arg = new (ctx.mem) String_Schema(pstate, 3);
+    String_Schema* kwd_arg = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate, 3);
     if (lex< variable >()) {
-      *kwd_arg << new (ctx.mem) Variable(pstate, Util::normalize_underscores(lexed));
+      *kwd_arg << SASS_MEMORY_NEW(ctx.mem, Variable, pstate, Util::normalize_underscores(lexed));
     } else {
       lex< alternatives< identifier_schema, identifier > >();
-      *kwd_arg << new (ctx.mem) String_Constant(pstate, lexed);
+      *kwd_arg << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
     }
     lex< exactly<'='> >();
-    *kwd_arg << new (ctx.mem) String_Constant(pstate, lexed);
+    *kwd_arg << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
     if (peek< variable >()) *kwd_arg << parse_list();
-    else if (lex< number >()) *kwd_arg << new (ctx.mem) Textual(pstate, Textual::NUMBER, Util::normalize_decimals(lexed));
+    else if (lex< number >()) *kwd_arg << SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::NUMBER, Util::normalize_decimals(lexed));
     else if (peek < ie_keyword_arg_value >()) { *kwd_arg << parse_list(); }
     return kwd_arg;
   }
@@ -1600,7 +1600,7 @@ namespace Sass {
   String_Schema* Parser::parse_value_schema(const char* stop)
   {
     // initialize the string schema object to add tokens
-    String_Schema* schema = new (ctx.mem) String_Schema(pstate);
+    String_Schema* schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate);
 
     if (peek<exactly<'}'>>()) {
       css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
@@ -1611,7 +1611,7 @@ namespace Sass {
     while (position < stop) {
       // parse space between tokens
       if (lex< spaces >() && num_items) {
-        (*schema) << new (ctx.mem) String_Constant(pstate, " ");
+        (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, " ");
       }
       if ((e = peek< re_functional >()) && e < stop) {
         (*schema) << parse_function_call();
@@ -1620,7 +1620,7 @@ namespace Sass {
       else if (lex< exactly < hash_lbrace > >()) {
         // Try to lex static expression first
         if (lex< re_static_expression >()) {
-          (*schema) << new (ctx.mem) String_Constant(pstate, lexed);
+          (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
         } else {
           (*schema) << parse_list();
         }
@@ -1629,41 +1629,41 @@ namespace Sass {
       }
       // lex some string constants
       else if (lex< alternatives < exactly<'%'>, exactly < '-' >, identifier > >()) {
-        (*schema) << new (ctx.mem) String_Constant(pstate, lexed);
+        (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
         if (*position == '"' || *position == '\'') {
-          (*schema) << new (ctx.mem) String_Constant(pstate, " ");
+          (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, " ");
         }
       }
       // lex a quoted string
       else if (lex< quoted_string >()) {
-        (*schema) << new (ctx.mem) String_Quoted(pstate, lexed, '"');
+        (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, lexed, '"');
         if (*position == '"' || *position == '\'' || alpha(position)) {
-          (*schema) << new (ctx.mem) String_Constant(pstate, " ");
+          (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, " ");
         }
       }
       // lex (normalized) variable
       else if (lex< variable >()) {
         std::string name(Util::normalize_underscores(lexed));
-        (*schema) << new (ctx.mem) Variable(pstate, name);
+        (*schema) << SASS_MEMORY_NEW(ctx.mem, Variable, pstate, name);
       }
       // lex percentage value
       else if (lex< percentage >()) {
-        (*schema) << new (ctx.mem) Textual(pstate, Textual::PERCENTAGE, lexed);
+        (*schema) << SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::PERCENTAGE, lexed);
       }
       // lex dimension value
       else if (lex< dimension >()) {
-        (*schema) << new (ctx.mem) Textual(pstate, Textual::DIMENSION, lexed);
+        (*schema) << SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::DIMENSION, lexed);
       }
       // lex number value
       else if (lex< number >()) {
-        (*schema) <<  new (ctx.mem) Textual(pstate, Textual::NUMBER, lexed);
+        (*schema) <<  SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::NUMBER, lexed);
       }
       // lex hex color value
       else if (lex< sequence < hex, negate < exactly < '-' > > > >()) {
-        (*schema) << new (ctx.mem) Textual(pstate, Textual::HEX, lexed);
+        (*schema) << SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::HEX, lexed);
       }
       else if (lex< sequence < exactly <'#'>, identifier > >()) {
-        (*schema) << new (ctx.mem) String_Quoted(pstate, lexed);
+        (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, lexed);
       }
       // lex a value in parentheses
       else if (peek< parenthese_scope >()) {
@@ -1686,10 +1686,10 @@ namespace Sass {
     // see if there any interpolants
     const char* p = find_first_in_interval< exactly<hash_lbrace> >(id.begin, id.end);
     if (!p) {
-      return new (ctx.mem) String_Constant(pstate, std::string(id.begin, id.end));
+      return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, std::string(id.begin, id.end));
     }
 
-    String_Schema* schema = new (ctx.mem) String_Schema(pstate);
+    String_Schema* schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate);
     while (i < id.end) {
       p = find_first_in_interval< exactly<hash_lbrace> >(i, id.end);
       if (p) {
@@ -1746,10 +1746,10 @@ namespace Sass {
           exactly < ')' >
         > >();
 
-    Argument* arg = new (ctx.mem) Argument(arg_pos, parse_interpolated_chunk(Token(arg_beg, arg_end)));
-    Arguments* args = new (ctx.mem) Arguments(arg_pos);
+    Argument* arg = SASS_MEMORY_NEW(ctx.mem, Argument, arg_pos, parse_interpolated_chunk(Token(arg_beg, arg_end)));
+    Arguments* args = SASS_MEMORY_NEW(ctx.mem, Arguments, arg_pos);
     *args << arg;
-    return new (ctx.mem) Function_Call(call_pos, name, args);
+    return SASS_MEMORY_NEW(ctx.mem, Function_Call, call_pos, name, args);
   }
 
   Function_Call* Parser::parse_function_call()
@@ -1760,7 +1760,7 @@ namespace Sass {
     ParserState call_pos = pstate;
     bool expect_url = name == "url" || name == "url-prefix";
     Arguments* args = parse_arguments(expect_url);
-    return new (ctx.mem) Function_Call(call_pos, name, args);
+    return SASS_MEMORY_NEW(ctx.mem, Function_Call, call_pos, name, args);
   }
 
   Function_Call_Schema* Parser::parse_function_call_schema()
@@ -1768,7 +1768,7 @@ namespace Sass {
     String* name = parse_identifier_schema();
     ParserState source_position_of_call = pstate;
 
-    Function_Call_Schema* the_call = new (ctx.mem) Function_Call_Schema(source_position_of_call, name, parse_arguments());
+    Function_Call_Schema* the_call = SASS_MEMORY_NEW(ctx.mem, Function_Call_Schema, source_position_of_call, name, parse_arguments());
     return the_call;
   }
 
@@ -1777,7 +1777,7 @@ namespace Sass {
     if (stack.back() != mixin_def) {
       error("@content may only be used within a mixin", pstate);
     }
-    return new (ctx.mem) Content(pstate);
+    return SASS_MEMORY_NEW(ctx.mem, Content, pstate);
   }
 
   If* Parser::parse_if_directive(bool else_if)
@@ -1789,13 +1789,13 @@ namespace Sass {
     Block* alternative = 0;
 
     if (lex< elseif_directive >()) {
-      alternative = new (ctx.mem) Block(pstate);
+      alternative = SASS_MEMORY_NEW(ctx.mem, Block, pstate);
       (*alternative) << parse_if_directive(true);
     }
     else if (lex< kwd_else_directive >()) {
       alternative = parse_block();
     }
-    return new (ctx.mem) If(if_source_position, predicate, block, alternative);
+    return SASS_MEMORY_NEW(ctx.mem, If, if_source_position, predicate, block, alternative);
   }
 
   For* Parser::parse_for_directive()
@@ -1813,7 +1813,7 @@ namespace Sass {
     Expression* upper_bound = parse_expression();
     upper_bound->is_delayed(false);
     Block* body = parse_block();
-    return new (ctx.mem) For(for_source_position, var, lower_bound, upper_bound, body, inclusive);
+    return SASS_MEMORY_NEW(ctx.mem, For, for_source_position, var, lower_bound, upper_bound, body, inclusive);
   }
 
   // helper to parse a var token
@@ -1862,14 +1862,14 @@ namespace Sass {
       }
     }
     Block* body = parse_block();
-    return new (ctx.mem) Each(each_source_position, vars, list, body);
+    return SASS_MEMORY_NEW(ctx.mem, Each, each_source_position, vars, list, body);
   }
 
   // called after parsing `kwd_while_directive`
   While* Parser::parse_while_directive()
   {
     // create the initial while call object
-    While* call = new (ctx.mem) While(pstate, 0, 0);
+    While* call = SASS_MEMORY_NEW(ctx.mem, While, pstate, 0, 0);
     // parse mandatory predicate
     Expression* predicate = parse_list();
     predicate->is_delayed(false);
@@ -1883,7 +1883,7 @@ namespace Sass {
   // EO parse_while_directive
   Media_Block* Parser::parse_media_block()
   {
-    Media_Block* media_block = new (ctx.mem) Media_Block(pstate, 0, 0);
+    Media_Block* media_block = SASS_MEMORY_NEW(ctx.mem, Media_Block, pstate, 0, 0);
     media_block->media_queries(parse_media_queries());
 
     media_block->block(parse_css_block());
@@ -1893,7 +1893,7 @@ namespace Sass {
 
   List* Parser::parse_media_queries()
   {
-    List* media_queries = new (ctx.mem) List(pstate, 0, SASS_COMMA);
+    List* media_queries = SASS_MEMORY_NEW(ctx.mem, List, pstate, 0, SASS_COMMA);
     if (!peek< exactly<'{'> >()) (*media_queries) << parse_media_query();
     while (lex< exactly<','> >()) (*media_queries) << parse_media_query();
     return media_queries;
@@ -1902,7 +1902,7 @@ namespace Sass {
   // Expression* Parser::parse_media_query()
   Media_Query* Parser::parse_media_query()
   {
-    Media_Query* media_query = new (ctx.mem) Media_Query(pstate);
+    Media_Query* media_query = SASS_MEMORY_NEW(ctx.mem, Media_Query, pstate);
 
     if (lex< exactly< not_kwd > >()) media_query->is_negated(true);
     else if (lex< exactly< only_kwd > >()) media_query->is_restricted(true);
@@ -1913,9 +1913,9 @@ namespace Sass {
 
     while (lex< exactly< and_kwd > >()) (*media_query) << parse_media_expression();
     if (lex < identifier_schema >()) {
-      String_Schema* schema = new (ctx.mem) String_Schema(pstate);
+      String_Schema* schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate);
       *schema << media_query->media_type();
-      *schema << new (ctx.mem) String_Constant(pstate, " ");
+      *schema << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, " ");
       *schema << parse_identifier_schema();
       media_query->media_type(schema);
     }
@@ -1927,7 +1927,7 @@ namespace Sass {
   {
     if (lex < identifier_schema >()) {
       String* ss = parse_identifier_schema();
-      return new (ctx.mem) Media_Query_Expression(pstate, ss, 0, true);
+      return SASS_MEMORY_NEW(ctx.mem, Media_Query_Expression, pstate, ss, 0, true);
     }
     if (!lex< exactly<'('> >()) {
       error("media query expression must begin with '('", pstate);
@@ -1944,7 +1944,7 @@ namespace Sass {
     if (!lex< exactly<')'> >()) {
       error("unclosed parenthesis in media query expression", pstate);
     }
-    return new (ctx.mem) Media_Query_Expression(feature->pstate(), feature, expression);
+    return SASS_MEMORY_NEW(ctx.mem, Media_Query_Expression, feature->pstate(), feature, expression);
   }
 
   // lexed after `kwd_supports_directive`
@@ -1953,7 +1953,7 @@ namespace Sass {
   {
     Supports_Condition* cond = parse_supports_condition();
     // create the ast node object for the support queries
-    Supports_Block* query = new (ctx.mem) Supports_Block(pstate, cond);
+    Supports_Block* query = SASS_MEMORY_NEW(ctx.mem, Supports_Block, pstate, cond);
     // additional block is mandatory
     // parse inner block
     query->block(parse_block());
@@ -1977,7 +1977,7 @@ namespace Sass {
     if (!lex < kwd_not >()) return 0;
 
     Supports_Condition* cond = parse_supports_condition_in_parens();
-    return new (ctx.mem) Supports_Negation(pstate, cond);
+    return SASS_MEMORY_NEW(ctx.mem, Supports_Negation, pstate, cond);
   }
 
   Supports_Condition* Parser::parse_supports_operator()
@@ -1992,8 +1992,8 @@ namespace Sass {
       lex < css_whitespace >();
       Supports_Condition* right = parse_supports_condition_in_parens();
 
-      // Supports_Condition* cc = new (ctx.mem) Supports_Condition(*static_cast<Supports_Condition*>(cond));
-      cond = new (ctx.mem) Supports_Operator(pstate, cond, right, op);
+      // Supports_Condition* cc = SASS_MEMORY_NEW(ctx.mem, Supports_Condition, *static_cast<Supports_Condition*>(cond));
+      cond = SASS_MEMORY_NEW(ctx.mem, Supports_Operator, pstate, cond, right, op);
     }
     return cond;
   }
@@ -2005,7 +2005,7 @@ namespace Sass {
     String* interp = parse_interpolated_chunk(lexed);
     if (!interp) return 0;
 
-    return new (ctx.mem) Supports_Interpolation(pstate, interp);
+    return SASS_MEMORY_NEW(ctx.mem, Supports_Interpolation, pstate, interp);
   }
 
   // TODO: This needs some major work. Although feature conditions
@@ -2016,9 +2016,10 @@ namespace Sass {
     // parse something declaration like
     Declaration* declaration = parse_declaration();
     if (!declaration) error("@supports condition expected declaration", pstate);
-    cond = new (ctx.mem) Supports_Declaration(declaration->pstate(),
-                                        declaration->property(),
-                                        declaration->value());
+    cond = SASS_MEMORY_NEW(ctx.mem, Supports_Declaration,
+                     declaration->pstate(),
+                     declaration->property(),
+                     declaration->value());
     // ToDo: maybe we need an additional error condition?
     return cond;
   }
@@ -2057,10 +2058,10 @@ namespace Sass {
     }
     else if ((lookahead_result = lookahead_for_selector(position)).found) {
       Ruleset* r = parse_ruleset(lookahead_result);
-      body = new (ctx.mem) Block(r->pstate(), 1, true);
+      body = SASS_MEMORY_NEW(ctx.mem, Block, r->pstate(), 1, true);
       *body << r;
     }
-    At_Root_Block* at_root = new (ctx.mem) At_Root_Block(at_source_position, body);
+    At_Root_Block* at_root = SASS_MEMORY_NEW(ctx.mem, At_Root_Block, at_source_position, body);
     if (expr) at_root->expression(expr);
     return at_root;
   }
@@ -2074,16 +2075,17 @@ namespace Sass {
     }
 
     Declaration* declaration = parse_declaration();
-    List* value = new (ctx.mem) List(declaration->value()->pstate(), 1);
+    List* value = SASS_MEMORY_NEW(ctx.mem, List, declaration->value()->pstate(), 1);
 
     if (declaration->value()->concrete_type() == Expression::LIST) {
         value = static_cast<List*>(declaration->value());
     }
     else *value << declaration->value();
 
-    At_Root_Expression* cond = new (ctx.mem) At_Root_Expression(declaration->pstate(),
-                                                                declaration->property(),
-                                                                value);
+    At_Root_Expression* cond = SASS_MEMORY_NEW(ctx.mem, At_Root_Expression,
+                                               declaration->pstate(),
+                                               declaration->property(),
+                                               value);
     if (!lex< exactly<')'> >()) error("unclosed parenthesis in @at-root expression", pstate);
     return cond;
   }
@@ -2091,7 +2093,7 @@ namespace Sass {
   At_Rule* Parser::parse_at_rule()
   {
     std::string kwd(lexed);
-    At_Rule* at_rule = new (ctx.mem) At_Rule(pstate, kwd);
+    At_Rule* at_rule = SASS_MEMORY_NEW(ctx.mem, At_Rule, pstate, kwd);
     Lookahead lookahead = lookahead_for_include(position);
     if (lookahead.found && !lookahead.has_interpolants) {
       at_rule->selector(parse_selector_list());
@@ -2116,17 +2118,17 @@ namespace Sass {
 
   Warning* Parser::parse_warning()
   {
-    return new (ctx.mem) Warning(pstate, parse_list());
+    return SASS_MEMORY_NEW(ctx.mem, Warning, pstate, parse_list());
   }
 
   Error* Parser::parse_error()
   {
-    return new (ctx.mem) Error(pstate, parse_list());
+    return SASS_MEMORY_NEW(ctx.mem, Error, pstate, parse_list());
   }
 
   Debug* Parser::parse_debug()
   {
-    return new (ctx.mem) Debug(pstate, parse_list());
+    return SASS_MEMORY_NEW(ctx.mem, Debug, pstate, parse_list());
   }
 
   Return* Parser::parse_return_directive()
@@ -2134,7 +2136,7 @@ namespace Sass {
     // check that we do not have an empty list (ToDo: check if we got all cases)
     if (peek_css < alternatives < exactly < ';' >, exactly < '}' >, end_of_file > >())
     { css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was "); }
-    return new (ctx.mem) Return(pstate, parse_list());
+    return SASS_MEMORY_NEW(ctx.mem, Return, pstate, parse_list());
   }
 
   Lookahead Parser::lookahead_for_selector(const char* start)
@@ -2374,7 +2376,7 @@ namespace Sass {
   Expression* Parser::fold_operands(Expression* base, std::vector<Expression*>& operands, enum Sass_OP op)
   {
     for (size_t i = 0, S = operands.size(); i < S; ++i) {
-      base = new (ctx.mem) Binary_Expression(pstate, op, base, operands[i]);
+      base = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, pstate, op, base, operands[i]);
       Binary_Expression* b = static_cast<Binary_Expression*>(base);
       if (op == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
         base->is_delayed(true);
@@ -2390,7 +2392,7 @@ namespace Sass {
   Expression* Parser::fold_operands(Expression* base, std::vector<Expression*>& operands, std::vector<enum Sass_OP>& ops)
   {
     for (size_t i = 0, S = operands.size(); i < S; ++i) {
-      base = new (ctx.mem) Binary_Expression(base->pstate(), ops[i], base, operands[i]);
+      base = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, base->pstate(), ops[i], base, operands[i]);
       Binary_Expression* b = static_cast<Binary_Expression*>(base);
       if (ops[i] == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
         base->is_delayed(true);

--- a/src/remove_placeholders.cpp
+++ b/src/remove_placeholders.cpp
@@ -21,7 +21,7 @@ namespace Sass {
         Selector_List* sl = static_cast<Selector_List*>(r->selector());
 
         if (sl) {
-            Selector_List* new_sl = new (ctx.mem) Selector_List(sl->pstate());
+            Selector_List* new_sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, sl->pstate());
 
             for (size_t i = 0, L = sl->length(); i < L; ++i) {
                 if (!(*sl)[i]->contains_placeholder()) {

--- a/src/to_value.cpp
+++ b/src/to_value.cpp
@@ -59,10 +59,11 @@ namespace Sass {
   // List is a valid value
   Value* To_Value::operator()(List* l)
   {
-    List* ll = new (mem) List(l->pstate(),
-                              l->length(),
-                              l->separator(),
-                              l->is_arglist());
+    List* ll = SASS_MEMORY_NEW(mem, List,
+                               l->pstate(),
+                               l->length(),
+                               l->separator(),
+                               l->is_arglist());
     for (size_t i = 0, L = l->length(); i < L; ++i) {
       *ll << (*l)[i]->perform(this);
     }
@@ -92,16 +93,18 @@ namespace Sass {
   Value* To_Value::operator()(Selector_List* s)
   {
     To_String to_string(&ctx);
-    return new (mem) String_Quoted(s->pstate(),
-                                   s->perform(&to_string));
+    return SASS_MEMORY_NEW(mem, String_Quoted,
+                           s->pstate(),
+                           s->perform(&to_string));
   }
 
   // Binary_Expression is converted to a string
   Value* To_Value::operator()(Binary_Expression* s)
   {
     To_String to_string(&ctx);
-    return new (mem) String_Quoted(s->pstate(),
-                                   s->perform(&to_string));
+    return SASS_MEMORY_NEW(mem, String_Quoted,
+                           s->pstate(),
+                           s->perform(&to_string));
   }
 
 };

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -67,29 +67,34 @@ namespace Sass {
   {
     switch (sass_value_get_tag(val)) {
       case SASS_NUMBER:
-        return new (mem) Number(ParserState("[C-VALUE]"),
-                                sass_number_get_value(val),
-                                sass_number_get_unit(val));
+        return SASS_MEMORY_NEW(mem, Number,
+                               ParserState("[C-VALUE]"),
+                               sass_number_get_value(val),
+                               sass_number_get_unit(val));
       break;
       case SASS_BOOLEAN:
-        return new (mem) Boolean(ParserState("[C-VALUE]"),
-                                 sass_boolean_get_value(val));
+        return SASS_MEMORY_NEW(mem, Boolean,
+                               ParserState("[C-VALUE]"),
+                               sass_boolean_get_value(val));
       break;
       case SASS_COLOR:
-        return new (mem) Color(ParserState("[C-VALUE]"),
+        return SASS_MEMORY_NEW(mem, Color,
+                               ParserState("[C-VALUE]"),
                                sass_color_get_r(val),
                                sass_color_get_g(val),
                                sass_color_get_b(val),
                                sass_color_get_a(val));
       break;
       case SASS_STRING:
-        return new (mem) String_Quoted(ParserState("[C-VALUE]"),
-                                       sass_string_get_value(val));
+        return SASS_MEMORY_NEW(mem, String_Quoted,
+                               ParserState("[C-VALUE]"),
+                               sass_string_get_value(val));
       break;
       case SASS_LIST: {
-        List* l = new (mem) List(ParserState("[C-VALUE]"),
-                                 sass_list_get_length(val),
-                                 sass_list_get_separator(val));
+        List* l = SASS_MEMORY_NEW(mem, List,
+                                  ParserState("[C-VALUE]"),
+                                  sass_list_get_length(val),
+                                  sass_list_get_separator(val));
         for (size_t i = 0, L = sass_list_get_length(val); i < L; ++i) {
           *l << sass_value_to_ast_node(mem, sass_list_get_value(val, i));
         }
@@ -97,7 +102,7 @@ namespace Sass {
       }
       break;
       case SASS_MAP: {
-        Map* m = new (mem) Map(ParserState("[C-VALUE]"));
+        Map* m = SASS_MEMORY_NEW(mem, Map, ParserState("[C-VALUE]"));
         for (size_t i = 0, L = sass_map_get_length(val); i < L; ++i) {
           *m << std::make_pair(
             sass_value_to_ast_node(mem, sass_map_get_key(val, i)),
@@ -107,15 +112,17 @@ namespace Sass {
       }
       break;
       case SASS_NULL:
-        return new (mem) Null(ParserState("[C-VALUE]"));
+        return SASS_MEMORY_NEW(mem, Null, ParserState("[C-VALUE]"));
       break;
       case SASS_ERROR:
-        return new (mem) Custom_Error(ParserState("[C-VALUE]"),
-                                      sass_error_get_message(val));
+        return SASS_MEMORY_NEW(mem, Custom_Error,
+                               ParserState("[C-VALUE]"),
+                               sass_error_get_message(val));
       break;
       case SASS_WARNING:
-        return new (mem) Custom_Warning(ParserState("[C-VALUE]"),
-                                        sass_warning_get_message(val));
+        return SASS_MEMORY_NEW(mem, Custom_Warning,
+                               ParserState("[C-VALUE]"),
+                               sass_warning_get_message(val));
       break;
     }
     return 0;


### PR DESCRIPTION
Fixes #1451
Fixes #1460 and properly addresses the problem described also in #1446

MSVC calls allocator first before evaluating arguments for the actual object constructor. Since the evaluation phase can quite easily throw an error (like in `parse_list`), the memory manager is left in an undefined state. The object is already tracked but not initialized and we get an error if we try to `delete` the object (we should use free instead).

```C++
new (ctx.mem) Warning(pstate, parse_list());
// -> calls overloaded `new` (allocate and manage memory)
// -> calls `parse_list` afterwards (throwing an error)
// -> memory already managed, so we try to delete it ...
```

In gcc `parse_list` is called before the overloaded new operator!
I've added a macro to be used instead of overloaded new operator!

Memory Manager now allocates an additional byte to keep status if the object was properly initialized. The macro makes sure that we first allocate the memory and once `new` was successfull, the status is updated, so we call the destructor once the object goes out of scope. Uninitalized objects, which is the case if `new` throws an error, are deallocated via `free` (without calling the destructor).

Note: we could also "abuse" the actual memory of the object, since `AST_Node` is a virtual class we probably always have the `vfptr` at the first position. Other than that nothing guarantees that the first byte of an object cannot be `0` after initialization, therefore keeping the "status" and the actual object separated in memory seems safer and I guess the overhead is minimal.