### PR TITLE
Implement error when multiple imports are found

### DIFF
--- a/src/context.hpp
+++ b/src/context.hpp
@@ -16,18 +16,12 @@
 #include "subset_map.hpp"
 #include "output.hpp"
 #include "plugins.hpp"
+#include "file.hpp"
 #include "sass_functions.h"
 
 struct Sass_Function;
 
 namespace Sass {
-  struct Sass_Queued {
-    std::string abs_path;
-    std::string load_path;
-    const char* source;
-  public:
-    Sass_Queued(const std::string& load_path, const std::string& abs_path, const char* source);
-  };
 
   class Context {
   public:
@@ -117,7 +111,7 @@ namespace Sass {
     void add_source(std::string, std::string, char*);
 
     std::string add_file(const std::string& file);
-    std::string add_file(const std::string& base, const std::string& file);
+    std::string add_file(const std::string& base, const std::string& file, ParserState pstate);
 
 
     // allow to optionally overwrite the input path

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -244,33 +244,39 @@ namespace Sass {
     // (2) underscore + given
     // (3) underscore + given + extension
     // (4) given + extension
-    std::string resolve_file(const std::string& filename)
+    std::vector<Sass_Queued> resolve_file(const std::string& root, const std::string& file)
     {
+      std::string filename = join_paths(root, file);
       // supported extensions
       const std::vector<std::string> exts = {
         ".scss", ".sass", ".css"
       };
       // split the filename
-      std::string base(dir_name(filename));
-      std::string name(base_name(filename));
+      std::string base(dir_name(file));
+      std::string name(base_name(file));
+      std::vector<Sass_Queued> resolved;
       // create full path (maybe relative)
-      std::string path(join_paths(base, name));
-      if (file_exists(path)) return path;
+      std::string rel_path(join_paths(base, name));
+      std::string abs_path(join_paths(root, rel_path));
+      if (file_exists(abs_path)) resolved.push_back(Sass_Queued(rel_path, abs_path, 0));
       // next test variation with underscore
-      path = join_paths(base, "_" + name);
-      if (file_exists(path)) return path;
+      rel_path = join_paths(base, "_" + name);
+      abs_path = join_paths(root, rel_path);
+      if (file_exists(abs_path)) resolved.push_back(Sass_Queued(rel_path, abs_path, 0));
       // next test exts plus underscore
       for(auto ext : exts) {
-        path = join_paths(base, "_" + name + ext);
-        if (file_exists(path)) return path;
+        rel_path = join_paths(base, "_" + name + ext);
+        abs_path = join_paths(root, rel_path);
+        if (file_exists(abs_path)) resolved.push_back(Sass_Queued(rel_path, abs_path, 0));
       }
       // next test plain name with exts
       for(auto ext : exts) {
-        path = join_paths(base, name + ext);
-        if (file_exists(path)) return path;
+        rel_path = join_paths(base, name + ext);
+        abs_path = join_paths(root, rel_path);
+        if (file_exists(abs_path)) resolved.push_back(Sass_Queued(rel_path, abs_path, 0));
       }
       // nothing found
-      return std::string("");
+      return resolved;
     }
 
     // helper function to resolve a filename
@@ -279,9 +285,8 @@ namespace Sass {
       // search in every include path for a match
       for (size_t i = 0, S = paths.size(); i < S; ++i)
       {
-        std::string path(join_paths(paths[i], file));
-        std::string resolved(resolve_file(path));
-        if (resolved != "") return resolved;
+        std::vector<Sass_Queued> resolved(resolve_file(paths[i], file));
+        if (resolved.size()) return resolved[0].abs_path;
       }
       // nothing found
       return std::string("");

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -5,7 +5,17 @@
 #include <vector>
 
 namespace Sass {
+
   class Context;
+
+  struct Sass_Queued {
+    std::string abs_path;
+    std::string load_path;
+    const char* source;
+  public:
+    Sass_Queued(const std::string& load_path, const std::string& abs_path, const char* source);
+  };
+
   namespace File {
 
     // return the current directory
@@ -41,7 +51,7 @@ namespace Sass {
     std::string resolve_relative_path(const std::string& path, const std::string& base, const std::string& cwd = ".");
 
     // try to find/resolve the filename
-    std::string resolve_file(const std::string& file);
+    std::vector<Sass_Queued> resolve_file(const std::string& root, const std::string& file);
 
     // helper function to resolve a filename
     std::string find_file(const std::string& file, const std::vector<std::string> paths);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -304,7 +304,7 @@ namespace Sass {
     }
     else {
       std::string current_dir = File::dir_name(path);
-      std::string resolved(ctx.add_file(current_dir, unquoted));
+      std::string resolved(ctx.add_file(current_dir, unquoted, *this));
       if (resolved.empty()) error("file to import not found or unreadable: " + unquoted + "\nCurrent dir: " + current_dir, pstate);
       imp->files().push_back(resolved);
     }

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -325,6 +325,20 @@ extern "C" {
       c_ctx->source_map_string = 0;
       json_delete(json_err);
     }
+    catch (const char* e) {
+      std::stringstream msg_stream;
+      JsonNode* json_err = json_mkobject();
+      msg_stream << "Error: " << e << std::endl;
+      json_append_member(json_err, "status", json_mknumber(4));
+      json_append_member(json_err, "message", json_mkstring(e));
+      c_ctx->error_json = json_stringify(json_err, "  ");;
+      c_ctx->error_message = sass_strdup(msg_stream.str().c_str());
+      c_ctx->error_text = sass_strdup(e);
+      c_ctx->error_status = 4;
+      c_ctx->output_string = 0;
+      c_ctx->source_map_string = 0;
+      json_delete(json_err);
+    }
     catch (...) {
       std::stringstream msg_stream;
       JsonNode* json_err = json_mkobject();

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -75,7 +75,7 @@ extern "C" {
     struct Sass_Map     map;
     struct Sass_Null    null;
     struct Sass_Error   error;
-    struct Sass_Warning   warning;
+    struct Sass_Warning warning;
   };
 
   struct Sass_MapPair {


### PR DESCRIPTION
When multiple errors are found, ruby sass gives this message:

```
Error: It's not clear which file to import for '@import "imp"'.
       Candidates:
         imp.sass
         imp.scss
       Please delete or rename all but one of these files.
        on line 1 of foo.sass
  Use --trace for backtrace.
```

With this patch, libsass gives this error message:

```
Error: It's not clear which file to import for '@import "imp"'.
       Candidates:
         imp.scss
         imp.sass
       Please delete or rename all but one of these files.
        on line 1 of foo.sass
>> @import "imp";
   ^
```