### PR TITLE
Improve number unit identifier parsing

### DIFF
--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -119,6 +119,42 @@ namespace Sass {
              >(src);
     }
 
+    const char* strict_identifier_alpha(const char* src)
+    {
+      return alternatives <
+               alpha,
+               unicode,
+               escape_seq,
+               exactly<'_'>
+             >(src);
+    }
+
+    const char* strict_identifier_alnum(const char* src)
+    {
+      return alternatives <
+               alnum,
+               unicode,
+               escape_seq,
+               exactly<'_'>
+             >(src);
+    }
+
+    // Match CSS unit identifier.
+    const char* unit_identifier(const char* src)
+    {
+      return sequence <
+               optional < exactly <'-'> >,
+               strict_identifier_alpha,
+               zero_plus < alternatives<
+                 strict_identifier_alnum,
+                 sequence <
+                   one_plus < exactly<'-'> >,
+                   strict_identifier_alpha
+                 >
+               > >
+             >(src);
+    }
+
     const char* identifier_alnums(const char* src)
     {
       return one_plus< identifier_alnum >(src);
@@ -528,7 +564,7 @@ namespace Sass {
       return sequence< number, exactly<em_kwd> >(src);
     } */
     const char* dimension(const char* src) {
-      return sequence<number, one_plus< alpha > >(src);
+      return sequence<number, unit_identifier >(src);
     }
     const char* hex(const char* src) {
       const char* p = sequence< exactly<'#'>, one_plus<xdigit> >(src);

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -195,7 +195,11 @@ namespace Sass {
     const char* identifier(const char* src);
     const char* identifier_alpha(const char* src);
     const char* identifier_alnum(const char* src);
-    const char* identifier_alnums(const char* src);
+    const char* strict_identifier_alpha(const char* src);
+    const char* strict_identifier_alnum(const char* src);
+    // Match a CSS unit identifier.
+    const char* unit_identifier(const char* src);
+    // const char* strict_identifier_alnums(const char* src);
     // Match reference selector.
     const char* re_reference_combinator(const char* src);
     const char* static_reference_combinator(const char* src);


### PR DESCRIPTION
Addresses https://github.com/sass/libsass/issues/1405

Now correctly handles:

```css
foo {
  result-1: 1em-.75em;
  result-2: 2em-1em;
  result-3: 2em-0.75em;
  result-4: 1.5em-1em;
  result-5: 2em-1.5em;

  type-1: type-of(1em-.75em);
  type-2: type-of(2em-1em);
  type-3: type-of(2em-0.75em);
  type-4: type-of(1.5em-1em);
  type-5: type-of(2em-1.5em);

  test-1: (1-em-2-em);
  test-1: (1-em - 2-em);

  test-2: (1--em-2--em);
  test-2: (1--em - 2--em);

  test-3: (1-0-em-2-0-em);
  test-3: (1-0-em - 2-0-em);

  test-4: (1-A-em-2-A-em);
  test-4: (1-A-em - 2-A-em);

  test-5: (1_em--_--e-2_em--_--e);
  test-5: (1_em--_--e - 2_em--_--e);

  test-6: (1_em--_--e0-2_em--_--e0);
  test-6: (1_em--_--e0 - 2_em--_--e0);

  test-7: (1_em--_--e0__-2_em--_--e0__);
  test-7: (1_em--_--e0__ - 2_em--_--e0__);

  test-8: (1\65 _em--_--e0-2\65 _em--_--e0);
  test-8: (1\65 _em--_--e0 - 2\65 _em--_--e0);
}
```

Last one only after https://github.com/sass/libsass/pull/1464 is applied!