### PR TITLE
Remove `$` from `uri_chars` to enable interpolation

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -140,7 +140,7 @@ namespace Sass {
     extern const char arglist_name[]    = "arglist";
 
     // constants for uri parsing (RFC 3986 Appendix A.)
-    extern const char uri_chars[]  = ":;/?!$%&#@|[]{}'`^\"*+-.,_=~";
+    extern const char uri_chars[]  = ":;/?!%&#@|[]{}'`^\"*+-.,_=~";
 
     // some specific constant character classes
     // they must be static to be useable by lexer


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1370