### PR TITLE
Ignore linefeed before scope opener `{` token

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -53,7 +53,8 @@ namespace Sass {
 
   bool Parser::peek_newline(const char* start)
   {
-    return peek_linefeed(start ? start : position);
+    return peek_linefeed(start ? start : position)
+           && ! peek_css<exactly<'{'>>(start);
   }
 
   Parser Parser::from_token(Token t, Context& ctx, ParserState pstate)


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1448