### PR TITLE
Fix copy paste error in `mergeFinalOps`

### DIFF
--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1032,8 +1032,8 @@ namespace Sass {
         res.collection()->push_front(op2);
         res.collection()->push_front(sel2);
 
-        seq2.collection()->push_back(sel1);
-        seq2.collection()->push_back(op1);
+        seq1.collection()->push_back(sel1);
+        seq1.collection()->push_back(op1);
 
       } else if (op2.combinator() == Complex_Selector::PARENT_OF && (op1.combinator() == Complex_Selector::PRECEDES || op1.combinator() == Complex_Selector::ADJACENT_TO)) {
 


### PR DESCRIPTION
And the sequel: Mission impossible 2 accomplished -> Fixes https://github.com/sass/libsass/issues/439
Original ruby sass code: https://github.com/sass/sass/blob/stable/lib/sass/selector/sequence.rb#L400