### PR TITLE
Add the extend-selector-pseudoclass feature flag

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -228,6 +228,7 @@ namespace Sass {
     // features
     static std::set<std::string> features {
       "global-variable-shadowing",
+      "extend-selector-pseudoclass",
       "at-error",
       "units-level-3"
     };


### PR DESCRIPTION
This PR added the `extend-selector-pseudoclass` feature flag.

With this we now implement all the [Sass feature checks](https://github.com/sass/sass/blob/7a2cb14d5812cd809def8d7c5b5802a92677569b/lib/sass/features.rb#L10-L15).

Spec https://github.com/sass/sass-spec/pull/487