### PR TITLE
Make `source_map_embed` independent of `source_map_file`

### DIFF
--- a/src/context.hpp
+++ b/src/context.hpp
@@ -129,7 +129,8 @@ namespace Sass {
     void collect_plugin_paths(const char** paths_array);
     void collect_include_paths(const char* paths_str);
     void collect_include_paths(const char** paths_array);
-    std::string format_source_mapping_url(const std::string& file);
+    std::string format_embedded_source_map();
+    std::string format_source_mapping_url(const std::string& out_path);
 
     std::string cwd;
     Plugins plugins;


### PR DESCRIPTION
This should IMO address https://github.com/sass/libsass/issues/885

The `source_map_embed` option no longer needs `source_map_file` to be present. We currently always return a source-map on the C-API level (AFAIR), but from the semantics we do not guarantee that, when neither of two main options are set. `source_map_embed` has higher priority and `source_map_contents` doesn't do anything on its own.

So we have these options in regard of source-maps:

`source_map_file`: libsass only adds the sourceMappingURL to the output
`source_map_embed`: generate sourceMappingURL with embedded source-map
`source_map_contents`: adds the `sourceContents` array to the source-map
`omit_source_map_url`: suppress any sourceMappingURL output