### PR TITLE
Improve integer test for `random` function

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1584,9 +1584,9 @@ namespace Sass {
   bool Number::operator== (const Expression& rhs) const
   {
     if (const Number* r = dynamic_cast<const Number*>(&rhs)) {
-      return (value() == r->value()) &&
-             (numerator_units_ == r->numerator_units_) &&
-             (denominator_units_ == r->denominator_units_);
+      return (numerator_units_ == r->numerator_units_) &&
+             (denominator_units_ == r->denominator_units_) &&
+             std::fabs(value() - r->value()) < NUMBER_EPSILON;
     }
     return false;
   }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -53,6 +53,8 @@
 
 namespace Sass {
 
+  const double NUMBER_EPSILON = 0.00000000000001;
+
   // from boost (functional/hash):
   // http://www.boost.org/doc/libs/1_35_0/doc/html/hash/combine.html
   // Boost Software License - Version 1.0

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1159,8 +1159,19 @@ namespace Sass {
     {
       Number* l = dynamic_cast<Number*>(env["$limit"]);
       if (l) {
-        if (trunc(l->value()) != l->value() || l->value() == 0) error("argument $limit of `" + std::string(sig) + "` must be a positive integer", pstate);
-        std::uniform_real_distribution<> distributor(1, l->value() + 1);
+        double v = l->value();
+        if (v < 1) {
+          stringstream err;
+          err << "$limit " << v << " must be greater than or equal to 1 for `random`";
+          error(err.str(), pstate);
+        }
+        bool eq_int = std::fabs(trunc(v) - v) < NUMBER_EPSILON;
+        if (!eq_int) {
+          stringstream err;
+          err << "Expected $limit to be an integer but got `" << v << "` for `random`";
+          error(err.str(), pstate);
+        }
+        std::uniform_real_distribution<> distributor(1, v + 1);
         uint_fast32_t distributed = static_cast<uint_fast32_t>(distributor(rand));
         return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)distributed);
       }


### PR DESCRIPTION
This should fix https://github.com/sass/libsass/issues/1514 ... maybe it is worth a further look as I expected a smaller rounding error to compensate. Also the checks should probably be implemented more generic so others can re-use them.