### PR TITLE
bool needs_parens(Supports_Condition* cond)

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -13,13 +13,13 @@ namespace Sass {
 
   static Null sass_null(Sass::Null(ParserState("null")));
 
-  const bool Supports_Operator::needs_parens(Supports_Condition* cond) {
+  bool Supports_Operator::needs_parens(Supports_Condition* cond) const {
     return dynamic_cast<Supports_Negation*>(cond) ||
           (dynamic_cast<Supports_Operator*>(cond) &&
            dynamic_cast<Supports_Operator*>(cond)->operand() != operand());
   }
 
-  const bool Supports_Negation::needs_parens(Supports_Condition* cond) {
+  bool Supports_Negation::needs_parens(Supports_Condition* cond) const {
     return dynamic_cast<Supports_Negation*>(cond) ||
           dynamic_cast<Supports_Operator*>(cond);
   }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1486,7 +1486,7 @@ namespace Sass {
     Supports_Condition(ParserState pstate)
     : Expression(pstate)
     { }
-    virtual const bool needs_parens(Supports_Condition* cond) { return false; }
+    virtual bool needs_parens(Supports_Condition* cond) const { return false; }
     ATTACH_OPERATIONS()
   };
 
@@ -1504,7 +1504,7 @@ namespace Sass {
     Supports_Operator(ParserState pstate, Supports_Condition* l, Supports_Condition* r, Operand o)
     : Supports_Condition(pstate), left_(l), right_(r), operand_(o)
     { }
-    virtual const bool needs_parens(Supports_Condition* cond);
+    virtual bool needs_parens(Supports_Condition* cond) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1518,7 +1518,7 @@ namespace Sass {
     Supports_Negation(ParserState pstate, Supports_Condition* c)
     : Supports_Condition(pstate), condition_(c)
     { }
-    virtual const bool needs_parens(Supports_Condition* cond);
+    virtual bool needs_parens(Supports_Condition* cond) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1533,7 +1533,7 @@ namespace Sass {
     Supports_Declaration(ParserState pstate, Expression* f, Expression* v)
     : Supports_Condition(pstate), feature_(f), value_(v)
     { }
-    virtual const bool needs_parens(Supports_Condition* cond) { return false; }
+    virtual bool needs_parens(Supports_Condition* cond) const { return false; }
     ATTACH_OPERATIONS()
   };
 
@@ -1547,7 +1547,7 @@ namespace Sass {
     Supports_Interpolation(ParserState pstate, Expression* v)
     : Supports_Condition(pstate), value_(v)
     { }
-    virtual const bool needs_parens(Supports_Condition* cond) { return false; }
+    virtual bool needs_parens(Supports_Condition* cond) const { return false; }
     ATTACH_OPERATIONS()
   };
 


### PR DESCRIPTION
Fixes:

````
  clang++ '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DLIBSASS_VERSION="3.2.5"' '-DDEBUG' '-D_DEBUG' -I/home/saper/.node-gyp/3.0.0/src -I/home/saper/.node-gyp/3.0.0/deps/uv/include -I/home/saper/.node-gyp/3.0.0/deps/v8/include -I../src/libsass/include  -fPIC -pthread -Wall -Wextra -Wno-unused-parameter -m64 -g -O0 -fno-rtti -std=gnu++0x -std=c++0x -fexceptions -frtti -MMD -MF ./Debug/.deps/Debug/obj.target/libsass/src/libsass/src/ast.o.d.raw -g -c -o Debug/obj.target/libsass/src/libsass/src/ast.o ../src/libsass/src/ast.cpp
In file included from ../src/libsass/src/ast.cpp:1:
../src/libsass/src/ast.hpp:1489:13: warning: 'const' type qualifier on return type has
      no effect [-Wignored-qualifiers]
    virtual const bool needs_parens(Supports_Condition* cond) { return false; }
            ^~~~~~
````

https://github.com/sass/libsass/pull/1426#issuecomment-137068114