### PR TITLE
VS Exception handling only in C++ code

### DIFF
--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -182,44 +182,6 @@ extern "C" {
     type sass_context_take_##option (struct Sass_Context* ctx) \
     { type foo = ctx->option; ctx->option = 0; return foo; }
 
-  // helper for safe access to c_ctx
-  static const char* safe_str (const char* str) {
-    return str == NULL ? "" : str;
-  }
-
-  static void free_string_array(char ** arr) {
-    if(!arr)
-        return;
-
-    char **it = arr;
-    while (it && (*it)) {
-      free(*it);
-      ++it;
-    }
-
-    free(arr);
-  }
-
-  static char **copy_strings(const std::vector<std::string>& strings, char*** array) {
-    int num = static_cast<int>(strings.size());
-    char** arr = (char**) calloc(num + 1, sizeof(char*));
-    if (arr == 0)
-      return *array = (char **)NULL;
-
-    for(int i = 0; i < num; i++) {
-      arr[i] = (char*) malloc(sizeof(char) * (strings[i].size() + 1));
-      if (arr[i] == 0) {
-        free_string_array(arr);
-        return *array = (char **)NULL;
-      }
-      std::copy(strings[i].begin(), strings[i].end(), arr[i]);
-      arr[i][strings[i].size()] = '\0';
-    }
-
-    arr[num] = 0;
-    return *array = arr;
-  }
-
   static int handle_errors(Sass_Context* c_ctx) {
     try {
      throw;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -48,6 +48,44 @@ namespace Sass {
     return atof(str);
   }
 
+  // helper for safe access to c_ctx
+  const char* safe_str (const char* str) {
+    return str == NULL ? "" : str;
+  }
+
+  void free_string_array(char ** arr) {
+    if(!arr)
+        return;
+
+    char **it = arr;
+    while (it && (*it)) {
+      free(*it);
+      ++it;
+    }
+
+    free(arr);
+  }
+
+  char **copy_strings(const std::vector<std::string>& strings, char*** array, int skip) {
+    int num = static_cast<int>(strings.size()) - skip;
+    char** arr = (char**) calloc(num + 1, sizeof(char*));
+    if (arr == 0) 
+      return *array = (char **)NULL;
+
+    for(int i = 0; i < num; i++) {
+      arr[i] = (char*) malloc(sizeof(char) * (strings[i + skip].size() + 1));
+      if (arr[i] == 0) {
+        free_string_array(arr);
+        return *array = (char **)NULL;
+      }
+      std::copy(strings[i + skip].begin(), strings[i + skip].end(), arr[i]);
+      arr[i][strings[i + skip].size()] = '\0';
+    }
+
+    arr[num] = 0;
+    return *array = arr;
+  }
+
   std::string string_eval_escapes(const std::string& s)
   {
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -12,6 +12,9 @@ namespace Sass {
 
   char* sass_strdup(const char* str);
   double sass_atof(const char* str);
+  const char* safe_str(const char *);
+  void free_string_array(char **);
+  char **copy_strings(const std::vector<std::string>&, char ***, int = 0);
   std::string string_escape(const std::string& str);
   std::string string_unescape(const std::string& str);
   std::string string_eval_escapes(const std::string& str);

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -126,7 +126,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -140,7 +140,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,7 +156,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -174,7 +174,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>SyncCThrow</ExceptionHandling>
+      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -126,7 +126,6 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -140,7 +139,6 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,7 +154,6 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -174,7 +171,6 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Catch exceptions only in C++ code,
extern "C" functions should (ideally) be exception-free.

While here, move functions shared between `sass_interface.cpp` and `sass_context.cpp` into `util.cpp`

Fixes: https://github.com/sass/libsass/issues/1508