### PR TITLE
Don't segfault on & {}

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -911,10 +911,9 @@ namespace Sass {
                 *retval << s;
               }
             }
-          }
+          } else {
           // have no tails but parents
           // loop above is inside out
-          else {
             for (size_t i = 0, iL = parents->length(); i < iL; ++i) {
               Complex_Selector* parent = (*parents)[i];
               Complex_Selector* s = parent->cloneFully(ctx);
@@ -930,11 +929,11 @@ namespace Sass {
             }
           }
           return retval;
-        }
-        // have no parent but some tails
-        else {
+        } else {
           Selector_List* retval = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
+
           if (tails && tails->length() > 0) {
+            // have no parent but some tails
             for (size_t n = 0, nL = tails->length(); n < nL; ++n) {
               Complex_Selector* cpy = this->clone(ctx);
               cpy->tail((*tails)[n]->cloneFully(ctx));
@@ -944,15 +943,14 @@ namespace Sass {
               if (!cpy->head()->length()) cpy->head(0);
               *retval << cpy->skip_empty_reference();
             }
-          }
-          // have no parent and not tails
-          else {
+          } else {
+            // have no parent and not tails 
             Complex_Selector* cpy = this->clone(ctx);
             cpy->head(SASS_MEMORY_NEW(ctx.mem, Compound_Selector, head->pstate()));
             for (size_t i = 1, L = this->head()->length(); i < L; ++i)
               *cpy->head() << (*this->head())[i];
             if (!cpy->head()->length()) cpy->head(0);
-            *retval << cpy->skip_empty_reference();
+            *retval << cpy;
           }
           return retval;
         }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2125,9 +2125,10 @@ namespace Sass {
       if ((!head_ || !head_->length() || head_->is_empty_reference()) &&
           combinator() == Combinator::ANCESTOR_OF)
       {
+        SASS_ASSERT(tail_, "tail_ is null");
         tail_->has_line_feed_ = this->has_line_feed_;
         // tail_->has_line_break_ = this->has_line_break_;
-        return tail_ ? tail_->skip_empty_reference() : 0;
+        return tail_->skip_empty_reference();
       }
       return this;
     }


### PR DESCRIPTION
Eases https://github.com/sass/libsass/issues/1519

Now "& {}" just returns an empty CSS - whereas Ruby
reports:

    Error: Base-level rules cannot contain the parent-selector-referencing character '&'.
            on line 1 of /home/saper/sw/nodes-sass-problems/1120/test.scss
      Use --trace for backtrace.
    
Another example:

    foo {
      @extend &;
    }

generates this error message:

    Error: nested selectors may not be extended

whereas Ruby Sass gives:

    Error: Can't extend &: can't extend parent selectors
            on line 2 of /home/saper/sw/nodes-sass-problems/1120/test1.scss
      Use --trace for backtrace.