### PR TITLE
Fix two segfaults with parent selectors

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1125,13 +1125,18 @@ namespace Sass {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = length(); i < L; ++i) {
       if (!(*this)[i]->head()) continue;
-      if ((*this)[i]->combinator() != Complex_Selector::ANCESTOR_OF) continue;
       if ((*this)[i]->head()->is_empty_reference()) {
-        Complex_Selector* tail = (*this)[i]->tail();
-        // if ((*this)[i]->has_line_feed()) {
-          // if (tail) tail->has_line_feed(true);
-        // }
-        (*this)[i] = tail;
+        // simply move to the next tail if we have "no" combinator
+        if ((*this)[i]->combinator() == Complex_Selector::ANCESTOR_OF) {
+          if ((*this)[i]->tail() && (*this)[i]->has_line_feed()) {
+            (*this)[i]->tail()->has_line_feed(true);
+          }
+          (*this)[i] = (*this)[i]->tail();
+        }
+        // otherwise remove the first item from head
+        else {
+          (*this)[i]->head()->erase((*this)[i]->head()->begin());
+        }
       }
     }
   }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -405,9 +405,10 @@ namespace Sass {
   class Ruleset : public Has_Block {
     ADD_PROPERTY(Selector*, selector)
     ADD_PROPERTY(bool, at_root);
+    ADD_PROPERTY(bool, is_root);
   public:
     Ruleset(ParserState pstate, Selector* s = 0, Block* b = 0)
-    : Has_Block(pstate, b), selector_(s), at_root_(false)
+    : Has_Block(pstate, b), selector_(s), at_root_(false), is_root_(false)
     { statement_type(RULESET); }
     bool is_invisible() const;
     // nested rulesets need to be hoisted out of their enclosing blocks

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -394,6 +394,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [indent: " << ruleset->tabs() << "]";
     std::cerr << (ruleset->at_root() ? " [@ROOT]" : "");
+    std::cerr << (ruleset->is_root() ? " [root]" : "");
     std::cerr << std::endl;
     debug_ast(ruleset->selector(), ind + ">");
     debug_ast(ruleset->block(), ind + " ");

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -2023,6 +2023,7 @@ namespace Sass {
     if (extendedSomething && pNewSelectorList) {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << static_cast<Selector_List*>(pObject->selector())->perform(&to_string))
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND SETTING NEW SELECTORS: " << pNewSelectorList->perform(&to_string))
+      pNewSelectorList->remove_parent_selectors();
       pObject->selector(pNewSelectorList);
     } else {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND DID NOT TRY TO EXTEND ANYTHING")

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -768,7 +768,7 @@ namespace Sass {
       }
     }
 
-    if (head && !head->is_empty_reference()) head->perform(this);
+    if (head && head->length() != 0) head->perform(this);
     bool is_empty = !head || head->length() == 0 || head->is_empty_reference();
     bool is_tail = head && !head->is_empty_reference() && tail;
     if (output_style() == COMPRESSED && comb != Complex_Selector::ANCESTOR_OF) scheduled_space = 0;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -223,7 +223,7 @@ namespace Sass {
     Argument* parse_argument(bool has_url = false);
     Assignment* parse_assignment();
     // Propset* parse_propset();
-    Ruleset* parse_ruleset(Lookahead lookahead);
+    Ruleset* parse_ruleset(Lookahead lookahead, bool is_root = false);
     Selector_Schema* parse_selector_schema(const char* end_of_selector);
     Selector_List* parse_selector_list(bool at_root = false);
     Complex_Selector* parse_complex_selector(bool in_root = true);
@@ -234,8 +234,8 @@ namespace Sass {
     Attribute_Selector* parse_attribute_selector();
     Block* parse_block(bool is_root = false);
     Block* parse_css_block(bool is_root = false);
-    bool parse_block_nodes();
-    bool parse_block_node();
+    bool parse_block_nodes(bool is_root = false);
+    bool parse_block_node(bool is_root = false);
 
     bool parse_number_prefix();
     Declaration* parse_declaration();


### PR DESCRIPTION
Slightly tweaks the way we parse selectors in regard to
the parent selector. We only add one if we are not parsing
inside some root context (passed by boolean argument).

Fixes https://github.com/sass/libsass/issues/1519

[test-1] [1]
```css
foo {
  @extend &;
}
```

[test-2] [2]
```css
& {}
```

[test-3] [3]
```css
& foo {
  bar: baz;
}
```
[test-4] [4]
```css
foo & {
  bar: baz;
}
```

[1]: http://libsass.ocbnet.ch/srcmap/#Zm9vIHsKICBAZXh0ZW5kICY7Cn0=
[2]: http://libsass.ocbnet.ch/srcmap/#JiB7fQ==
[3]: http://libsass.ocbnet.ch/srcmap/#JiBmb28gewogIGJhcjogYmF6Owp9
[4]: http://libsass.ocbnet.ch/srcmap/#Zm9vICYgewogIGJhcjogYmF6Owp9