### PR TITLE
Hotfix for interpolation adding additional escapes

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1424,10 +1424,10 @@ namespace Sass {
   ////////////////////////////////////////////////////////
   class String_Quoted : public String_Constant {
   public:
-    String_Quoted(ParserState pstate, std::string val, char q = 0)
+    String_Quoted(ParserState pstate, std::string val, char q = 0, bool keep_utf8_escapes = false)
     : String_Constant(pstate, val)
     {
-      value_ = unquote(value_, &quote_mark_);
+      value_ = unquote(value_, &quote_mark_, keep_utf8_escapes);
       if (q && quote_mark_) quote_mark_ = q;
     }
     virtual bool operator==(const Expression& rhs) const;

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -96,7 +96,7 @@ namespace Sass {
     static Value* op_strings(Memory_Manager<AST_Node>&, enum Sass_OP, Value&, Value&, bool compressed = false, int precision = 5);
 
   private:
-    std::string interpolation(Expression* s);
+    std::string interpolation(Expression* s, bool into_quotes = false);
 
   };
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -879,7 +879,7 @@ namespace Sass {
         return SASS_MEMORY_NEW(ctx.mem, Null, pstate);
       }
       else if (String_Quoted* string_quoted = dynamic_cast<String_Quoted*>(arg)) {
-        String_Quoted* result = SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, string_quoted->value());
+        String_Constant* result = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, string_quoted->value());
         // remember if the string was quoted (color tokens)
         result->sass_fix_1291(string_quoted->quote_mark() != 0);
         return result;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1460,7 +1460,7 @@ namespace Sass {
     if (lex< sequence< dimension, optional< sequence< exactly<'-'>, negate< digit > > > > >())
     { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::DIMENSION, lexed); }
 
-    if (lex< sequence< static_component, one_plus< identifier > > >())
+    if (lex< sequence< static_component, one_plus< strict_identifier > > >())
     { return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed); }
 
     if (lex< number >())

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -109,6 +109,16 @@ namespace Sass {
     }
 
     // Match CSS identifiers.
+    const char* strict_identifier(const char* src)
+    {
+      return sequence<
+               one_plus < strict_identifier_alpha >,
+               zero_plus < strict_identifier_alnum >
+               // word_boundary not needed
+             >(src);
+    }
+
+    // Match CSS identifiers.
     const char* identifier(const char* src)
     {
       return sequence<

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -195,6 +195,7 @@ namespace Sass {
     const char* identifier(const char* src);
     const char* identifier_alpha(const char* src);
     const char* identifier_alnum(const char* src);
+    const char* strict_identifier(const char* src);
     const char* strict_identifier_alpha(const char* src);
     const char* strict_identifier_alnum(const char* src);
     // Match a CSS unit identifier.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -317,7 +317,7 @@ namespace Sass {
     return quote_mark;
   }
 
-  std::string unquote(const std::string& s, char* qd)
+  std::string unquote(const std::string& s, char* qd, bool keep_utf8_sequences)
   {
 
     // not enough room for quotes
@@ -357,7 +357,9 @@ namespace Sass {
         while (i + len < L && s[i + len] && isxdigit(s[i + len])) ++ len;
 
         // hex string?
-        if (len > 1) {
+        if (keep_utf8_sequences) {
+          unq.push_back(s[i]);
+        } else if (len > 1) {
 
           // convert the extracted hex string to code point value
           // ToDo: Maybe we could do this without creating a substring

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -23,7 +23,7 @@ namespace Sass {
   std::string normalize_wspace(const std::string& str);
 
   std::string quote(const std::string&, char q = 0, bool keep_linefeed_whitespace = false);
-  std::string unquote(const std::string&, char* q = 0);
+  std::string unquote(const std::string&, char* q = 0, bool keep_utf8_sequences = false);
   char detect_best_quotemark(const char* s, char qm = '"');
 
   bool is_hex_doublet(double n);


### PR DESCRIPTION
This fixes one of the last urgent issues with interpolations. I have tried to solve it multiple times but I fail to see any other logic than implemented here (look ahead if we expect the final string to be a quoted string or not). With this patch we pass these additional spec tests:

- libsass-todo-issues\issue_1115 (Fixes #1115)
- parser\interpolate\29_binary_operation\todo\06_escape_interpolation
- parser\interpolate\30_base_test\todo\06_escape_interpolation

