### PR TITLE
Fix a small parsing edge case issue

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1460,7 +1460,7 @@ namespace Sass {
     if (lex< sequence< dimension, optional< sequence< exactly<'-'>, negate< digit > > > > >())
     { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::DIMENSION, lexed); }
 
-    if (lex< sequence< static_component, one_plus< identifier > > >())
+    if (lex< sequence< static_component, one_plus< strict_identifier > > >())
     { return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed); }
 
     if (lex< number >())

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -109,6 +109,16 @@ namespace Sass {
     }
 
     // Match CSS identifiers.
+    const char* strict_identifier(const char* src)
+    {
+      return sequence<
+               one_plus < strict_identifier_alpha >,
+               zero_plus < strict_identifier_alnum >
+               // word_boundary not needed
+             >(src);
+    }
+
+    // Match CSS identifiers.
     const char* identifier(const char* src)
     {
       return sequence<

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -195,6 +195,7 @@ namespace Sass {
     const char* identifier(const char* src);
     const char* identifier_alpha(const char* src);
     const char* identifier_alnum(const char* src);
+    const char* strict_identifier(const char* src);
     const char* strict_identifier_alpha(const char* src);
     const char* strict_identifier_alnum(const char* src);
     // Match a CSS unit identifier.


### PR DESCRIPTION
This fixes a small parser issue (related to https://github.com/sass/libsass/issues/1526)!

```scss
foo {
  test: type-of(1--em);
  test-2: (1--em-2--em);
  test-2: (1--em- 2--em);
  test-2: (1--em -2--em);
  test-2: (1--em - 2--em);
}
```

Before:
```css
foo {
  test: string;
  test-2: 1--em-2--em;
  test-2: 1--em-2--em;
  test-2: 1--em -2--em;
  test-2: 1--em-2--em; }
```

After:
```css
foo {
  test: list;
  test-2: 1 --em-2--em;
  test-2: 1 --em- 2 --em;
  test-2: 1 --em -2 --em;
  test-2: 1 --em-2--em; }
```

Expected:
```css
foo {
  test: list;
  test-2: 1 --em-2--em;
  test-2: 1 --em- 2 --em;
  test-2: 1 --em -2 --em;
  test-2: 1 --em-2 --em; }
```