### PR TITLE
Use empty C++ aggregate initializer for Lookahead

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2161,7 +2161,7 @@ namespace Sass {
   Lookahead Parser::lookahead_for_selector(const char* start)
   {
     // init result struct
-    Lookahead rv { 0 };
+    Lookahead rv { };
     // get start position
     const char* p = start ? start : position;
     // match in one big "regex"
@@ -2278,7 +2278,7 @@ namespace Sass {
   Lookahead Parser::lookahead_for_value(const char* start)
   {
     // init result struct
-    Lookahead rv { 0 };
+    Lookahead rv { };
     // get start position
     const char* p = start ? start : position;
     // match in one big "regex"


### PR DESCRIPTION
Lookahead rv { };

is a C++ syntax for aggregated initialization

Should fix 

````
>     clang++ '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64'  \
>    '-DLIBSASS_VERSION="3.3.0"' '-DDEBUG' '-D_DEBUG' \
>    -I/usr/local/include/node -I/usr/local/include/node/src \
>    -I/usr/local/include/node/deps/uv/include -I/usr/local/include/node/deps/v8/include \
>    -I../src/libsass/include  -fPIC -pthread -Wall -Wextra -Wno-unused-parameter -m64 -g -O0 \
>    -fno-rtti -std=gnu++0x -std=c++0x -fexceptions -frtti -MMD -MF \
>     ./Debug/.deps/Debug/obj.target/libsass/src/libsass/src/parser.o.d.raw -g -c \
>     -o Debug/obj.target/libsass/src/libsass/src/parser.o ../src/libsass/src/parser.cpp
> ../src/libsass/src/parser.cpp:2164:22: warning: missing field 'error' initializer
>       [-Wmissing-field-initializers]
>     Lookahead rv { 0 };
>                      ^
> ../src/libsass/src/parser.cpp:2281:22: warning: missing field 'error' initializer
>       [-Wmissing-field-initializers]
>     Lookahead rv { 0 };
>                      ^
> 2 warnings generated.
````

https://github.com/sass/libsass/issues/1541