### PR TITLE
Protect `sass_value_op` from thrown C++ exceptions

### DIFF
--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -246,7 +246,7 @@ extern "C" {
       c_ctx->source_map_string = 0;
       json_delete(json_err);
     }
-    catch(std::bad_alloc& ba) {
+    catch (std::bad_alloc& ba) {
       std::stringstream msg_stream;
       JsonNode* json_err = json_mkobject();
       msg_stream << "Unable to allocate memory: " << ba.what() << std::endl;


### PR DESCRIPTION
Errors get converted to a simple `Sass_Error` value for now ...