### PR TITLE
Fix sass2scss sometimes producing incorrect output for `@include`

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -389,7 +389,7 @@ namespace Sass {
     { }
     virtual bool has_content()
     {
-      return block_->has_content() || Statement::has_content();
+      return (block_ && block_->has_content()) || Statement::has_content();
     }
     virtual ~Has_Block() = 0;
   };

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -386,7 +386,8 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Mixin_Call*>(node)) {
     Mixin_Call* block = dynamic_cast<Mixin_Call*>(node);
     std::cerr << ind << "Mixin_Call " << block << " " << block->tabs();
-    std::cerr << " [" <<  block->name() << "]" << std::endl;
+    std::cerr << " [" <<  block->name() << "]";
+    std::cerr << " [has_content: " << block->has_content() << "] " << std::endl;
     debug_ast(block->arguments(), ind + " args: ");
     if (block->block()) for(auto i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Ruleset* ruleset = dynamic_cast<Ruleset*>(node)) {

--- a/src/sass2scss.cpp
+++ b/src/sass2scss.cpp
@@ -605,6 +605,7 @@ namespace Sass
 			else if (
 				sass.substr(pos_left, 7) != "@return" &&
 				sass.substr(pos_left, 7) != "@extend" &&
+				sass.substr(pos_left, 8) != "@include" &&
 				sass.substr(pos_left, 8) != "@content"
 			) {
 


### PR DESCRIPTION
This PR fixes sass2scss converting `@include foo` to `@include foo() {}` which in turn triggered the error added in https://github.com/sass/libsass/issues/1487. sass2scss now correctly outputs `@include foo()`.

Fixes https://github.com/sass/libsass/issues/1546
Spec https://github.com/sass/sass-spec/pull/492