### PR TITLE
Implement static parameters for built-in functions

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -226,6 +226,8 @@ namespace Sass {
   public:
     Vectorized(size_t s = 0) : elements_(std::vector<T>())
     { elements_.reserve(s); }
+    Vectorized(std::vector<T> els) : elements_(els)
+    { }
     virtual ~Vectorized() = 0;
     size_t length() const   { return elements_.size(); }
     bool empty() const      { return elements_.empty(); }
@@ -775,7 +777,7 @@ namespace Sass {
   struct Backtrace;
   typedef Environment<AST_Node*> Env;
   typedef const char* Signature;
-  typedef Expression* (*Native_Function)(Env&, Env&, Context&, Signature, ParserState, Backtrace*);
+  typedef Expression* (*Native_Function)(Env&, Env&, Context&, Signature, Parameters*, ParserState, Backtrace*);
   typedef const char* Signature;
   class Definition : public Has_Block {
   public:
@@ -1846,11 +1848,17 @@ namespace Sass {
       }
     }
   public:
-    Parameters(ParserState pstate)
+    Parameters(ParserState pstate, bool has_optional = false, bool has_rest = false)
     : AST_Node(pstate),
       Vectorized<Parameter*>(),
-      has_optional_parameters_(false),
-      has_rest_parameter_(false)
+      has_optional_parameters_(has_optional),
+      has_rest_parameter_(has_rest)
+    { }
+    Parameters(ParserState pstate, std::vector<Parameter*> params, bool has_optional = false, bool has_rest = false)
+    : AST_Node(pstate),
+      Vectorized<Parameter*>(params),
+      has_optional_parameters_(has_optional),
+      has_rest_parameter_(has_rest)
     { }
     ATTACH_OPERATIONS()
   };

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -711,16 +711,15 @@ namespace Sass {
       return includes;
   }
 
-  void register_function(Context& ctx, Signature sig, Native_Function f, Env* env)
+  void register_function(Context& ctx, std::string name, Signature sig, Parameters* params, Native_Function f, Env* env)
   {
-    Definition* def = make_native_function(sig, f, ctx);
+    Definition* def = make_native_function(name, sig, params, f, ctx);
     def->environment(env);
     (*env)[def->name() + "[f]"] = def;
   }
-
-  void register_function(Context& ctx, Signature sig, Native_Function f, size_t arity, Env* env)
+  void register_function(Context& ctx, std::string name, Signature sig, Parameters* params, Native_Function f, size_t arity, Env* env)
   {
-    Definition* def = make_native_function(sig, f, ctx);
+    Definition* def = make_native_function(name, sig, params, f, ctx);
     std::stringstream ss;
     ss << def->name() << "[f]" << arity;
     def->environment(env);
@@ -744,101 +743,101 @@ namespace Sass {
   {
     using namespace Functions;
     // RGB Functions
-    register_function(ctx, rgb_sig, rgb, env);
+    register_function(ctx, "rgb", rgb_sig, &rgb_params, rgb, env);
     register_overload_stub(ctx, "rgba", env);
-    register_function(ctx, rgba_4_sig, rgba_4, 4, env);
-    register_function(ctx, rgba_2_sig, rgba_2, 2, env);
-    register_function(ctx, red_sig, red, env);
-    register_function(ctx, green_sig, green, env);
-    register_function(ctx, blue_sig, blue, env);
-    register_function(ctx, mix_sig, mix, env);
+    register_function(ctx, "rgba", rgba_4_sig, &rgba_4_params, rgba_4, 4, env);
+    register_function(ctx, "rgba", rgba_2_sig, &rgba_2_params, rgba_2, 2, env);
+    register_function(ctx, "red", red_sig, &red_params, red, env);
+    register_function(ctx, "green", green_sig, &green_params, green, env);
+    register_function(ctx, "blue", blue_sig, &blue_params, blue, env);
+    register_function(ctx, "mix", mix_sig, &mix_params, mix, env);
     // HSL Functions
-    register_function(ctx, hsl_sig, hsl, env);
-    register_function(ctx, hsla_sig, hsla, env);
-    register_function(ctx, hue_sig, hue, env);
-    register_function(ctx, saturation_sig, saturation, env);
-    register_function(ctx, lightness_sig, lightness, env);
-    register_function(ctx, adjust_hue_sig, adjust_hue, env);
-    register_function(ctx, lighten_sig, lighten, env);
-    register_function(ctx, darken_sig, darken, env);
-    register_function(ctx, saturate_sig, saturate, env);
-    register_function(ctx, desaturate_sig, desaturate, env);
-    register_function(ctx, grayscale_sig, grayscale, env);
-    register_function(ctx, complement_sig, complement, env);
-    register_function(ctx, invert_sig, invert, env);
+    register_function(ctx, "hsl", hsl_sig, &hsl_params, hsl, env);
+    register_function(ctx, "hsla", hsla_sig, &hsla_params, hsla, env);
+    register_function(ctx, "hue", hue_sig, &hue_params, hue, env);
+    register_function(ctx, "saturation", saturation_sig, &saturation_params, saturation, env);
+    register_function(ctx, "lightness", lightness_sig, &lightness_params, lightness, env);
+    register_function(ctx, "adjust-hue", adjust_hue_sig, &adjust_hue_params, adjust_hue, env);
+    register_function(ctx, "lighten", lighten_sig, &lighten_params, lighten, env);
+    register_function(ctx, "darken", darken_sig, &darken_params, darken, env);
+    register_function(ctx, "saturate", saturate_sig, &saturate_params, saturate, env);
+    register_function(ctx, "desaturate", desaturate_sig, &desaturate_params, desaturate, env);
+    register_function(ctx, "grayscale", grayscale_sig, &grayscale_params, grayscale, env);
+    register_function(ctx, "complement", complement_sig, &complement_params, complement, env);
+    register_function(ctx, "invert", invert_sig, &invert_params, invert, env);
     // Opacity Functions
-    register_function(ctx, alpha_sig, alpha, env);
-    register_function(ctx, opacity_sig, alpha, env);
-    register_function(ctx, opacify_sig, opacify, env);
-    register_function(ctx, fade_in_sig, opacify, env);
-    register_function(ctx, transparentize_sig, transparentize, env);
-    register_function(ctx, fade_out_sig, transparentize, env);
+    register_function(ctx, "alpha", alpha_sig, &alpha_params, alpha, env);
+    register_function(ctx, "opacity", opacity_sig, &opacity_params, alpha, env);
+    register_function(ctx, "opacify", opacify_sig, &opacify_params, opacify, env);
+    register_function(ctx, "fade-in", fade_in_sig, &fade_in_params, opacify, env);
+    register_function(ctx, "transparentize", transparentize_sig, &transparentize_params, transparentize, env);
+    register_function(ctx, "fade-out", fade_out_sig, &fade_out_params, transparentize, env);
     // Other Color Functions
-    register_function(ctx, adjust_color_sig, adjust_color, env);
-    register_function(ctx, scale_color_sig, scale_color, env);
-    register_function(ctx, change_color_sig, change_color, env);
-    register_function(ctx, ie_hex_str_sig, ie_hex_str, env);
+    register_function(ctx, "adjust-color", adjust_color_sig, &adjust_color_params, adjust_color, env);
+    register_function(ctx, "scale-color", scale_color_sig, &scale_color_params, scale_color, env);
+    register_function(ctx, "change-color", change_color_sig, &change_color_params, change_color, env);
+    register_function(ctx, "ie-hex-str", ie_hex_str_sig, &ie_hex_str_params, ie_hex_str, env);
     // String Functions
-    register_function(ctx, unquote_sig, sass_unquote, env);
-    register_function(ctx, quote_sig, sass_quote, env);
-    register_function(ctx, str_length_sig, str_length, env);
-    register_function(ctx, str_insert_sig, str_insert, env);
-    register_function(ctx, str_index_sig, str_index, env);
-    register_function(ctx, str_slice_sig, str_slice, env);
-    register_function(ctx, to_upper_case_sig, to_upper_case, env);
-    register_function(ctx, to_lower_case_sig, to_lower_case, env);
+    register_function(ctx, "unquote", unquote_sig, &unquote_params, sass_unquote, env);
+    register_function(ctx, "quote", quote_sig, &quote_params, sass_quote, env);
+    register_function(ctx, "str-length", str_length_sig, &str_length_params, str_length, env);
+    register_function(ctx, "str-insert", str_insert_sig, &str_insert_params, str_insert, env);
+    register_function(ctx, "str-index", str_index_sig, &str_index_params, str_index, env);
+    register_function(ctx, "str-slice", str_slice_sig, &str_slice_params, str_slice, env);
+    register_function(ctx, "to-upper-case", to_upper_case_sig, &to_upper_case_params, to_upper_case, env);
+    register_function(ctx, "to-lower-case", to_lower_case_sig, &to_lower_case_params, to_lower_case, env);
     // Number Functions
-    register_function(ctx, percentage_sig, percentage, env);
-    register_function(ctx, round_sig, round, env);
-    register_function(ctx, ceil_sig, ceil, env);
-    register_function(ctx, floor_sig, floor, env);
-    register_function(ctx, abs_sig, abs, env);
-    register_function(ctx, min_sig, min, env);
-    register_function(ctx, max_sig, max, env);
-    register_function(ctx, random_sig, random, env);
+    register_function(ctx, "percentage", percentage_sig, &percentage_params, percentage, env);
+    register_function(ctx, "round", round_sig, &round_params, round, env);
+    register_function(ctx, "ceil", ceil_sig, &ceil_params, ceil, env);
+    register_function(ctx, "floor", floor_sig, &floor_params, floor, env);
+    register_function(ctx, "abs", abs_sig, &abs_params, abs, env);
+    register_function(ctx, "min", min_sig, &min_params, min, env);
+    register_function(ctx, "max", max_sig, &max_params, max, env);
+    register_function(ctx, "random", random_sig, &random_params, random, env);
     // List Functions
-    register_function(ctx, length_sig, length, env);
-    register_function(ctx, nth_sig, nth, env);
-    register_function(ctx, set_nth_sig, set_nth, env);
-    register_function(ctx, index_sig, index, env);
-    register_function(ctx, join_sig, join, env);
-    register_function(ctx, append_sig, append, env);
-    register_function(ctx, zip_sig, zip, env);
-    register_function(ctx, list_separator_sig, list_separator, env);
+    register_function(ctx, "length", length_sig, &length_params, length, env);
+    register_function(ctx, "nth", nth_sig, &nth_params, nth, env);
+    register_function(ctx, "set-nth", set_nth_sig, &set_nth_params, set_nth, env);
+    register_function(ctx, "index", index_sig, &index_params, index, env);
+    register_function(ctx, "join", join_sig, &join_params, join, env);
+    register_function(ctx, "append", append_sig, &append_params, append, env);
+    register_function(ctx, "zip", zip_sig, &zip_params, zip, env);
+    register_function(ctx, "list-separator", list_separator_sig, &list_separator_params, list_separator, env);
     // Map Functions
-    register_function(ctx, map_get_sig, map_get, env);
-    register_function(ctx, map_merge_sig, map_merge, env);
-    register_function(ctx, map_remove_sig, map_remove, env);
-    register_function(ctx, map_keys_sig, map_keys, env);
-    register_function(ctx, map_values_sig, map_values, env);
-    register_function(ctx, map_has_key_sig, map_has_key, env);
-    register_function(ctx, keywords_sig, keywords, env);
+    register_function(ctx, "map-get", map_get_sig, &map_get_params, map_get, env);
+    register_function(ctx, "map-merge", map_merge_sig, &map_merge_params, map_merge, env);
+    register_function(ctx, "map-remove", map_remove_sig, &map_remove_params, map_remove, env);
+    register_function(ctx, "map-keys", map_keys_sig, &map_keys_params, map_keys, env);
+    register_function(ctx, "map-values", map_values_sig, &map_values_params, map_values, env);
+    register_function(ctx, "map-has-key", map_has_key_sig, &map_has_key_params, map_has_key, env);
+    register_function(ctx, "keywords", keywords_sig, &keywords_params, keywords, env);
     // Introspection Functions
-    register_function(ctx, type_of_sig, type_of, env);
-    register_function(ctx, unit_sig, unit, env);
-    register_function(ctx, unitless_sig, unitless, env);
-    register_function(ctx, comparable_sig, comparable, env);
-    register_function(ctx, variable_exists_sig, variable_exists, env);
-    register_function(ctx, global_variable_exists_sig, global_variable_exists, env);
-    register_function(ctx, function_exists_sig, function_exists, env);
-    register_function(ctx, mixin_exists_sig, mixin_exists, env);
-    register_function(ctx, feature_exists_sig, feature_exists, env);
-    register_function(ctx, call_sig, call, env);
+    register_function(ctx, "type-of", type_of_sig, &type_of_params, type_of, env);
+    register_function(ctx, "unit", unit_sig, &unit_params, unit, env);
+    register_function(ctx, "unitless", unitless_sig, &unitless_params,unitless, env);
+    register_function(ctx, "comparable", comparable_sig, &comparable_params, comparable, env);
+    register_function(ctx, "variable-exists", variable_exists_sig, &variable_exists_params, variable_exists, env);
+    register_function(ctx, "global-variable-exists", global_variable_exists_sig, &global_variable_exists_params, global_variable_exists, env);
+    register_function(ctx, "function-exists", function_exists_sig, &function_exists_params, function_exists, env);
+    register_function(ctx, "mixin-exists", mixin_exists_sig, &mixin_exists_params,mixin_exists, env);
+    register_function(ctx, "feature-exists", feature_exists_sig, &feature_exists_params, feature_exists, env);
+    register_function(ctx, "call", call_sig, &call_params, call, env);
     // Boolean Functions
-    register_function(ctx, not_sig, sass_not, env);
-    register_function(ctx, if_sig, sass_if, env);
+    register_function(ctx, "not", not_sig, &not_params, sass_not, env);
+    register_function(ctx, "if", if_sig, &if_params, sass_if, env);
     // Misc Functions
-    register_function(ctx, inspect_sig, inspect, env);
-    register_function(ctx, unique_id_sig, unique_id, env);
+    register_function(ctx, "inspect", inspect_sig, &inspect_params, inspect, env);
+    register_function(ctx, "unique-id", unique_id_sig, &unique_id_params, unique_id, env);
     // Selector functions
-    register_function(ctx, selector_nest_sig, selector_nest, env);
-    register_function(ctx, selector_append_sig, selector_append, env);
-    register_function(ctx, selector_extend_sig, selector_extend, env);
-    register_function(ctx, selector_replace_sig, selector_replace, env);
-    register_function(ctx, selector_unify_sig, selector_unify, env);
-    register_function(ctx, is_superselector_sig, is_superselector, env);
-    register_function(ctx, simple_selectors_sig, simple_selectors, env);
-    register_function(ctx, selector_parse_sig, selector_parse, env);
+    register_function(ctx, "selector-nest", selector_nest_sig, &selector_nest_params, selector_nest, env);
+    register_function(ctx, "selector-append", selector_append_sig, &selector_append_params, selector_append, env);
+    register_function(ctx, "selector-extend", selector_extend_sig, &selector_extend_params, selector_extend, env);
+    register_function(ctx, "selector-replace", selector_replace_sig, &selector_replace_params, selector_replace, env);
+    register_function(ctx, "selector-unify", selector_unify_sig, &selector_unify_params, selector_unify, env);
+    register_function(ctx, "is-superselector", is_superselector_sig, &is_superselector_params, is_superselector, env);
+    register_function(ctx, "simple-selectors", simple_selectors_sig, &simple_selectors_params, simple_selectors, env);
+    register_function(ctx, "selector-parse", selector_parse_sig, &selector_parse_params, selector_parse, env);
   }
 
   void register_c_functions(Context& ctx, Env* env, Sass_Function_List descrs)

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -829,7 +829,7 @@ namespace Sass {
       exp.backtrace_stack.push_back(&here);
       // eval the body if user-defined or special, invoke underlying CPP function if native
       if (body && !Prelexer::re_special_fun(c->name().c_str())) { result = body->perform(this); }
-      else if (func) { result = func(fn_env, *env, ctx, def->signature(), c->pstate(), backtrace()); }
+      else if (func) { result = func(fn_env, *env, ctx, def->signature(), def->parameters(),  c->pstate(), backtrace()); }
       if (!result) error(std::string("Function ") + c->name() + " did not return a value", c->pstate());
       exp.backtrace_stack.pop_back();
     }

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -4,10 +4,11 @@
 #include "listize.hpp"
 #include "position.hpp"
 #include "environment.hpp"
+#include "ast_fwd_decl.hpp"
 #include "sass/functions.h"
 
 #define BUILT_IN(name) Expression*\
-name(Env& env, Env& d_env, Context& ctx, Signature sig, ParserState pstate, Backtrace* backtrace)
+name(Env& env, Env& d_env, Context& ctx, Signature sig, Parameters* params, ParserState pstate, Backtrace* backtrace)
 
 namespace Sass {
   class Context;
@@ -17,9 +18,9 @@ namespace Sass {
   class Definition;
   typedef Environment<AST_Node*> Env;
   typedef const char* Signature;
-  typedef Expression* (*Native_Function)(Env&, Env&, Context&, Signature, ParserState, Backtrace*);
+  typedef Expression* (*Native_Function)(Env&, Env&, Context&, Signature, Parameters*, ParserState, Backtrace*);
 
-  Definition* make_native_function(Signature, Native_Function, Context& ctx);
+  Definition* make_native_function(std::string name, Signature, Parameters*, Native_Function, Context& ctx);
   Definition* make_c_function(Sass_Function_Entry c_func, Context& ctx);
 
   std::string function_name(Signature);
@@ -27,89 +28,427 @@ namespace Sass {
   namespace Functions {
 
     extern Signature rgb_sig;
+    extern Parameter rgb_red;
+    extern Parameter rgb_green;
+    extern Parameters rgb_params;
+
     extern Signature rgba_4_sig;
+    extern Parameter rgba_4_red;
+    extern Parameter rgba_4_green;
+    extern Parameter rgba_4_blue;
+    extern Parameter rgba_4_alpha;
+    extern Parameters rgba_4_params;
+
     extern Signature rgba_2_sig;
+    extern Parameter rgba_2_alpha;
+    extern Parameter rgba_2_color;
+    extern Parameters rgba_2_params;
+
     extern Signature red_sig;
+    extern Parameter red_color;
+    extern Parameters red_params;
+
     extern Signature green_sig;
+    extern Parameter green_color;
+    extern Parameters green_params;
+
     extern Signature blue_sig;
+    extern Parameter blue_color;
+    extern Parameters blue_params;
+
     extern Signature mix_sig;
+    extern Parameter mix_color_1;
+    extern Parameter mix_color_2;
+    extern Parameter mix_weight;
+    extern Number mix_weight_default;
+    extern Parameters mix_params;
+
     extern Signature hsl_sig;
+    extern Parameter hsl_hue;
+    extern Parameter hsl_saturation;
+    extern Parameter hsl_lightness;
+    extern Parameters hsl_params;
+
     extern Signature hsla_sig;
+    extern Parameter hsla_hue;
+    extern Parameter hsla_saturation;
+    extern Parameter hsla_lightness;
+    extern Parameter hsla_alpha;
+    extern Parameters hsla_params;
+
     extern Signature hue_sig;
+    extern Parameter hue_color;
+    extern Parameters hue_params;
+
     extern Signature saturation_sig;
+    extern Parameter saturation_color;
+    extern Parameters saturation_params;
+
     extern Signature lightness_sig;
+    extern Parameter lightness_color;
+    extern Parameters lightness_params;
+
     extern Signature adjust_hue_sig;
+    extern Parameter adjust_hue_color;
+    extern Parameter adjust_hue_degrees;
+    extern Parameters adjust_hue_params;
+
     extern Signature lighten_sig;
+    extern Parameter lighten_color;
+    extern Parameter lighten_amount;
+    extern Parameters lighten_params;
+
     extern Signature darken_sig;
+    extern Parameter darken_color;
+    extern Parameter darken_amount;
+    extern Parameters darken_params;
+
     extern Signature saturate_sig;
+    extern Parameter saturate_color;
+    extern Parameter saturate_amount;
+    extern Parameters saturate_params;
+    extern Boolean saturate_amount_default;
+
     extern Signature desaturate_sig;
+    extern Parameter desaturate_color;
+    extern Parameter desaturate_amount;
+    extern Parameters desaturate_params;
+
     extern Signature grayscale_sig;
+    extern Parameter grayscale_color;
+    extern Parameters grayscale_params;
+
     extern Signature complement_sig;
+    extern Parameter compliment_color;
+    extern Parameters complement_params;
+
     extern Signature invert_sig;
+    extern Parameter invert_color;
+    extern Parameters invert_params;
+
+
     extern Signature alpha_sig;
+    extern Parameter alpha_color;
+    extern Parameters alpha_params;
+
     extern Signature opacity_sig;
+    extern Parameter opacity_color;
+    extern Parameters opacity_params;
+
     extern Signature opacify_sig;
+    extern Parameter opacify_color;
+    extern Parameter opacify_amount;
+    extern Parameters opacify_params;
+
     extern Signature fade_in_sig;
+    extern Parameter fade_in_color;
+    extern Parameter fade_in_amount;
+    extern Parameters fade_in_params;
+
     extern Signature transparentize_sig;
+    extern Parameter transparentize_color;
+    extern Parameter transparentize_amount;
+    extern Parameters transparentize_params;
+
     extern Signature fade_out_sig;
+    extern Parameter fade_out_color;
+    extern Parameter fade_out_amount;
+    extern Parameters fade_out_params;
+
+
     extern Signature adjust_color_sig;
+    extern Parameter adjust_color_color;
+    extern Parameter adjust_color_red;
+    extern Parameter adjust_color_green;
+    extern Parameter adjust_color_blue;
+    extern Parameter adjust_color_hue;
+    extern Parameter adjust_color_saturation;
+    extern Parameter adjust_color_lightness;
+    extern Parameter adjust_color_alpha;
+    extern Parameters adjust_color_params;
+    extern Boolean adjust_color_red_default;
+    extern Boolean adjust_color_green_default;
+    extern Boolean adjust_color_blue_default;
+    extern Boolean adjust_color_hue_default;
+    extern Boolean adjust_color_saturation_default;
+    extern Boolean adjust_color_lightness_default;
+    extern Boolean adjust_color_alpha_default;
+
     extern Signature scale_color_sig;
+    extern Parameter scale_color_color;
+    extern Parameter scale_color_red;
+    extern Parameter scale_color_green;
+    extern Parameter scale_color_blue;
+    extern Parameter scale_color_hue;
+    extern Parameter scale_color_saturation;
+    extern Parameter scale_color_lightness;
+    extern Parameter scale_color_alpha;
+    extern Parameters scale_color_params;
+    extern Boolean scale_color_red_default;
+    extern Boolean scale_color_green_default;
+    extern Boolean scale_color_blue_default;
+    extern Boolean scale_color_hue_default;
+    extern Boolean scale_color_saturation_default;
+    extern Boolean scale_color_lightness_default;
+    extern Boolean scale_color_alpha_default;
+
     extern Signature change_color_sig;
+    extern Parameter change_color_color;
+    extern Parameter change_color_red;
+    extern Parameter change_color_green;
+    extern Parameter change_color_blue;
+    extern Parameter change_color_hue;
+    extern Parameter change_color_saturation;
+    extern Parameter change_color_lightness;
+    extern Parameter change_color_alpha;
+    extern Parameters change_color_params;
+    extern Boolean change_color_red_default;
+    extern Boolean change_color_green_default;
+    extern Boolean change_color_blue_default;
+    extern Boolean change_color_hue_default;
+    extern Boolean change_color_saturation_default;
+    extern Boolean change_color_lightness_default;
+    extern Boolean change_color_alpha_default;
+
     extern Signature ie_hex_str_sig;
+    extern Parameter ie_hex_str_color;
+    extern Parameters ie_hex_str_params;
+
     extern Signature unquote_sig;
+    extern Parameter unquote_string;
+    extern Parameters unquote_params;
+
     extern Signature quote_sig;
+    extern Parameter quote_string;
+    extern Parameters quote_params;
+
     extern Signature str_length_sig;
+    extern Parameter str_length_string;
+    extern Parameters str_length_params;
+
     extern Signature str_insert_sig;
+    extern Parameter str_insert_string;
+    extern Parameter str_insert_insert;
+    extern Parameter str_insert_index;
+    extern Parameters str_insert_params;
+
     extern Signature str_index_sig;
+    extern Parameter str_index_string;
+    extern Parameter str_index_substring;
+    extern Parameters str_index_params;
+
     extern Signature str_slice_sig;
+    extern Parameter str_slice_string;
+    extern Parameter str_slice_start_at;
+    extern Parameter str_slice_end_at;
+    extern Parameters str_slice_params;
+    extern Number str_slice_end_at_default;
+
     extern Signature to_upper_case_sig;
+    extern Parameter to_upper_case_string;
+    extern Parameters to_upper_case_params;
+
     extern Signature to_lower_case_sig;
+    extern Parameter to_lower_case_string;
+    extern Parameters to_lower_case_params;
+
     extern Signature percentage_sig;
+    extern Parameter percentage_number;
+    extern Parameters percentage_params;
+
     extern Signature round_sig;
+    extern Parameter round_number;
+    extern Parameters round_params;
+
     extern Signature ceil_sig;
+    extern Parameter ceil_number;
+    extern Parameters ceil_params;
+
     extern Signature floor_sig;
+    extern Parameter floor_number;
+    extern Parameters floor_params;
+
     extern Signature abs_sig;
+    extern Parameter abs_number;
+    extern Parameters abs_params;
+
     extern Signature min_sig;
+    extern Parameter min_numbers;
+    extern Parameters min_params;
+
     extern Signature max_sig;
-    extern Signature inspect_sig;
+    extern Parameter max_numbers;
+    extern Parameters max_params;
+
     extern Signature random_sig;
+    extern Parameter random_limit;
+    extern Parameters random_params;
+    extern Boolean random_limit_default;
+
     extern Signature length_sig;
+    extern Parameter length_list;
+    extern Parameters length_params;
+
     extern Signature nth_sig;
-    extern Signature index_sig;
-    extern Signature join_sig;
-    extern Signature append_sig;
-    extern Signature zip_sig;
-    extern Signature list_separator_sig;
-    extern Signature type_of_sig;
-    extern Signature unit_sig;
-    extern Signature unitless_sig;
-    extern Signature comparable_sig;
-    extern Signature variable_exists_sig;
-    extern Signature global_variable_exists_sig;
-    extern Signature function_exists_sig;
-    extern Signature mixin_exists_sig;
-    extern Signature feature_exists_sig;
-    extern Signature call_sig;
-    extern Signature not_sig;
-    extern Signature if_sig;
-    extern Signature image_url_sig;
-    extern Signature map_get_sig;
-    extern Signature map_merge_sig;
-    extern Signature map_remove_sig;
-    extern Signature map_keys_sig;
-    extern Signature map_values_sig;
-    extern Signature map_has_key_sig;
-    extern Signature keywords_sig;
+    extern Parameter nth_list;
+    extern Parameter nth_n;
+    extern Parameters nth_params;
+
     extern Signature set_nth_sig;
+    extern Parameter set_nth_list;
+    extern Parameter set_nth_n;
+    extern Parameter set_nth_value;
+    extern Parameters set_nth_params;
+
+    extern Signature index_sig;
+    extern Parameter index_list;
+    extern Parameter index_value;
+    extern Parameters index_params;
+
+    extern Signature join_sig;
+    extern Parameter join_list_1;
+    extern Parameter join_list_2;
+    extern Parameter join_separator;
+    extern Parameters join_params;
+    extern String_Constant join_separator_default;
+
+    extern Signature append_sig;
+    extern Parameter append_list;
+    extern Parameter append_val;
+    extern Parameter append_separator;
+    extern Parameters append_params;
+    extern String_Constant append_separator_default;
+
+    extern Signature zip_sig;
+    extern Parameter zip_lists;
+    extern Parameters zip_params;
+
+    extern Signature list_separator_sig;
+    extern Parameter list_separator_lists;
+    extern Parameters list_separator_params;
+
+    extern Signature map_get_sig;
+    extern Parameter map_get_map;
+    extern Parameter map_get_key;
+    extern Parameters map_get_params;
+
+    extern Signature map_has_key_sig;
+    extern Parameter map_has_key_map;
+    extern Parameter map_has_key_key;
+    extern Parameters map_has_key_params;
+
+    extern Signature map_keys_sig;
+    extern Parameter map_keys_map;
+    extern Parameters map_keys_params;
+
+    extern Signature map_values_sig;
+    extern Parameter map_values_map;
+    extern Parameters map_values_params;
+
+    extern Signature map_merge_sig;
+    extern Parameter map_merge_map_1;
+    extern Parameter map_merge_map_2;
+    extern Parameters map_merge_params;
+
+    extern Signature map_remove_sig;
+    extern Parameter map_remove_map;
+    extern Parameter map_remove_keys;
+    extern Parameters map_remove_params;
+
+    extern Signature keywords_sig;
+    extern Parameter keywords_args;
+    extern Parameters keywords_params;
+
+    extern Signature type_of_sig;
+    extern Parameter type_of_value;
+    extern Parameters type_of_params;
+
+    extern Signature unit_sig;
+    extern Parameter unit_number;
+    extern Parameters unit_params;
+
+    extern Signature unitless_sig;
+    extern Parameter unitless_number;
+    extern Parameters unitless_params;
+
+    extern Signature comparable_sig;
+    extern Parameter comparable_number_1;
+    extern Parameter comparable_number_2;
+    extern Parameters comparable_params;
+
+    extern Signature variable_exists_sig;
+    extern Parameter variable_exists_name;
+    extern Parameters variable_exists_params;
+
+    extern Signature global_variable_exists_sig;
+    extern Parameter global_variable_exists_name;
+    extern Parameters global_variable_exists_params;
+
+    extern Signature function_exists_sig;
+    extern Parameter function_exists_name;
+    extern Parameters function_exists_params;
+
+    extern Signature mixin_exists_sig;
+    extern Parameter mixin_exists_name;
+    extern Parameters mixin_exists_params;
+
+    extern Signature feature_exists_sig;
+    extern Parameter feature_exists_name;
+    extern Parameters feature_exists_params;
+
+    extern Signature call_sig;
+    extern Parameter call_name;
+    extern Parameter call_args;
+    extern Parameters call_params;
+
+    extern Signature not_sig;
+    extern Parameters not_params;
+    extern Signature if_sig;
+    extern Parameters if_params;
+
+    extern Signature inspect_sig;
+    extern Parameters inspect_params;
+
     extern Signature unique_id_sig;
+    extern Parameters unique_id_params;
+
     extern Signature selector_nest_sig;
+    extern Parameter selector_nest_selectors;
+    extern Parameters selector_nest_params;
+
     extern Signature selector_append_sig;
-    extern Signature selector_extend_sig;
-    extern Signature selector_replace_sig;
+    extern Parameter selector_append_selectors;
+    extern Parameters selector_append_params;
+
     extern Signature selector_unify_sig;
-    extern Signature is_superselector_sig;
+    extern Parameter selector_unify_selector_1;
+    extern Parameter selector_unify_selector_2;
+    extern Parameters selector_unify_params;
+
     extern Signature simple_selectors_sig;
+    extern Parameter simple_selectors_selector;
+    extern Parameters simple_selectors_params;
+
+    extern Signature selector_extend_sig;
+    extern Parameter selector_extend_selector;
+    extern Parameter selector_extend_extendee;
+    extern Parameter selector_extend_extender;
+    extern Parameters selector_extend_params;
+
+    extern Signature selector_replace_sig;
+    extern Parameter selector_replace_selector;
+    extern Parameter selector_replace_original;
+    extern Parameter selector_replace_replacement;
+    extern Parameters selector_replace_params;
+
     extern Signature selector_parse_sig;
+    extern Parameter selector_parse_selector;
+    extern Parameters selector_parse_params;
+
+    extern Signature is_superselector_sig;
+    extern Parameter is_superselector_super;
+    extern Parameter is_superselector_sub;
+    extern Parameters is_superselector_params;
 
     BUILT_IN(rgb);
     BUILT_IN(rgba_4);


### PR DESCRIPTION
Brings about 15% performance gain for the spec test suite!

I recently made some more performance assessments. One of the more obvious performance drawbacks is that we currenlty parse the function prototypes everytime we create a new context. This overhead is "noticable" (in term of overall compile time) for small inputs and we also do it over and over again for long running processes. 

The easiest way to fix it is to implement the prototypes (`Parameters`) directly as AST_Nodes. While it is not overly complex, it does add some additional complexity when adding new internal functions. This PR adds static prototypes for all internal functions, but I keept the code for parsing the `Parameters` node if the Parameters are not statically implemented (so it's actually optional).

It may add some complexity but IMO it's worth for the performance we get! I tried to research some alternative methods to achieve this, but doing it by hand was IMO the most portable option. Most functions are straight forward and there only a few cases with `rest` arguments.

