### PR TITLE
[WIP] Test: Uses Criterion framework to test LibSass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,6 @@ src/support/libsass.pc
 
 # Cloned testing dirs
 sassc/
-sass-spec/
+test/*/
 
 installer/

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required( VERSION 2.8 )
+
+project( LibSassTests C )
+
+if( $ENV{LIBSASS_TEST_SPEC_BRANCH} )
+  set( SPEC_BRANCH $ENV{LIBSASS_TEST_SPEC_BRANCH} )
+else()
+  set( SPEC_BRANCH master )
+endif()
+
+if( NOT DEFINED $ENV{LIBSASS_TEST_SKIP_DOWNLOAD_DEPS} )
+  if(WIN32)
+    execute_process( COMMAND powershell "rm -r -fo ${CMAKE_CURRENT_LIST_DIR}/Criterion 2>&1> $null" )
+    execute_process( COMMAND powershell "rm -r -fo ${CMAKE_CURRENT_LIST_DIR}/sass-spec 2>&1> $null" )
+    execute_process( COMMAND powershell "rm -r -fo ${CMAKE_CURRENT_LIST_DIR}/slre 2>&1> $null" )
+    execute_process( COMMAND powershell "rm -r -fo ${CMAKE_CURRENT_LIST_DIR}/tinydir 2>&1> $null" )
+  else()
+    execute_process( COMMAND rm -rf ${CMAKE_CURRENT_LIST_DIR}/sass-spec ${CMAKE_CURRENT_LIST_DIR}/Criterion ${CMAKE_CURRENT_LIST_DIR}/tinydir ${CMAKE_CURRENT_LIST_DIR}/slre 2>1> /dev/null )
+  endif()
+
+  execute_process( COMMAND git clone https://github.com/Snaipe/Criterion --recursive ${CMAKE_CURRENT_LIST_DIR}/Criterion )
+  execute_process( COMMAND git clone https://github.com/sass/sass-spec --recursive -b ${SPEC_BRANCH} ${CMAKE_CURRENT_LIST_DIR}/sass-spec )
+  execute_process( COMMAND git clone https://github.com/cesanta/slre --recursive ${CMAKE_CURRENT_LIST_DIR}/slre )
+  execute_process( COMMAND git clone https://github.com/cxong/tinydir --recursive ${CMAKE_CURRENT_LIST_DIR}/tinydir )
+endif()
+
+add_subdirectory( Criterion )
+
+add_executable( RUN ./spec_theories.c Criterion/src/ slre/slre.c )
+
+add_library( libsass STATIC IMPORTED )
+
+if( MSVC )
+  set_target_properties( libsass PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_LIST_DIR}/../win/bin/libsass.lib )
+else()
+  set_target_properties( libsass PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_LIST_DIR}/../build/lib/libsass.a )
+endif()
+
+target_link_libraries( RUN criterion libsass )
+
+include_directories(
+  Criterion/include/
+  ../include/
+)

--- a/test/spec_theories.c
+++ b/test/spec_theories.c
@@ -1,0 +1,287 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <Criterion/theories.h>
+#include <sass.h>
+#include "tinydir/tinydir.h"
+#include "slre/slre.h"
+
+static bool skip_todo = false, unexpected_pass = false;
+
+static void add(char ***arr, const char *value, int *length) {
+  ++(*length);
+  char *temp = (char *)realloc(*arr, (*length) * sizeof(**arr));
+
+  if (!temp) {
+    --(*length);
+    return;
+  }
+
+  *arr = temp;
+  (*arr)[*length - 1] = (char *)malloc(strlen(value) * sizeof(char) + 1);
+  strcpy((*arr)[*length - 1], value);
+}
+
+static void empty(char ***arr, int length) {
+  for (int i = 0; i < length; ++i) {
+    free((*arr)[i]);
+  }
+}
+
+// You must free the result if result is non-NULL.
+char *str_replace(char *orig, char *rep, char *with) {
+  char *result; // the return string
+  char *ins;    // the next insert point
+  char *tmp;    // varies
+  int len_rep;  // length of rep
+  int len_with; // length of with
+  int len_front; // distance between rep and end of last rep
+  int count;    // number of replacements
+
+  if (!orig)
+    return NULL;
+  if (!rep)
+    rep = "";
+  len_rep = strlen(rep);
+  if (!with)
+    with = "";
+  len_with = strlen(with);
+
+  ins = orig;
+  for (count = 0; tmp = strstr(ins, rep); ++count) {
+    ins = tmp + len_rep;
+  }
+
+  // first time through the loop, all the variable are set correctly
+  // from here on,
+  //    tmp points to the end of the result string
+  //    ins points to the next occurrence of rep in orig
+  //    orig points to the remainder of orig after "end of rep"
+  tmp = result = malloc(strlen(orig) + (len_with - len_rep) * count + 1);
+
+  if (!result)
+    return NULL;
+
+  while (count--) {
+    ins = strstr(orig, rep);
+    len_front = ins - orig;
+    tmp = strncpy(tmp, orig, len_front) + len_front;
+    tmp = strcpy(tmp, with) + len_with;
+    orig += len_front + len_rep; // move to next "end of rep"
+  }
+  strcpy(tmp, orig);
+  return result;
+}
+
+static void recursively_collect(char ***arr, const char *path, int *len) {
+  tinydir_dir dir;
+
+  tinydir_open(&dir, path);
+
+  while (dir.has_next) {
+    tinydir_file file;
+    if (tinydir_readfile(&dir, &file) == -1) {
+      perror("Error getting file");
+      break;
+    }
+    if (strcmp(file.name, ".") == 0 || strcmp(file.name, "..") == 0) {
+      tinydir_next(&dir);
+      continue;
+    }
+
+    if (file.is_dir && (!skip_todo || !strstr(file.name, "-todo-"))) {
+      recursively_collect(arr, file.path, len);
+    }
+    else if (strcmp(file.name, "input.scss") == 0 || strcmp(file.name, "input.sass") == 0) {
+      add(arr, file.path, len);
+    }
+
+    tinydir_next(&dir);
+  }
+
+  tinydir_close(&dir);
+}
+
+static char *read_file(const char *path) {
+  FILE *fp;
+  long lSize;
+  char *buffer;
+
+  fp = fopen(path, "rb");
+  if (!fp) perror(path), exit(1);
+
+  fseek(fp, 0L, SEEK_END);
+  lSize = ftell(fp);
+  rewind(fp);
+
+  buffer = calloc(1, lSize + 1);
+  if (!buffer) fclose(fp), fputs("memory alloc fails", stderr), exit(1);
+
+  fread(buffer, lSize, 1, fp);
+  fclose(fp);
+
+  return buffer;
+}
+
+static void list_directories(void ***out, size_t *size) {
+  int len = 0;
+  char *spec_dir = str_replace(__FILE__, "spec_theories.c", "sass-spec/spec");
+  char *todo_var = getenv("LIBSASS_SKIP_TODO");
+  char *unexpected_pass_var = getenv("LIBSASS_UNEXPECTED_PASS");
+
+  skip_todo = !strcmp("1", (todo_var ? todo_var : "0"));
+  unexpected_pass = !strcmp("1", (unexpected_pass_var ? unexpected_pass_var : "0"));
+
+  (*out) = malloc(sizeof(char*));
+  recursively_collect(&(*out), spec_dir, &len);
+  free(spec_dir);
+
+  (*size) = len;
+}
+
+TheoryDataPoints(theory, gen) = {
+  DataPoints(const char *, "") // parameter placeholder
+};
+
+static void generate_datapoints(void) {
+  list_directories(&TheoryDataPoint(theory, gen)[0].arr, &TheoryDataPoint(theory, gen)[0].len);
+}
+
+static void free_datapoints(void) {
+  empty(&TheoryDataPoint(theory, gen)[0].arr, TheoryDataPoint(theory, gen)[0].len);
+  free(TheoryDataPoint(theory, gen)[0].arr);
+}
+
+static char *slre_replace_alternative_dynamic_capture_version(const char *buf, const char *regex, const char *sub, const int num) {
+  char *s = NULL;
+  int n, n1, n2, n3, s_len, len = strlen(buf);
+  struct slre_cap *cap = malloc(sizeof(struct slre_cap) * num);// = { NULL, 0 };
+
+  do {
+    s_len = s == NULL ? 0 : strlen(s);
+    if ((n = slre_match(regex, buf, len, cap, num, 0)) > 0) {
+      n1 = cap[0].ptr - buf, n2 = strlen(sub),
+        n3 = &buf[n] - &cap[0].ptr[cap[0].len];
+    }
+    else {
+      n1 = len, n2 = 0, n3 = 0;
+    }
+    s = (char *)realloc(s, s_len + n1 + n2 + n3 + 1);
+    memcpy(s + s_len, buf, n1);
+    memcpy(s + s_len + n1, sub, n2);
+    memcpy(s + s_len + n1 + n2, cap[0].ptr + cap[0].len, n3);
+    s[s_len + n1 + n2 + n3] = '\0';
+
+    buf += n > 0 ? n : len;
+    len -= n > 0 ? n : len;
+  } while (len > 0);
+
+  free(cap);
+  return s;
+}
+
+static char *slre_replace(const char *buf, const char *regex, const char *sub) {
+  char *s = NULL;
+  int n, n1, n2, n3, s_len, len = strlen(buf);
+  struct slre_cap cap = { NULL, 0 };
+
+  do {
+    s_len = s == NULL ? 0 : strlen(s);
+    if ((n = slre_match(regex, buf, len, &cap, 1, 0)) > 0) {
+      n1 = cap.ptr - buf, n2 = strlen(sub),
+        n3 = &buf[n] - &cap.ptr[cap.len];
+    }
+    else {
+      n1 = len, n2 = 0, n3 = 0;
+    }
+    s = (char *)realloc(s, s_len + n1 + n2 + n3 + 1);
+    memcpy(s + s_len, buf, n1);
+    memcpy(s + s_len + n1, sub, n2);
+    memcpy(s + s_len + n1 + n2, cap.ptr + cap.len, n3);
+    s[s_len + n1 + n2 + n3] = '\0';
+
+    buf += n > 0 ? n : len;
+    len -= n > 0 ? n : len;
+  } while (len > 0);
+
+  return s;
+}
+
+static char *sanitize_str(const char *input) {
+  char *s1 = slre_replace(input, "(\t+)", " ");
+  char *s2 = slre_replace(s1, "(\r+)", " ");
+  char *s3 = slre_replace(s2, "(\n+)", " ");
+  char *s4 = slre_replace(s3, "(\f+)", " ");
+  char *s5 = slre_replace(s4, "( +)", " ");
+  char *s6 = slre_replace(s5, "( *\{)", " {\n");
+  char *s7 = slre_replace(s6, "(; *)", ";\n");
+  char *s8 = slre_replace(s7, "(, *)", ",\n");
+  char *s9 = slre_replace(s8, "( *\} *)", " }\n");
+  char *s10 = slre_replace(s9, "((\r?\n)*;(\r?\n)*(?(\r?\n)*:(\r?\n)*\s*(\r?\n)*;(\r?\n)*)+(\r?\n)*)", ";");
+  char *s11 = slre_replace(s10, "((\r?\n)*;(\r?\n)* *(\r?\n)*})", "; }");
+
+  free(s1);
+  free(s2);
+  free(s3);
+  free(s4);
+  free(s5);
+  free(s6);
+  free(s7);
+  free(s8);
+  free(s9);
+  free(s10);
+
+  return s11;
+}
+
+Theory((const char *input_path), theory, gen, .init = generate_datapoints, .fini = free_datapoints) {
+  char *output_path = strstr(input_path, "input.scss") ?
+    str_replace(input_path, "input.scss", "expected_output.css") :
+    str_replace(input_path, "input.sass", "expected_output.css");
+
+  /* TODO: Needs an efficient way to repeat the process for these:
+  char *output_compact = str_replace(str_replace(input_path, "input.scss", "expected.compact.css"), "input.sass", "expected.compact.css");
+  char *output_compressed = str_replace(str_replace(input_path, "input.scss", "expected.compressed.css"), "input.sass", "expected.compressed.css");
+  char *output_expanded = str_replace(str_replace(input_path, "input.scss", "expected.expanded.css"), "input.sass", "expected.expanded.css");
+  */
+
+  struct Sass_File_Context* ctx = sass_make_file_context(input_path);
+  struct Sass_Context* ctx_out = sass_file_context_get_context(ctx);
+  struct Sass_Options* options = sass_make_options();
+
+  sass_option_set_output_style(options, SASS_STYLE_NESTED);
+  sass_option_set_output_path(options, output_path);
+  sass_option_set_input_path(options, input_path);
+  sass_file_context_set_options(ctx, options);
+  sass_compile_file_context(ctx);
+
+  int error_status = sass_context_get_error_status(ctx_out);
+  const char *error_message = sass_context_get_error_message(ctx_out);
+  const char *actual = sass_context_get_output_string(ctx_out);
+  char *expected = read_file(output_path);
+  bool is_todo = skip_todo ? false : strstr(input_path, "-todo-");
+  bool is_match;
+
+  if (error_status) {
+    is_match = !strcmp(expected, error_message);
+  }
+  else {
+    char *sanitized_expected = sanitize_str(expected);
+    char *sanitized_actual = sanitize_str(actual);
+
+    is_match = !strcmp(sanitized_expected, sanitized_actual);
+
+    free(sanitized_expected);
+    free(sanitized_actual);
+  }
+
+  if (unexpected_pass && is_todo) {
+    cr_assert(!is_match, "\n[%s] -> passed a test we expected it to fail\n\n", output_path);
+  }
+  else {
+    cr_assert(is_match, "\n[%s] -> Expected did not match output\n\n", output_path);
+  }
+
+  free(output_path);
+  free(expected);
+  sass_delete_file_context(ctx);
+}


### PR DESCRIPTION
[Work in progress]

Issue-URL: sass/sassc#90.

#### Summary of current progress:

* Users Criterion as a testing framework: https://github.com/Snaipe/Criterion.
* Revokes SassC and Ruby dependencies for running tests.
* Use Cmake to DRY make logic (only targets tests: `test/CMakeLists.txt`).
* Clone dependencies within `CMakeLists`.
* Uses `Theory` and `TheoryDataPoints` to test.
* Uses array to capture all the `input.scss` | `input.sass`.
* Controls TODOs and unexpected mode with environment variables.
* Use SLRE for regex replacements: https://github.com/cesanta/slre.

Besides all the non-TODO tests are running and passing (with both debug and release configurations).

#### Rationale

The idea is to first make the test runner (close to) the drop-in replacement of Ruby test runner, then make enhancement and incorporate ability to test those features of LibSass which ruby-runner wasn't able to test.

#### Scope of this PR (checklist):

##### Existing infrastructure features:

- [x] Ability to collect all specs from sass/spec repo.
- [x] Ability to filer TODO specs.
  - Implemented using environment variable: `LIBSASS_SKIP_TODO`.
- [x] Ability to alter unexpected passes for TODO tests.
  - Implemented using environment variable: `LIBSASS_UNEXPECTED_PASS`.
- [x] Ability to select sass-spec branch.
  - Set `LIBSASS_TEST_SPEC_BRANCH` to the name of the desired branch (default is master).
- [x] Ability to compile all spec files and compare with the expected output.
- [ ] Ability to test all styles of output: `expanded`, `nested`, `compact`, `compressed`.
  - Currently only `nested` output is being compiled and tested.
- [x] Buildable and run-able on Windows.
  - Compiles with VS2015 and MinGW.
- [ ] Account for each spec individually.
  - Blocked by https://github.com/Snaipe/Criterion/issues/43.
- [ ] Configure and report coverage.
- [ ] Configure CI to run tests.

##### Non-existing in ruby-runner, but most wanted feature:

- [x] ability to test error messages.

#### Usage:

Currently, I have only tested on Windows 10 with VS2015. I intend to test on Unix before merging it.

```powershell
# in powershell..
cd somewhere
git clone https://github.com/sass/libsass

# build libsass with VS2015
&"${env:ProgramFiles(x86)}\MSBuild\14.0\Bin\MSBuild" libsass\win\libsass.sln `
/p:Configuration=Release

mkdir blah
cd blah
cmake ../libsass/test
cmake --build . --config Release

# following step will be automated:
# * either by (somehow) setting the compile target of subdirectory project to run.exe's.
# * OR with execute_process( COMMAND cp ..) in CMakeLists
cp Criterion/Release/criterion.dll Release/

# disable TODO specs
$env:LIBSASS_SKIP_TODO=1

# need to unify the path of output executable (in test/bin for instance)
Release/run --ascii
# in *nix Shells, --ascii switch can be skipped
```

#### Questions:

* Using too many dependencies: is it good / bad / ok?
  * IMO it is an ok working solution at least for the starters and aligns with separation of concerns and DRY principles.
  * With `LIBSASS_TEST_SKIP_DOWNLOAD_DEPS` set, re-downloading all dependencies with `cmake libsass/test` can be skipped.
* SLRE based Regex has negative performance:
  * Should we update the `spec/**/*.css` files to exactly match libsass output?
    * I have a feeling this is not going to happen. :)
  * OR Should we invest time in optimizing sanitize function?
    * I discourage this option very much in favor of the next one.
  * OR Should we tap into LibSass's AST and find out *the absolute* equality of given CSS outputs? :)

---

Special thanks to @Snaipe for all the advises + assistance and for building the great testing framework for C: Criterion. :trophy: 