### PR TITLE
Error messages for selector functions

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1880,12 +1880,8 @@ namespace Sass {
     BUILT_IN(is_superselector)
     {
       To_String to_string(&ctx, false);
-      Expression*  ex_sup = ARG("$super", Expression);
-      Expression*  ex_sub = ARG("$sub", Expression);
-      std::string sup_src = ex_sup->perform(&to_string) + "{";
-      std::string sub_src = ex_sub->perform(&to_string) + "{";
-      Selector_List* sel_sup = Parser::parse_selector(sup_src.c_str(), ctx);
-      Selector_List* sel_sub = Parser::parse_selector(sub_src.c_str(), ctx);
+      Selector_List*  sel_sup = ARGSEL("$super", Selector_List, p_contextualize);
+      Selector_List*  sel_sub = ARGSEL("$sub", Selector_List, p_contextualize);
       bool result = sel_sup->is_superselector_of(sel_sub);
       return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, result);
     }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -188,8 +188,7 @@ namespace Sass {
       Expression* exp = ARG(argname, Expression);
       if (exp->concrete_type() == Expression::NULL_VAL) {
         std::stringstream msg;
-        msg << argname << ": null is not a valid selector: it must be a string,\n";
-        msg << "a list of strings, or a list of lists of strings for `" << function_name(sig) << "'";
+        msg << argname << ": null is not a string for `" << function_name(sig) << "'";
         error(msg.str(), pstate);
       }
       std::string exp_src = exp->perform(&to_string) + "{";


### PR DESCRIPTION
is-superselector("foo", null) fixes https://github.com/sass/libsass/issues/1565
simple-selectors(null) fixes https://github.com/sass/libsass/issues/1563