### PR TITLE
Fix error not being thrown for empty interpolants

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2435,7 +2435,7 @@ namespace Sass {
   // print a css parsing error with actual context information from parsed source
   void Parser::css_error(const std::string& msg, const std::string& prefix, const std::string& middle)
   {
-    int max_len = 14;
+    int max_len = 18;
     const char* pos = peek < optional_spaces >();
 
     const char* last_pos(pos - 1);
@@ -2446,7 +2446,7 @@ namespace Sass {
     const char* pos_left(last_pos + 1);
     const char* end_left(last_pos + 1);
     while (pos_left > source) {
-      if (end_left - pos_left > max_len) {
+      if (end_left - pos_left >= max_len) {
         ellipsis_left = true;
         break;
       }
@@ -2476,8 +2476,8 @@ namespace Sass {
 
     std::string left(pos_left, end_left);
     std::string right(pos_right, end_right);
-    if (ellipsis_left) left = ellipsis + left;
-    if (ellipsis_right) right = right + ellipsis;
+    if (ellipsis_left) left = ellipsis + left.substr(left.size() - 15);
+    if (ellipsis_right) right = right.substr(right.size() - 15) + ellipsis;
     // now pass new message to the more generic error function
     error(msg + prefix + quote(left) + middle + quote(right), pstate);
   }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1638,6 +1638,9 @@ namespace Sass {
       // lex an interpolant /#{...}/
       else if (lex< exactly < hash_lbrace > >()) {
         // Try to lex static expression first
+        if (peek< exactly< rbrace > >()) {
+          css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
+        }
         if (lex< re_static_expression >()) {
           (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
         } else {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -519,6 +519,10 @@ namespace Sass {
 
   Argument* Parser::parse_argument(bool has_url)
   {
+    if (peek_css< sequence < exactly< hash_lbrace >, exactly< rbrace > > >()) {
+      position += 2;
+      css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
+    }
 
     Argument* arg;
     // some urls can look like line comments (parse literally - chunk would not work)
@@ -1723,7 +1727,7 @@ namespace Sass {
         }
         // we need to skip anything inside strings
         // create a new target in parser/prelexer
-        if (peek < sequence < optional_spaces, exactly<rbrace> > >(p+2)) { position = p+2;
+        if (peek < sequence < optional_spaces, exactly<rbrace> > >(p+2)) { position = p;
           css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
         }
         const char* j = skip_over_scopes< exactly<hash_lbrace>, exactly<rbrace> >(p+2, id.end); // find the closing brace


### PR DESCRIPTION
This PR fixes errors not being thrown for empty interpolants. 
It also fixes the error message formatting to better match Sass.

Fixes #1093
Specs https://github.com/sass/sass-spec/pull/526