### PR TITLE
Fix incorrect parsing of font shorthand values

### DIFF
--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -960,6 +960,7 @@ namespace Sass {
                            hex,
                            exactly<'|'>,
                            // exactly<'+'>,
+                           sequence < number, identifier >,
                            number,
                            sequence< exactly<'!'>, word<important_kwd> >
                           >(src);

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1010,15 +1010,15 @@ namespace Sass {
                          zero_plus< identifier >
                        >,
                        zero_plus < sequence<
-                                   alternatives<
-                                     sequence< optional_spaces, alternatives<
-                                       exactly < '/' >,
-                                       exactly < ',' >,
-                                       exactly < ' ' >
-                                     >, optional_spaces >,
-                                     spaces
-                                   >,
-                                   static_component
+                                     alternatives<
+                                       sequence< optional_spaces, alternatives<
+                                         exactly < '/' >,
+                                         exactly < ',' >,
+                                         exactly < ' ' >
+                                       >, optional_spaces >,
+                                       spaces
+                                     >,
+                                     static_component
                        > >,
                        optional_css_whitespace,
                        alternatives< exactly<';'>, exactly<'}'> >


### PR DESCRIPTION
Fix incorrect parsing of font shorthand values.

Fixes #1570
Specs https://github.com/sass/sass-spec/pull/525