### PR TITLE
Named arguments to call should stay named arguments when called

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -107,7 +107,7 @@ namespace Sass {
             (*arglist) << SASS_MEMORY_NEW(ctx.mem, Argument,
                                           key->pstate(),
                                           argmap->at(key),
-                                          name,
+                                          "$" + name,
                                           false,
                                           false);
           }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1579,7 +1579,7 @@ namespace Sass {
       size_t param_size = params ? params->length() : 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression* expr = arglist->value_at_index(i);
-        if (params->has_rest_parameter()) {
+        if (params && params->has_rest_parameter()) {
           Parameter* p = param_size > i ? (*params)[i] : 0;
           List* list = dynamic_cast<List*>(expr);
           if (list && p && !p->is_rest_parameter()) expr = (*list)[0];

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1589,7 +1589,7 @@ namespace Sass {
           *args << SASS_MEMORY_NEW(ctx.mem, Argument,
                                    pstate,
                                    expr,
-                                   "",
+                                   arg ? arg->name() : "",
                                    arg ? arg->is_rest_argument() : false,
                                    arg ? arg->is_keyword_argument() : false);
         } else {


### PR DESCRIPTION
This PR fixes a bug in the `call` function where keyword word arguments were dropping their keyword in the `call`ed function.

Fixes #1418
Spec https://github.com/sass/sass-spec/pull/535