### PR TITLE
Fix operator overloading for attribute selectors

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -205,6 +205,10 @@ namespace Sass {
 
   bool Simple_Selector::operator== (const Simple_Selector& rhs) const
   {
+    const Attribute_Selector* ll = dynamic_cast<const Attribute_Selector*>(this);
+    const Attribute_Selector* rr = dynamic_cast<const Attribute_Selector*>(&rhs);
+    if (ll && rr) return *ll == *rr;
+
     if (is_ns_eq(ns(), rhs.ns()))
     { return name() == rhs.name(); }
     return ns() == rhs.ns();
@@ -212,6 +216,10 @@ namespace Sass {
 
   bool Simple_Selector::operator< (const Simple_Selector& rhs) const
   {
+    const Attribute_Selector* ll = dynamic_cast<const Attribute_Selector*>(this);
+    const Attribute_Selector* rr = dynamic_cast<const Attribute_Selector*>(&rhs);
+    if (ll && rr) return *ll < *rr;
+
     if (is_ns_eq(ns(), rhs.ns()))
     { return name() < rhs.name(); }
     return ns() < rhs.ns();
@@ -421,6 +429,47 @@ namespace Sass {
       }
     }
     return Simple_Selector::unify_with(rhs, ctx);
+  }
+
+  bool Attribute_Selector::operator< (const Attribute_Selector& rhs) const
+  {
+    if (is_ns_eq(ns(), rhs.ns())) {
+      if (name() == rhs.name()) {
+        if (matcher() == rhs.matcher()) {
+          return value() < rhs.value();
+        } else { return matcher() < rhs.matcher(); }
+      } else { return name() < rhs.name(); }
+    }
+    else return false;
+  }
+
+  bool Attribute_Selector::operator< (const Simple_Selector& rhs) const
+  {
+    if (const Attribute_Selector* w = dynamic_cast<const Attribute_Selector*>(&rhs))
+    {
+      return *this < *w;
+    }
+    if (is_ns_eq(ns(), rhs.ns()))
+    { return name() < rhs.name(); }
+    return ns() < rhs.ns();
+  }
+
+  bool Attribute_Selector::operator== (const Attribute_Selector& rhs) const
+  {
+    if (is_ns_eq(ns(), rhs.ns()) && name() == rhs.name())
+    { return matcher() == rhs.matcher() && value() == rhs.value(); }
+    else return false;
+  }
+
+  bool Attribute_Selector::operator== (const Simple_Selector& rhs) const
+  {
+    if (const Attribute_Selector* w = dynamic_cast<const Attribute_Selector*>(&rhs))
+    {
+      return *this == *w;
+    }
+    if (is_ns_eq(ns(), rhs.ns()))
+    { return name() == rhs.name(); }
+    return ns() == rhs.ns();
   }
 
   bool Wrapped_Selector::operator== (const Wrapped_Selector& rhs) const

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1926,6 +1926,10 @@ namespace Sass {
     {
       return Constants::Specificity_Attr;
     }
+    bool operator==(const Simple_Selector& rhs) const;
+    bool operator==(const Attribute_Selector& rhs) const;
+    bool operator<(const Simple_Selector& rhs) const;
+    bool operator<(const Attribute_Selector& rhs) const;
     ATTACH_OPERATIONS()
   };
 


### PR DESCRIPTION
This PR fixes an `@extend` regression with multiple attribute
selectors introduced in 0e32dca5112534a74fe12348ad8ddb567100a5a3.

Granted this could be more elegant but it gets the job done for now.

Fixes #1574
Spec https://github.com/sass/sass-spec/pull/537