### PR TITLE
Fix regression is allowing `@extend`ing across media queries

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1121,6 +1121,7 @@ namespace Sass {
   Complex_Selector* Complex_Selector::clone(Context& ctx) const
   {
     Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, *this);
+    cpy->media_block(this->media_block());
     if (tail()) cpy->tail(tail()->clone(ctx));
     return cpy;
   }
@@ -1143,12 +1144,14 @@ namespace Sass {
   Compound_Selector* Compound_Selector::clone(Context& ctx) const
   {
     Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *this);
+    cpy->media_block(this->media_block());
     return cpy;
   }
 
   Selector_List* Selector_List::clone(Context& ctx) const
   {
     Selector_List* cpy = SASS_MEMORY_NEW(ctx.mem, Selector_List, *this);
+    cpy->media_block(this->media_block());
     return cpy;
   }
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1395,6 +1395,7 @@ namespace Sass {
   {
     std::vector<Selector_List*> rv;
     Selector_List* sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, s->pstate());
+    sl->media_block(s->media_block());
     for (size_t i = 0, iL = s->length(); i < iL; ++i) {
       rv.push_back(operator()((*s)[i]));
     }

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -550,9 +550,13 @@ namespace Sass {
             dynamic_cast<Parent_Selector*>((*sel->head())[0])))
         {
           Compound_Selector* hh = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, (*extender)[i]->pstate());
+          hh->media_block((*extender)[i]->media_block());
           Complex_Selector* ssel = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, (*extender)[i]->pstate());
+          ssel->media_block((*extender)[i]->media_block());
           if (sel->has_line_feed()) ssel->has_line_feed(true);
-          *hh << SASS_MEMORY_NEW(ctx.mem, Parent_Selector, (*extender)[i]->pstate());
+          Parent_Selector* ps = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, (*extender)[i]->pstate());
+          ps->media_block((*extender)[i]->media_block());
+          *hh << ps;
           ssel->tail(sel);
           ssel->head(hh);
           sel = ssel;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -32,6 +32,7 @@ namespace Sass {
     Context& ctx;
     std::vector<Block*> block_stack;
     std::vector<Syntactic_Context> stack;
+    Media_Block* last_media_block;
     const char* source;
     const char* position;
     const char* end;
@@ -45,7 +46,7 @@ namespace Sass {
     bool in_at_root;
 
     Parser(Context& ctx, const ParserState& pstate)
-    : ParserState(pstate), ctx(ctx), block_stack(0), stack(0),
+    : ParserState(pstate), ctx(ctx), block_stack(0), stack(0), last_media_block(0),
       source(0), position(0), end(0), before_token(pstate), after_token(pstate), pstate(pstate), indentation(0)
     { in_at_root = false; stack.push_back(nothing); }
 


### PR DESCRIPTION
This PR fixes a regression is allowing `@extend`ing across media
queries. Still needs a bit of work.

Regressed in 9f5ef6da0e8ec9287cd800bf98174f049591b286
Fixes #1562
Spec https://github.com/sass/sass-spec/pull/538