### PR TITLE
Emulate Ruby Sass' url() parsing semantics

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -79,6 +79,7 @@ namespace Sass {
     extern const char only_kwd[]         = "only";
     extern const char rgb_kwd[]          = "rgb(";
     extern const char url_kwd[]          = "url(";
+    // extern const char url_prefix_kwd[]   = "url-prefix(";
     extern const char important_kwd[]    = "important";
     extern const char pseudo_not_kwd[]   = ":not(";
     extern const char even_kwd[]         = "even";

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -141,6 +141,7 @@ namespace Sass {
 
     // constants for uri parsing (RFC 3986 Appendix A.)
     extern const char uri_chars[]  = ":;/?!%&#@|[]{}'`^\"*+-.,_=~";
+    extern const char real_uri_chars[]  = "#%&";
 
     // some specific constant character classes
     // they must be static to be useable by lexer

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -144,6 +144,7 @@ namespace Sass {
 
     // constants for uri parsing (RFC 3986 Appendix A.)
     extern const char uri_chars[];
+    extern const char real_uri_chars[];
 
     // some specific constant character classes
     // they must be static to be useable by lexer

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -80,6 +80,7 @@ namespace Sass {
     extern const char only_kwd[];
     extern const char rgb_kwd[];
     extern const char url_kwd[];
+    // extern const char url_prefix_kwd[];
     extern const char image_url_kwd[];
     extern const char important_kwd[];
     extern const char pseudo_not_kwd[];

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -75,6 +75,24 @@ namespace Sass {
       return unsigned(chr) > 127;
     }
 
+    // check if char is outside ascii range
+    // but with specific ranges (copied from Ruby Sass)
+    bool is_nonascii(const char& chr)
+    {
+      return (
+        (unsigned(chr) > 127 && unsigned(chr) < 55296) ||
+        (unsigned(chr) > 57343 && unsigned(chr) < 65534) ||
+        (unsigned(chr) > 65535 && unsigned(chr) < 1114111)
+      );
+    }
+
+    // check if char is within a reduced ascii range
+    // valid in a uri (copied from Ruby Sass)
+    bool is_uri_character(const char& chr)
+    {
+      return unsigned(chr) > 41 && unsigned(chr) < 127;
+    }
+
     // Match word character (look ahead)
     bool is_character(const char& chr)
     {
@@ -90,11 +108,13 @@ namespace Sass {
     const char* space(const char* src) { return is_space(*src) ? src + 1 : 0; }
     const char* alpha(const char* src) { return is_alpha(*src) ? src + 1 : 0; }
     const char* unicode(const char* src) { return is_unicode(*src) ? src + 1 : 0; }
+    const char* nonascii(const char* src) { return is_nonascii(*src) ? src + 1 : 0; }
     const char* digit(const char* src) { return is_digit(*src) ? src + 1 : 0; }
     const char* xdigit(const char* src) { return is_xdigit(*src) ? src + 1 : 0; }
     const char* alnum(const char* src) { return is_alnum(*src) ? src + 1 : 0; }
     const char* punct(const char* src) { return is_punct(*src) ? src + 1 : 0; }
     const char* character(const char* src) { return is_character(*src) ? src + 1 : 0; }
+    const char* uri_character(const char* src) { return is_uri_character(*src) ? src + 1 : 0; }
 
     // Match multiple ctype characters.
     const char* spaces(const char* src) { return one_plus<space>(src); }

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -32,7 +32,9 @@ namespace Sass {
     bool is_alnum(const char& src);
     bool is_xdigit(const char& src);
     bool is_unicode(const char& src);
+    bool is_nonascii(const char& src);
     bool is_character(const char& src);
+    bool is_uri_character(const char& src);
 
     // Match a single ctype predicate.
     const char* space(const char* src);
@@ -42,7 +44,9 @@ namespace Sass {
     const char* alnum(const char* src);
     const char* punct(const char* src);
     const char* unicode(const char* src);
+    const char* nonascii(const char* src);
     const char* character(const char* src);
+    const char* uri_character(const char* src);
 
     // Match multiple ctype characters.
     const char* spaces(const char* src);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -220,8 +220,8 @@ namespace Sass {
     Parameters* parse_parameters();
     Parameter* parse_parameter();
     Mixin_Call* parse_include_directive();
-    Arguments* parse_arguments(bool has_url = false);
-    Argument* parse_argument(bool has_url = false);
+    Arguments* parse_arguments();
+    Argument* parse_argument();
     Assignment* parse_assignment();
     // Propset* parse_propset();
     Ruleset* parse_ruleset(Lookahead lookahead, bool is_root = false);
@@ -256,6 +256,7 @@ namespace Sass {
     Function_Call* parse_calc_function();
     Function_Call* parse_function_call();
     Function_Call_Schema* parse_function_call_schema();
+    String* parse_url_function_string();
     String* parse_interpolated_chunk(Token, bool constant = false);
     String* parse_string();
     String_Constant* parse_static_expression();

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -951,23 +951,31 @@ namespace Sass {
     }
 
 
+    // const char* real_uri_prefix(const char* src) {
+    //   return alternatives<
+    //     exactly< url_kwd >,
+    //     exactly< url_prefix_kwd >
+    //   >(src);
+    // }
+
+    const char* real_uri_suffix(const char* src) {
+      return sequence< W, exactly< ')' > >(src);
+    }
+
     const char* real_uri_value(const char* src) {
       return
       sequence<
-        exactly< url_kwd >,
-        W,
-        zero_plus< alternatives<
-          class_char< real_uri_chars >,
-          uri_character,
-          NONASCII,
-          ESCAPE
-        > >,
-        alternatives<
-          sequence<
-            W,
-            exactly< ')' >
+        non_greedy<
+          alternatives<
+            class_char< real_uri_chars >,
+            uri_character,
+            NONASCII,
+            ESCAPE
           >,
-          exactly< hash_lbrace >
+          alternatives<
+            real_uri_suffix,
+            exactly< hash_lbrace >
+          >
         >
       >
       (src);

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -914,22 +914,64 @@ namespace Sass {
                            exactly<'\f'> >(src);
     }*/
 
-    /* not used anymore - remove?
     const char* H(const char* src) {
       return std::isxdigit(*src) ? src+1 : 0;
-    }*/
+    }
 
-    /* not used anymore - remove?
-    const char* unicode(const char* src) {
+    const char* W(const char* src) {
+      return zero_plus< alternatives<
+        space,
+        exactly< '\t' >,
+        exactly< '\r' >,
+        exactly< '\n' >,
+        exactly< '\f' >
+      > >(src);
+    }
+
+    const char* UUNICODE(const char* src) {
       return sequence< exactly<'\\'>,
                        between<H, 1, 6>,
-                       optional< class_char<url_space_chars> > >(src);
-    }*/
+                       optional< W >
+                       >(src);
+    }
 
-    /* not used anymore - remove?
+    const char* NONASCII(const char* src) {
+      return nonascii(src);
+    }
+
     const char* ESCAPE(const char* src) {
-      return alternatives< unicode, class_char<escape_chars> >(src);
-    }*/
+      return alternatives<
+        UUNICODE,
+        sequence<
+          exactly<'\\'>,
+          NONASCII,
+          class_char< escape_chars >
+        >
+      >(src);
+    }
+
+
+    const char* real_uri_value(const char* src) {
+      return
+      sequence<
+        exactly< url_kwd >,
+        W,
+        zero_plus< alternatives<
+          class_char< real_uri_chars >,
+          uri_character,
+          NONASCII,
+          ESCAPE
+        > >,
+        alternatives<
+          sequence<
+            W,
+            exactly< ')' >
+          >,
+          exactly< hash_lbrace >
+        >
+      >
+      (src);
+    }
 
     const char* static_string(const char* src) {
       const char* pos = src;

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -347,6 +347,8 @@ namespace Sass {
     const char* UUNICODE(const char* src);
     const char* NONASCII(const char* src);
     const char* ESCAPE(const char* src);
+    const char* real_uri_suffix(const char* src);
+    // const char* real_uri_prefix(const char* src);
     const char* real_uri_value(const char* src);
 
     // Path matching functions.

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -340,6 +340,15 @@ namespace Sass {
     // match urls
     const char* url(const char* src);
 
+    // match url()
+    const char* H(const char* src);
+    const char* W(const char* src);
+    // `UNICODE` makes VS sad
+    const char* UUNICODE(const char* src);
+    const char* NONASCII(const char* src);
+    const char* ESCAPE(const char* src);
+    const char* real_uri_value(const char* src);
+
     // Path matching functions.
     // const char* folder(const char* src);
     // const char* folders(const char* src);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -529,6 +529,15 @@ namespace Sass {
   namespace Util {
     using std::string;
 
+    std::string rtrim(const std::string &str) {
+      std::string trimmed = str;
+      size_t pos_ws = trimmed.find_last_not_of(" \t\n\v\f\r");
+      if (pos_ws != std::string::npos)
+      { trimmed.erase(pos_ws + 1); }
+      else { trimmed.clear(); }
+      return trimmed;
+    }
+
     std::string normalize_underscores(const std::string& str) {
       std::string normalized = str;
       for(size_t i = 0, L = normalized.length(); i < L; ++i) {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -36,6 +36,8 @@ namespace Sass {
 
   namespace Util {
 
+    std::string rtrim(const std::string& str);
+
     std::string normalize_underscores(const std::string& str);
     std::string normalize_decimals(const std::string& str);
     std::string normalize_sixtuplet(const std::string& col);


### PR DESCRIPTION
We've had countless bugs and regressions with parsing `url()`. This
patch is complete refactor of our `url()` parsing semantics to closer
match that of Ruby Sass.

## TODO

- [x] implement the correct handling of interpolants in `url()`
- [ ] ~~implement the correct semantics for `url-prefix()`~~
- [ ] ~~determine / implement the correct semantics for `@import url()`~~
- [ ] ~~replace uri functions / variables with their `real_` prefixed versions~~

**Update:** I've reduced the scope of this PR to the regression at hand. This update to `url()` semantics will need to applied to `url-prefix()` (#1596) and `@import url()` (#1597) for 3.4.

Fixes #674
Spec https://github.com/sass/sass-spec/pull/539