### PR TITLE
Improve error reporting involving selectors

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -983,6 +983,11 @@ namespace Sass {
               Complex_Selector* parent = (*parents)[i];
               Complex_Selector* s = parent->cloneFully(ctx);
               Complex_Selector* ss = this->clone(ctx);
+              // this is only if valid if the parent has no trailing op
+              // otherwise we cannot append more simple selectors to head
+              if (parent->last()->combinator() != ANCESTOR_OF) {
+                throw Exception::InvalidParent(parent, ss);
+              }
               ss->tail(tail ? tail->clone(ctx) : 0);
               Compound_Selector* h = head_->clone(ctx);
               if (h->length()) h->erase(h->begin());
@@ -1009,7 +1014,7 @@ namespace Sass {
               *retval << cpy->skip_empty_reference();
             }
           }
-          // have no parent and not tails
+          // have no parent nor tails
           else {
             Complex_Selector* cpy = this->clone(ctx);
             cpy->head(SASS_MEMORY_NEW(ctx.mem, Compound_Selector, head->pstate()));
@@ -2023,6 +2028,91 @@ namespace Sass {
   std::string Custom_Warning::to_string(bool compressed, int precision) const
   {
     return message();
+  }
+
+  std::string Selector_List::to_string(bool compressed, int precision) const
+  {
+    std::string str("");
+    auto end = this->end();
+    auto start = this->begin();
+    while (start < end && *start) {
+      Complex_Selector* sel = *start;
+      if (!str.empty()) str += ", ";
+      str += sel->to_string(compressed, precision);
+      ++ start;
+    }
+    return str;
+  }
+
+  std::string Compound_Selector::to_string(bool compressed, int precision) const
+  {
+    std::string str("");
+    auto end = this->end();
+    auto start = this->begin();
+    while (start < end && *start) {
+      Simple_Selector* sel = *start;
+      str += sel->to_string(compressed, precision);
+      ++ start;
+    }
+    return str;
+  }
+
+  std::string Complex_Selector::to_string(bool compressed, int precision) const
+  {
+    // first render head and tail if they are available
+    std::string str_head(head() ? head()->to_string(compressed, precision) : "");
+    std::string str_tail(tail() ? tail()->to_string(compressed, precision) : "");
+    std::string str_ref(reference() ? reference()->to_string(compressed, precision) : "");
+    // combinator in between
+    std::string str_op("");
+    // use a switch statement
+    switch (combinator()) {
+      case ANCESTOR_OF: str_op = " "; break;
+      case PARENT_OF:   str_op = ">"; break;
+      case PRECEDES:    str_op = "~"; break;
+      case ADJACENT_TO: str_op = "+"; break;
+      case REFERENCE:   str_op = "/" + str_ref + "/"; break;
+    }
+    // prettify for non ancestors
+    if (combinator() != ANCESTOR_OF) {
+      // no spaces needed for compressed
+      if (compressed == false) {
+        // make sure we add some spaces where needed
+        if (str_tail != "") str_op += " ";
+        if (str_head != "") str_head += " ";
+      }
+    }
+    // is ancestor with no tail
+    else if (str_tail == "") {
+      str_op = ""; // superflous
+    }
+    // now build the final result
+    return str_head + str_op + str_tail;
+  }
+
+  std::string Selector_Schema::to_string(bool compressed, int precision) const
+  {
+    return contents()->to_string(compressed, precision);
+  }
+
+  std::string Parent_Selector::to_string(bool compressed, int precision) const
+  {
+    return "&";
+  }
+
+  std::string Attribute_Selector::to_string(bool compressed, int precision) const
+  {
+    std::string val(value() ? value()->to_string(compressed, precision) : "");
+    return "[" + this->ns_name() + this->matcher() + val + "]";
+  }
+
+  std::string Wrapped_Selector::to_string(bool compressed, int precision) const
+  {
+    // first render the
+    std::string main(this->Simple_Selector::to_string(compressed, precision));
+    std::string wrapped(selector() ? selector()->to_string(compressed, precision) : "");
+    // now build the final result
+    return main + "(" + wrapped + ")";
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1767,6 +1767,7 @@ namespace Sass {
     virtual unsigned long specificity() {
       return Constants::Specificity_Universal;
     }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
   };
   inline Selector::~Selector() { }
 
@@ -1781,6 +1782,7 @@ namespace Sass {
     Selector_Schema(ParserState pstate, String* c)
     : Selector(pstate), contents_(c), at_root_(false)
     { }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1849,6 +1851,8 @@ namespace Sass {
     inline bool operator!=(const Simple_Selector& rhs) const { return !(*this == rhs); }
 
     bool operator<(const Simple_Selector& rhs) const;
+    // default implementation should work for most of the simple selectors (otherwise overload)
+    virtual std::string to_string(bool compressed = false, int precision = 5) const { return this->ns_name(); };
     ATTACH_OPERATIONS();
   };
   inline Simple_Selector::~Simple_Selector() { }
@@ -1872,6 +1876,7 @@ namespace Sass {
     }
     std::string type() { return "selector"; }
     static std::string type_name() { return "selector"; }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1884,6 +1889,7 @@ namespace Sass {
     : Simple_Selector(pstate, n)
     { has_placeholder(true); }
     // virtual Selector_Placeholder* find_placeholder();
+    virtual ~Selector_Placeholder() {};
     ATTACH_OPERATIONS()
   };
 
@@ -1942,6 +1948,7 @@ namespace Sass {
     bool operator==(const Attribute_Selector& rhs) const;
     bool operator<(const Simple_Selector& rhs) const;
     bool operator<(const Attribute_Selector& rhs) const;
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2016,6 +2023,7 @@ namespace Sass {
     }
     bool operator==(const Simple_Selector& rhs) const;
     bool operator==(const Wrapped_Selector& rhs) const;
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2102,6 +2110,7 @@ namespace Sass {
     Compound_Selector* clone(Context&) const; // does not clone the Simple_Selector*s
 
     Compound_Selector* minus(Compound_Selector* rhs, Context& ctx);
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2250,6 +2259,7 @@ namespace Sass {
     Complex_Selector* clone(Context&) const;      // does not clone Compound_Selector*s
     Complex_Selector* cloneFully(Context&) const; // clones Compound_Selector*s
     // std::vector<Compound_Selector*> to_vector();
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2295,6 +2305,7 @@ namespace Sass {
     virtual bool operator==(const Selector_List& rhs) const;
     // Selector Lists can be compared to comma lists
     virtual bool operator==(const Expression& rhs) const;
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -1,14 +1,55 @@
+#include "ast.hpp"
 #include "prelexer.hpp"
 #include "backtrace.hpp"
+#include "to_string.hpp"
 #include "error_handling.hpp"
 
 #include <iostream>
 
 namespace Sass {
 
-  Error_Invalid::Error_Invalid(Type type, ParserState pstate, std::string message)
-  : type(type), pstate(pstate), message(message)
-  { }
+  namespace Exception {
+
+    Base::Base(ParserState pstate, std::string msg)
+    : std::runtime_error(msg),
+      msg(msg), pstate(pstate)
+    { }
+
+    const char* Base::what() const throw()
+    {
+      return msg.c_str();
+    }
+
+    InvalidSass::InvalidSass(ParserState pstate, std::string msg)
+    : Base(pstate, msg)
+    { }
+
+
+    InvalidParent::InvalidParent(Selector* parent, Selector* selector)
+    : Base(selector->pstate()), parent(parent), selector(selector)
+    {
+      msg = "Invalid parent selector for \"";
+      msg += selector->to_string(false);
+      msg += "\": \"";
+      msg += parent->to_string(false);;
+      msg += "\"";
+    }
+
+    InvalidArgumentType::InvalidArgumentType(ParserState pstate, std::string fn, std::string arg, std::string type, const Value* value)
+    : Base(pstate), fn(fn), arg(arg), type(type), value(value)
+    {
+      msg  = arg + ": \"";
+      msg += value->to_string(true, 5);
+      msg += "\" is not a " + type;
+      msg += " for `" + fn + "'";
+    }
+
+    InvalidSyntax::InvalidSyntax(ParserState pstate, std::string msg)
+    : Base(pstate, msg)
+    { }
+
+  }
+
 
   void warn(std::string msg, ParserState pstate)
   {
@@ -33,7 +74,7 @@ namespace Sass {
 
   void error(std::string msg, ParserState pstate)
   {
-    throw Error_Invalid(Error_Invalid::syntax, pstate, msg);
+    throw Exception::InvalidSyntax(pstate, msg);
   }
 
   void error(std::string msg, ParserState pstate, Backtrace* bt)

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -2,23 +2,62 @@
 #define SASS_ERROR_HANDLING_H
 
 #include <string>
-
+#include <sstream>
+#include <stdexcept>
 #include "position.hpp"
 
 namespace Sass {
 
   struct Backtrace;
 
-  struct Error_Invalid {
-    enum Type { read, write, syntax, evaluation };
+  namespace Exception {
 
-    Type type;
-    ParserState pstate;
-    std::string message;
+    const std::string def_msg = "Invalid sass";
 
-    Error_Invalid(Type type, ParserState pstate, std::string message);
+    class Base : public std::runtime_error {
+      protected:
+        std::string msg;
+      public:
+        ParserState pstate;
+      public:
+        Base(ParserState pstate, std::string msg = def_msg);
+        virtual const char* what() const throw();
+        virtual ~Base() throw() {};
+    };
 
-  };
+    class InvalidSass : public Base {
+      public:
+        InvalidSass(ParserState pstate, std::string msg);
+        virtual ~InvalidSass() throw() {};
+    };
+
+    class InvalidParent : public Base {
+      protected:
+        Selector* parent;
+        Selector* selector;
+      public:
+        InvalidParent(Selector* parent, Selector* selector);
+        virtual ~InvalidParent() throw() {};
+    };
+
+    class InvalidArgumentType : public Base {
+      protected:
+        std::string fn;
+        std::string arg;
+        std::string type;
+        const Value* value;
+      public:
+        InvalidArgumentType(ParserState pstate, std::string fn, std::string arg, std::string type, const Value* value = 0);
+        virtual ~InvalidArgumentType() throw() {};
+    };
+
+    class InvalidSyntax : public Base {
+      public:
+        InvalidSyntax(ParserState pstate, std::string msg);
+        virtual ~InvalidSyntax() throw() {};
+    };
+
+  }
 
   void warn(std::string msg, ParserState pstate);
   void warn(std::string msg, ParserState pstate, Backtrace* bt);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1155,7 +1155,10 @@ namespace Sass {
     Signature random_sig = "random($limit:false)";
     BUILT_IN(random)
     {
-      Number* l = dynamic_cast<Number*>(env["$limit"]);
+      AST_Node* arg = env["$limit"];
+      Value* v = dynamic_cast<Value*>(arg);
+      Number* l = dynamic_cast<Number*>(arg);
+      Boolean* b = dynamic_cast<Boolean*>(arg);
       if (l) {
         double v = l->value();
         if (v < 1) {
@@ -1173,11 +1176,16 @@ namespace Sass {
         uint_fast32_t distributed = static_cast<uint_fast32_t>(distributor(rand));
         return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)distributed);
       }
-      else {
+      else if (b) {
         std::uniform_real_distribution<> distributor(0, 1);
         double distributed = static_cast<double>(distributor(rand));
         return SASS_MEMORY_NEW(ctx.mem, Number, pstate, distributed);
-     }
+      } else if (v) {
+        throw Exception::InvalidArgumentType(pstate, "random", "$limit", "number", v);
+      } else {
+        throw Exception::InvalidArgumentType(pstate, "random", "$limit", "number");
+      }
+      return 0;
     }
 
     /////////////////

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2380,7 +2380,7 @@ namespace Sass {
 
   void Parser::error(std::string msg, Position pos)
   {
-    throw Error_Invalid(Error_Invalid::syntax, ParserState(path, source, pos.line ? pos : before_token, Offset(0, 0)), msg);
+    throw Exception::InvalidSass(ParserState(path, source, pos.line ? pos : before_token, Offset(0, 0)), msg);
   }
 
   // print a css parsing error with actual context information from parsed source

--- a/src/sass_interface.cpp
+++ b/src/sass_interface.cpp
@@ -88,9 +88,9 @@ extern "C" {
       if (copy_strings(cpp_ctx.get_included_files(true), &c_ctx->included_files, 1) == NULL)
         throw(std::bad_alloc());
     }
-    catch (Error_Invalid& e) {
+    catch (Exception::InvalidSass& e) {
       std::stringstream msg_stream;
-      msg_stream << e.pstate.path << ":" << e.pstate.line << ": " << e.message << std::endl;
+      msg_stream << e.pstate.path << ":" << e.pstate.line << ": " << e.what() << std::endl;
       c_ctx->error_message = sass_strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;
@@ -164,9 +164,9 @@ extern "C" {
       if (copy_strings(cpp_ctx.get_included_files(false), &c_ctx->included_files) == NULL)
         throw(std::bad_alloc());
     }
-    catch (Error_Invalid& e) {
+    catch (Exception::InvalidSass& e) {
       std::stringstream msg_stream;
-      msg_stream << e.pstate.path << ":" << e.pstate.line << ": " << e.message << std::endl;
+      msg_stream << e.pstate.path << ":" << e.pstate.line << ": " << e.what() << std::endl;
       c_ctx->error_message = sass_strdup(msg_stream.str().c_str());
       c_ctx->error_status = 1;
       c_ctx->output_string = 0;

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -337,7 +337,7 @@ extern "C" {
     }
 
     // simply pass the error message back to the caller for now
-    catch (Error_Invalid& e) { return sass_make_error(e.message.c_str()); }
+    catch (Exception::InvalidSass& e) { return sass_make_error(e.what()); }
     catch (std::bad_alloc&) { return sass_make_error("memory exhausted"); }
     catch (std::exception& e) { return sass_make_error(e.what()); }
     catch (std::string& e) { return sass_make_error(e.c_str()); }


### PR DESCRIPTION
- Implements `to_string` for all selector types
- Adds `InvalidParent` and refactors to exceptions
- Add error on invalid parentize operation

Fixes https://github.com/sass/libsass/issues/1601 and https://github.com/sass/libsass/issues/1606
Spec Test PR: https://github.com/sass/sass-spec/pull/593