### PR TITLE
Add `Sass::round` to work around compiler issues

### DIFF
--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -93,6 +93,13 @@ then
 
   JSON=$(curl -L -sS https://api.github.com/repos/sass/libsass/pulls/$TRAVIS_PULL_REQUEST)
 
+  if [[ $JSON =~ "API rate limit exceeded" ]];
+  then
+    echo "Travis rate limit on github exceeded"
+    echo "Retrying via 'special purpose proxy'"
+    JSON=$(curl -L -sS http://libsass.ocbnet.ch/libsass-spec-pr.psgi/$TRAVIS_PULL_REQUEST)
+  fi
+
   RE_SPEC_PR="sass\/sass-spec(#|\/pull\/)([0-9]+)"
 
   if [[ $JSON =~ $RE_SPEC_PR ]];

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1864,17 +1864,17 @@ namespace Sass {
     // resolved color
     std::string res_name = name;
 
-    double r = round(cap_channel<0xff>(r_));
-    double g = round(cap_channel<0xff>(g_));
-    double b = round(cap_channel<0xff>(b_));
+    double r = Sass::round(cap_channel<0xff>(r_), precision);
+    double g = Sass::round(cap_channel<0xff>(g_), precision);
+    double b = Sass::round(cap_channel<0xff>(b_), precision);
     double a = cap_channel<1>   (a_);
 
     // get color from given name (if one was given at all)
     if (name != "" && name_to_color(name)) {
       const Color* n = name_to_color(name);
-      r = round(cap_channel<0xff>(n->r()));
-      g = round(cap_channel<0xff>(n->g()));
-      b = round(cap_channel<0xff>(n->b()));
+      r = Sass::round(cap_channel<0xff>(n->r()), precision);
+      g = Sass::round(cap_channel<0xff>(n->g()), precision);
+      b = Sass::round(cap_channel<0xff>(n->b()), precision);
       a = cap_channel<1>   (n->a());
     }
     // otherwise get the possible resolved color name

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -11,6 +11,7 @@
 #include "util.hpp"
 #include "expand.hpp"
 #include "utf8_string.hpp"
+#include "sass/base.h"
 #include "utf8.h"
 
 #include <cstdlib>
@@ -310,9 +311,9 @@ namespace Sass {
 
       return SASS_MEMORY_NEW(ctx.mem, Color,
                              pstate,
-                             std::round(w1*color1->r() + w2*color2->r()),
-                             std::round(w1*color1->g() + w2*color2->g()),
-                             std::round(w1*color1->b() + w2*color2->b()),
+                             Sass::round(w1*color1->r() + w2*color2->r(), ctx.c_options->precision),
+                             Sass::round(w1*color1->g() + w2*color2->g(), ctx.c_options->precision),
+                             Sass::round(w1*color1->b() + w2*color2->b(), ctx.c_options->precision),
                              color1->a()*p + color2->a()*(1-p));
     }
 
@@ -853,10 +854,10 @@ namespace Sass {
 
       std::stringstream ss;
       ss << '#' << std::setw(2) << std::setfill('0');
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(std::floor(a+0.5));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(std::floor(r+0.5));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(std::floor(g+0.5));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(std::floor(b+0.5));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(a, ctx.c_options->precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(r, ctx.c_options->precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(g, ctx.c_options->precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(b, ctx.c_options->precision));
 
       std::string result(ss.str());
       for (size_t i = 0, L = result.length(); i < L; ++i) {
@@ -1087,7 +1088,7 @@ namespace Sass {
       Number* n = ARG("$number", Number);
       Number* r = SASS_MEMORY_NEW(ctx.mem, Number, *n);
       r->pstate(pstate);
-      r->value(std::floor(r->value() + 0.5));
+      r->value(Sass::round(r->value(), ctx.c_options->precision));
       return r;
     }
 

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1019,7 +1019,7 @@ namespace Sass {
                            hex,
                            exactly<'|'>,
                            // exactly<'+'>,
-                           sequence < number, identifier >,
+                           sequence < number, unit_identifier >,
                            number,
                            sequence< exactly<'!'>, word<important_kwd> >
                           >(src);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6,6 +6,7 @@
 #include "constants.hpp"
 #include "utf8/checked.h"
 
+#include <cmath>
 #include <stdint.h>
 
 namespace Sass {
@@ -14,6 +15,20 @@ namespace Sass {
       std::cerr << "Out of memory.\n";    \
       exit(EXIT_FAILURE);                 \
     } while (0)
+
+  double round(double val, size_t precision)
+  {
+    // apply epsilon?
+    if (precision) {
+      // implement ruby sass round behavior
+      if (val < 0) val -= std::pow(0.1, precision + 1);
+      else if (val) val += std::pow(0.1, precision + 1);
+    }
+    // work around some compiler issue
+    // cygwin has it not defined in std
+    using namespace std;
+    return ::round(val);
+  }
 
   /* Sadly, sass_strdup is not portable. */
   char *sass_strdup(const char *str)

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -11,6 +11,7 @@
 
 namespace Sass {
 
+  double round(double val, size_t precision = 0);
   char* sass_strdup(const char* str);
   double sass_atof(const char* str);
   const char* safe_str(const char *, const char* = "");


### PR DESCRIPTION
Needs sass/sass-spec#555 to be merged to pass!

It seems with some compilers (cygwin) round is not defined
within the `std` namespace, but in the root namespace.
Working around this issue by `using namespace std` and
then using `::round` function from the root namespace.