### PR TITLE
[RFC] Add back gcc 4.4 compatibility

### DIFF
--- a/script/replace-range-for-loops.pl
+++ b/script/replace-range-for-loops.pl
@@ -1,0 +1,42 @@
+use strict;
+use warnings;
+
+use File::Slurp;
+use File::Basename;
+use File::Spec::Functions;
+
+my $root = $ENV{'SASS_LIBSASS_PATH'} || catfile(dirname($0), '..');
+
+sub process($)
+{
+
+	my $count = 0;
+	my ($file) = @_;
+
+	my $cpp = read_file($file, { binmode => ':raw' });
+
+	my $org = $cpp;
+
+	my $re_decl = qr/(?:const\s*)?\w+(?:\:\:\w+)*(?:\s*[\*\&])?/;
+	my $re_val = qr/\w+(?:\(\))?(?:(?:->|\.)\w+(?:\(\))?)*/;
+
+	$cpp =~ s/for\s*\(\s*($re_decl)\s*(\w+)\s*:\s*(\(\*?$re_val\)|$re_val)\s*\)\s*{/
+		$count ++;
+		"for (auto __$2 = $3.begin(); __$2 != $3.end(); ++__$2) { $1 $2 = *(__$2); ";
+	/gex;
+
+	return if $org eq $cpp || $count == 0;
+
+	warn sprintf "made %02d replacements in %s\n", $count, $file;
+
+	write_file($file, { binmode => ':raw' }, $cpp);
+
+}
+
+my $rv = opendir(my $dh, catfile($root, "src"));
+die "not found ", catfile($root, "src") unless $rv;
+while (my $entry = readdir($dh)) {
+	next if $entry eq "." || $entry eq "..";
+	next unless $entry =~ m/\.[hc]pp$/;
+	process(catfile($root, "src", $entry));
+}

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -242,7 +242,7 @@ namespace Sass {
     virtual void adjust_after_pushing(std::pair<Expression*, Expression*> p) { }
   public:
     Hashed(size_t s = 0) : elements_(std::unordered_map<Expression*, Expression*>(s)), list_(std::vector<Expression*>())
-    { elements_.reserve(s); list_.reserve(s); reset_duplicate_key(); }
+    { /* elements_.reserve(s); */ list_.reserve(s); reset_duplicate_key(); }
     virtual ~Hashed();
     size_t length() const                  { return list_.size(); }
     bool empty() const                     { return list_.empty(); }
@@ -1096,7 +1096,7 @@ namespace Sass {
       if (hash_ == 0) {
         hash_ = std::hash<std::string>()(name());
         for (auto argument : arguments()->elements())
-          hash_combine(hash_, argument->hash());
+        { hash_combine(hash_, argument->hash()); }
       }
       return hash_;
     }
@@ -1363,7 +1363,7 @@ namespace Sass {
     {
       if (hash_ == 0) {
         for (auto string : elements())
-          hash_combine(hash_, string->hash());
+        { hash_combine(hash_, string->hash()); }
       }
       return hash_;
     }

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -325,7 +325,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->media_queries(), ind + " @ ");
     // std::vector<std::string>         files_;
-    for (auto imp : block->urls()) debug_ast(imp, "@ ", env);
+    for (auto imp : block->urls()) { debug_ast(imp, "@ ", env); }
   } else if (dynamic_cast<Assignment*>(node)) {
     Assignment* block = dynamic_cast<Assignment*>(node);
     std::cerr << ind << "Assignment " << block;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -885,7 +885,7 @@ namespace Sass {
 
       std::string res = "";
       for(auto i : str_schema->elements())
-        res += (interpolation(i));
+      { res += (interpolation(i)); }
       //ToDo: do this in one step
       auto esc = evacuate_escapes(res);
       auto unq = unquote(esc);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -399,7 +399,7 @@ namespace Sass {
         {
           // push single file import
           // import_single_file(imp, lexed);
-          to_import.push_back(std::pair<std::string,Function_Call*>(std::string(lexed), 0));
+          to_import.push_back(std::pair<std::string,Function_Call*>(std::string(lexed), (Function_Call*)0));
         }
       }
       else if (lex< uri_prefix >()) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -107,7 +107,7 @@ namespace Sass {
 
           // convert the extracted hex string to code point value
           // ToDo: Maybe we could do this without creating a substring
-          uint32_t cp = strtol(s.substr (i + 1, len - 1).c_str(), nullptr, 16);
+          uint32_t cp = strtol(s.substr (i + 1, len - 1).c_str(), 0, 16);
 
           if (cp == 0) cp = 0xFFFD;
 
@@ -401,7 +401,7 @@ namespace Sass {
 
           // convert the extracted hex string to code point value
           // ToDo: Maybe we could do this without creating a substring
-          uint32_t cp = strtol(s.substr (i + 1, len - 1).c_str(), nullptr, 16);
+          uint32_t cp = strtol(s.substr (i + 1, len - 1).c_str(), 0, 16);
 
           if (s[i + len] == ' ') ++ len;
 


### PR DESCRIPTION
Since I get quite a few build fails from [cpan test matrix] [1] for gcc 4.4, I tried how difficult it is to bring back gcc 4.4 compatibility based upon some previous work. It actually is not too hard to get libsass compiled with gcc 4.4 (and passing the spec tests). I want to put this PR into consideration, since I would like to apply the `replace-range-for-loops` automatically when gcc 4.4 is detected by perl-libsass. Falls under "nice to have", but changes seem rather minimal.

Feedback welcome

[1]: http://matrix.cpantesters.org/?dist=CSS-Sass%203.3.0_02