### PR TITLE
Fix regression with evalution binary operatons with strings

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1325,6 +1325,12 @@ namespace Sass {
     if (ltype == Expression::NULL_VAL) error("Invalid null operation: \"null plus "+quote(unquote(rstr), '"')+"\".", lhs.pstate());
     if (rtype == Expression::NULL_VAL) error("Invalid null operation: \""+quote(unquote(lstr), '"')+" plus null\".", rhs.pstate());
 
+    if (ltype == Expression::NUMBER && sep == "/" && rtype == Expression::STRING)
+    {
+      return SASS_MEMORY_NEW(mem, String_Constant, lhs.pstate(),
+        lhs.to_string() + sep + rhs.to_string());
+    }
+
     if ( (ltype == Expression::STRING || sep == "") &&
          (sep != "/" || !rqstr || !rqstr->quote_mark())
     ) {


### PR DESCRIPTION
Ruby Sass does does not evaluate binary operations between numbers and string. Instead is simply outputs the expression.

Fixes #1629 
Spec sass/sass-spec#560