### PR TITLE
Fix regression in interpolated selectors

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1445,7 +1445,8 @@ namespace Sass {
   {
     To_String to_string;
     // the parser will look for a brace to end the selector
-    std::string result_str(s->contents()->perform(this)->perform(&to_string) + "{");
+    std::string result_str(s->contents()->perform(this)->perform(&to_string));
+    result_str = unquote(Util::rtrim(result_str)) + "{";
     Parser p = Parser::from_c_str(result_str.c_str(), ctx, s->pstate());
     return operator()(p.parse_selector_list(exp.block_stack.back()->is_root()));
   }


### PR DESCRIPTION
Ruby Sass explicitly unquotes the results of interpolations in
selectors. This patch is very thorough but it address all the
use cases I think of and it fixes the regression causing people
issues.

Fixes #1624
Spec https://github.com/sass/sass-spec/pull/564