### PR TITLE
Fix regression in static value parsing

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -127,7 +127,6 @@ namespace Sass {
     extern const char hyphen[]          = "-";
     extern const char ellipsis[]        = "...";
     // extern const char url_space_chars[] = " \t\r\n\f";
-    extern const char escape_chars[]    = " -~"; // need to include unicode spaces too
     // type names
     extern const char numeric_name[]    = "numeric value";
     extern const char number_name[]     = "number";

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -129,7 +129,6 @@ namespace Sass {
     extern const char hyphen[];
     extern const char ellipsis[];
     // extern const char url_space_chars[];
-    extern const char escape_chars[];
 
     // type names
     extern const char numeric_name[];

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -93,6 +93,13 @@ namespace Sass {
       return unsigned(chr) > 41 && unsigned(chr) < 127;
     }
 
+    // check if char is within a reduced ascii range
+    // valid for escaping (copied from Ruby Sass)
+    bool is_escapable_character(const char& chr)
+    {
+      return unsigned(chr) > 31 && unsigned(chr) < 127;
+    }
+
     // Match word character (look ahead)
     bool is_character(const char& chr)
     {
@@ -115,6 +122,7 @@ namespace Sass {
     const char* punct(const char* src) { return is_punct(*src) ? src + 1 : 0; }
     const char* character(const char* src) { return is_character(*src) ? src + 1 : 0; }
     const char* uri_character(const char* src) { return is_uri_character(*src) ? src + 1 : 0; }
+    const char* escapable_character(const char* src) { return is_escapable_character(*src) ? src + 1 : 0; }
 
     // Match multiple ctype characters.
     const char* spaces(const char* src) { return one_plus<space>(src); }

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -35,6 +35,7 @@ namespace Sass {
     bool is_nonascii(const char& src);
     bool is_character(const char& src);
     bool is_uri_character(const char& src);
+    bool escapable_character(const char& src);
 
     // Match a single ctype predicate.
     const char* space(const char* src);
@@ -47,6 +48,7 @@ namespace Sass {
     const char* nonascii(const char* src);
     const char* character(const char* src);
     const char* uri_character(const char* src);
+    const char* escapable_character(const char* src);
 
     // Match multiple ctype characters.
     const char* spaces(const char* src);

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -91,6 +91,8 @@ namespace Sass {
                unicode,
                exactly<'-'>,
                exactly<'_'>,
+               NONASCII,
+               ESCAPE,
                escape_seq
              >(src);
     }
@@ -104,6 +106,8 @@ namespace Sass {
                unicode,
                exactly<'-'>,
                exactly<'_'>,
+               NONASCII,
+               ESCAPE,
                escape_seq
              >(src);
     }
@@ -944,8 +948,10 @@ namespace Sass {
         UUNICODE,
         sequence<
           exactly<'\\'>,
-          NONASCII,
-          class_char< escape_chars >
+          alternatives<
+            NONASCII,
+            escapable_character
+          >
         >
       >(src);
     }


### PR DESCRIPTION
The static parser wasn't correctly accounting for escaped values.
This is being futher addressed in an upcoming refactor but this
addresses the current regression being experienced by users.

Fixes #1632
Spec https://github.com/sass/sass-spec/pull/567