### PR TITLE
add "File input path" to formatted error json

### DIFF
--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -228,6 +228,10 @@ extern "C" {
         msg_stream << "   " << std::string(e.pstate.column - move_in, '-') << "^\n";
       }
 
+      std::string msg_input_file_prefix("Input path: ");
+      std::string rel_input_path(Sass::File::resolve_relative_path(c_ctx->input_path, cwd, cwd));
+      msg_stream << msg_input_file_prefix << rel_input_path << "\n";
+
       JsonNode* json_err = json_mkobject();
       json_append_member(json_err, "status", json_mknumber(1));
       json_append_member(json_err, "file", json_mkstring(e.pstate.path));

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -228,9 +228,14 @@ extern "C" {
         msg_stream << "   " << std::string(e.pstate.column - move_in, '-') << "^\n";
       }
 
-      std::string msg_input_file_prefix("Input path: ");
-      std::string rel_input_path(Sass::File::resolve_relative_path(c_ctx->input_path, cwd, cwd));
-      msg_stream << msg_input_file_prefix << rel_input_path << "\n";
+      std::string input_path = safe_str(c_ctx->input_path);
+
+      if (c_ctx->type == SASS_CONTEXT_FILE) {
+          // if file error include "File input path: file/path" in the error msg
+          std::string msg_input_file_prefix("File input path: ");
+          std::string rel_input_path(Sass::File::resolve_relative_path(input_path, cwd, cwd));
+          msg_stream << msg_input_file_prefix << rel_input_path << "\n";
+      }
 
       JsonNode* json_err = json_mkobject();
       json_append_member(json_err, "status", json_mknumber(1));


### PR DESCRIPTION
Adds `File input path: path/to/sass/input` line to `formatted` json error key.

As a consumer of grunt sass (and therefore libsass), it would be very valuable to know the input file that was being processed at the time of error.

Here is an example of where it would be useful in a large code base.

#### Example

_error.scss_
```scss
@import './lib.scss';

.test {
    color: $map;
}
```
_lib.scss_
```scss
$map: (
    1: '#000'
);
```

This is an error, but there is the output given currently:

```
Error: (1: "#000") isn't a valid CSS value.
        on line 2 of lib.scss
>>     1: '#000'
   ----^
```

If `lib.scss` is very commonly imported in a large codebase it can be cumbersome to track down which file is actually the cause of error.

With this change the output would be:

```
Error: (1: "#000") isn't a valid CSS value.
        on line 2 of lib.scss
>>     1: '#000'
   ----^
File input path: error.scss
```

Which points you (at least) to the file being processed at time of error - hopefully saving some headaches for people trying to track down their errors.

#### Notes

Only added in the file context, processing from `stdin` via `sassc` does not apply this line.