### PR TITLE
Fix parsing of At_Root_Blocks with expressions

### DIFF
--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -71,8 +71,17 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << root_block->tabs();
     std::cerr << std::endl;
-    debug_ast(root_block->expression(), ind + ":", env);
+    debug_ast(root_block->expression()->feature(), ind + "=", env);
+    debug_ast(root_block->expression()->value(), ind + ":", env);
     debug_ast(root_block->block(), ind + " ", env);
+  } else if (dynamic_cast<At_Root_Expression*>(node)) {
+    At_Root_Expression* ex = dynamic_cast<At_Root_Expression*>(node);
+    std::cerr << ind << "At_Root_Expression " << ex;
+    std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << (ex->is_interpolated() ? " [is_interpolated]": "");
+    std::cerr << std::endl;
+    debug_ast(ex->feature(), ind + "=", env);
+    debug_ast(ex->value(), ind + ":", env);
   } else if (dynamic_cast<Selector_List*>(node)) {
     Selector_List* selector = dynamic_cast<Selector_List*>(node);
     std::cerr << ind << "Selector_List " << selector;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2121,7 +2121,11 @@ namespace Sass {
       expr = parse_at_root_expression();
     }
     if (peek < exactly<'{'> >()) {
-      body = parse_block(true);
+      std::string feat("");
+      if (expr && expr->feature())
+        feat = expr->feature()->to_string();
+      // allow declarations in certain cases
+      body = parse_block(feat != "without");
     }
     else if ((lookahead_result = lookahead_for_selector(position)).found) {
       Ruleset* r = parse_ruleset(lookahead_result, false);


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1651
Spec: https://github.com/sass/sass-spec/pull/575

Does not pass the error spec. Couldn't come up with anything better, but it should solve the reported regression. We could need some more spec tests for this ...