### PR TITLE
Clean up some internal method names

### DIFF
--- a/src/backtrace.hpp
+++ b/src/backtrace.hpp
@@ -33,7 +33,7 @@ namespace Sass {
       while (this_point->parent) {
 
         // make path relative to the current directory
-        std::string rel_path(Sass::File::resolve_relative_path(this_point->pstate.path, cwd, cwd));
+        std::string rel_path(Sass::File::abs2rel(this_point->pstate.path, cwd, cwd));
 
         if (warning) {
           ss << std::endl

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -399,7 +399,7 @@ namespace Sass {
 
   std::string Context::format_embedded_source_map()
   {
-    std::string map = emitter.generate_source_map(*this);
+    std::string map = emitter.render_srcmap(*this);
     std::istringstream is( map );
     std::ostringstream buffer;
     base64::encoder E;
@@ -415,11 +415,11 @@ namespace Sass {
     return "/*# sourceMappingURL=" + url + " */";
   }
 
-  char* Context::generate_source_map()
+  char* Context::render_srcmap()
   {
     if (source_map_file == "") return 0;
     char* result = 0;
-    std::string map = emitter.generate_source_map(*this);
+    std::string map = emitter.render_srcmap(*this);
     result = sass_strdup(map.c_str());
     return result;
   }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -288,7 +288,7 @@ namespace Sass {
   void register_c_functions(Context&, Env* env, Sass_Function_List);
   void register_c_function(Context&, Env* env, Sass_Function_Entry);
 
-  char* Context::compile_block(Block* root)
+  char* Context::render(Block* root)
   {
     if (!root) return 0;
     root->perform(&emitter);
@@ -388,13 +388,13 @@ namespace Sass {
   char* Context::compile_file()
   {
     // returns NULL if something fails
-    return compile_block(parse_file());
+    return render(parse_file());
   }
 
   char* Context::compile_string()
   {
     // returns NULL if something fails
-    return compile_block(parse_string());
+    return render(parse_string());
   }
 
   std::string Context::format_embedded_source_map()

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -119,7 +119,7 @@ namespace Sass {
       }
     }
 
-    emitter.set_filename(resolve_relative_path(output_path, source_map_file, cwd));
+    emitter.set_filename(abs2rel(output_path, source_map_file, cwd));
 
   }
 
@@ -227,7 +227,7 @@ namespace Sass {
     included_files.push_back(abs_path);
     queue.push_back(Sass_Queued(load_path, abs_path, contents));
     emitter.add_source_index(sources.size() - 1);
-    include_links.push_back(resolve_relative_path(abs_path, source_map_file, cwd));
+    include_links.push_back(abs2rel(abs_path, source_map_file, cwd));
   }
 
   // Add a new import file to the context
@@ -411,7 +411,7 @@ namespace Sass {
 
   std::string Context::format_source_mapping_url(const std::string& file)
   {
-    std::string url = resolve_relative_path(file, output_path, cwd);
+    std::string url = abs2rel(file, output_path, cwd);
     return "/*# sourceMappingURL=" + url + " */";
   }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -227,7 +227,7 @@ namespace Sass {
     included_files.push_back(abs_path);
     queue.push_back(Sass_Queued(load_path, abs_path, contents));
     emitter.add_source_index(sources.size() - 1);
-    include_links.push_back(abs2rel(abs_path, source_map_file, cwd));
+    srcmap_links.push_back(abs2rel(abs_path, source_map_file, cwd));
   }
 
   // Add a new import file to the context

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -257,7 +257,7 @@ namespace Sass {
     std::string path(make_canonical_path(file));
     std::string base_file(join_paths(base, path));
     if (style_sheets.count(base_file)) return base_file;
-    std::vector<Sass_Queued> resolved(resolve_file(base, path));
+    std::vector<Sass_Queued> resolved(resolve_includes(base, path));
     if (resolved.size() > 1) {
       std::stringstream msg_stream;
       msg_stream << "It's not clear which file to import for ";

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -120,7 +120,7 @@ namespace Sass {
     // usefull to influence the source-map generating etc.
     char* compile_file();
     char* compile_string();
-    char* compile_block(Block* root);
+    char* render(Block* root);
     char* render_srcmap();
 
     std::vector<std::string> get_included_files(bool skip = false, size_t headers = 0);

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -40,7 +40,7 @@ namespace Sass {
     // absolute paths to includes
     std::vector<std::string> included_files;
     // relative links to includes
-    std::vector<std::string> include_links;
+    std::vector<std::string> srcmap_links;
     // vectors above have same size
 
     std::vector<std::string> plugin_paths; // relative paths to load plugins

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -121,7 +121,7 @@ namespace Sass {
     char* compile_file();
     char* compile_string();
     char* compile_block(Block* root);
-    char* generate_source_map();
+    char* render_srcmap();
 
     std::vector<std::string> get_included_files(bool skip = false, size_t headers = 0);
 

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -37,8 +37,8 @@ namespace Sass {
   void Emitter::add_source_index(size_t idx)
   { wbuf.smap.source_index.push_back(idx); }
 
-  std::string Emitter::generate_source_map(Context &ctx)
-  { return wbuf.smap.generate_source_map(ctx); }
+  std::string Emitter::render_srcmap(Context &ctx)
+  { return wbuf.smap.render_srcmap(ctx); }
 
   void Emitter::set_filename(const std::string& str)
   { wbuf.smap.file = str; }

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -25,7 +25,7 @@ namespace Sass {
       void set_filename(const std::string& str);
       void add_open_mapping(AST_Node* node);
       void add_close_mapping(AST_Node* node);
-      std::string generate_source_map(Context &ctx);
+      std::string render_srcmap(Context &ctx);
       ParserState remap(const ParserState& pstate);
 
     public:

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -27,7 +27,7 @@ namespace Sass {
     std::string cwd(Sass::File::get_cwd());
     std::cerr << "DEPRECATION WARNING: " << msg << std::endl;
     std::cerr << "will be an error in future versions of Sass." << std::endl;
-    std::string rel_path(Sass::File::resolve_relative_path(pstate.path, cwd, cwd));
+    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
     std::cerr << "        on line " << pstate.line+1 << " of " << rel_path << std::endl;
   }
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -402,7 +402,7 @@ namespace Sass {
 
     std::string cwd(ctx.get_cwd());
     std::string result(unquote(message->perform(&to_string)));
-    std::string rel_path(Sass::File::resolve_relative_path(d->pstate().path, cwd, cwd));
+    std::string rel_path(Sass::File::abs2rel(d->pstate().path, cwd, cwd));
     std::cerr << rel_path << ":" << d->pstate().line+1 << " DEBUG: " << result;
     std::cerr << std::endl;
     return 0;

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1751,7 +1751,7 @@ namespace Sass {
           std::stringstream err;
           std::string cwd(Sass::File::get_cwd());
           ParserState pstate(ext.second->pstate());
-          std::string rel_path(Sass::File::resolve_relative_path(pstate.path, cwd, cwd));
+          std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
           err << "You may not @extend an outer selector from within @media.\n";
           err << "You may only @extend selectors within the same directive.\n";
           err << "From \"@extend " << ext.second->perform(&to_string) << "\"";

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -193,7 +193,7 @@ namespace Sass {
     }
 
     // create an absolute path by resolving relative paths with cwd
-    std::string make_absolute_path(const std::string& path, const std::string& cwd)
+    std::string rel2abs(const std::string& path, const std::string& cwd)
     {
       return make_canonical_path((is_absolute_path(path) ? path : join_paths(cwd, path)));
     }
@@ -203,8 +203,8 @@ namespace Sass {
     std::string abs2rel(const std::string& uri, const std::string& base, const std::string& cwd)
     {
 
-      std::string absolute_uri = make_absolute_path(uri, cwd);
-      std::string absolute_base = make_absolute_path(base, cwd);
+      std::string absolute_uri = rel2abs(uri, cwd);
+      std::string absolute_base = rel2abs(base, cwd);
 
       size_t proto = 0;
       // check if we have a protocol

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -193,9 +193,9 @@ namespace Sass {
     }
 
     // create an absolute path by resolving relative paths with cwd
-    std::string rel2abs(const std::string& path, const std::string& cwd)
+    std::string rel2abs(const std::string& path, const std::string& base, const std::string& cwd)
     {
-      return make_canonical_path((is_absolute_path(path) ? path : join_paths(cwd, path)));
+      return make_canonical_path(join_paths(join_paths(cwd, base), path));
     }
 
     // create a path that is relative to the given base directory

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -278,7 +278,7 @@ namespace Sass {
     // (2) underscore + given
     // (3) underscore + given + extension
     // (4) given + extension
-    std::vector<Sass_Queued> resolve_file(const std::string& root, const std::string& file)
+    std::vector<Sass_Queued> resolve_includes(const std::string& root, const std::string& file)
     {
       std::string filename = join_paths(root, file);
       // supported extensions
@@ -288,29 +288,29 @@ namespace Sass {
       // split the filename
       std::string base(dir_name(file));
       std::string name(base_name(file));
-      std::vector<Sass_Queued> resolved;
+      std::vector<Sass_Queued> includes;
       // create full path (maybe relative)
       std::string rel_path(join_paths(base, name));
       std::string abs_path(join_paths(root, rel_path));
-      if (file_exists(abs_path)) resolved.push_back(Sass_Queued(rel_path, abs_path, 0));
+      if (file_exists(abs_path)) includes.push_back(Sass_Queued(rel_path, abs_path, 0));
       // next test variation with underscore
       rel_path = join_paths(base, "_" + name);
       abs_path = join_paths(root, rel_path);
-      if (file_exists(abs_path)) resolved.push_back(Sass_Queued(rel_path, abs_path, 0));
+      if (file_exists(abs_path)) includes.push_back(Sass_Queued(rel_path, abs_path, 0));
       // next test exts plus underscore
       for(auto ext : exts) {
         rel_path = join_paths(base, "_" + name + ext);
         abs_path = join_paths(root, rel_path);
-        if (file_exists(abs_path)) resolved.push_back(Sass_Queued(rel_path, abs_path, 0));
+        if (file_exists(abs_path)) includes.push_back(Sass_Queued(rel_path, abs_path, 0));
       }
       // next test plain name with exts
       for(auto ext : exts) {
         rel_path = join_paths(base, name + ext);
         abs_path = join_paths(root, rel_path);
-        if (file_exists(abs_path)) resolved.push_back(Sass_Queued(rel_path, abs_path, 0));
+        if (file_exists(abs_path)) includes.push_back(Sass_Queued(rel_path, abs_path, 0));
       }
       // nothing found
-      return resolved;
+      return includes;
     }
 
     // helper function to resolve a filename
@@ -319,7 +319,7 @@ namespace Sass {
       // search in every include path for a match
       for (size_t i = 0, S = paths.size(); i < S; ++i)
       {
-        std::vector<Sass_Queued> resolved(resolve_file(paths[i], file));
+        std::vector<Sass_Queued> resolved(resolve_includes(paths[i], file));
         if (resolved.size()) return resolved[0].abs_path;
       }
       // nothing found

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -200,7 +200,7 @@ namespace Sass {
 
     // create a path that is relative to the given base directory
     // path and base will first be resolved against cwd to make them absolute
-    std::string resolve_relative_path(const std::string& uri, const std::string& base, const std::string& cwd)
+    std::string abs2rel(const std::string& uri, const std::string& base, const std::string& cwd)
     {
 
       std::string absolute_uri = make_absolute_path(uri, cwd);

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -44,11 +44,11 @@ namespace Sass {
     std::string join_paths(std::string root, std::string name);
 
     // create an absolute path by resolving relative paths with cwd
-    std::string rel2abs(const std::string& path, const std::string& cwd = ".");
+    std::string rel2abs(const std::string& path, const std::string& base = ".", const std::string& cwd = get_cwd());
 
     // create a path that is relative to the given base directory
     // path and base will first be resolved against cwd to make them absolute
-    std::string abs2rel(const std::string& path, const std::string& base, const std::string& cwd = ".");
+    std::string abs2rel(const std::string& path, const std::string& base = ".", const std::string& cwd = get_cwd());
 
     // try to find/resolve the filename
     std::vector<Sass_Queued> resolve_includes(const std::string& root, const std::string& file);

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -48,7 +48,7 @@ namespace Sass {
 
     // create a path that is relative to the given base directory
     // path and base will first be resolved against cwd to make them absolute
-    std::string resolve_relative_path(const std::string& path, const std::string& base, const std::string& cwd = ".");
+    std::string abs2rel(const std::string& path, const std::string& base, const std::string& cwd = ".");
 
     // try to find/resolve the filename
     std::vector<Sass_Queued> resolve_file(const std::string& root, const std::string& file);

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -44,7 +44,7 @@ namespace Sass {
     std::string join_paths(std::string root, std::string name);
 
     // create an absolute path by resolving relative paths with cwd
-    std::string make_absolute_path(const std::string& path, const std::string& cwd = ".");
+    std::string rel2abs(const std::string& path, const std::string& cwd = ".");
 
     // create a path that is relative to the given base directory
     // path and base will first be resolved against cwd to make them absolute

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -51,7 +51,7 @@ namespace Sass {
     std::string abs2rel(const std::string& path, const std::string& base, const std::string& cwd = ".");
 
     // try to find/resolve the filename
-    std::vector<Sass_Queued> resolve_file(const std::string& root, const std::string& file);
+    std::vector<Sass_Queued> resolve_includes(const std::string& root, const std::string& file);
 
     // helper function to resolve a filename
     std::string find_file(const std::string& file, const std::vector<std::string> paths);

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -659,7 +659,7 @@ extern "C" {
     // pass catched errors to generic error handler
     catch (...) { return handle_errors(compiler->c_ctx) | 1; }
     // generate source map json and store on context
-    compiler->c_ctx->source_map_string = cpp_ctx->generate_source_map();
+    compiler->c_ctx->source_map_string = cpp_ctx->render_srcmap();
     // success
     return 0;
   }

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -655,7 +655,7 @@ extern "C" {
     Context* cpp_ctx = compiler->cpp_ctx;
     Block* root = compiler->root;
     // compile the parsed root block
-    try { compiler->c_ctx->output_string = cpp_ctx->compile_block(root); }
+    try { compiler->c_ctx->output_string = cpp_ctx->render(root); }
     // pass catched errors to generic error handler
     catch (...) { return handle_errors(compiler->c_ctx) | 1; }
     // generate source map json and store on context

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -186,7 +186,7 @@ extern "C" {
     catch (Error_Invalid& e) {
       std::stringstream msg_stream;
       std::string cwd(Sass::File::get_cwd());
-      std::string rel_path(Sass::File::resolve_relative_path(e.pstate.path, cwd, cwd));
+      std::string rel_path(Sass::File::abs2rel(e.pstate.path, cwd, cwd));
 
       std::string msg_prefix("Error: ");
       bool got_newline = false;

--- a/src/sass_interface.cpp
+++ b/src/sass_interface.cpp
@@ -98,7 +98,7 @@ extern "C" {
         }
       }
       c_ctx->output_string = cpp_ctx.compile_string();
-      c_ctx->source_map_string = cpp_ctx.generate_source_map();
+      c_ctx->source_map_string = cpp_ctx.render_srcmap();
       c_ctx->error_message = 0;
       c_ctx->error_status = 0;
 
@@ -191,7 +191,7 @@ extern "C" {
         }
       }
       c_ctx->output_string = cpp_ctx.compile_file();
-      c_ctx->source_map_string = cpp_ctx.generate_source_map();
+      c_ctx->source_map_string = cpp_ctx.render_srcmap();
       c_ctx->error_message = 0;
       c_ctx->error_status = 0;
 

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -14,7 +14,7 @@ namespace Sass {
   SourceMap::SourceMap() : current_position(0, 0, 0), file("stdin") { }
   SourceMap::SourceMap(const std::string& file) : current_position(0, 0, 0), file(file) { }
 
-  std::string SourceMap::generate_source_map(Context &ctx) {
+  std::string SourceMap::render_srcmap(Context &ctx) {
 
     const bool include_sources = ctx.source_map_contents;
     const std::vector<std::string> includes = ctx.include_links;

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -17,7 +17,7 @@ namespace Sass {
   std::string SourceMap::render_srcmap(Context &ctx) {
 
     const bool include_sources = ctx.source_map_contents;
-    const std::vector<std::string> includes = ctx.include_links;
+    const std::vector<std::string> links = ctx.srcmap_links;
     const std::vector<char*> sources = ctx.sources;
 
     JsonNode* json_srcmap = json_mkobject();
@@ -36,7 +36,7 @@ namespace Sass {
 
     JsonNode *json_includes = json_mkarray();
     for (size_t i = 0; i < source_index.size(); ++i) {
-      const char *include = includes[source_index[i]].c_str();
+      const char *include = links[source_index[i]].c_str();
       JsonNode *json_include = json_mkstring(include);
       json_append_element(json_includes, json_include);
     }

--- a/src/source_map.hpp
+++ b/src/source_map.hpp
@@ -34,7 +34,7 @@ namespace Sass {
     void add_open_mapping(AST_Node* node);
     void add_close_mapping(AST_Node* node);
 
-    std::string generate_source_map(Context &ctx);
+    std::string render_srcmap(Context &ctx);
     ParserState remap(const ParserState& pstate);
 
   private:


### PR DESCRIPTION
Extracted from #1626

Clean up some internal method names for accuracy in preparation for a refactor `context.cpp`.