### PR TITLE
Fix links and remove "wiki" references in documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ https://github.com/sass/libsass
 LibSass is just a library, but if you want to RUN LibSass,
 then go to https://github.com/sass/sassc or
 https://github.com/sass/ruby-libsass or
-[find your local implementer](https://github.com/sass/libsass/wiki/Implementations).
+[find your local implementer](docs/implementations.md).
 
 LibSass requires GCC 4.6+ or Clang/LLVM. If your OS is older, this version may not compile.
 
@@ -54,12 +54,12 @@ Library Usage
 While LibSass is a library primarily written in C++, it provides a simple
 C interface which should be used by most implementers. LibSass does not do
 much on its own without an implementer. This can be a command line tool, like
-[sassc](https://github.com/sass/sassc) or a [binding](https://github.com/sass/libsass/wiki/Implementations)
+[sassc](https://github.com/sass/sassc) or a [binding](docs/implementations.md)
 to your favorite programing language.
 
 If you want to build or interface with LibSass, we recommend to check out the
-wiki pages about [building LibSass](https://github.com/sass/libsass/wiki/building-libsass) and
-the [C-API documentation](https://github.com/sass/libsass/wiki/API-Documentation).
+wiki pages about [building LibSass](docs/build.md) and
+the [C-API documentation](docs/api-doc.md).
 
 About Sass
 ----------

--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ much on its own without an implementer. This can be a command line tool, like
 to your favorite programing language.
 
 If you want to build or interface with LibSass, we recommend to check out the
-wiki pages about [building LibSass](docs/build.md) and
+documentation pages about [building LibSass](docs/build.md) and
 the [C-API documentation](docs/api-doc.md).
 
 About Sass

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-Welcome to the LibSass wiki!
+Welcome to the LibSass documentation!
 
 ## First Off
 LibSass is just a library. To run the code locally (i.e. to compile your stylesheets), you need an implementer. SassC (get it?) is an implementer written in C. There are a number of other implementations of LibSass - for example Node. We encourage you to write your own port - the whole point of LibSass is that we want to bring Sass to many other languages, not just Ruby!


### PR DESCRIPTION
The libsass wiki appears to have been removed, but the README still links to it in several places.

This pull request corrects the links in the README to link to the documentation in docs/,
and changes mentions of the libsass wiki to say "documentation" instead.