### PR TITLE
Fix inconsistencies with @debug

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -18,7 +18,8 @@ namespace Sass {
     in_media_block(false),
     in_declaration(false),
     in_space_array(false),
-    in_comma_array(false)
+    in_comma_array(false),
+    in_debug(false)
   { }
 
   // return buffer as string
@@ -190,7 +191,7 @@ namespace Sass {
 
   void Emitter::append_optional_space()
   {
-    if (output_style() != SASS_STYLE_COMPRESSED && buffer().size()) {
+    if ((output_style() != SASS_STYLE_COMPRESSED || in_debug) && buffer().size()) {
       char lst = buffer().at(buffer().length() - 1);
       if (!isspace(lst) || scheduled_delimiter) {
         append_mandatory_space();

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -48,6 +48,8 @@ namespace Sass {
       // nested lists need parentheses
       bool in_space_array;
       bool in_comma_array;
+      // list separators don't get compressed in @debug
+      bool in_debug;
 
     public:
       // return buffer as std::string

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -403,7 +403,14 @@ namespace Sass {
     std::string cwd(ctx.cwd());
     std::string result(unquote(message->perform(&to_string)));
     std::string rel_path(Sass::File::abs2rel(d->pstate().path, cwd, cwd));
-    std::cerr << rel_path << ":" << d->pstate().line+1 << " DEBUG: " << result;
+    std::string output_path = rel_path;
+
+    // if the file is outside this directory show the absolute path
+    if (rel_path.substr(0, 3) == "../") {
+      output_path = d->pstate().path;
+    }
+
+    std::cerr << output_path << ":" << d->pstate().line+1 << " DEBUG: " << result;
     std::cerr << std::endl;
     return 0;
   }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -378,7 +378,7 @@ namespace Sass {
   Expression* Eval::operator()(Debug* d)
   {
     Expression* message = d->value()->perform(this);
-    To_String to_string(&ctx);
+    To_String to_string(&ctx, false, true);
     Env* env = exp.environment();
 
     // try to use generic function

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -363,7 +363,7 @@ namespace Sass {
   void Inspect::operator()(List* list)
   {
     std::string sep(list->separator() == SASS_SPACE ? " " : ",");
-    if (output_style() != SASS_STYLE_COMPRESSED && sep == ",") sep += " ";
+    if ((output_style() != SASS_STYLE_COMPRESSED || in_debug) && sep == ",") sep += " ";
     else if (in_media_block && sep != " ") sep += " "; // verified
     if (list->empty()) return;
     bool items_output = false;

--- a/src/to_string.cpp
+++ b/src/to_string.cpp
@@ -10,8 +10,8 @@
 
 namespace Sass {
 
-  To_String::To_String(Context* ctx, bool in_declaration)
-  : ctx(ctx), in_declaration(in_declaration) { }
+  To_String::To_String(Context* ctx, bool in_declaration, bool in_debug)
+  : ctx(ctx), in_declaration(in_declaration), in_debug(in_debug) { }
   To_String::~To_String() { }
 
   inline std::string To_String::fallback_impl(AST_Node* n)
@@ -19,6 +19,7 @@ namespace Sass {
     Emitter emitter(ctx);
     Inspect i(emitter);
     i.in_declaration = in_declaration;
+    i.in_debug = in_debug;
     if (n) n->perform(&i);
     return i.get_buffer();
   }

--- a/src/to_string.cpp
+++ b/src/to_string.cpp
@@ -44,5 +44,5 @@ namespace Sass {
   }
 
   inline std::string To_String::operator()(Null* n)
-  { return ""; }
+  { return in_debug ? "null" : ""; }
 }

--- a/src/to_string.hpp
+++ b/src/to_string.hpp
@@ -18,10 +18,11 @@ namespace Sass {
 
     Context* ctx;
     bool in_declaration;
+    bool in_debug;
 
   public:
 
-    To_String(Context* ctx = 0, bool in_declaration = true);
+    To_String(Context* ctx = 0, bool in_declaration = true, bool in_debug = false);
     virtual ~To_String();
 
     std::string operator()(Null* n);


### PR DESCRIPTION
This PR address some inconsistencies with `@debug`. It turns out sass-spec was not regenerated after @saper implemented error-specs. Doing so in preparation for the 3.4.19 bump showed we have currently have 30 specs failing the correct error output.

This addresses some cases.