### PR TITLE
More consistent deprecation warnings

### DIFF
--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -22,7 +22,7 @@ namespace Sass {
     warn(msg, pstate);
   }
 
-  void deprecated(std::string msg, ParserState pstate)
+  void deprecated_function(std::string msg, ParserState pstate)
   {
     std::string cwd(Sass::File::get_cwd());
     std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
@@ -32,6 +32,21 @@ namespace Sass {
     std::cerr << "DEPRECATION WARNING: " << msg << std::endl;
     std::cerr << "will be an error in future versions of Sass." << std::endl;
     std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
+  }
+
+  void deprecated(std::string msg, std::string msg2, ParserState pstate)
+  {
+    std::string cwd(Sass::File::get_cwd());
+    std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
+    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
+    std::string output_path(Sass::File::path_for_console(rel_path, pstate.path, pstate.path));
+
+    std::cerr << "DEPRECATION WARNING on line " << pstate.line + 1;
+    if (output_path.length()) std::cerr << " of " << output_path;
+    std::cerr << ":" << std::endl;
+    std::cerr << msg << " and will be an error in future versions of Sass." << std::endl;
+    if (msg2.length()) std::cerr << msg2 << std::endl;
+    std::cerr << std::endl;
   }
 
   void error(std::string msg, ParserState pstate)

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -25,10 +25,13 @@ namespace Sass {
   void deprecated(std::string msg, ParserState pstate)
   {
     std::string cwd(Sass::File::get_cwd());
+    std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
+    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
+    std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
+
     std::cerr << "DEPRECATION WARNING: " << msg << std::endl;
     std::cerr << "will be an error in future versions of Sass." << std::endl;
-    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
-    std::cerr << "        on line " << pstate.line+1 << " of " << rel_path << std::endl;
+    std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
   }
 
   void error(std::string msg, ParserState pstate)

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -23,7 +23,8 @@ namespace Sass {
   void warn(std::string msg, ParserState pstate);
   void warn(std::string msg, ParserState pstate, Backtrace* bt);
 
-  void deprecated(std::string msg, ParserState pstate);
+  void deprecated_function(std::string msg, ParserState pstate);
+  void deprecated(std::string msg, std::string msg2, ParserState pstate);
   // void deprecated(std::string msg, ParserState pstate, Backtrace* bt);
 
   void error(std::string msg, ParserState pstate);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -402,13 +402,9 @@ namespace Sass {
 
     std::string cwd(ctx.cwd());
     std::string result(unquote(message->perform(&to_string)));
+    std::string abs_path(Sass::File::rel2abs(d->pstate().path, cwd, cwd));
     std::string rel_path(Sass::File::abs2rel(d->pstate().path, cwd, cwd));
-    std::string output_path = rel_path;
-
-    // if the file is outside this directory show the absolute path
-    if (rel_path.substr(0, 3) == "../") {
-      output_path = d->pstate().path;
-    }
+    std::string output_path(Sass::File::path_for_console(rel_path, abs_path, d->pstate().path));
 
     std::cerr << output_path << ":" << d->pstate().line+1 << " DEBUG: " << result;
     std::cerr << std::endl;

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -590,6 +590,21 @@ namespace Sass {
     Definition* dd = SASS_MEMORY_NEW(ctx.mem, Definition, *d);
     env->local_frame()[d->name() +
                         (d->type() == Definition::MIXIN ? "[m]" : "[f]")] = dd;
+
+    if (d->type() == Definition::FUNCTION && (
+      d->name() == "calc"       ||
+      d->name() == "element"    ||
+      d->name() == "expression" ||
+      d->name() == "url"
+    )) {
+      deprecated(
+        "Naming a function \"" + d->name() + "\" is disallowed",
+        "This name conflicts with an existing CSS function with special parse rules.",
+         d->pstate()
+      );
+    }
+
+
     // set the static link so we can have lexical scoping
     dd->environment(env);
     return 0;

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -192,6 +192,18 @@ namespace Sass {
       return l + r;
     }
 
+    std::string path_for_console(const std::string& rel_path, const std::string& abs_path, const std::string& orig_path)
+    {
+      // magic algorith goes here!!
+
+      // if the file is outside this directory show the absolute path
+      if (rel_path.substr(0, 3) == "../") {
+        return orig_path;
+      }
+      // this seems to work most of the time
+      return abs_path == orig_path ? abs_path : rel_path;
+    }
+
     // create an absolute path by resolving relative paths with cwd
     std::string rel2abs(const std::string& path, const std::string& base, const std::string& cwd)
     {

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -36,6 +36,10 @@ namespace Sass {
     // but only if right side is not absolute yet
     std::string join_paths(std::string root, std::string name);
 
+    // if the relative path is outside of the cwd we want want to
+    // show the absolute path in console messages
+    std::string path_for_console(const std::string& rel_path, const std::string& abs_path, const std::string& orig_path);
+
     // create an absolute path by resolving relative paths with cwd
     std::string rel2abs(const std::string& path, const std::string& base = ".", const std::string& cwd = get_cwd());
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -883,11 +883,11 @@ namespace Sass {
         return (Expression*) arg;
       }
       else {
-        To_String to_string(&ctx);
+        To_String to_string(&ctx, false, true);
         std::string val(arg->perform(&to_string));
         val = dynamic_cast<Null*>(arg) ? "null" : val;
 
-        deprecated("Passing " + val + ", a non-string value, to unquote()", pstate);
+        deprecated_function("Passing " + val + ", a non-string value, to unquote()", pstate);
         return (Expression*) arg;
       }
     }


### PR DESCRIPTION
The deprecation warning format in Ruby Sass is inconsistent which makes it difficult to
match. These are the two common cases. This PR addresses the two most common cases.

Spec https://github.com/sass/sass-spec/pull/581
