### PR TITLE
Should throw too many arguments error with varargs

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -49,9 +49,11 @@ namespace Sass {
           }
         }
         std::stringstream msg;
-        msg << callee << " only takes " << LP << " arguments; "
-            << "given " << LA;
-        error(msg.str(), as->pstate());
+        msg << callee << " takes " << LP;
+        msg << (LP == 1 ? " argument" : " arguments");
+        msg << " but " << LA;
+        msg << (LA == 1 ? " was passed" : " were passed.");
+        deprecated_bind(msg.str(), as->pstate());
       }
       Parameter* p = (*ps)[ip];
 
@@ -183,6 +185,16 @@ namespace Sass {
         // empty rest arg - treat all args as default values
         if (!arglist->length()) {
           break;
+        } else {
+          if (arglist->length() + ia > LP) {
+            int arg_count = (arglist->length() + LA - 1);
+            std::stringstream msg;
+            msg << callee << " takes " << LP;
+            msg << (LP == 1 ? " argument" : " arguments");
+            msg << " but " << arg_count;
+            msg << (arg_count == 1 ? " was passed" : " were passed.");
+            deprecated_bind(msg.str(), as->pstate());
+          }
         }
         // otherwise move one of the rest args into the param, converting to argument if necessary
         if (!(a = dynamic_cast<Argument*>((*arglist)[0]))) {

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -49,6 +49,18 @@ namespace Sass {
     std::cerr << std::endl;
   }
 
+  void deprecated_bind(std::string msg, ParserState pstate)
+  {
+    std::string cwd(Sass::File::get_cwd());
+    std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
+    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
+    std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
+
+    std::cerr << "WARNING: " << msg << std::endl;
+    std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
+    std::cerr << "This will be an error in future versions of Sass." << std::endl;
+  }
+
   void error(std::string msg, ParserState pstate)
   {
     throw Error_Invalid(Error_Invalid::syntax, pstate, msg);

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -25,6 +25,7 @@ namespace Sass {
 
   void deprecated_function(std::string msg, ParserState pstate);
   void deprecated(std::string msg, std::string msg2, ParserState pstate);
+  void deprecated_bind(std::string msg, ParserState pstate);
   // void deprecated(std::string msg, ParserState pstate, Backtrace* bt);
 
   void error(std::string msg, ParserState pstate);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -661,14 +661,14 @@ namespace Sass {
     exp.env_stack.push_back(&fn_env);
 
     if (func || body) {
-      bind("function " + c->name(), params, args, &ctx, &fn_env, this);
+      bind("Function " + c->name(), params, args, &ctx, &fn_env, this);
       Backtrace here(backtrace(), c->pstate(), ", in function `" + c->name() + "`");
       exp.backtrace_stack.push_back(&here);
       // if it's user-defined, eval the body
       if (body) result = body->perform(this);
       // if it's native, invoke the underlying CPP function
       else result = func(fn_env, *env, ctx, def->signature(), c->pstate(), backtrace());
-      if (!result) error(std::string("function ") + c->name() + " did not return a value", c->pstate());
+      if (!result) error(std::string("Function ") + c->name() + " did not return a value", c->pstate());
       exp.backtrace_stack.pop_back();
     }
 
@@ -685,7 +685,7 @@ namespace Sass {
       }
 
       // populates env with default values for params
-      bind("function " + c->name(), params, args, &ctx, &fn_env, this);
+      bind("Function " + c->name(), params, args, &ctx, &fn_env, this);
 
       Backtrace here(backtrace(), c->pstate(), ", in function `" + c->name() + "`");
       exp.backtrace_stack.push_back(&here);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -641,7 +641,8 @@ namespace Sass {
       thunk->environment(env);
       new_env.local_frame()["@content[m]"] = thunk;
     }
-    bind("mixin " + c->name(), params, args, &ctx, &new_env, &eval);
+
+    bind("Mixin " + c->name(), params, args, &ctx, &new_env, &eval);
     append_block(body);
     backtrace_stack.pop_back();
     env_stack.pop_back();


### PR DESCRIPTION
This PR fixes a missing error when expanding varargs results in
too many arguments for a function or mixin. It also addresses
some inconsistencies in the warning messages. These inconsistencies
are inconsistent with previous inconsistencies also. I've opened
a bug with the Ruby Sass team to help slow out these rough edges.
https://github.com/sass/sass/issues/1880

Fixes #1683
Spec https://github.com/sass/sass-spec/pull/584