### PR TITLE
Don't throw too many arguments error is there is a rest parameter

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -186,7 +186,7 @@ namespace Sass {
         if (!arglist->length()) {
           break;
         } else {
-          if (arglist->length() + ia > LP) {
+          if (arglist->length() + ia > LP && !ps->has_rest_parameter()) {
             int arg_count = (arglist->length() + LA - 1);
             std::stringstream msg;
             msg << callee << " takes " << LP;


### PR DESCRIPTION
This addresses a regression introduced #1683.

Fixes #1685
Spec https://github.com/sass/sass-spec/pull/586