### PR TITLE
Implement `Sass::round` function

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1864,17 +1864,17 @@ namespace Sass {
     // resolved color
     std::string res_name = name;
 
-    double r = round(cap_channel<0xff>(r_));
-    double g = round(cap_channel<0xff>(g_));
-    double b = round(cap_channel<0xff>(b_));
+    double r = Sass::round(cap_channel<0xff>(r_));
+    double g = Sass::round(cap_channel<0xff>(g_));
+    double b = Sass::round(cap_channel<0xff>(b_));
     double a = cap_channel<1>   (a_);
 
     // get color from given name (if one was given at all)
     if (name != "" && name_to_color(name)) {
       const Color* n = name_to_color(name);
-      r = round(cap_channel<0xff>(n->r()));
-      g = round(cap_channel<0xff>(n->g()));
-      b = round(cap_channel<0xff>(n->b()));
+      r = Sass::round(cap_channel<0xff>(n->r()));
+      g = Sass::round(cap_channel<0xff>(n->g()));
+      b = Sass::round(cap_channel<0xff>(n->b()));
       a = cap_channel<1>   (n->a());
     }
     // otherwise get the possible resolved color name

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -11,6 +11,7 @@
 #include "util.hpp"
 #include "expand.hpp"
 #include "utf8_string.hpp"
+#include "sass/base.h"
 #include "utf8.h"
 
 #include <cstdlib>
@@ -310,9 +311,9 @@ namespace Sass {
 
       return SASS_MEMORY_NEW(ctx.mem, Color,
                              pstate,
-                             std::round(w1*color1->r() + w2*color2->r()),
-                             std::round(w1*color1->g() + w2*color2->g()),
-                             std::round(w1*color1->b() + w2*color2->b()),
+                             Sass::round(w1*color1->r() + w2*color2->r()),
+                             Sass::round(w1*color1->g() + w2*color2->g()),
+                             Sass::round(w1*color1->b() + w2*color2->b()),
                              color1->a()*p + color2->a()*(1-p));
     }
 
@@ -853,10 +854,10 @@ namespace Sass {
 
       std::stringstream ss;
       ss << '#' << std::setw(2) << std::setfill('0');
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(std::floor(a+0.5));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(std::floor(r+0.5));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(std::floor(g+0.5));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(std::floor(b+0.5));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(a));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(r));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(g));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(b));
 
       std::string result(ss.str());
       for (size_t i = 0, L = result.length(); i < L; ++i) {
@@ -1087,7 +1088,7 @@ namespace Sass {
       Number* n = ARG("$number", Number);
       Number* r = SASS_MEMORY_NEW(ctx.mem, Number, *n);
       r->pstate(pstate);
-      r->value(std::floor(r->value() + 0.5));
+      r->value(Sass::round(r->value()));
       return r;
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6,6 +6,7 @@
 #include "constants.hpp"
 #include "utf8/checked.h"
 
+#include <cmath>
 #include <stdint.h>
 
 namespace Sass {
@@ -14,6 +15,23 @@ namespace Sass {
       std::cerr << "Out of memory.\n";    \
       exit(EXIT_FAILURE);                 \
     } while (0)
+
+  double round(double val)
+  {
+    // work around some compiler issue
+    // cygwin has it not defined in std
+    using namespace std;
+
+    // This was later repatched in 3.4.20
+    // which is as yet unreleased.
+    // https://github.com/sass/sass/commit/4e3e1d5684cc29073a507578fc977434ff488c93
+    if (fmod(val, 1) - 0.5 > -0.00001) return std::ceil(val);
+    return ::round(val);
+
+    // Use this version once sass-spec is at 3.4.20
+    // if (fmod(val, 1) - 0.5 > -0.00001) return ::round(val);
+    // return value > 0 ? std::ceil(val) : std::floor(val);
+  }
 
   /* Sadly, sass_strdup is not portable. */
   char *sass_strdup(const char *str)

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -11,6 +11,7 @@
 
 namespace Sass {
 
+  double round(double val);
   char* sass_strdup(const char* str);
   double sass_atof(const char* str);
   const char* safe_str(const char *, const char* = "");


### PR DESCRIPTION
Cherry picked from https://github.com/sass/libsass/pull/1621

This PR implements `Sass::round` which emulates Ruby Sass' elipson rounding. This allows us to bump sass-spec to 3.4.15. One step closer to 3.4.19 which will come after my static value parsing refactor is complete.

Spec https://github.com/sass/sass-spec/pull/590
Closes #1621