### PR TITLE
Use an access token to increase the GH API limit

### DIFF
--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -91,14 +91,8 @@ then
 
   echo "Fetching PR $TRAVIS_PULL_REQUEST"
 
-  JSON=$(curl -L -sS https://api.github.com/repos/sass/libsass/pulls/$TRAVIS_PULL_REQUEST)
 
-  if [[ $JSON =~ "API rate limit exceeded" ]];
-  then
-    echo "Travis rate limit on github exceeded"
-    echo "Retrying via 'special purpose proxy'"
-    JSON=$(curl -L -sS http://libsass.ocbnet.ch/libsass-spec-pr.psgi/$TRAVIS_PULL_REQUEST)
-  fi
+  JSON=$(curl -L -sS https://api.github.com/repos/sass/libsass/pulls/$TRAVIS_PULL_REQUEST)
 
   RE_SPEC_PR="sass\/sass-spec(#|\/pull\/)([0-9]+)"
 


### PR DESCRIPTION
The proxy approach is unreliable, and I'm wasting too much time with this. If this hack works I'm shipping it.

```
Travis rate limit on github exceeded
Retrying via 'special purpose proxy'
curl: (7) Failed connect to libsass.ocbnet.ch:80; Connection refused
```

The key needs to obfuscated like this because github as a bot that scans for committed keys and revokes them for security. This is a read only key so it's safe to be out in the public. Alternatively there are TravsiCI's [encrypted env vars](http://docs.travis-ci.com/user/encryption-keys/) but they don't work for [PRs from forks](http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests) which makes them useless to us.

