### PR TITLE
Reenable code coverage

### DIFF
--- a/script/ci-install-deps
+++ b/script/ci-install-deps
@@ -1,5 +1,6 @@
 #!/bin/bash
 if [ "x$COVERAGE" == "xyes" ]; then
+  pip install --user gcovr
   pip install --user cpp-coveralls
 else
   echo "no dependencies to install"

--- a/script/ci-report-coverage
+++ b/script/ci-report-coverage
@@ -3,20 +3,28 @@
 if [ "x$COVERAGE" = "xyes" ]; then
 
   # exclude some directories from profiling (.libs is from autotools)
-  export EXCLUDE_COVERAGE="--exclude sassc --exclude sass-spec
-                             --exclude .libs --exclude debug.hpp
-                             --exclude json.cpp --exclude json.hpp
-                             --exclude cencode.c --exclude b64
-                             --exclude utf8 --exclude utf8_string.hpp
-                             --exclude utf8.h --exclude utf8_string.cpp
-                             --exclude sass2scss.h --exclude sass2scss.cpp
-                             --exclude test --exclude posix
-                             --exclude debugger.hpp"
+  export EXCLUDE_COVERAGE="--exclude src/sassc
+                           --exclude src/sass-spec
+                           --exclude src/.libs
+                           --exclude src/debug.hpp
+                           --exclude src/json.cpp
+                           --exclude src/json.hpp
+                           --exclude src/cencode.c
+                           --exclude src/b64
+                           --exclude src/utf8
+                           --exclude src/utf8_string.hpp
+                           --exclude src/utf8.h
+                           --exclude src/utf8_string.cpp
+                           --exclude src/sass2scss.h
+                           --exclude src/sass2scss.cpp
+                           --exclude src/test
+                           --exclude src/posix
+                           --exclude src/debugger.hpp"
   # debug via gcovr
   gcov -v
   gcovr -r .
   # generate and submit report to coveralls.io
-  coveralls $EXCLUDE_COVERAGE --root src/ --gcov-options '\-lp'
+  coveralls $EXCLUDE_COVERAGE --gcov-options '\-lp'
 
 else
   echo "skip coverage reporting"


### PR DESCRIPTION
Continuing on from https://github.com/sass/libsass/pull/1690

```
Traceback (most recent call last):
  File "/home/travis/.local/bin/coveralls", line 9, in <module>
    load_entry_point('cpp-coveralls==0.3.10', 'console_scripts', 'coveralls')()
  File "/home/travis/.local/lib/python2.7/site-packages/cpp_coveralls/__init__.py", line 96, in run
    cov_report = coverage.collect(args)
  File "/home/travis/.local/lib/python2.7/site-packages/cpp_coveralls/coverage.py", line 378, in collect
    with io.open(source_file_path, mode='rb') as src_file:
IOError: [Errno 2] No such file or directory: '/home/travis/build/sass/libsass/src/src/cencode.c'
```