### PR TITLE
[WIP] Refactor static value parsing to match Ruby Sass

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -32,6 +32,7 @@
 #include "sass2scss.h"
 #include "prelexer.hpp"
 #include "emitter.hpp"
+#include "debugger.hpp"
 
 namespace Sass {
   using namespace Constants;
@@ -638,8 +639,10 @@ namespace Sass {
     // create crtp visitor objects
     Expand expand(*this, &global, &backtrace);
     Cssize cssize(*this, &backtrace);
+    // debug_ast(root);
     // expand and eval the tree
     root = root->perform(&expand)->block();
+    // debug_ast(root);
     // merge and bubble certain rules
     root = root->perform(&cssize)->block();
     // should we extend something?

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -95,7 +95,7 @@ namespace Sass {
 
     // check if char is within a reduced ascii range
     // valid for escaping (copied from Ruby Sass)
-    bool is_escapable_character(const char& chr)
+    bool is_escape_character(const char& chr)
     {
       return unsigned(chr) > 31 && unsigned(chr) < 127;
     }
@@ -122,7 +122,7 @@ namespace Sass {
     const char* punct(const char* src) { return is_punct(*src) ? src + 1 : 0; }
     const char* character(const char* src) { return is_character(*src) ? src + 1 : 0; }
     const char* uri_character(const char* src) { return is_uri_character(*src) ? src + 1 : 0; }
-    const char* escapable_character(const char* src) { return is_escapable_character(*src) ? src + 1 : 0; }
+    const char* escape_character(const char* src) { return is_escape_character(*src) ? src + 1 : 0; }
 
     // Match multiple ctype characters.
     const char* spaces(const char* src) { return one_plus<space>(src); }

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -35,7 +35,7 @@ namespace Sass {
     bool is_nonascii(const char& src);
     bool is_character(const char& src);
     bool is_uri_character(const char& src);
-    bool escapable_character(const char& src);
+    bool is_escape_character(const char& src);
 
     // Match a single ctype predicate.
     const char* space(const char* src);
@@ -48,7 +48,7 @@ namespace Sass {
     const char* nonascii(const char* src);
     const char* character(const char* src);
     const char* uri_character(const char* src);
-    const char* escapable_character(const char* src);
+    const char* escape_character(const char* src);
 
     // Match multiple ctype characters.
     const char* spaces(const char* src);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -11,6 +11,8 @@
 #include "color_maps.hpp"
 #include "sass/functions.h"
 #include "error_handling.hpp"
+#include "debug.hpp"
+#include "debugger.hpp"
 
 #include <typeinfo>
 #include <tuple>
@@ -925,13 +927,26 @@ namespace Sass {
     if (peek_css< exactly<';'> >()) error("style declaration must contain a value", pstate);
     if (peek_css< exactly<'{'> >()) is_indented = false; // don't indent if value is empty
     if (peek_css< static_value >()) {
+      // DEBUG_PRINTLN(ALL, "static_value");
       return SASS_MEMORY_NEW(ctx.mem, Declaration, prop->pstate(), prop, parse_static_value()/*, lex<kwd_important>()*/);
+    }
+    else if (lex_css< id_name >()) {
+      String_Constant* value = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
+      return SASS_MEMORY_NEW(ctx.mem, Declaration, prop->pstate(), prop, value/*, lex<kwd_important>()*/);
+    }
+    else if (lex_css< HEXCOLOR >()) {
+      String_Constant* value = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
+      return SASS_MEMORY_NEW(ctx.mem, Declaration, prop->pstate(), prop, value/*, lex<kwd_important>()*/);
     }
     else {
       Expression* value;
       Lookahead lookahead = lookahead_for_value(position);
+      // DEBUG_PRINTLN(ALL, "lookahead");
       if (lookahead.found) {
+      // DEBUG_PRINTLN(ALL, "lookahead.has_interpolants >> " << lookahead.has_interpolants);
+      // DEBUG_PRINTLN(ALL, "++" << lookahead.found << "++");
         if (lookahead.has_interpolants) {
+
           value = parse_value_schema(lookahead.found);
         } else {
           value = parse_list();
@@ -2254,6 +2269,8 @@ namespace Sass {
         >
       >(p)
     ) {
+      // DEBUG_PRINTLN(ALL, "++" << p);
+      // DEBUG_PRINTLN(ALL, "**" << q);
       if (p == q) return rv;
       while (p < q) {
         // did we have interpolations?

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1043,16 +1043,16 @@ namespace Sass {
         // commented section once we bump sass-spec to use
         // Sass >= 3.4.16.
         identifier,
-        // sequence<
-        //   optional< exactly<'-'> >,
-        //   NMSTART,
-        //   zero_plus< alternatives<
-        //     alternatives< alnum, exactly<'_'> >,
-        //     NONASCII,
-        //     ESCAPE,
-        //     sequence< exactly<'-'>, negate< number > >
-        //   > >
-        // >,
+        sequence<
+          optional< exactly<'-'> >,
+          NMSTART,
+          zero_plus< alternatives<
+            alternatives< alnum, exactly<'_'> >,
+            NONASCII,
+            ESCAPE,
+            sequence< exactly<'-'>, negate< number > >
+          > >
+        >,
         exactly<'%'>
       >(src);
     }

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -354,6 +354,14 @@ namespace Sass {
     // const char* folders(const char* src);
 
 
+    const char* NMSTART(const char* src);
+    const char* NMCHAR(const char* src);
+    const char* UNIT(const char* src);
+    const char* NNUMBER(const char* src);
+    const char* UNITLESS_NUMBER(const char* src);
+    const char* HEXCOLOR(const char* src);
+
+
     const char* static_string(const char* src);
     const char* static_component(const char* src);
     const char* static_property(const char* src);


### PR DESCRIPTION
This is heavily in WIP.

This refactors the static value parsing to match Ruby Sass' implementation. This mostly affects declaration parsing. This fixes some specs that start failing once regenerated on with 3.4.16.
