### PR TITLE
Should return unquoted strings from function calls in interpolants

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -933,7 +933,7 @@ namespace Sass {
       return evacuate_quotes(interpolation(ex));
     } else if (dynamic_cast<Function_Call*>(s)) {
       Expression* ex = s->perform(this);
-      return evacuate_quotes(interpolation(ex));
+      return evacuate_quotes(unquote(interpolation(ex)));
     } else if (dynamic_cast<Unary_Expression*>(s)) {
       Expression* ex = s->perform(this);
       return evacuate_quotes(interpolation(ex));


### PR DESCRIPTION
This is a tricky bug to produce a test case for. I've only been able to reproduce it using custom functions which return `Sass_String`. The test case I have shows that this is a regression in 3.2.5.

