### PR TITLE
Implement rounding precision

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2116,17 +2116,17 @@ namespace Sass {
     // resolved color
     std::string res_name = name;
 
-    double r = Sass::round(cap_channel<0xff>(r_));
-    double g = Sass::round(cap_channel<0xff>(g_));
-    double b = Sass::round(cap_channel<0xff>(b_));
+    double r = Sass::round(cap_channel<0xff>(r_), precision);
+    double g = Sass::round(cap_channel<0xff>(g_), precision);
+    double b = Sass::round(cap_channel<0xff>(b_), precision);
     double a = cap_channel<1>   (a_);
 
     // get color from given name (if one was given at all)
     if (name != "" && name_to_color(name)) {
       const Color* n = name_to_color(name);
-      r = Sass::round(cap_channel<0xff>(n->r()));
-      g = Sass::round(cap_channel<0xff>(n->g()));
-      b = Sass::round(cap_channel<0xff>(n->b()));
+      r = Sass::round(cap_channel<0xff>(n->r()), precision);
+      g = Sass::round(cap_channel<0xff>(n->g()), precision);
+      b = Sass::round(cap_channel<0xff>(n->b()), precision);
       a = cap_channel<1>   (n->a());
     }
     // otherwise get the possible resolved color name
@@ -2238,11 +2238,16 @@ namespace Sass {
       res = std::string(ss.str());
       // maybe we truncated up to decimal point
       size_t pos = res.find_last_not_of("0");
-      bool at_dec_point = res[pos] == '.' ||
-                          res[pos] == ',';
-      // don't leave a blank point
-      if (at_dec_point) ++ pos;
-      res.resize (pos + 1);
+      // handle case where we have a "0"
+      if (pos == std::string::npos) {
+        res = "0.0";
+      } else {
+        bool at_dec_point = res[pos] == '.' ||
+                            res[pos] == ',';
+        // don't leave a blank point
+        if (at_dec_point) ++ pos;
+        res.resize (pos + 1);
+      }
     }
 
     // some final cosmetics

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -313,9 +313,9 @@ namespace Sass {
 
       return SASS_MEMORY_NEW(ctx.mem, Color,
                              pstate,
-                             Sass::round(w1*color1->r() + w2*color2->r()),
-                             Sass::round(w1*color1->g() + w2*color2->g()),
-                             Sass::round(w1*color1->b() + w2*color2->b()),
+                             Sass::round(w1*color1->r() + w2*color2->r(), ctx.c_options->precision),
+                             Sass::round(w1*color1->g() + w2*color2->g(), ctx.c_options->precision),
+                             Sass::round(w1*color1->b() + w2*color2->b(), ctx.c_options->precision),
                              color1->a()*p + color2->a()*(1-p));
     }
 
@@ -856,10 +856,10 @@ namespace Sass {
 
       std::stringstream ss;
       ss << '#' << std::setw(2) << std::setfill('0');
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(a));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(r));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(g));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(b));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(a, ctx.c_options->precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(r, ctx.c_options->precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(g, ctx.c_options->precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(b, ctx.c_options->precision));
 
       std::string result(ss.str());
       for (size_t i = 0, L = result.length(); i < L; ++i) {
@@ -1090,7 +1090,7 @@ namespace Sass {
       Number* n = ARG("$number", Number);
       Number* r = SASS_MEMORY_NEW(ctx.mem, Number, *n);
       r->pstate(pstate);
-      r->value(Sass::round(r->value()));
+      r->value(Sass::round(r->value(), ctx.c_options->precision));
       return r;
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -17,21 +17,15 @@ namespace Sass {
       exit(EXIT_FAILURE);                 \
     } while (0)
 
-  double round(double val)
+  double round(double val, size_t precision)
   {
+    // https://github.com/sass/sass/commit/4e3e1d5684cc29073a507578fc977434ff488c93
+    if (fmod(val, 1) - 0.5 > - std::pow(0.1, precision + 1)) return std::ceil(val);
+    else if (fmod(val, 1) - 0.5 > std::pow(0.1, precision)) return std::floor(val);
     // work around some compiler issue
     // cygwin has it not defined in std
     using namespace std;
-
-    // This was later repatched in 3.4.20
-    // which is as yet unreleased.
-    // https://github.com/sass/sass/commit/4e3e1d5684cc29073a507578fc977434ff488c93
-    if (fmod(val, 1) - 0.5 > -0.00001) return std::ceil(val);
     return ::round(val);
-
-    // Use this version once sass-spec is at 3.4.20
-    // if (fmod(val, 1) - 0.5 > -0.00001) return ::round(val);
-    // return value > 0 ? std::ceil(val) : std::floor(val);
   }
 
   /* Sadly, sass_strdup is not portable. */

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -11,7 +11,7 @@
 
 namespace Sass {
 
-  double round(double val);
+  double round(double val, size_t precision = 0);
   char* sass_strdup(const char* str);
   double sass_atof(const char* str);
   const char* safe_str(const char *, const char* = "");


### PR DESCRIPTION
Should pass https://github.com/sass/sass-spec/pull/696

Update rounding behavior for upcoming [ruby sass 3.4.20] [1].

My implementation should return the same results but avoids the fmod division operation.
We may also want to calculate the epsilon only once at startup and store it in options.

[1]: https://github.com/sass/sass/issues/1883