### PR TITLE
Fix regressions in context refactor

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -276,7 +276,7 @@ namespace Sass {
     resources.push_back(res);
 
     // add a relative link to the working directory
-    included_files.push_back(abs2rel(inc.abs_path, CWD));
+    included_files.push_back(inc.abs_path);
     // add a relative link  to the source map output file
     srcmap_links.push_back(abs2rel(inc.abs_path, source_map_file, CWD));
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -259,11 +259,11 @@ namespace Sass {
 
     // do not parse same resource twice
     // maybe raise an error in this case
-    if (sheets.count(inc.abs_path)) {
-      free(res.contents); free(res.srcmap);
-      throw std::runtime_error("duplicate resource registered");
-      return;
-    }
+    // if (sheets.count(inc.abs_path)) {
+    //   free(res.contents); free(res.srcmap);
+    //   throw std::runtime_error("duplicate resource registered");
+    //   return;
+    // }
 
     // get index for this resource
     size_t idx = resources.size();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -135,8 +135,7 @@ namespace Sass {
       if (ctx && ctx->c_options->source_comments) {
         std::stringstream ss;
         append_indentation();
-        std::string path = Sass::File::abs2rel(r->pstate().path, ctx->cwd());
-        ss << "/* line " << r->pstate().line + 1 << ", " << path << " */";
+        ss << "/* line " << r->pstate().line + 1 << ", " << r->pstate().path << " */";
         append_string(ss.str());
         append_optional_linefeed();
       }


### PR DESCRIPTION
This PR fixes two major regressions from the context refactor.

#### Don't throw an error when importing the same path

> Importing the same path is completely valid in Sass. We don't error when `@import`ing the same path, this should not when using custom importers.

Fixes #1712 

#### The included_file vector should be absolute paths not relative

>This behaviour was incorrectly changed in 610acbf which caused some serious regressions.

Fixes #1711 

#### Line comments should be absolute

>This was incorrectly changed in 610acbf to show relative paths.

Fixes #1714