### PR TITLE
Fix segfault when too many arguments are passed

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -9,8 +9,9 @@
 
 namespace Sass {
 
-  void bind(std::string callee, Parameters* ps, Arguments* as, Context* ctx, Env* env, Eval* eval)
+  void bind(std::string type, std::string name, Parameters* ps, Arguments* as, Context* ctx, Env* env, Eval* eval)
   {
+    std::string callee(type + " " + name);
     Listize listize(*ctx);
     std::map<std::string, Parameter*> param_map;
 
@@ -49,11 +50,9 @@ namespace Sass {
           }
         }
         std::stringstream msg;
-        msg << callee << " takes " << LP;
-        msg << (LP == 1 ? " argument" : " arguments");
-        msg << " but " << LA;
-        msg << (LA == 1 ? " was passed" : " were passed.");
-        deprecated_bind(msg.str(), as->pstate());
+        msg << "wrong number of arguments (" << LA << " for " << LP << ")";
+        msg << " for `" << name << "'";
+        return error(msg.str(), as->pstate());
       }
       Parameter* p = (*ps)[ip];
 

--- a/src/bind.hpp
+++ b/src/bind.hpp
@@ -12,7 +12,7 @@ namespace Sass {
   class   Eval;
   typedef Environment<AST_Node*> Env;
 
-  void bind(std::string caller, Parameters*, Arguments*, Context*, Env*, Eval*);
+  void bind(std::string type, std::string name, Parameters*, Arguments*, Context*, Env*, Eval*);
 }
 
 #endif

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -708,7 +708,7 @@ namespace Sass {
     exp.env_stack.push_back(&fn_env);
 
     if (func || body) {
-      bind("Function " + c->name(), params, args, &ctx, &fn_env, this);
+      bind(std::string("Function"), c->name(), params, args, &ctx, &fn_env, this);
       Backtrace here(backtrace(), c->pstate(), ", in function `" + c->name() + "`");
       exp.backtrace_stack.push_back(&here);
       // if it's user-defined, eval the body
@@ -732,7 +732,8 @@ namespace Sass {
       }
 
       // populates env with default values for params
-      bind("Function " + c->name(), params, args, &ctx, &fn_env, this);
+      std::string ff(c->name());
+      bind(std::string("Function"), c->name(), params, args, &ctx, &fn_env, this);
 
       Backtrace here(backtrace(), c->pstate(), ", in function `" + c->name() + "`");
       exp.backtrace_stack.push_back(&here);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -642,7 +642,7 @@ namespace Sass {
       new_env.local_frame()["@content[m]"] = thunk;
     }
 
-    bind("Mixin " + c->name(), params, args, &ctx, &new_env, &eval);
+    bind(std::string("Mixin"), c->name(), params, args, &ctx, &new_env, &eval);
     append_block(body);
     backtrace_stack.pop_back();
     env_stack.pop_back();


### PR DESCRIPTION
It also turns out the Ruby Sass error for too many arguments is different depending on the circumstances.

Spec https://github.com/sass/sass-spec/pull/601
Fixes #1715