### PR TITLE
Fix VS compilation errors on VS < 2015

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -14,6 +14,7 @@
 #include "sass/base.h"
 #include "utf8.h"
 
+#include <atomic>
 #include <cstdlib>
 #include <cmath>
 #include <cctype>


### PR DESCRIPTION
This header was removed in 827eac5f which subsequently broke node-sass.

Not 100% what our stance is on VS support. Since we have hacks in out build files for VS 2013 I suspect we intend to support it. If that's the case we should try to figure out an way to test against it in CI.

I can work around this in node-sass buy bumping our AppVeyor to VS 2015 but this still an open question for us. I'd love @am11 thoughts.