### PR TITLE
Fix error messages for `min` and `max`

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1125,11 +1125,15 @@ namespace Sass {
     Signature min_sig = "min($numbers...)";
     BUILT_IN(min)
     {
+      To_String to_string(&ctx);
       List* arglist = ARG("$numbers", List);
       Number* least = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        Number* xi = dynamic_cast<Number*>(arglist->value_at_index(i));
-        if (!xi) error("`" + std::string(sig) + "` only takes numeric arguments", pstate);
+        Expression* val = arglist->value_at_index(i);
+        Number* xi = dynamic_cast<Number*>(val);
+        if (!xi) {
+          error("\"" + val->perform(&to_string) + "\" is not a number for `min'", pstate);
+        }
         if (least) {
           if (Eval::lt(xi, least)) least = xi;
         } else least = xi;
@@ -1140,11 +1144,15 @@ namespace Sass {
     Signature max_sig = "max($numbers...)";
     BUILT_IN(max)
     {
+      To_String to_string(&ctx);
       List* arglist = ARG("$numbers", List);
       Number* greatest = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        Number* xi = dynamic_cast<Number*>(arglist->value_at_index(i));
-        if (!xi) error("`" + std::string(sig) + "` only takes numeric arguments", pstate);
+        Expression* val = arglist->value_at_index(i);
+        Number* xi = dynamic_cast<Number*>(val);
+        if (!xi) {
+          error("\"" + val->perform(&to_string) + "\" is not a number for `max'", pstate);
+        }
         if (greatest) {
           if (Eval::lt(greatest, xi)) greatest = xi;
         } else greatest = xi;


### PR DESCRIPTION
This PR fixes the error messages for the `min` and `max` functions
when they're passed a non-numeric value.

Fixes #1559
Spec sass/spec#612