### PR TITLE
Fix edge-case for extend with `Wrapped_Selector`

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -205,10 +205,8 @@ namespace Sass {
 
   bool Simple_Selector::operator== (const Simple_Selector& rhs) const
   {
-    const Attribute_Selector* ll = dynamic_cast<const Attribute_Selector*>(this);
-    const Attribute_Selector* rr = dynamic_cast<const Attribute_Selector*>(&rhs);
-    if (ll && rr) return *ll == *rr;
-
+    if (const Wrapped_Selector* lw = dynamic_cast<const Wrapped_Selector*>(this)) return *lw == rhs;
+    if (const Attribute_Selector* la = dynamic_cast<const Attribute_Selector*>(this)) return *la == rhs;
     if (is_ns_eq(ns(), rhs.ns()))
     { return name() == rhs.name(); }
     return ns() == rhs.ns();
@@ -216,10 +214,8 @@ namespace Sass {
 
   bool Simple_Selector::operator< (const Simple_Selector& rhs) const
   {
-    const Attribute_Selector* ll = dynamic_cast<const Attribute_Selector*>(this);
-    const Attribute_Selector* rr = dynamic_cast<const Attribute_Selector*>(&rhs);
-    if (ll && rr) return *ll < *rr;
-
+    if (const Wrapped_Selector* lw = dynamic_cast<const Wrapped_Selector*>(this)) return *lw < rhs;
+    if (const Attribute_Selector* la = dynamic_cast<const Attribute_Selector*>(this)) return *la < rhs;
     if (is_ns_eq(ns(), rhs.ns()))
     { return name() < rhs.name(); }
     return ns() < rhs.ns();
@@ -498,6 +494,26 @@ namespace Sass {
     if (is_ns_eq(ns(), rhs.ns()))
     { return name() == rhs.name(); }
     return ns() == rhs.ns();
+  }
+
+  bool Wrapped_Selector::operator< (const Wrapped_Selector& rhs) const
+  {
+    if (is_ns_eq(ns(), rhs.ns()) && name() == rhs.name())
+    { return *(selector()) < *(rhs.selector()); }
+    if (is_ns_eq(ns(), rhs.ns()))
+    { return name() < rhs.name(); }
+    return ns() < rhs.ns();
+  }
+
+  bool Wrapped_Selector::operator< (const Simple_Selector& rhs) const
+  {
+    if (const Wrapped_Selector* w = dynamic_cast<const Wrapped_Selector*>(&rhs))
+    {
+      return *this < *w;
+    }
+    if (is_ns_eq(ns(), rhs.ns()))
+    { return name() < rhs.name(); }
+    return ns() < rhs.ns();
   }
 
   bool Wrapped_Selector::is_superselector_of(Wrapped_Selector* sub)

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -77,6 +77,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Selector_List* selector = dynamic_cast<Selector_List*>(node);
     std::cerr << ind << "Selector_List " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
     std::cerr << " [@media:" << selector->media_block() << "]";
     std::cerr << (selector->is_optional() ? " [is_optional]": " -");
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
@@ -94,6 +95,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "Parent_Selector " << selector;
 //    if (selector->not_selector()) cerr << " [in_declaration]";
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
 //    debug_ast(selector->selector(), ind + "->", env);
 
@@ -101,6 +103,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Complex_Selector* selector = dynamic_cast<Complex_Selector*>(node);
     std::cerr << ind << "Complex_Selector " << selector
       << " (" << pstate_source_position(node) << ")"
+      << " <" << selector->hash() << ">"
       << " [weight:" << longToHex(selector->specificity()) << "]"
       << " [@media:" << selector->media_block() << "]"
       << (selector->is_optional() ? " [is_optional]": " -")
@@ -129,6 +132,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Compound_Selector* selector = dynamic_cast<Compound_Selector*>(node);
     std::cerr << ind << "Compound_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
     std::cerr << " [weight:" << longToHex(selector->specificity()) << "]";
     std::cerr << " [@media:" << selector->media_block() << "]";
     std::cerr << (selector->is_optional() ? " [is_optional]": " -");
@@ -146,35 +150,41 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Wrapped_Selector* selector = dynamic_cast<Wrapped_Selector*>(node);
     std::cerr << ind << "Wrapped_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
     debug_ast(selector->selector(), ind + " () ", env);
   } else if (dynamic_cast<Pseudo_Selector*>(node)) {
     Pseudo_Selector* selector = dynamic_cast<Pseudo_Selector*>(node);
     std::cerr << ind << "Pseudo_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
     debug_ast(selector->expression(), ind + " <= ", env);
   } else if (dynamic_cast<Attribute_Selector*>(node)) {
     Attribute_Selector* selector = dynamic_cast<Attribute_Selector*>(node);
     std::cerr << ind << "Attribute_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
     debug_ast(selector->value(), ind + "[" + selector->matcher() + "] ", env);
   } else if (dynamic_cast<Selector_Qualifier*>(node)) {
     Selector_Qualifier* selector = dynamic_cast<Selector_Qualifier*>(node);
     std::cerr << ind << "Selector_Qualifier " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
   } else if (dynamic_cast<Type_Selector*>(node)) {
     Type_Selector* selector = dynamic_cast<Type_Selector*>(node);
     std::cerr << ind << "Type_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") <<
       " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
   } else if (dynamic_cast<Selector_Placeholder*>(node)) {
 
     Selector_Placeholder* selector = dynamic_cast<Selector_Placeholder*>(node);
     std::cerr << ind << "Selector_Placeholder [" << selector->ns_name() << "] " << selector
+      << " <" << selector->hash() << ">"
       << " [@media:" << selector->media_block() << "]"
       << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
@@ -660,10 +670,10 @@ inline void debug_node(const Node* node, std::string ind = "")
   debug_node(const_cast<Node*>(node), ind);
 }
 
-inline void debug_extenstion_map(Sass::ExtensionSubsetMap* map, std::string ind = "")
+inline void debug_subset_map(Sass::ExtensionSubsetMap& map, std::string ind = "")
 {
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
-  for(auto const &it : map->values()) {
+  for(auto const &it : map.values()) {
     debug_ast(it.first, ind + "first: ");
     debug_ast(it.second, ind + "second: ");
   }

--- a/src/sass_util.hpp
+++ b/src/sass_util.hpp
@@ -221,28 +221,28 @@ namespace Sass {
 
     std::map<unsigned int, KeyType> order;
 
-    std::map<KeyType, std::vector<EnumType> > grouped;
+    std::map<size_t, std::vector<EnumType> > grouped;
 
     for (typename std::vector<EnumType>::iterator enumIter = enumeration.begin(), enumIterEnd = enumeration.end(); enumIter != enumIterEnd; enumIter++) {
       EnumType& e = *enumIter;
 
       KeyType key = keyFunc(e);
 
-      if (grouped.find(key) == grouped.end()) {
+      if (grouped.find(key.hash()) == grouped.end()) {
         order.insert(std::make_pair((unsigned int)order.size(), key));
 
         std::vector<EnumType> newCollection;
         newCollection.push_back(e);
-        grouped.insert(std::make_pair(key, newCollection));
+        grouped.insert(std::make_pair(key.hash(), newCollection));
       } else {
-        std::vector<EnumType>& collection = grouped.at(key);
+        std::vector<EnumType>& collection = grouped.at(key.hash());
         collection.push_back(e);
       }
     }
 
     for (unsigned int index = 0; index < order.size(); index++) {
       KeyType& key = order.at(index);
-      std::vector<EnumType>& values = grouped.at(key);
+      std::vector<EnumType>& values = grouped.at(key.hash());
 
       std::pair<KeyType, std::vector<EnumType> > grouping = std::make_pair(key, values);
 


### PR DESCRIPTION
Fixes #1729 

Not sure how this even worked before for other selector
types? Looks like this was never implemented correctly?

To-Do:
- [x] Hashing for Selectors need more work