### PR TITLE
Defer creation of hash maps into eval stage

### DIFF
--- a/include/sass/values.h
+++ b/include/sass/values.h
@@ -29,7 +29,8 @@ enum Sass_Tag {
 // Tags for denoting Sass list separators
 enum Sass_Separator {
   SASS_COMMA,
-  SASS_SPACE
+  SASS_SPACE,
+  SASS_HASH
 };
 
 // Value Operators

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1880,17 +1880,112 @@ namespace Sass {
     if (empty()) return res;
     if (is_invisible()) return res;
     bool items_output = false;
-    std::string sep = separator() == SASS_COMMA ? "," : " ";
+    std::string sep = separator() == SASS_SPACE ? " " : ",";
     if (!compressed && sep == ",") sep += " ";
     for (size_t i = 0, L = size(); i < L; ++i) {
+      if (separator_ == SASS_HASH)
+      { sep[0] = i % 2 ? ':' : ','; }
       Expression* item = (*this)[i];
       if (item->is_invisible()) continue;
       if (items_output) res += sep;
-      if (Value* v_val = dynamic_cast<Value*>(item))
-      { res += v_val->to_string(compressed, precision); }
+      if (Expression* ex = dynamic_cast<Expression*>(item))
+      { res += ex->to_string(compressed, precision); }
+      // else if (Function_Call* v_fn = dynamic_cast<Function_Call*>(item))
+      // { res += v_fn->to_string(compressed, precision); }
+      else { res += "[unknown type]"; }
       items_output = true;
     }
     return res;
+  }
+
+  std::string Function_Call::to_string(bool compressed, int precision) const
+  {
+    std::string str(name());
+    str += "(";
+    str += arguments()->to_string(compressed, precision);
+    str += ")";
+    return str;
+  }
+
+  std::string Arguments::to_string(bool compressed, int precision) const
+  {
+    std::string str("");
+    for(auto arg : elements()) {
+      if (str != "") str += compressed ? "," : ", ";
+      str += arg->to_string(compressed, precision);
+    }
+    return str;
+  }
+
+  std::string Argument::to_string(bool compressed, int precision) const
+  {
+    return value()->to_string(compressed, precision);
+  }
+
+  std::string Binary_Expression::to_string(bool compressed, int precision) const
+  {
+    std::string str("");
+    str += left()->to_string(compressed, precision);
+    if (!compressed) str += " ";
+    switch (type()) {
+      case Sass_OP::AND: str += "and"; break;
+      case Sass_OP::OR:  str += "or";  break;
+      case Sass_OP::EQ:  str += "==";  break;
+      case Sass_OP::NEQ: str += "!=";  break;
+      case Sass_OP::GT:  str += ">";   break;
+      case Sass_OP::GTE: str += ">=";  break;
+      case Sass_OP::LT:  str += "<";   break;
+      case Sass_OP::LTE: str += "<=";  break;
+      case Sass_OP::ADD: str += "+";   break;
+      case Sass_OP::SUB: str += "-";   break;
+      case Sass_OP::MUL: str += "*";   break;
+      case Sass_OP::DIV: str += "/"; break;
+      case Sass_OP::MOD: str += "%";   break;
+      default: break; // shouldn't get here
+    }
+    if (!compressed) str += " ";
+    str += right()->to_string(compressed, precision);
+    return str;
+  }
+  std::string Textual::to_string(bool compressed, int precision) const
+  {
+    return value();
+  }
+  std::string Variable::to_string(bool compressed, int precision) const
+  {
+    return name();
+  }
+
+  // For now it seems easiest to just implement these, since we need it to
+  // ie. report the values as is for error reporting (like duplicate keys).
+  // We cannot use inspect since we do not always have a context object.
+  std::string Unary_Expression::to_string(bool compressed, int precision) const
+  {
+    return "[Unary_Expression.to_string not implemented]";
+  }
+  std::string Function_Call_Schema::to_string(bool compressed, int precision) const
+  {
+    return "[Function_Call_Schema.to_string not implemented]";
+  }
+  std::string Media_Query::to_string(bool compressed, int precision) const
+  {
+    return "[Media_Query.to_string not implemented]";
+  }
+  std::string Media_Query_Expression::to_string(bool compressed, int precision) const
+  {
+    return "[Media_Query_Expression.to_string not implemented]";
+  }
+  std::string Supports_Condition::to_string(bool compressed, int precision) const
+  {
+    return "[Supports_Condition.to_string not implemented]";
+  }
+  std::string At_Root_Expression::to_string(bool compressed, int precision) const
+  {
+    return "[At_Root_Expression.to_string not implemented]";
+  }
+  std::string Thunk::to_string(bool compressed, int precision) const
+  {
+    return "[Thunk.to_string not implemented]";
   }
 
   std::string String_Schema::to_string(bool compressed, int precision) const
@@ -1923,6 +2018,54 @@ namespace Sass {
     else                return c;
   }
 
+  std::string Color::to_hex(bool compressed, int precision) const
+  {
+
+    std::stringstream ss;
+
+    // original color name
+    // maybe an unknown token
+    std::string name = disp();
+
+    // resolved color
+    std::string res_name = name;
+
+    double r = Sass::round(cap_channel<0xff>(r_));
+    double g = Sass::round(cap_channel<0xff>(g_));
+    double b = Sass::round(cap_channel<0xff>(b_));
+    double a = cap_channel<1>   (a_);
+
+    // get color from given name (if one was given at all)
+    if (name != "" && name_to_color(name)) {
+      const Color* n = name_to_color(name);
+      r = Sass::round(cap_channel<0xff>(n->r()));
+      g = Sass::round(cap_channel<0xff>(n->g()));
+      b = Sass::round(cap_channel<0xff>(n->b()));
+      a = cap_channel<1>   (n->a());
+    }
+    // otherwise get the possible resolved color name
+    else {
+      double numval = r * 0x10000 + g * 0x100 + b;
+      if (color_to_name(numval))
+        res_name = color_to_name(numval);
+    }
+
+    std::stringstream hexlet;
+    hexlet << '#' << std::setw(1) << std::setfill('0');
+    // create a short color hexlet if there is any need for it
+    if (compressed && is_color_doublet(r, g, b) && a == 1) {
+      hexlet << std::hex << std::setw(1) << (static_cast<unsigned long>(r) >> 4);
+      hexlet << std::hex << std::setw(1) << (static_cast<unsigned long>(g) >> 4);
+      hexlet << std::hex << std::setw(1) << (static_cast<unsigned long>(b) >> 4);
+    } else {
+      hexlet << std::hex << std::setw(2) << static_cast<unsigned long>(r);
+      hexlet << std::hex << std::setw(2) << static_cast<unsigned long>(g);
+      hexlet << std::hex << std::setw(2) << static_cast<unsigned long>(b);
+    }
+
+    return hexlet.str();
+
+  }
   std::string Color::to_string(bool compressed, int precision) const
   {
     std::stringstream ss;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -539,7 +539,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "List " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " (" << expression->length() << ") " <<
-      (expression->separator() == SASS_COMMA ? "Comma " : "Space ") <<
+      (expression->separator() == SASS_COMMA ? "Comma " : expression->separator() == SASS_HASH ? "Map" : "Space ") <<
       " [delayed: " << expression->is_delayed() << "] " <<
       " [interpolant: " << expression->is_interpolant() << "] " <<
       " [arglist: " << expression->is_arglist() << "] " <<

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -381,6 +381,8 @@ namespace Sass {
     else if (list->separator() == SASS_COMMA) in_comma_array = true;
 
     for (size_t i = 0, L = list->size(); i < L; ++i) {
+      if (list->separator() == SASS_HASH)
+      { sep[0] = i % 2 ? ':' : ','; }
       Expression* list_item = (*list)[i];
       if (list_item->is_invisible()) {
         continue;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -427,8 +427,11 @@ namespace Sass {
       bool is_keyword = false;
       Expression* val = parse_space_list();
       val->is_delayed(false);
+      List* l = dynamic_cast<List*>(val);
       if (lex_css< exactly< ellipsis > >()) {
-        if (val->concrete_type() == Expression::MAP) is_keyword = true;
+        if (val->concrete_type() == Expression::MAP || (
+           (l != NULL && l->separator() == SASS_HASH)
+        )) is_keyword = true;
         else is_arglist = true;
       }
       arg = SASS_MEMORY_NEW(ctx.mem, Argument, pstate, val, "", is_arglist, is_keyword);
@@ -981,7 +984,7 @@ namespace Sass {
   Expression* Parser::parse_map()
   {
     Expression* key = parse_list();
-    Map* map = SASS_MEMORY_NEW(ctx.mem, Map, pstate, 1);
+    List* map = SASS_MEMORY_NEW(ctx.mem, List, pstate, 0, SASS_HASH);
     if (String_Quoted* str = dynamic_cast<String_Quoted*>(key)) {
       if (!str->quote_mark() && !str->is_delayed()) {
         if (const Color* col = name_to_color(str->value())) {
@@ -999,7 +1002,7 @@ namespace Sass {
 
     Expression* value = parse_space_list();
 
-    (*map) << std::make_pair(key, value);
+    (*map) << key << value;
 
     while (lex_css< exactly<','> >())
     {
@@ -1024,7 +1027,7 @@ namespace Sass {
 
       Expression* value = parse_space_list();
 
-      (*map) << std::make_pair(key, value);
+      (*map) << key << value;
     }
 
     ParserState ps = map->pstate();


### PR DESCRIPTION
This finally fixes #1169, which was caused by a severe bug with how we handle maps!
Additional Spec-Tests: https://github.com/sass/sass-spec/pull/623

The current behavior seems rather random and I didn't care to check when exactly it wouldn't work as expected. The bug is rather obvious, as can be seen with the [following example] [1]:
```
$map: (
  random(): foo,
  random(): bar
);
```

This will currently result in a duplicate key error. The parser actually already creates a map for the given sass code above, which will never work correctly, since we only know the actual keys after the evaluation phase (which is not available to the parser). It feels rather natural to use an even-sized list to carry it over to the evaluation phase, and create the actual map there.

A lot of languages allow the creation of maps from even-sized lists, so it felt natural to extend the existing List class to support this. But we only use this internally (from an external point, we only have space and comma separated lists). Unsure if sass can convert hash maps to lists and vice versa?

The error reporting is once again rather funky. It will always report the hex representation for duplicate color keys. This is the first time I see this happen and our codebase didn't support that in anyway without adding a new function just to get that representation (it's not `to_string` nor `inspect`).

ToDo:

- [x] Implement `to_string` for missing expression types
- [x] Re-use new `to_string` functions in CRTP visitors

[1]: http://libsass.ocbnet.ch/srcmap/#JG1hcDogKAogIHJhbmRvbSgpOiBmb28sCiAgcmFuZG9tKCk6IGJhcgopOw==