### PR TITLE
[WIP] Refactor interpolation

### DIFF
--- a/include/sass/values.h
+++ b/include/sass/values.h
@@ -29,7 +29,8 @@ enum Sass_Tag {
 // Tags for denoting Sass list separators
 enum Sass_Separator {
   SASS_COMMA,
-  SASS_SPACE
+  SASS_SPACE,
+  SASS_HASH
 };
 
 // Value Operators

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1815,17 +1815,109 @@ namespace Sass {
     if (empty()) return res;
     if (is_invisible()) return res;
     bool items_output = false;
-    std::string sep = separator() == SASS_COMMA ? "," : " ";
+    std::string sep = separator() == SASS_SPACE ? " " : ",";
     if (!compressed && sep == ",") sep += " ";
     for (size_t i = 0, L = size(); i < L; ++i) {
+      if (separator_ == SASS_HASH)
+      { sep[0] = i % 2 ? ':' : ','; }
       Expression* item = (*this)[i];
       if (item->is_invisible()) continue;
       if (items_output) res += sep;
       if (Value* v_val = dynamic_cast<Value*>(item))
       { res += v_val->to_string(compressed, precision); }
+      else if (Function_Call* v_fn = dynamic_cast<Function_Call*>(item))
+      { res += v_fn->to_string(compressed, precision); }
+      else { res += "[unknown type]"; }
       items_output = true;
     }
     return res;
+  }
+
+  std::string Function_Call::to_string(bool compressed, int precision) const
+  {
+    std::string str(name());
+    str += "(";
+    str += arguments()->to_string(compressed, precision);
+    str += ")";
+    return str;
+  }
+
+  std::string Arguments::to_string(bool compressed, int precision) const
+  {
+    std::string str("");
+    for(auto arg : elements()) {
+      if (str != "") str += compressed ? "," : ", ";
+      str += arg->to_string(compressed, precision);
+    }
+    return str;
+  }
+
+  std::string Argument::to_string(bool compressed, int precision) const
+  {
+    return value()->to_string(compressed, precision);
+  }
+
+  std::string Binary_Expression::to_string(bool compressed, int precision) const
+  {
+    std::string str("");
+    str += left()->to_string(compressed, precision);
+    if (!compressed) str += " ";
+    switch (type()) {
+      case Sass_OP::AND: str += "and"; break;
+      case Sass_OP::OR:  str += "or";  break;
+      case Sass_OP::EQ:  str += "==";  break;
+      case Sass_OP::NEQ: str += "!=";  break;
+      case Sass_OP::GT:  str += ">";   break;
+      case Sass_OP::GTE: str += ">=";  break;
+      case Sass_OP::LT:  str += "<";   break;
+      case Sass_OP::LTE: str += "<=";  break;
+      case Sass_OP::ADD: str += "+";   break;
+      case Sass_OP::SUB: str += "-";   break;
+      case Sass_OP::MUL: str += "*";   break;
+      case Sass_OP::DIV: str += "/"; break;
+      case Sass_OP::MOD: str += "%";   break;
+      default: break; // shouldn't get here
+    }
+    if (!compressed) str += " ";
+    str += right()->to_string(compressed, precision);
+    return str;
+  }
+  std::string Unary_Expression::to_string(bool compressed, int precision) const
+  {
+    return "Unary_Expression";
+  }
+  std::string Function_Call_Schema::to_string(bool compressed, int precision) const
+  {
+    return "Function_Call_Schema";
+  }
+  std::string Textual::to_string(bool compressed, int precision) const
+  {
+    return value();
+  }
+
+  std::string Media_Query::to_string(bool compressed, int precision) const
+  {
+    return "Media_Query";
+  }
+  std::string Media_Query_Expression::to_string(bool compressed, int precision) const
+  {
+    return "Media_Query_Expression";
+  }
+  std::string Supports_Condition::to_string(bool compressed, int precision) const
+  {
+    return "Supports_Condition";
+  }
+  std::string At_Root_Expression::to_string(bool compressed, int precision) const
+  {
+    return "At_Root_Expression";
+  }
+  std::string Thunk::to_string(bool compressed, int precision) const
+  {
+    return "Thunk";
+  }
+  std::string Variable::to_string(bool compressed, int precision) const
+  {
+    return "Variable";
   }
 
   std::string String_Schema::to_string(bool compressed, int precision) const
@@ -1858,6 +1950,54 @@ namespace Sass {
     else                return c;
   }
 
+  std::string Color::to_hex(bool compressed, int precision) const
+  {
+
+    std::stringstream ss;
+
+    // original color name
+    // maybe an unknown token
+    std::string name = disp();
+
+    // resolved color
+    std::string res_name = name;
+
+    double r = Sass::round(cap_channel<0xff>(r_));
+    double g = Sass::round(cap_channel<0xff>(g_));
+    double b = Sass::round(cap_channel<0xff>(b_));
+    double a = cap_channel<1>   (a_);
+
+    // get color from given name (if one was given at all)
+    if (name != "" && name_to_color(name)) {
+      const Color* n = name_to_color(name);
+      r = Sass::round(cap_channel<0xff>(n->r()));
+      g = Sass::round(cap_channel<0xff>(n->g()));
+      b = Sass::round(cap_channel<0xff>(n->b()));
+      a = cap_channel<1>   (n->a());
+    }
+    // otherwise get the possible resolved color name
+    else {
+      double numval = r * 0x10000 + g * 0x100 + b;
+      if (color_to_name(numval))
+        res_name = color_to_name(numval);
+    }
+
+    std::stringstream hexlet;
+    hexlet << '#' << std::setw(1) << std::setfill('0');
+    // create a short color hexlet if there is any need for it
+    if (compressed && is_color_doublet(r, g, b) && a == 1) {
+      hexlet << std::hex << std::setw(1) << (static_cast<unsigned long>(r) >> 4);
+      hexlet << std::hex << std::setw(1) << (static_cast<unsigned long>(g) >> 4);
+      hexlet << std::hex << std::setw(1) << (static_cast<unsigned long>(b) >> 4);
+    } else {
+      hexlet << std::hex << std::setw(2) << static_cast<unsigned long>(r);
+      hexlet << std::hex << std::setw(2) << static_cast<unsigned long>(g);
+      hexlet << std::hex << std::setw(2) << static_cast<unsigned long>(b);
+    }
+
+    return hexlet.str();
+
+  }
   std::string Color::to_string(bool compressed, int precision) const
   {
     std::stringstream ss;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1375,14 +1375,22 @@ namespace Sass {
   // evaluation phase.
   ///////////////////////////////////////////////////////////////////////
   class String_Schema : public String, public Vectorized<Expression*> {
-    ADD_PROPERTY(bool, has_interpolants)
+    // ADD_PROPERTY(bool, has_interpolants)
     size_t hash_;
   public:
     String_Schema(ParserState pstate, size_t size = 0, bool has_interpolants = false)
-    : String(pstate), Vectorized<Expression*>(size), has_interpolants_(has_interpolants), hash_(0)
+    : String(pstate), Vectorized<Expression*>(size), hash_(0)
     { concrete_type(STRING); }
     std::string type() { return "string"; }
     static std::string type_name() { return "string"; }
+
+    void has_interpolants(bool tc) { }
+    bool has_interpolants() {
+      for (auto el : elements()) {
+        if (el->is_interpolant()) return true;
+      }
+      return false;
+    }
 
     virtual size_t hash()
     {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -129,6 +129,7 @@ namespace Sass {
     virtual bool is_false() { return false; }
     virtual bool operator== (const Expression& rhs) const { return false; }
     virtual void set_delayed(bool delayed) { is_delayed(delayed); }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
     virtual size_t hash() { return 0; }
   };
 
@@ -820,8 +821,8 @@ namespace Sass {
     std::string type() { return is_arglist_ ? "arglist" : "list"; }
     static std::string type_name() { return "list"; }
     const char* sep_string(bool compressed = false) const {
-      return separator() == SASS_COMMA ?
-        (compressed ? "," : ", ") : " ";
+      return separator() == SASS_SPACE ?
+        " " : (compressed ? "," : ", ");
     }
     bool is_invisible() const { return empty(); }
     Expression* value_at_index(size_t i);
@@ -950,6 +951,7 @@ namespace Sass {
       }
       return hash_;
     }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -998,6 +1000,7 @@ namespace Sass {
       };
       return hash_;
     }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1043,6 +1046,7 @@ namespace Sass {
       return hash_;
     }
 
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1065,6 +1069,7 @@ namespace Sass {
       has_rest_argument_(false),
       has_keyword_argument_(false)
     { }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1112,6 +1117,7 @@ namespace Sass {
       return hash_;
     }
 
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1125,6 +1131,7 @@ namespace Sass {
     Function_Call_Schema(ParserState pstate, String* n, Arguments* args)
     : Expression(pstate), name_(n), arguments_(args)
     { concrete_type(STRING); }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1156,6 +1163,7 @@ namespace Sass {
     {
       return std::hash<std::string>()(name());
     }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1199,6 +1207,7 @@ namespace Sass {
       }
       return hash_;
     }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1279,6 +1288,7 @@ namespace Sass {
     }
 
     virtual bool operator== (const Expression& rhs) const;
+    virtual std::string to_hex(bool compressed = false, int precision = 5) const;
     virtual std::string to_string(bool compressed = false, int precision = 5) const;
 
     ATTACH_OPERATIONS()
@@ -1462,6 +1472,7 @@ namespace Sass {
     : Expression(pstate), Vectorized<Media_Query_Expression*>(s),
       media_type_(t), is_negated_(n), is_restricted_(r)
     { }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1477,6 +1488,7 @@ namespace Sass {
                            Expression* f, Expression* v, bool i = false)
     : Expression(pstate), feature_(f), value_(v), is_interpolated_(i)
     { }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1503,6 +1515,7 @@ namespace Sass {
     : Expression(pstate)
     { }
     virtual bool needs_parens(Supports_Condition* cond) const { return false; }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1607,6 +1620,7 @@ namespace Sass {
         return false;
       }
     }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1680,6 +1694,7 @@ namespace Sass {
     Thunk(ParserState pstate, Expression* exp, Env* env = 0)
     : Expression(pstate), expression_(exp), environment_(env)
     { }
+    virtual std::string to_string(bool compressed = false, int precision = 5) const;
   };
 
   /////////////////////////////////////////////////////////

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -32,6 +32,7 @@
 #include "sass2scss.h"
 #include "prelexer.hpp"
 #include "emitter.hpp"
+#include "debugger.hpp"
 
 namespace Sass {
   using namespace Constants;
@@ -639,6 +640,7 @@ namespace Sass {
     Expand expand(*this, &global, &backtrace);
     Cssize cssize(*this, &backtrace);
     // expand and eval the tree
+// debug_ast(root);
     root = root->perform(&expand)->block();
     // merge and bubble certain rules
     root = root->perform(&cssize)->block();
@@ -650,6 +652,7 @@ namespace Sass {
       root->perform(&extend);
     }
 
+// debug_ast(root);
     // clean up by removing empty placeholders
     // ToDo: maybe we can do this somewhere else?
     Remove_Placeholders remove_placeholders(*this);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -419,6 +419,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Variable*>(node)) {
     Variable* expression = dynamic_cast<Variable*>(node);
     std::cerr << ind << "Variable " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->name() << "]" << std::endl;
     std::string name(expression->name());
@@ -426,6 +427,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Function_Call_Schema*>(node)) {
     Function_Call_Schema* expression = dynamic_cast<Function_Call_Schema*>(node);
     std::cerr << ind << "Function_Call_Schema " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << "" << std::endl;
     debug_ast(expression->name(), ind + "name: ", env);
@@ -433,6 +435,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Function_Call*>(node)) {
     Function_Call* expression = dynamic_cast<Function_Call*>(node);
     std::cerr << ind << "Function_Call " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->name() << "]" << std::endl;
     debug_ast(expression->arguments(), ind + " args: ", env);
@@ -473,12 +476,14 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Unary_Expression*>(node)) {
     Unary_Expression* expression = dynamic_cast<Unary_Expression*>(node);
     std::cerr << ind << "Unary_Expression " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->type() << "]" << std::endl;
     debug_ast(expression->operand(), ind + " operand: ", env);
   } else if (dynamic_cast<Binary_Expression*>(node)) {
     Binary_Expression* expression = dynamic_cast<Binary_Expression*>(node);
     std::cerr << ind << "Binary_Expression " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [delayed: " << expression->is_delayed() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->type_name() << "]" << std::endl;
@@ -487,6 +492,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Map*>(node)) {
     Map* expression = dynamic_cast<Map*>(node);
     std::cerr << ind << "Map " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [Hashed]" << std::endl;
     for (auto i : expression->elements()) {

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -414,6 +414,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     else if (expression->type() == Textual::DIMENSION) std::cerr << " [DIMENSION]";
     else if (expression->type() == Textual::HEX) std::cerr << " [HEX]";
     std::cerr << expression << " [" << expression->value() << "]";
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     if (expression->is_delayed()) std::cerr << " [delayed]";
     std::cerr << std::endl;
   } else if (dynamic_cast<Variable*>(node)) {
@@ -520,16 +521,19 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Boolean* expression = dynamic_cast<Boolean*>(node);
     std::cerr << ind << "Boolean " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->value() << "]" << std::endl;
   } else if (dynamic_cast<Color*>(node)) {
     Color* expression = dynamic_cast<Color*>(node);
     std::cerr << ind << "Color " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->r() << ":"  << expression->g() << ":" << expression->b() << "@" << expression->a() << "]" << std::endl;
   } else if (dynamic_cast<Number*>(node)) {
     Number* expression = dynamic_cast<Number*>(node);
     std::cerr << ind << "Number " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->value() << expression->unit() << "]" <<
       " [hash: " << expression->hash() << "] " <<
       std::endl;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -498,7 +498,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "List " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " (" << expression->length() << ") " <<
-      (expression->separator() == SASS_COMMA ? "Comma " : "Space ") <<
+      (expression->separator() == SASS_COMMA ? "Comma " : expression->separator() == SASS_HASH ? "Map" : "Space ") <<
       " [delayed: " << expression->is_delayed() << "] " <<
       " [interpolant: " << expression->is_interpolant() << "] " <<
       " [arglist: " << expression->is_arglist() << "] " <<

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -413,7 +413,32 @@ namespace Sass {
 
   Expression* Eval::operator()(List* l)
   {
+    // special case for unevaluated map
+    if (l->separator() == SASS_HASH) {
+      Map* lm = SASS_MEMORY_NEW(ctx.mem, Map,
+                                l->pstate(),
+                                l->length() / 2);
+      for (size_t i = 0, L = l->length(); i < L; i += 2)
+      {
+        Expression* key = (*l)[i+0]->perform(this);
+        Expression* val = (*l)[i+1]->perform(this);
+        // make sure the color key never displays its real name
+        *lm << std::make_pair(key, val);
+      }
+      if (lm->has_duplicate_key()) {
+        To_String to_string(&ctx);
+        if (Color* col = dynamic_cast<Color*>(lm->get_duplicate_key())) {
+          error("Duplicate key " + col->to_hex() + " in map (" + l->to_string() + ").", lm->pstate());
+        } else {
+          error("Duplicate key \"" + lm->get_duplicate_key()->perform(&to_string) + "\" in map (" + l->to_string() + ").", lm->pstate());
+        }
+      }
+
+      return lm->perform(this);
+    }
+    // check if we should expand it
     if (l->is_expanded()) return l;
+    // regular case for unevaluated lists
     List* ll = SASS_MEMORY_NEW(ctx.mem, List,
                                l->pstate(),
                                l->length(),

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -423,6 +423,7 @@ namespace Sass {
         Expression* key = (*l)[i+0]->perform(this);
         Expression* val = (*l)[i+1]->perform(this);
         // make sure the color key never displays its real name
+        key->is_delayed(true);
         *lm << std::make_pair(key, val);
       }
       if (lm->has_duplicate_key()) {
@@ -434,6 +435,7 @@ namespace Sass {
         }
       }
 
+      lm->is_interpolant(l->is_interpolant());
       return lm->perform(this);
     }
     // check if we should expand it
@@ -447,6 +449,7 @@ namespace Sass {
     for (size_t i = 0, L = l->length(); i < L; ++i) {
       *ll << (*l)[i]->perform(this);
     }
+    ll->is_interpolant(l->is_interpolant());
     ll->is_expanded(true);
     return ll;
   }
@@ -640,6 +643,7 @@ namespace Sass {
       if (String_Constant* org = lstr ? lstr : rstr)
       { str->quote_mark(org->quote_mark()); }
     }
+    ex->is_interpolant(b->is_interpolant());
     return ex;
 
   }
@@ -702,9 +706,11 @@ namespace Sass {
         if (args->has_named_arguments()) {
           error("Function " + c->name() + " doesn't support keyword arguments", c->pstate());
         }
-        return SASS_MEMORY_NEW(ctx.mem, String_Quoted,
-                               c->pstate(),
-                               lit->perform(&to_string));
+        String_Quoted* str = SASS_MEMORY_NEW(ctx.mem, String_Quoted,
+                                             c->pstate(),
+                                             lit->perform(&to_string));
+        str->is_interpolant(c->is_interpolant());
+        return str;
       } else {
         // call generic function
         full_name = "*[f]";
@@ -792,6 +798,7 @@ namespace Sass {
 
     result->is_delayed(result->concrete_type() == Expression::STRING);
     if (!result->is_delayed()) result = result->perform(this);
+    result->is_interpolant(c->is_interpolant());
     exp.env_stack.pop_back();
     return result;
   }
@@ -848,6 +855,7 @@ namespace Sass {
     }
 
     // std::cerr << "\ttype is now: " << typeid(*value).name() << std::endl << std::endl;
+    value->is_interpolant(v->is_interpolant());
     return value;
   }
 
@@ -917,6 +925,7 @@ namespace Sass {
         }
       } break;
     }
+    result->is_interpolant(t->is_interpolant());
     return result;
   }
 
@@ -942,126 +951,159 @@ namespace Sass {
     }
   }
 
-  std::string Eval::interpolation(Expression* s, bool into_quotes) {
-    Env* env = environment();
-    if (String_Quoted* str_quoted = dynamic_cast<String_Quoted*>(s)) {
-      if (str_quoted->quote_mark()) {
-        if (str_quoted->quote_mark() == '*' || str_quoted->is_delayed()) {
-          return evacuate_escapes(str_quoted->value());
-        } else {
-          return string_escape(quote(str_quoted->value(), str_quoted->quote_mark()));
-        }
-      } else {
-        return evacuate_escapes(str_quoted->value());
-      }
-    } else if (String_Constant* str_constant = dynamic_cast<String_Constant*>(s)) {
-      if (into_quotes && !str_constant->is_interpolant()) return str_constant->value();
-      return evacuate_escapes(str_constant->value());
-    } else if (dynamic_cast<Parent_Selector*>(s)) {
-      To_String to_string(&ctx);
-      Expression* sel = s->perform(this);
-      return evacuate_quotes(sel ? sel->perform(&to_string) : "");
+  void Eval::interpolation(Context& ctx, std::string& res, Expression* ex, bool into_quotes, bool was_itpl) {
+    int precision = (int)ctx.c_options->precision;
+    bool compressed = ctx.output_style() == SASS_STYLE_COMPRESSED;
+    bool needs_closing_brace = false;
 
-    } else if (String_Schema* str_schema = dynamic_cast<String_Schema*>(s)) {
-      // To_String to_string(&ctx);
-      // return evacuate_quotes(str_schema->perform(&to_string));
-
-      std::string res = "";
-      for(auto i : str_schema->elements())
-        res += (interpolation(i));
-      //ToDo: do this in one step
-      auto esc = evacuate_escapes(res);
-      auto unq = unquote(esc);
-      if (unq == esc) {
-        return string_to_output(res);
-      } else {
-        return evacuate_quotes(unq);
+// std::cerr << "IN\n";
+    if (Arguments* args = dynamic_cast<Arguments*>(ex)) {
+      List* ll = SASS_MEMORY_NEW(ctx.mem, List, args->pstate(), 0, SASS_COMMA);
+      for(auto arg : *args) {
+        *ll << arg->value();
       }
-    } else if (List* list = dynamic_cast<List*>(s)) {
-      std::string acc = ""; // ToDo: different output styles
-      std::string sep = list->separator() == SASS_COMMA ? "," : " ";
-      if (ctx.output_style() != SASS_STYLE_COMPRESSED && sep == ",") sep += " ";
-      bool initial = false;
-      for(auto item : list->elements()) {
-        if (item->concrete_type() != Expression::NULL_VAL) {
-          if (initial) acc += sep;
-          acc += interpolation(item);
-          initial = true;
-        }
-      }
-      return evacuate_quotes(acc);
-    } else if (Variable* var = dynamic_cast<Variable*>(s)) {
-      std::string name(var->name());
-      if (!env->has(name)) error("Undefined variable: \"" + var->name() + "\".", var->pstate());
-      Expression* value = static_cast<Expression*>((*env)[name]);
-      return evacuate_quotes(interpolation(value));
-    } else if (dynamic_cast<Binary_Expression*>(s)) {
-      Expression* ex = s->perform(this);
-      // avoid recursive calls if same object gets returned
-      // since we will call interpolate again for the result
-      if (ex == s) {
-        To_String to_string(&ctx);
-        return evacuate_quotes(s->perform(&to_string));
-      }
-      return evacuate_quotes(interpolation(ex));
-    } else if (dynamic_cast<Function_Call*>(s)) {
-      Expression* ex = s->perform(this);
-      return evacuate_quotes(unquote(interpolation(ex)));
-    } else if (dynamic_cast<Unary_Expression*>(s)) {
-      Expression* ex = s->perform(this);
-      return evacuate_quotes(interpolation(ex));
-    } else if (dynamic_cast<Map*>(s)) {
-      To_String to_string(&ctx);
-      std::string dbg(s->perform(&to_string));
-      error(dbg + " isn't a valid CSS value.", s->pstate());
-      return dbg;
-    } else {
-      To_String to_string(&ctx);
-      return evacuate_quotes(s->perform(&to_string));
+      ll->is_interpolant(args->is_interpolant());
+      needs_closing_brace = true;
+      res += "(";
+      ex = ll;
     }
+    if (Argument* arg = dynamic_cast<Argument*>(ex)) {
+      ex = arg->value();
+    }
+    if (String_Constant* sq = dynamic_cast<String_Quoted*>(ex)) {
+      if (was_itpl) {
+        bool was_interpolant = ex->is_interpolant();
+        ex = SASS_MEMORY_NEW(ctx.mem, String_Constant, sq->pstate(), sq->value());
+        ex->is_interpolant(was_interpolant);
+      }
+    }
+    if (dynamic_cast<Null*>(ex)) { return; }
+
+    if (List* l = dynamic_cast<List*>(ex)) {
+      List* ll = SASS_MEMORY_NEW(ctx.mem, List, l->pstate(), 0, l->separator());
+      for(auto item : *l) {
+        item->is_interpolant(l->is_interpolant());
+        std::string rl(""); interpolation(ctx, rl, item, into_quotes, l->is_interpolant());
+        if (rl != "") *ll << SASS_MEMORY_NEW(ctx.mem, String_Quoted, item->pstate(), rl);
+      }
+      To_String to_string(&ctx);
+      res += (ll->to_string(compressed, precision));
+      ll->is_interpolant(l->is_interpolant());
+    }
+
+    else if (String_Quoted* val = dynamic_cast<String_Quoted*>(ex)) {
+      To_String to_string(&ctx);
+      if (into_quotes && val->is_interpolant()) {
+        res += evacuate_escapes(val->to_string(compressed, precision));
+        // res += evacuate_escapes(val ? val->perform(&to_string) : "");
+      } else {
+        res += val->to_string(compressed, precision);
+        // res += val ? val->perform(&to_string) : "";
+      }
+    }
+    else if (String_Constant* val = dynamic_cast<String_Constant*>(ex)) {
+      To_String to_string(&ctx);
+      if (into_quotes && val->is_interpolant()) {
+        res += evacuate_escapes(val->to_string(compressed, precision));
+        // res += evacuate_escapes(val ? val->perform(&to_string) : "");
+      } else {
+        val->quote_mark(0);
+        res += val->to_string(compressed, precision);
+        // res += val ? val->perform(&to_string) : "";
+      }
+    }
+    else if (Value* val = dynamic_cast<Value*>(ex)) {
+      To_String to_string(&ctx);
+      if (into_quotes && val->is_interpolant()) {
+        res += evacuate_escapes(val->to_string(compressed, precision));
+        // res += evacuate_escapes(val ? val->perform(&to_string) : "");
+      } else {
+        res += val->to_string(compressed, precision);
+        // res += val ? val->perform(&to_string) : "";
+      }
+    }
+    else if (Textual* val = dynamic_cast<Textual*>(ex)) {
+      To_String to_string(&ctx);
+      if (into_quotes && val->is_interpolant()) {
+
+        res += evacuate_escapes(val ? val->perform(&to_string) : "");
+      } else {
+        res += val ? val->perform(&to_string) : "";
+      }
+    }
+    else if (Binary_Expression* val = dynamic_cast<Binary_Expression*>(ex)) {
+      To_String to_string(&ctx);
+      if (into_quotes && val->is_interpolant()) {
+
+        res += evacuate_escapes(val ? val->perform(&to_string) : "");
+      } else {
+        res += val ? val->perform(&to_string) : "";
+      }
+    }
+
+    else if (Parent_Selector* pr = dynamic_cast<Parent_Selector*>(ex)) {
+      To_String to_string(&ctx);
+      Expression* sel = pr->perform(this);
+      if (into_quotes && sel->is_interpolant()) {
+        res += evacuate_escapes(sel ? sel->perform(&to_string) : "");
+      } else {
+        res += sel ? sel->perform(&to_string) : "";
+      }
+    }
+    else if (Selector_List* sl = dynamic_cast<Selector_List*>(ex)) {
+
+      if (into_quotes) {
+        res += evacuate_escapes(sl->to_string(compressed, precision));
+      } else {
+        res += sl->to_string(compressed, precision);
+      }
+    }
+    else if (dynamic_cast<Function_Call*>(ex)) {
+      throw std::runtime_error("fn not handlerd");
+    }
+    else {
+      throw std::runtime_error(ex->type());
+    }
+
+    if (needs_closing_brace) res += ")";
+
+// std::cerr << "OUT\n";
   }
 
   Expression* Eval::operator()(String_Schema* s)
   {
-    std::string acc;
-    bool into_quotes = false;
     size_t L = s->length();
+    bool into_quotes = false;
     if (L > 1) {
+      if (!dynamic_cast<String_Quoted*>((*s)[0]) && !dynamic_cast<String_Quoted*>((*s)[L - 1])) {
       if (String_Constant* l = dynamic_cast<String_Constant*>((*s)[0])) {
         if (String_Constant* r = dynamic_cast<String_Constant*>((*s)[L - 1])) {
           if (l->value()[0] == '"' && r->value()[r->value().size() - 1] == '"') into_quotes = true;
           if (l->value()[0] == '\'' && r->value()[r->value().size() - 1] == '\'') into_quotes = true;
         }
       }
-    }
-    for (size_t i = 0; i < L; ++i) {
-      // really a very special fix, but this is the logic I got from
-      // analyzing the ruby sass behavior and it actually seems to work
-      // https://github.com/sass/libsass/issues/1333
-      if (i == 0 && L > 1 && dynamic_cast<Function_Call*>((*s)[i])) {
-        Expression* ex = (*s)[i]->perform(this);
-        if (auto sq = dynamic_cast<String_Quoted*>(ex)) {
-          if (sq->is_delayed() && ! s->has_interpolants()) {
-            acc += string_escape(quote(sq->value(), sq->quote_mark()));
-          } else {
-            acc += interpolation((*s)[i], into_quotes);
-          }
-        } else if (ex) {
-          acc += interpolation((*s)[i], into_quotes);
-        }
-      } else if ((*s)[i]) {
-        acc += interpolation((*s)[i], into_quotes);
       }
     }
-    String_Quoted* str = SASS_MEMORY_NEW(ctx.mem, String_Quoted, s->pstate(), acc);
-    if (!str->quote_mark()) {
-      str->value(string_unescape(str->value()));
-    } else if (str->quote_mark()) {
-      str->quote_mark('*');
+    std::string res("");
+    for (size_t i = 0; i < L; ++i) {
+      (*s)[i]->perform(this);
+      Expression* ex = (*s)[i]->is_delayed() ? (*s)[i] : (*s)[i]->perform(this);
+      interpolation(ctx, res, ex, into_quotes, ex->is_interpolant());
+
     }
-    str->is_delayed(true);
+    if (!s->is_interpolant()) {
+      if (res == "") return SASS_MEMORY_NEW(ctx.mem, Null, s->pstate());
+      return SASS_MEMORY_NEW(ctx.mem, String_Constant, s->pstate(), res);
+    }
+    String_Quoted* str = SASS_MEMORY_NEW(ctx.mem, String_Quoted, s->pstate(), res);
+    // if (s->is_interpolant()) str->quote_mark(0);
+    // String_Constant* str = SASS_MEMORY_NEW(ctx.mem, String_Constant, s->pstate(), res);
+    if (str->quote_mark()) str->quote_mark('*');
+    else if (!is_in_comment) str->value(string_to_output(str->value()));
+    str->is_interpolant(s->is_interpolant());
     return str;
   }
+
 
   Expression* Eval::operator()(String_Constant* s)
   {
@@ -1076,7 +1118,11 @@ namespace Sass {
 
   Expression* Eval::operator()(String_Quoted* s)
   {
-    return s;
+    String_Quoted* str = SASS_MEMORY_NEW(ctx.mem, String_Quoted, s->pstate(), "");
+    str->value(s->value());
+    str->quote_mark(s->quote_mark());
+    str->is_interpolant(s->is_interpolant());
+    return str;
   }
 
   Expression* Eval::operator()(Supports_Operator* c)

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -23,6 +23,8 @@ namespace Sass {
     Eval(Expand& exp);
     virtual ~Eval();
 
+    bool is_in_comment;
+
     Env* environment();
     Context& context();
     Selector_List* selector();
@@ -96,7 +98,7 @@ namespace Sass {
     static Value* op_strings(Memory_Manager&, enum Sass_OP, Value&, Value&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
 
   private:
-    std::string interpolation(Expression* s, bool into_quotes = false);
+    void interpolation(Context& ctx, std::string& res, Expression* ex, bool into_quotes, bool was_itpl = false);
 
   };
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -355,8 +355,11 @@ namespace Sass {
 
   Statement* Expand::operator()(Comment* c)
   {
+    eval.is_in_comment = true;
+    auto rv = SASS_MEMORY_NEW(ctx.mem, Comment, c->pstate(), static_cast<String*>(c->text()->perform(&eval)), c->is_important());
+    eval.is_in_comment = false;
     // TODO: eval the text, once we're parsing/storing it as a String_Schema
-    return SASS_MEMORY_NEW(ctx.mem, Comment, c->pstate(), static_cast<String*>(c->text()->perform(&eval)), c->is_important());
+    return rv;
   }
 
   Statement* Expand::operator()(If* i)

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -381,6 +381,8 @@ namespace Sass {
     else if (list->separator() == SASS_COMMA) in_comma_array = true;
 
     for (size_t i = 0, L = list->size(); i < L; ++i) {
+      if (list->separator() == SASS_HASH)
+      { sep[0] = i % 2 ? ':' : ','; }
       Expression* list_item = (*list)[i];
       if (list_item->is_invisible()) {
         continue;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -431,8 +431,11 @@ namespace Sass {
       bool is_keyword = false;
       Expression* val = parse_space_list();
       val->is_delayed(false);
+      List* l = dynamic_cast<List*>(val);
       if (lex_css< exactly< ellipsis > >()) {
-        if (val->concrete_type() == Expression::MAP) is_keyword = true;
+        if (val->concrete_type() == Expression::MAP || (
+           (l != NULL && l->separator() == SASS_HASH)
+        )) is_keyword = true;
         else is_arglist = true;
       }
       arg = SASS_MEMORY_NEW(ctx.mem, Argument, pstate, val, "", is_arglist, is_keyword);
@@ -971,7 +974,7 @@ namespace Sass {
   Expression* Parser::parse_map()
   {
     Expression* key = parse_list();
-    Map* map = SASS_MEMORY_NEW(ctx.mem, Map, pstate, 1);
+    List* map = SASS_MEMORY_NEW(ctx.mem, List, pstate, 0, SASS_HASH);
     if (String_Quoted* str = dynamic_cast<String_Quoted*>(key)) {
       if (!str->quote_mark() && !str->is_delayed()) {
         if (const Color* col = name_to_color(str->value())) {
@@ -991,7 +994,7 @@ namespace Sass {
 
     Expression* value = parse_space_list();
 
-    (*map) << std::make_pair(key, value);
+    (*map) << key << value;
 
     while (lex_css< exactly<','> >())
     {
@@ -1016,7 +1019,7 @@ namespace Sass {
 
       Expression* value = parse_space_list();
 
-      (*map) << std::make_pair(key, value);
+      (*map) << key << value;
     }
 
     ParserState ps = map->pstate();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1403,6 +1403,7 @@ namespace Sass {
     }
 
     String_Schema* schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate);
+    schema->is_interpolant(true);
     while (i < chunk.end) {
       p = find_first_in_interval< exactly<hash_lbrace> >(i, chunk.end);
       if (p) {
@@ -1550,11 +1551,14 @@ namespace Sass {
         if (peek< exactly< rbrace > >()) {
           css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
         }
+        Expression* ex = 0;
         if (lex< re_static_expression >()) {
-          (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
+          ex = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
         } else {
-          (*schema) << parse_list();
+          ex = parse_list();
         }
+        ex->is_interpolant(true);
+        (*schema) << ex;
         // ToDo: no error check here?
         lex < exactly < rbrace > >();
       }

--- a/src/subset_map.hpp
+++ b/src/subset_map.hpp
@@ -94,7 +94,6 @@ namespace Sass {
     { ss.insert(s[i]); }
     for (size_t i = 0, S = s.size(); i < S; ++i)
     {
-      hash_[s[i]];
       hash_[s[i]].push_back(make_triple(s, ss, index));
     }
   }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -104,94 +104,6 @@ namespace Sass {
     return *array = arr;
   }
 
-  std::string string_eval_escapes(const std::string& s)
-  {
-
-    std::string out("");
-    bool esc = false;
-    for (size_t i = 0, L = s.length(); i < L; ++i) {
-      if(s[i] == '\\' && esc == false) {
-        esc = true;
-
-        // escape length
-        size_t len = 1;
-
-        // parse as many sequence chars as possible
-        // ToDo: Check if ruby aborts after possible max
-        while (i + len < L && s[i + len] && isxdigit(s[i + len])) ++ len;
-
-        // hex string?
-        if (len > 1) {
-
-          // convert the extracted hex string to code point value
-          // ToDo: Maybe we could do this without creating a substring
-          uint32_t cp = strtol(s.substr (i + 1, len - 1).c_str(), NULL, 16);
-
-          if (cp == 0) cp = 0xFFFD;
-
-          // assert invalid code points
-          if (cp >= 1) {
-
-            // use a very simple approach to convert via utf8 lib
-            // maybe there is a more elegant way; maybe we shoud
-            // convert the whole output from string to a stream!?
-            // allocate memory for utf8 char and convert to utf8
-            unsigned char u[5] = {0,0,0,0,0}; utf8::append(cp, u);
-            for(size_t m = 0; u[m] && m < 5; m++) out.push_back(u[m]);
-
-            // skip some more chars?
-            i += len - 1; esc = false;
-            if (cp == 10) out += ' ';
-
-          }
-
-        }
-
-      }
-      else {
-        out += s[i];
-        esc = false;
-      }
-    }
-    return out;
-
-  }
-
-  // double escape every escape sequences
-  // escape unescaped quotes and backslashes
-  std::string string_escape(const std::string& str)
-  {
-    std::string out("");
-    for (auto i : str) {
-      // escape some characters
-      if (i == '"') out += '\\';
-      if (i == '\'') out += '\\';
-      if (i == '\\') out += '\\';
-      out += i;
-    }
-    return out;
-  }
-
-  // unescape every escape sequence
-  // only removes unescaped backslashes
-  std::string string_unescape(const std::string& str)
-  {
-    std::string out("");
-    bool esc = false;
-    for (auto i : str) {
-      if (esc || i != '\\') {
-        esc = false;
-        out += i;
-      } else {
-        esc = true;
-      }
-    }
-    // open escape sequence at end
-    // maybe it should thow an error
-    if (esc) { out += '\\'; }
-    return out;
-  }
-
   // read css string (handle multiline DELIM)
   std::string read_css_string(const std::string& str)
   {
@@ -212,28 +124,6 @@ namespace Sass {
       out.push_back(i);
     }
     if (esc) out += '\\';
-    return out;
-  }
-
-  // evacuate unescaped quoted
-  // leave everything else untouched
-  std::string evacuate_quotes(const std::string& str)
-  {
-    std::string out("");
-    bool esc = false;
-    for (auto i : str) {
-      if (!esc) {
-        // ignore next character
-        if (i == '\\') esc = true;
-        // evacuate unescaped quotes
-        else if (i == '"') out += '\\';
-        else if (i == '\'') out += '\\';
-      }
-      // get escaped char now
-      else { esc = false; }
-      // remove nothing
-      out += i;
-    }
     return out;
   }
 
@@ -278,7 +168,9 @@ namespace Sass {
     std::string out("");
     bool lf = false;
     for (auto i : str) {
-      if (i == 10) {
+      if (i == 13) {
+        lf = true;
+      } if (i == 10) {
         out += ' ';
         lf = true;
       } else if (!(lf && isspace(i))) {
@@ -319,38 +211,6 @@ namespace Sass {
     }
     if (has) return str;
     else return text;
-  }
-
-   std::string normalize_wspace(const std::string& str)
-  {
-    bool ws = false;
-    bool esc = false;
-    std::string text = "";
-    for(const char& i : str) {
-      if (!esc && i == '\\') {
-        esc = true;
-        ws = false;
-        text += i;
-      } else if (esc) {
-        esc = false;
-        ws = false;
-        text += i;
-      } else if (
-        i == ' ' ||
-        i == '\r' ||
-        i == '\n' ||
-        i == '	'
-      ) {
-        // only add one space
-        if (!ws) text += ' ';
-        ws = true;
-      } else {
-        ws = false;
-        text += i;
-      }
-    }
-    if (esc) text += '\\';
-    return text;
   }
 
   // find best quote_mark by detecting if the string contains any single

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -170,7 +170,7 @@ namespace Sass {
     for (auto i : str) {
       if (i == 13) {
         lf = true;
-      } if (i == 10) {
+      } else if (i == 10) {
         out += ' ';
         lf = true;
       } else if (!(lf && isspace(i))) {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -17,15 +17,10 @@ namespace Sass {
   const char* safe_str(const char *, const char* = "");
   void free_string_array(char **);
   char **copy_strings(const std::vector<std::string>&, char ***, int = 0);
-  std::string string_escape(const std::string& str);
-  std::string string_unescape(const std::string& str);
-  std::string string_eval_escapes(const std::string& str);
   std::string read_css_string(const std::string& str);
-  std::string evacuate_quotes(const std::string& str);
   std::string evacuate_escapes(const std::string& str);
   std::string string_to_output(const std::string& str);
   std::string comment_to_string(const std::string& text);
-  std::string normalize_wspace(const std::string& str);
 
   std::string quote(const std::string&, char q = 0, bool keep_linefeed_whitespace = false);
   std::string unquote(const std::string&, char* q = 0, bool keep_utf8_sequences = false);


### PR DESCRIPTION
Preview (WIP) of interpolation refactoring. Got rid of most of the escape vodoo.

Currently still fails in two main corners:
- [ ] missing leading white-space in argument lists (nulls in arglists)
- [ ] another white-space related bug with selector lists
- [ ] libsass issue #948 (we seem to parse it wrong, see below)

Parsed AST for issue 948:
```
Binary_Expression 0x26933f0 [interpolant: 0]  [delayed: 0]  (0@[0:11]-[0:13]) [mul]
 left:  Textual  [NUMBER]0x2693240 [10]
 right: String_Schema 0x2b15f30 4 [has_interpolants] <>
 right:  Textual  [NUMBER]0x26932d0 [5] [delayed]
 right:  String_Constant 0x2693360 4 (0@[0:19]-[0:21]) [px] [interpolant] <>
```
I guess we had a "hotfix" in place for this before. But we may just don't parse it correctly.
Edit: Seems to be related to how we handle binary_expressions, see test code below:

```scss
foo {
  bar: 10 * 5#{px};
  bar: 10 / 5#{px};
  bar: 10 + 5#{px};
  bar: 10 - 5#{px};
}
```