### PR TITLE
Improve binary expressions to preserve whitespace at operands

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -930,7 +930,28 @@ namespace Sass {
         case MUL: return "mul"; break;
         case DIV: return "div"; break;
         case MOD: return "mod"; break;
-        case NUM_OPS: return "num_ops"; break;
+        // this is only used internally!
+        case NUM_OPS: return "[OPS]"; break;
+        default: return "invalid"; break;
+      }
+    }
+    const std::string separator() {
+      switch (type()) {
+        case AND: return "&&"; break;
+        case OR: return "||"; break;
+        case EQ: return "=="; break;
+        case NEQ: return "!="; break;
+        case GT: return ">"; break;
+        case GTE: return ">="; break;
+        case LT: return "<"; break;
+        case LTE: return "<="; break;
+        case ADD: return "+"; break;
+        case SUB: return "-"; break;
+        case MUL: return "*"; break;
+        case DIV: return "/"; break;
+        case MOD: return "%"; break;
+        // this is only used internally!
+        case NUM_OPS: return "[OPS]"; break;
         default: return "invalid"; break;
       }
     }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -51,7 +51,22 @@
 
 namespace Sass {
 
+  // ToDo: should this really be hardcoded
+  // Note: most methods follow precision option
   const double NUMBER_EPSILON = 0.00000000000001;
+
+  // ToDo: where does this fit best?
+  // We don't share this with C-API?
+  class Operand {
+    public:
+      Operand(Sass_OP operand, bool ws_before = false, bool ws_after = false)
+      : operand(operand), ws_before(ws_before), ws_after(ws_after)
+      { }
+    public:
+      enum Sass_OP operand;
+      bool ws_before;
+      bool ws_after;
+  };
 
   // from boost (functional/hash):
   // http://www.boost.org/doc/libs/1_35_0/doc/html/hash/combine.html
@@ -891,17 +906,17 @@ namespace Sass {
   //////////////////////////////////////////////////////////////////////////
   class Binary_Expression : public Expression {
   private:
-    ADD_HASHED(enum Sass_OP, type)
+    ADD_HASHED(Operand, op)
     ADD_HASHED(Expression*, left)
     ADD_HASHED(Expression*, right)
     size_t hash_;
   public:
     Binary_Expression(ParserState pstate,
-                      enum Sass_OP t, Expression* lhs, Expression* rhs)
-    : Expression(pstate), type_(t), left_(lhs), right_(rhs), hash_(0)
+                      Operand op, Expression* lhs, Expression* rhs)
+    : Expression(pstate), op_(op), left_(lhs), right_(rhs), hash_(0)
     { }
     const std::string type_name() {
-      switch (type_) {
+      switch (type()) {
         case AND: return "and"; break;
         case OR: return "or"; break;
         case EQ: return "eq"; break;
@@ -944,12 +959,13 @@ namespace Sass {
     virtual size_t hash()
     {
       if (hash_ == 0) {
-        hash_ = std::hash<size_t>()(type_);
+        hash_ = std::hash<size_t>()(type());
         hash_combine(hash_, left()->hash());
         hash_combine(hash_, right()->hash());
       }
       return hash_;
     }
+    enum Sass_OP type() const { return op_.operand; }
     ATTACH_OPERATIONS()
   };
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -535,16 +535,11 @@ namespace Sass {
     String_Schema* s1 = dynamic_cast<String_Schema*>(b->left());
     String_Schema* s2 = dynamic_cast<String_Schema*>(b->right());
 
-    if ((s1 && s1->has_interpolants()) || (s2 && s2->has_interpolants())) {
-      std::string sep;
-      switch (op_type) {
-        case Sass_OP::SUB: sep = "-"; break;
-        case Sass_OP::DIV: sep = "/"; break;
-        case Sass_OP::ADD: sep = "+"; break;
-        case Sass_OP::MUL: sep = "*"; break;
-        default:                      break;
-      }
+    int precision = (int)ctx.c_options->precision;
+    bool compressed = ctx.output_style() == SASS_STYLE_COMPRESSED;
 
+    if ((s1 && s1->has_interpolants()) || (s2 && s2->has_interpolants()))
+    {
       // If possible upgrade LHS to a number
       if (op_type == Sass_OP::DIV || op_type == Sass_OP::MUL || op_type == Sass_OP::ADD || op_type == Sass_OP::SUB) {
         if (String_Constant* str = dynamic_cast<String_Constant*>(lhs)) {
@@ -572,16 +567,19 @@ namespace Sass {
       Expression::Concrete_Type r_type = rhs->concrete_type();
 
       if (l_type == Expression::NUMBER && r_type == Expression::NUMBER) {
-        return SASS_MEMORY_NEW(ctx.mem, String_Constant, lhs->pstate(),
-          v_l->to_string() + " " + sep + " " + v_r->to_string());
+        std::string str("");
+        str += v_l->to_string(compressed, precision);
+        if (b->op().ws_before) str += " ";
+        str += b->separator();
+        if (b->op().ws_after) str += " ";
+        str += v_r->to_string(compressed, precision);
+        return SASS_MEMORY_NEW(ctx.mem, String_Constant, lhs->pstate(), str);
       }
     }
 
     // ToDo: throw error in op functions
     // ToDo: then catch and re-throw them
     ParserState pstate(b->pstate());
-    int precision = (int)ctx.c_options->precision;
-    bool compressed = ctx.output_style() == SASS_STYLE_COMPRESSED;
     if (l_type == Expression::NUMBER && r_type == Expression::NUMBER) {
       const Number* l_n = dynamic_cast<const Number*>(lhs);
       const Number* r_n = dynamic_cast<const Number*>(rhs);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -541,7 +541,7 @@ namespace Sass {
     if ((s1 && s1->has_interpolants()) || (s2 && s2->has_interpolants()))
     {
       // If possible upgrade LHS to a number
-      if (op_type == Sass_OP::DIV || op_type == Sass_OP::MUL || op_type == Sass_OP::ADD || op_type == Sass_OP::SUB) {
+      if (op_type == Sass_OP::DIV || op_type == Sass_OP::MUL || op_type == Sass_OP::MOD || op_type == Sass_OP::ADD || op_type == Sass_OP::SUB) {
         if (String_Constant* str = dynamic_cast<String_Constant*>(lhs)) {
           std::string value(str->value());
           const char* start = value.c_str();

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -408,22 +408,30 @@ namespace Sass {
   void Inspect::operator()(Binary_Expression* expr)
   {
     expr->left()->perform(this);
+    if ( in_media_block || (
+          expr->op().ws_before
+          && !expr->is_delayed()
+    )) append_string(" ");
     switch (expr->type()) {
-      case Sass_OP::AND: append_string(" and "); break;
-      case Sass_OP::OR:  append_string(" or ");  break;
-      case Sass_OP::EQ:  append_string(" == ");  break;
-      case Sass_OP::NEQ: append_string(" != ");  break;
-      case Sass_OP::GT:  append_string(" > ");   break;
-      case Sass_OP::GTE: append_string(" >= ");  break;
-      case Sass_OP::LT:  append_string(" < ");   break;
-      case Sass_OP::LTE: append_string(" <= ");  break;
-      case Sass_OP::ADD: append_string(" + ");   break;
-      case Sass_OP::SUB: append_string(" - ");   break;
-      case Sass_OP::MUL: append_string(" * ");   break;
-      case Sass_OP::DIV: append_string(in_media_block ? " / " : "/"); break;
-      case Sass_OP::MOD: append_string(" % ");   break;
+      case Sass_OP::AND: append_string("&&"); break;
+      case Sass_OP::OR:  append_string("||");  break;
+      case Sass_OP::EQ:  append_string("==");  break;
+      case Sass_OP::NEQ: append_string("!=");  break;
+      case Sass_OP::GT:  append_string(">");   break;
+      case Sass_OP::GTE: append_string(">=");  break;
+      case Sass_OP::LT:  append_string("<");   break;
+      case Sass_OP::LTE: append_string("<=");  break;
+      case Sass_OP::ADD: append_string("+");   break;
+      case Sass_OP::SUB: append_string("-");   break;
+      case Sass_OP::MUL: append_string("*");   break;
+      case Sass_OP::DIV: append_string("/"); break;
+      case Sass_OP::MOD: append_string("%");   break;
       default: break; // shouldn't get here
     }
+    if ( in_media_block || (
+          expr->op().ws_after
+          && !expr->is_delayed()
+    )) append_string(" ");
     expr->right()->perform(this);
   }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1230,11 +1230,6 @@ namespace Sass {
   Expression* Parser::parse_operators()
   {
     Expression* factor = parse_factor();
-    // Special case: Ruby sass never tries to modulo if the lhs contains an interpolant
-    if (peek_css< exactly<'%'> >() && factor->concrete_type() == Expression::STRING) {
-      String_Schema* ss = dynamic_cast<String_Schema*>(factor);
-      if (ss && ss->has_interpolants()) return factor;
-    }
     // if it's a singleton, return it (don't wrap it)
     if (!peek_css< class_char< static_ops > >()) return factor;
     // parse more factors and operators

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1565,8 +1565,9 @@ namespace Sass {
         // ToDo: no error check here?
         lex < exactly < rbrace > >();
       }
-      // lex some string constants
-      else if (lex< alternatives < exactly<'%'>, exactly < '-' >, identifier > >()) {
+      // lex some string constants or other valid token
+      // Note: [-+] chars are left over from ie. `#{3}+3`
+      else if (lex< alternatives < exactly<'%'>, exactly < '-' >, exactly < '+' >, identifier > >()) {
         (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
         if (*position == '"' || *position == '\'') {
           (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, " ");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1140,7 +1140,7 @@ namespace Sass {
     // if it's a singleton, return it directly
     if (operands.size() == 0) return conj;
     // fold all operands into one binary expression
-    return fold_operands(conj, operands, Sass_OP::OR);
+    return fold_operands(conj, operands, { Sass_OP::OR });
   }
   // EO parse_disjunction
 
@@ -1156,7 +1156,7 @@ namespace Sass {
     // if it's a singleton, return it directly
     if (operands.size() == 0) return rel;
     // fold all operands into one binary expression
-    return fold_operands(rel, operands, Sass_OP::AND);
+    return fold_operands(rel, operands, { Sass_OP::AND });
   }
   // EO parse_conjunction
 
@@ -1176,6 +1176,8 @@ namespace Sass {
           > >(position)))
     { return lhs; }
     // parse the operator
+    bool left_ws = peek < css_comments >();
+    // parse the operator
     enum Sass_OP op
     = lex<kwd_eq>()  ? Sass_OP::EQ
     : lex<kwd_neq>() ? Sass_OP::NEQ
@@ -1186,9 +1188,11 @@ namespace Sass {
     // we checked the possibilites on top of fn
     :                  Sass_OP::EQ;
     // parse the right hand side expression
+    bool right_ws = peek < css_comments >();
+    // parse the right hand side expression
     Expression* rhs = parse_expression();
     // return binary expression with a left and a right hand side
-    return SASS_MEMORY_NEW(ctx.mem, Binary_Expression, lhs->pstate(), op, lhs, rhs);
+    return SASS_MEMORY_NEW(ctx.mem, Binary_Expression, lhs->pstate(), { op, left_ws, right_ws }, lhs, rhs);
   }
   // parse_relation
 
@@ -1209,10 +1213,13 @@ namespace Sass {
     { return lhs; }
 
     std::vector<Expression*> operands;
-    std::vector<Sass_OP> operators;
+    std::vector<Operand> operators;
+    bool left_ws = peek < css_comments >();
     while (lex< exactly<'+'> >() || lex< sequence< negate< digit >, exactly<'-'> > >()) {
-      operators.push_back(lexed.to_string() == "+" ? Sass_OP::ADD : Sass_OP::SUB);
+      bool right_ws = peek < css_comments >();
+      operators.push_back({ lexed.to_string() == "+" ? Sass_OP::ADD : Sass_OP::SUB, left_ws, right_ws });
       operands.push_back(parse_operators());
+      left_ws = peek < css_comments >();
     }
 
     if (operands.size() == 0) return lhs;
@@ -1232,16 +1239,19 @@ namespace Sass {
     if (!peek_css< class_char< static_ops > >()) return factor;
     // parse more factors and operators
     std::vector<Expression*> operands; // factors
-    std::vector<enum Sass_OP> operators; // ops
+    std::vector<Operand> operators; // ops
     // lex operations to apply to lhs
+    bool left_ws = peek < css_comments >();
     while (lex_css< class_char< static_ops > >()) {
+      bool right_ws = peek < css_comments >();
       switch(*lexed.begin) {
-        case '*': operators.push_back(Sass_OP::MUL); break;
-        case '/': operators.push_back(Sass_OP::DIV); break;
-        case '%': operators.push_back(Sass_OP::MOD); break;
+        case '*': operators.push_back({ Sass_OP::MUL, left_ws, right_ws }); break;
+        case '/': operators.push_back({ Sass_OP::DIV, left_ws, right_ws }); break;
+        case '%': operators.push_back({ Sass_OP::MOD, left_ws, right_ws }); break;
         default: throw std::runtime_error("unknown static op parsed"); break;
       }
       operands.push_back(parse_factor());
+      left_ws = peek < css_comments >();
     }
     // operands and operators to binary expression
     return fold_operands(factor, operands, operators);
@@ -2346,12 +2356,12 @@ namespace Sass {
   }
 
 
-  Expression* Parser::fold_operands(Expression* base, std::vector<Expression*>& operands, enum Sass_OP op)
+  Expression* Parser::fold_operands(Expression* base, std::vector<Expression*>& operands, Operand op)
   {
     for (size_t i = 0, S = operands.size(); i < S; ++i) {
       base = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, pstate, op, base, operands[i]);
       Binary_Expression* b = static_cast<Binary_Expression*>(base);
-      if (op == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
+      if (op.operand == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
         base->is_delayed(true);
       }
       else {
@@ -2362,12 +2372,12 @@ namespace Sass {
     return base;
   }
 
-  Expression* Parser::fold_operands(Expression* base, std::vector<Expression*>& operands, std::vector<enum Sass_OP>& ops)
+  Expression* Parser::fold_operands(Expression* base, std::vector<Expression*>& operands, std::vector<Operand>& ops)
   {
     for (size_t i = 0, S = operands.size(); i < S; ++i) {
       base = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, base->pstate(), ops[i], base, operands[i]);
       Binary_Expression* b = static_cast<Binary_Expression*>(base);
-      if (ops[i] == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
+      if (ops[i].operand == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
         base->is_delayed(true);
       }
       else {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -298,8 +298,8 @@ namespace Sass {
     Lookahead lookahead_for_selector(const char* start = 0);
     Lookahead lookahead_for_include(const char* start = 0);
 
-    Expression* fold_operands(Expression* base, std::vector<Expression*>& operands, Sass_OP op);
-    Expression* fold_operands(Expression* base, std::vector<Expression*>& operands, std::vector<Sass_OP>& ops);
+    Expression* fold_operands(Expression* base, std::vector<Expression*>& operands, Operand op);
+    Expression* fold_operands(Expression* base, std::vector<Expression*>& operands, std::vector<Operand>& ops);
 
     void throw_syntax_error(std::string message, size_t ln = 0);
     void throw_read_error(std::string message, size_t ln = 0);

--- a/src/subset_map.hpp
+++ b/src/subset_map.hpp
@@ -94,7 +94,6 @@ namespace Sass {
     { ss.insert(s[i]); }
     for (size_t i = 0, S = s.size(); i < S; ++i)
     {
-      hash_[s[i]];
       hash_[s[i]].push_back(make_triple(s, ss, index));
     }
   }


### PR DESCRIPTION
@xzyfer couldn't resist to fix this :see_no_evil:  I hope you can incorporate this easily with your parsing refactor. This here doesn't touch the static value parsing and should be pretty well self contained.

This should currently pass this specs (https://github.com/sass/sass-spec/pull/624):

```scss
div {
  baz: #{1/2}/3;
  baz: #{1/  2}/  3;
  baz: #{1  /2}  /3;
  baz: #{1  /  2}  /  3;
}

add {
  baz: #{1+2}+3;
  baz: #{1+  2}+  3;
  baz: #{1  +2}  +3;
  baz: #{1  +  2}  +  3;
}

sub {
  baz: #{1-2}-3;
  baz: #{1-  2}-  3;
  baz: #{1  -2}  -3;
  baz: #{1  -  2}  -  3;
}

mul {
  baz: #{1*2}*3;
  baz: #{1*  2}*  3;
  baz: #{1  *2}  *3;
  baz: #{1  *  2}  *  3;
}

mod {
  baz: #{1%2}%3;
  baz: #{1%  2}%  3;
  baz: #{1  %2}  %3;
  baz: #{1  %  2}  %  3;
}
```