### PR TITLE
Don't allocate std::random_device statically

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -215,9 +215,9 @@ namespace Sass {
       return seed;
     }
     #else
-    static std::random_device rd;
     uint64_t GetSeed()
     {
+      std::random_device rd;
       return rd();
     }
     #endif


### PR DESCRIPTION
It appears that on Linux with gcc (tested with gcc 4.6.3 on Ubuntu 12.04 and
gcc 5.2.1 on Ubuntu 15.10) std::random_device will open /dev/urandom, and keep
the file open for the lifetime of the std::random_device object.

Since libsass allocates the std::random_device globally, it will not be
destroyed if the process execs. Futhermore std::random_device does not set
close-on-exec on the fd, so the fd will be leaked to the child process.

The std::random_device object is only used by the GetSeed function, and as the
GetSeed function is only called once to seed the rand variable, there is no
need to keep the std::random_device object.

So this patch moves the std::random_device object into the GetSeed function,
thereby eliminating the fd-leak.

The following program illustrates the problem:
```C
// To compile: g++ -o fdleak_example fdleak_example.cpp -Llib -lsass -Iinclude -ldl
#include <stdlib.h>
#include <sys/types.h>
#include <unistd.h>
#include <stdio.h>
#include "sass.h"

int main() {
  pid_t pid = getpid();
  char command[250];

  struct Sass_Options *options = sass_make_options();
  free(options);

  sprintf(command, "pfd=\"/proc/%d/fd\";"
	  "cfd=\"/proc/$$/fd\";"
	  "echo \"Parent: $pfd\";"
	  "ls -l $pfd;"
	  "echo \"Child: $cfd\";"
	  "ls -l $cfd;"
	  "ps uf --pid %d --ppid %d", pid, pid, pid);
  system(command);
  return 0;
}
```

Output from program before this patch:

```
Parent: /proc/6494/fd
total 0
lrwx------ 1 ksm ksm 64 nov 18 11:20 0 -> /dev/pts/3
lrwx------ 1 ksm ksm 64 nov 18 11:20 1 -> /dev/pts/3
lrwx------ 1 ksm ksm 64 nov 18 11:20 2 -> /dev/pts/3
lr-x------ 1 ksm ksm 64 nov 18 11:20 3 -> /dev/urandom
Child: /proc/6495/fd
total 0
lrwx------ 1 ksm ksm 64 nov 18 11:20 0 -> /dev/pts/3
lrwx------ 1 ksm ksm 64 nov 18 11:20 1 -> /dev/pts/3
lrwx------ 1 ksm ksm 64 nov 18 11:20 2 -> /dev/pts/3
lr-x------ 1 ksm ksm 64 nov 18 11:20 3 -> /dev/urandom
  PID TTY      STAT   TIME COMMAND
 6494 pts/3    S+     0:00 ./fdleak_example
 6495 pts/3    S+     0:00  \_ sh -c pfd="/proc/6494/fd";cfd="/proc/$$/fd";echo "Parent: $pfd";ls -l $pfd;echo "Child: $cfd";ls -l $cfd;ps f --pid 6494 --ppid 6494
```

Output from program after this patch:

```
Parent: /proc/6568/fd
total 0
lrwx------ 1 ksm ksm 64 nov 18 11:21 0 -> /dev/pts/3
lrwx------ 1 ksm ksm 64 nov 18 11:21 1 -> /dev/pts/3
lrwx------ 1 ksm ksm 64 nov 18 11:21 2 -> /dev/pts/3
Child: /proc/6569/fd
total 0
lrwx------ 1 ksm ksm 64 nov 18 11:21 0 -> /dev/pts/3
lrwx------ 1 ksm ksm 64 nov 18 11:21 1 -> /dev/pts/3
lrwx------ 1 ksm ksm 64 nov 18 11:21 2 -> /dev/pts/3
  PID TTY      STAT   TIME COMMAND
 6568 pts/3    S+     0:00 ./fdleak_example
 6569 pts/3    S+     0:00  \_ sh -c pfd="/proc/6568/fd";cfd="/proc/$$/fd";echo "Parent: $pfd";ls -l $pfd;echo "Child: $cfd";ls -l $cfd;ps f --pid 6568 --ppid 6568
```