### PR TITLE
Implement variable shadow scoping

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -4,11 +4,20 @@
 namespace Sass {
 
   template <typename T>
-  Environment<T>::Environment() : local_frame_(std::map<std::string, T>()), parent_(0) { }
+  Environment<T>::Environment(bool is_shadow)
+  : local_frame_(std::map<std::string, T>()),
+    parent_(0), is_shadow_(false)
+  { }
   template <typename T>
-  Environment<T>::Environment(Environment<T>* env) : local_frame_(std::map<std::string, T>()), parent_(env) { }
+  Environment<T>::Environment(Environment<T>* env, bool is_shadow)
+  : local_frame_(std::map<std::string, T>()),
+    parent_(env), is_shadow_(is_shadow)
+  { }
   template <typename T>
-  Environment<T>::Environment(Environment<T>& env) : local_frame_(std::map<std::string, T>()), parent_(&env) { }
+  Environment<T>::Environment(Environment<T>& env, bool is_shadow)
+  : local_frame_(std::map<std::string, T>()),
+    parent_(&env), is_shadow_(is_shadow)
+  { }
 
   // link parent to create a stack
   template <typename T>
@@ -118,12 +127,13 @@ namespace Sass {
   template <typename T>
   void Environment<T>::set_lexical(const std::string& key, T val)
   {
-    auto cur = this;
-    while (cur->is_lexical()) {
+    auto cur = this; bool shadow = false;
+    while (cur->is_lexical() || shadow) {
       if (cur->has_local(key)) {
         cur->set_local(key, val);
         return;
       }
+      shadow = cur->is_shadow();
       cur = cur->parent_;
     }
     set_local(key, val);

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -15,12 +15,13 @@ namespace Sass {
     // TODO: test with map
     std::map<std::string, T> local_frame_;
     ADD_PROPERTY(Environment*, parent)
+    ADD_PROPERTY(bool, is_shadow)
 
   public:
     Memory_Manager mem;
-    Environment();
-    Environment(Environment* env);
-    Environment(Environment& env);
+    Environment(bool is_shadow = false);
+    Environment(Environment* env, bool is_shadow = false);
+    Environment(Environment& env, bool is_shadow = false);
 
     // link parent to create a stack
     void link(Environment& env);
@@ -87,6 +88,7 @@ namespace Sass {
     #endif
 
   };
+
 }
 
 #endif

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -120,12 +120,21 @@ namespace Sass {
     if (sel == 0) throw std::runtime_error("Expanded null selector");
 
     selector_stack.push_back(sel);
+    Env* env = 0;
+    if (block_stack.back()->is_root()) {
+      env = new Env(environment());
+      env_stack.push_back(env);
+    }
     Block* blk = r->block()->perform(this)->block();
     Ruleset* rr = SASS_MEMORY_NEW(ctx.mem, Ruleset,
                                   r->pstate(),
                                   sel,
                                   blk);
     selector_stack.pop_back();
+    if (block_stack.back()->is_root()) {
+      env_stack.pop_back();
+      delete env;
+    }
     rr->tabs(r->tabs());
 
     return rr;
@@ -361,6 +370,8 @@ namespace Sass {
 
   Statement* Expand::operator()(If* i)
   {
+    Env env(environment(), true);
+    env_stack.push_back(&env);
     if (*i->predicate()->perform(&eval)) {
       append_block(i->block());
     }
@@ -368,6 +379,7 @@ namespace Sass {
       Block* alt = i->alternative();
       if (alt) append_block(alt);
     }
+    env_stack.pop_back();
     return 0;
   }
 
@@ -396,10 +408,10 @@ namespace Sass {
     double start = sass_start->value();
     double end = sass_end->value();
     // only create iterator once in this environment
-    Env* env = environment();
-    Number* it = SASS_MEMORY_NEW(env->mem, Number, low->pstate(), start, sass_end->unit());
-    AST_Node* old_var = env->has_local(variable) ? env->get_local(variable) : 0;
-    env->set_local(variable, it);
+    Env env(environment(), true);
+    env_stack.push_back(&env);
+    Number* it = SASS_MEMORY_NEW(env.mem, Number, low->pstate(), start, sass_end->unit());
+    env.set_local(variable, it);
     Block* body = f->block();
     if (start < end) {
       if (f->is_inclusive()) ++end;
@@ -407,7 +419,7 @@ namespace Sass {
            i < end;
            ++i) {
         it->value(i);
-        env->set_local(variable, it);
+        env.set_local(variable, it);
         append_block(body);
       }
     } else {
@@ -416,13 +428,11 @@ namespace Sass {
            i > end;
            --i) {
         it->value(i);
-        env->set_local(variable, it);
+        env.set_local(variable, it);
         append_block(body);
       }
     }
-    // restore original environment
-    if (!old_var) env->del_local(variable);
-    else env->set_local(variable, old_var);
+    env_stack.pop_back();
     return 0;
   }
 
@@ -445,12 +455,8 @@ namespace Sass {
       list = static_cast<List*>(expr);
     }
     // remember variables and then reset them
-    Env* env = environment();
-    std::vector<AST_Node*> old_vars(variables.size());
-    for (size_t i = 0, L = variables.size(); i < L; ++i) {
-      old_vars[i] = env->has_local(variables[i]) ? env->get_local(variables[i]) : 0;
-      env->set_local(variables[i], 0);
-    }
+    Env env(environment(), true);
+    env_stack.push_back(&env);
     Block* body = e->block();
 
     if (map) {
@@ -462,10 +468,10 @@ namespace Sass {
           List* variable = SASS_MEMORY_NEW(ctx.mem, List, map->pstate(), 2, SASS_SPACE);
           *variable << k;
           *variable << v;
-          env->set_local(variables[0], variable);
+          env.set_local(variables[0], variable);
         } else {
-          env->set_local(variables[0], k);
-          env->set_local(variables[1], v);
+          env.set_local(variables[0], k);
+          env.set_local(variables[1], v);
         }
         append_block(body);
       }
@@ -481,32 +487,28 @@ namespace Sass {
           if (variables.size() == 1) {
             Expression* var = scalars;
             if (arglist) var = (*scalars)[0];
-            env->set_local(variables[0], var);
+            env.set_local(variables[0], var);
           } else {
             for (size_t j = 0, K = variables.size(); j < K; ++j) {
               Expression* res = j >= scalars->length()
                 ? SASS_MEMORY_NEW(ctx.mem, Null, expr->pstate())
                 : (*scalars)[j]->perform(&eval);
-              env->set_local(variables[j], res);
+              env.set_local(variables[j], res);
             }
           }
         } else {
           if (variables.size() > 0) {
-            env->set_local(variables[0], e);
+            env.set_local(variables[0], e);
             for (size_t j = 1, K = variables.size(); j < K; ++j) {
               Expression* res = SASS_MEMORY_NEW(ctx.mem, Null, expr->pstate());
-              env->set_local(variables[j], res);
+              env.set_local(variables[j], res);
             }
           }
         }
         append_block(body);
       }
     }
-    // restore original environment
-    for (size_t j = 0, K = variables.size(); j < K; ++j) {
-      if(!old_vars[j]) env->del_local(variables[j]);
-      else env->set_local(variables[j], old_vars[j]);
-    }
+    env_stack.pop_back();
     return 0;
   }
 
@@ -514,9 +516,12 @@ namespace Sass {
   {
     Expression* pred = w->predicate();
     Block* body = w->block();
+    Env env(environment(), true);
+    env_stack.push_back(&env);
     while (*pred->perform(&eval)) {
       append_block(body);
     }
+    env_stack.pop_back();
     return 0;
   }
 


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1746 (spec tests: https://github.com/sass/sass-spec/pull/625)
Shadow scopes overwrite variables in global scopes if
they already exist there. Normal scopes do not allow
this without setting the `!global` flag on assignment.