### PR TITLE
Refactor to remove `Context` dependency from `To_String` and others

### DIFF
--- a/include/sass/base.h
+++ b/include/sass/base.h
@@ -56,7 +56,9 @@ enum Sass_Output_Style {
   SASS_STYLE_NESTED,
   SASS_STYLE_EXPANDED,
   SASS_STYLE_COMPACT,
-  SASS_STYLE_COMPRESSED
+  SASS_STYLE_COMPRESSED,
+  // only used internal
+  SASS_STYLE_INSPECT
 };
 
 // Some convenient string helper function

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -148,8 +148,8 @@ namespace Sass {
     virtual bool has_interpolant() const { return is_interpolant(); }
     virtual bool is_left_interpolant() const { return is_interpolant(); }
     virtual bool is_right_interpolant() const { return is_interpolant(); }
-    virtual std::string inspect() const { return to_string(); } // defaults to to_string
-    virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
+    virtual std::string inspect() const { return to_string({ NESTED, 5 }); }
+    virtual std::string to_string(Sass_Inspect_Options opt) const = 0;
     virtual size_t hash() { return 0; }
   };
 
@@ -162,7 +162,7 @@ namespace Sass {
                bool d = false, bool e = false, bool i = false, Concrete_Type ct = NONE)
     : Expression(pstate, d, e, i, ct)
     { }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
+    virtual std::string to_string(Sass_Inspect_Options opt) const = 0;
     virtual ~PreValue() { }
   };
 
@@ -176,7 +176,7 @@ namespace Sass {
     : Expression(pstate, d, e, i, ct)
     { }
     virtual bool operator== (const Expression& rhs) const = 0;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
+    virtual std::string to_string(Sass_Inspect_Options opt) const = 0;
   };
 }
 
@@ -890,7 +890,7 @@ namespace Sass {
     }
 
     virtual bool operator== (const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -923,7 +923,7 @@ namespace Sass {
     }
 
     virtual bool operator== (const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1043,7 +1043,7 @@ namespace Sass {
       }
       return hash_;
     }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     enum Sass_OP type() const { return op_.operand; }
     ATTACH_OPERATIONS()
   };
@@ -1093,7 +1093,7 @@ namespace Sass {
       };
       return hash_;
     }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1139,7 +1139,7 @@ namespace Sass {
       return hash_;
     }
 
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1162,7 +1162,7 @@ namespace Sass {
       has_rest_argument_(false),
       has_keyword_argument_(false)
     { }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     Argument* get_rest_argument();
     Argument* get_keyword_argument();
@@ -1214,7 +1214,7 @@ namespace Sass {
       return hash_;
     }
 
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1228,7 +1228,7 @@ namespace Sass {
     Function_Call_Schema(ParserState pstate, String* n, Arguments* args)
     : Expression(pstate), name_(n), arguments_(args)
     { concrete_type(STRING); }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1260,7 +1260,7 @@ namespace Sass {
     {
       return std::hash<std::string>()(name());
     }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1304,7 +1304,7 @@ namespace Sass {
       }
       return hash_;
     }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1349,7 +1349,7 @@ namespace Sass {
 
     virtual bool operator< (const Number& rhs) const;
     virtual bool operator== (const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1384,8 +1384,8 @@ namespace Sass {
     }
 
     virtual bool operator== (const Expression& rhs) const;
-    virtual std::string to_hex(bool compressed = false, int precision = 5) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_hex(Sass_Inspect_Options opt) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1400,7 +1400,7 @@ namespace Sass {
     : Value(pstate), message_(msg)
     { concrete_type(C_ERROR); }
     virtual bool operator== (const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1414,7 +1414,7 @@ namespace Sass {
     : Value(pstate), message_(msg)
     { concrete_type(C_WARNING); }
     virtual bool operator== (const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1443,7 +1443,7 @@ namespace Sass {
     }
 
     virtual bool operator== (const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1461,7 +1461,7 @@ namespace Sass {
     static std::string type_name() { return "string"; }
     virtual ~String() = 0;
     virtual bool operator==(const Expression& rhs) const = 0;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
+    virtual std::string to_string(Sass_Inspect_Options opt) const = 0;
     ATTACH_OPERATIONS()
   };
   inline String::~String() { };
@@ -1500,7 +1500,7 @@ namespace Sass {
     }
 
     virtual bool operator==(const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1540,7 +1540,7 @@ namespace Sass {
 
     virtual bool operator==(const Expression& rhs) const;
     virtual std::string inspect() const; // quotes are forced on inspection
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     // static char auto_quote() { return '*'; }
     static char double_quote() { return '"'; }
@@ -1562,7 +1562,7 @@ namespace Sass {
     }
     virtual bool operator==(const Expression& rhs) const;
     virtual std::string inspect() const; // quotes are forced on inspection
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1580,7 +1580,7 @@ namespace Sass {
     : Expression(pstate), Vectorized<Media_Query_Expression*>(s),
       media_type_(t), is_negated_(n), is_restricted_(r)
     { }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1596,7 +1596,7 @@ namespace Sass {
                            Expression* f, Expression* v, bool i = false)
     : Expression(pstate), feature_(f), value_(v), is_interpolated_(i)
     { }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1623,7 +1623,7 @@ namespace Sass {
     : Expression(pstate)
     { }
     virtual bool needs_parens(Supports_Condition* cond) const { return false; }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1728,7 +1728,7 @@ namespace Sass {
         return false;
       }
     }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -1787,7 +1787,7 @@ namespace Sass {
     }
 
     virtual bool operator== (const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
 
     ATTACH_OPERATIONS()
   };
@@ -1802,7 +1802,7 @@ namespace Sass {
     Thunk(ParserState pstate, Expression* exp, Env* env = 0)
     : Expression(pstate), expression_(exp), environment_(env)
     { }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
   };
 
   /////////////////////////////////////////////////////////
@@ -1901,7 +1901,7 @@ namespace Sass {
     virtual unsigned long specificity() {
       return Constants::Specificity_Universal;
     }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
+    virtual std::string to_string(Sass_Inspect_Options opt) const = 0;
   };
   inline Selector::~Selector() { }
 
@@ -1922,7 +1922,7 @@ namespace Sass {
       }
       return hash_;
     }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2001,7 +2001,7 @@ namespace Sass {
 
     bool operator<(const Simple_Selector& rhs) const;
     // default implementation should work for most of the simple selectors (otherwise overload)
-    virtual std::string to_string(bool compressed = false, int precision = 5) const { return this->ns_name(); };
+    virtual std::string to_string(Sass_Inspect_Options opt) const { return this->ns_name(); };
     ATTACH_OPERATIONS();
   };
   inline Simple_Selector::~Simple_Selector() { }
@@ -2025,7 +2025,7 @@ namespace Sass {
     }
     std::string type() { return "selector"; }
     static std::string type_name() { return "selector"; }
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2106,7 +2106,7 @@ namespace Sass {
     bool operator==(const Attribute_Selector& rhs) const;
     bool operator<(const Simple_Selector& rhs) const;
     bool operator<(const Attribute_Selector& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2205,7 +2205,7 @@ namespace Sass {
     bool operator==(const Wrapped_Selector& rhs) const;
     bool operator<(const Simple_Selector& rhs) const;
     bool operator<(const Wrapped_Selector& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2302,7 +2302,7 @@ namespace Sass {
     Compound_Selector* clone(Context&) const; // does not clone the Simple_Selector*s
 
     Compound_Selector* minus(Compound_Selector* rhs, Context& ctx);
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2461,7 +2461,7 @@ namespace Sass {
     Complex_Selector* clone(Context&) const;      // does not clone Compound_Selector*s
     Complex_Selector* cloneFully(Context&) const; // clones Compound_Selector*s
     // std::vector<Compound_Selector*> to_vector();
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 
@@ -2516,7 +2516,7 @@ namespace Sass {
     virtual bool operator==(const Selector_List& rhs) const;
     // Selector Lists can be compared to comma lists
     virtual bool operator==(const Expression& rhs) const;
-    virtual std::string to_string(bool compressed = false, int precision = 5) const;
+    virtual std::string to_string(Sass_Inspect_Options opt) const;
     ATTACH_OPERATIONS()
   };
 

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -14,7 +14,7 @@ namespace Sass {
   {
     std::string callee(type + " " + name);
 
-    Listize listize(*ctx);
+    Listize listize(ctx->mem);
     std::map<std::string, Parameter*> param_map;
 
     for (size_t i = 0, L = as->length(); i < L; ++i) {

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -259,7 +259,7 @@ namespace Sass {
     // That's only okay if they have default values, or were already bound by
     // named arguments, or if it's a single rest-param.
     for (size_t i = ip; i < LP; ++i) {
-      To_String to_string(ctx);
+      To_String to_string(ctx->c_options);
       Parameter* leftover = (*ps)[i];
       // cerr << "env for default params:" << endl;
       // env->print();

--- a/src/bind.hpp
+++ b/src/bind.hpp
@@ -2,6 +2,7 @@
 #define SASS_BIND_H
 
 #include <string>
+#include "listize.hpp"
 #include "environment.hpp"
 
 namespace Sass {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -58,7 +58,7 @@ namespace Sass {
     return safe_path == "" ? "stdout" : safe_path;
   }
 
-  Context::Context(struct Sass_Context* c_ctx)
+  Context::Context(struct Sass_Context& c_ctx)
   : CWD(File::get_cwd()),
     entry_path(""),
     head_imports(0),
@@ -78,13 +78,13 @@ namespace Sass {
     c_importers             (std::vector<Sass_Importer_Entry>()),
     c_functions             (std::vector<Sass_Function_Entry>()),
 
-    indent                  (safe_str(c_options->indent, "  ")),
-    linefeed                (safe_str(c_options->linefeed, "\n")),
+    indent                  (safe_str(c_options.indent, "  ")),
+    linefeed                (safe_str(c_options.linefeed, "\n")),
 
-    input_path              (make_canonical_path(safe_input(c_options->input_path))),
-    output_path             (make_canonical_path(safe_output(c_options->output_path, input_path))),
-    source_map_file         (make_canonical_path(safe_str(c_options->source_map_file, ""))),
-    source_map_root         (make_canonical_path(safe_str(c_options->source_map_root, "")))
+    input_path              (make_canonical_path(safe_input(c_options.input_path))),
+    output_path             (make_canonical_path(safe_output(c_options.output_path, input_path))),
+    source_map_file         (make_canonical_path(safe_str(c_options.source_map_file, ""))),
+    source_map_root         (make_canonical_path(safe_str(c_options.source_map_root, "")))
 
   {
 
@@ -92,10 +92,10 @@ namespace Sass {
     include_paths.push_back(CWD);
 
     // collect more paths from different options
-    collect_include_paths(sass_option_get_include_path(c_options));
-    // collect_include_paths(initializers.include_paths_array());
-    collect_plugin_paths(sass_option_get_plugin_path(c_options));
-    // collect_plugin_paths(initializers.plugin_paths_array());
+    collect_include_paths(c_options.include_path);
+    // collect_include_paths(c_options.include_paths);
+    collect_plugin_paths(c_options.plugin_path);
+    // collect_plugin_paths(c_options.plugin_paths);
 
     // load plugins and register custom behaviors
     for(auto plug : plugin_paths) plugins.load_plugins(plug);
@@ -505,9 +505,9 @@ namespace Sass {
     // get the resulting buffer from stream
     OutputBuffer emitted = emitter.get_buffer();
     // should we append a source map url?
-    if (!c_options->omit_source_map_url) {
+    if (!c_options.omit_source_map_url) {
       // generate an embeded source map
-      if (c_options->source_map_embed) {
+      if (c_options.source_map_embed) {
         emitted.buffer += linefeed;
         emitted.buffer += format_embedded_source_map();
       }
@@ -592,7 +592,7 @@ namespace Sass {
     if (!source_c_str) return 0;
 
     // convert indented sass syntax
-    if(c_options->is_indented_syntax_src) {
+    if(c_options.is_indented_syntax_src) {
       // call sass2scss to convert the string
       char * converted = sass2scss(source_c_str,
         // preserve the structure as much as possible

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -60,19 +60,18 @@ namespace Sass {
 
   Context::Context(struct Sass_Context& c_ctx)
   : CWD(File::get_cwd()),
+    c_options(c_ctx),
     entry_path(""),
     head_imports(0),
     mem(Memory_Manager()),
     plugins(),
-    emitter(this),
+    emitter(c_options),
 
     strings(),
     resources(),
     sheets(),
     subset_map(),
     import_stack(),
-
-    c_options               (c_ctx),
 
     c_headers               (std::vector<Sass_Importer_Entry>()),
     c_importers             (std::vector<Sass_Importer_Entry>()),

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -53,7 +53,7 @@ namespace Sass {
     std::vector<Sass_Import_Entry> import_stack;
 
     struct Sass_Compiler* c_compiler;
-    struct Sass_Options* c_options;
+    struct Sass_Options& c_options;
 
     // absolute paths to includes
     std::vector<std::string> included_files;
@@ -86,7 +86,7 @@ namespace Sass {
     const std::string source_map_root; // path for sourceRoot property (pass-through)
 
     virtual ~Context();
-    Context(struct Sass_Context*);
+    Context(struct Sass_Context&);
     virtual Block* parse() = 0;
     virtual Block* compile();
     virtual char* render(Block* root);
@@ -96,7 +96,7 @@ namespace Sass {
     std::vector<Include> find_includes(const Importer& import);
     Include load_import(const Importer&, ParserState pstate);
 
-    Sass_Output_Style output_style() { return c_options->output_style; };
+    Sass_Output_Style output_style() { return c_options.output_style; };
     std::vector<std::string> get_included_files(bool skip = false, size_t headers = 0);
 
   private:
@@ -119,7 +119,7 @@ namespace Sass {
 
   class File_Context : public Context {
   public:
-    File_Context(struct Sass_File_Context* ctx)
+    File_Context(struct Sass_File_Context& ctx)
     : Context(ctx)
     { }
     virtual ~File_Context();
@@ -130,13 +130,13 @@ namespace Sass {
   public:
     char* source_c_str;
     char* srcmap_c_str;
-    Data_Context(struct Sass_Data_Context* ctx)
+    Data_Context(struct Sass_Data_Context& ctx)
     : Context(ctx)
     {
-      source_c_str       = ctx->source_string;
-      srcmap_c_str       = ctx->srcmap_string;
-      ctx->source_string = 0; // passed away
-      ctx->srcmap_string = 0; // passed away
+      source_c_str       = ctx.source_string;
+      srcmap_c_str       = ctx.srcmap_string;
+      ctx.source_string = 0; // passed away
+      ctx.srcmap_string = 0; // passed away
     }
     virtual ~Data_Context();
     virtual Block* parse();

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -38,6 +38,7 @@ namespace Sass {
 
   public:
     const std::string CWD;
+    struct Sass_Options& c_options;
     std::string entry_path;
     size_t head_imports;
     Memory_Manager mem;
@@ -53,7 +54,6 @@ namespace Sass {
     std::vector<Sass_Import_Entry> import_stack;
 
     struct Sass_Compiler* c_compiler;
-    struct Sass_Options& c_options;
 
     // absolute paths to includes
     std::vector<std::string> included_files;

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -518,7 +518,7 @@ namespace Sass {
 
   Media_Query* Cssize::merge_media_query(Media_Query* mq1, Media_Query* mq2)
   {
-    To_String to_string(&ctx);
+    To_String to_string(ctx.c_options);
 
     std::string type;
     std::string mod;

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -7,9 +7,9 @@
 
 namespace Sass {
 
-  Emitter::Emitter(Context* ctx)
+  Emitter::Emitter(struct Sass_Output_Options& opt)
   : wbuf(),
-    ctx(ctx),
+    opt(opt),
     indentation(0),
     scheduled_space(0),
     scheduled_linefeed(0),
@@ -31,7 +31,7 @@ namespace Sass {
 
   Sass_Output_Style Emitter::output_style(void) const
   {
-    return ctx ? ctx->output_style() : COMPRESSED;
+    return opt.output_style;
   }
 
   // PROXY METHODS FOR SOURCE MAPS
@@ -75,7 +75,7 @@ namespace Sass {
       std::string linefeeds = "";
 
       for (size_t i = 0; i < scheduled_linefeed; i++)
-        linefeeds += ctx ? ctx->linefeed : "\n";
+        linefeeds += opt.linefeed;
       scheduled_space = 0;
       scheduled_linefeed = 0;
       append_string(linefeeds);
@@ -164,7 +164,7 @@ namespace Sass {
       scheduled_linefeed = 1;
     std::string indent = "";
     for (size_t i = 0; i < indentation; i++)
-      indent += ctx ? ctx->indent : "  ";
+      indent += opt.indent;
     append_string(indent);
   }
 
@@ -216,7 +216,7 @@ namespace Sass {
     if (output_style() == COMPACT) {
       append_mandatory_linefeed();
       for (size_t p = 0; p < indentation; p++)
-        append_string(ctx ? ctx->indent : "  ");
+        append_string(opt.indent);
     }
   }
 

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -30,7 +30,7 @@ namespace Sass {
     return wbuf.buffer;
   }
 
-  Sass_Output_Style Emitter::output_style(void)
+  Sass_Output_Style Emitter::output_style(void) const
   {
     return ctx ? ctx->output_style() : COMPRESSED;
   }
@@ -46,11 +46,11 @@ namespace Sass {
   void Emitter::set_filename(const std::string& str)
   { wbuf.smap.file = str; }
 
-  void Emitter::schedule_mapping(AST_Node* node)
+  void Emitter::schedule_mapping(const AST_Node* node)
   { scheduled_mapping = node; }
-  void Emitter::add_open_mapping(AST_Node* node)
+  void Emitter::add_open_mapping(const AST_Node* node)
   { wbuf.smap.add_open_mapping(node); }
-  void Emitter::add_close_mapping(AST_Node* node)
+  void Emitter::add_close_mapping(const AST_Node* node)
   { wbuf.smap.add_close_mapping(node); }
   ParserState Emitter::remap(const ParserState& pstate)
   { return wbuf.smap.remap(pstate); }
@@ -140,7 +140,7 @@ namespace Sass {
 
   // append some text or token to the buffer
   // this adds source-mappings for node start and end
-  void Emitter::append_token(const std::string& text, AST_Node* node)
+  void Emitter::append_token(const std::string& text, const AST_Node* node)
   {
     flush_schedules();
     add_open_mapping(node);

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -20,8 +20,7 @@ namespace Sass {
     in_media_block(false),
     in_declaration(false),
     in_space_array(false),
-    in_comma_array(false),
-    in_debug(false)
+    in_comma_array(false)
   { }
 
   // return buffer as string
@@ -204,7 +203,7 @@ namespace Sass {
 
   void Emitter::append_optional_space()
   {
-    if ((output_style() != COMPRESSED || in_debug) && buffer().size()) {
+    if ((output_style() != COMPRESSED) && buffer().size()) {
       char lst = buffer().at(buffer().length() - 1);
       if (!isspace(lst) || scheduled_delimiter) {
         append_mandatory_space();

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -32,7 +32,7 @@ namespace Sass {
 
   Sass_Output_Style Emitter::output_style(void)
   {
-    return ctx ? ctx->output_style() : SASS_STYLE_COMPRESSED;
+    return ctx ? ctx->output_style() : COMPRESSED;
   }
 
   // PROXY METHODS FOR SOURCE MAPS
@@ -113,7 +113,7 @@ namespace Sass {
     // write space/lf
     flush_schedules();
 
-    if (in_comment && output_style() == SASS_STYLE_COMPACT) {
+    if (in_comment && output_style() == COMPACT) {
       // unescape comment nodes
       std::string out = comment_to_string(text);
       // add to buffer
@@ -158,8 +158,8 @@ namespace Sass {
 
   void Emitter::append_indentation()
   {
-    if (output_style() == SASS_STYLE_COMPRESSED) return;
-    if (output_style() == SASS_STYLE_COMPACT) return;
+    if (output_style() == COMPRESSED) return;
+    if (output_style() == COMPACT) return;
     if (in_declaration && in_comma_array) return;
     if (scheduled_linefeed && indentation)
       scheduled_linefeed = 1;
@@ -172,13 +172,13 @@ namespace Sass {
   void Emitter::append_delimiter()
   {
     scheduled_delimiter = true;
-    if (output_style() == SASS_STYLE_COMPACT) {
+    if (output_style() == COMPACT) {
       if (indentation == 0) {
         append_mandatory_linefeed();
       } else {
         append_mandatory_space();
       }
-    } else if (output_style() != SASS_STYLE_COMPRESSED) {
+    } else if (output_style() != COMPRESSED) {
       append_optional_linefeed();
     }
   }
@@ -204,7 +204,7 @@ namespace Sass {
 
   void Emitter::append_optional_space()
   {
-    if ((output_style() != SASS_STYLE_COMPRESSED || in_debug) && buffer().size()) {
+    if ((output_style() != COMPRESSED || in_debug) && buffer().size()) {
       char lst = buffer().at(buffer().length() - 1);
       if (!isspace(lst) || scheduled_delimiter) {
         append_mandatory_space();
@@ -214,7 +214,7 @@ namespace Sass {
 
   void Emitter::append_special_linefeed()
   {
-    if (output_style() == SASS_STYLE_COMPACT) {
+    if (output_style() == COMPACT) {
       append_mandatory_linefeed();
       for (size_t p = 0; p < indentation; p++)
         append_string(ctx ? ctx->indent : "  ");
@@ -224,7 +224,7 @@ namespace Sass {
   void Emitter::append_optional_linefeed()
   {
     if (in_declaration && in_comma_array) return;
-    if (output_style() == SASS_STYLE_COMPACT) {
+    if (output_style() == COMPACT) {
       append_mandatory_space();
     } else {
       append_mandatory_linefeed();
@@ -233,7 +233,7 @@ namespace Sass {
 
   void Emitter::append_mandatory_linefeed()
   {
-    if (output_style() != SASS_STYLE_COMPRESSED) {
+    if (output_style() != COMPRESSED) {
       scheduled_linefeed = 1;
       scheduled_space = 0;
       // flush_schedules();
@@ -255,9 +255,9 @@ namespace Sass {
   {
     -- indentation;
     scheduled_linefeed = 0;
-    if (output_style() == SASS_STYLE_COMPRESSED)
+    if (output_style() == COMPRESSED)
       scheduled_delimiter = false;
-    if (output_style() == SASS_STYLE_EXPANDED) {
+    if (output_style() == EXPANDED) {
       append_optional_linefeed();
       append_indentation();
     } else {
@@ -267,7 +267,7 @@ namespace Sass {
     if (node) add_close_mapping(node);
     append_optional_linefeed();
     if (indentation != 0) return;
-    if (output_style() != SASS_STYLE_COMPRESSED)
+    if (output_style() != COMPRESSED)
       scheduled_linefeed = 2;
   }
 

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -2,6 +2,7 @@
 #define SASS_EMITTER_H
 
 #include <string>
+#include "sass.hpp"
 #include "sass/base.h"
 #include "source_map.hpp"
 #include "ast_fwd_decl.hpp"
@@ -12,7 +13,7 @@ namespace Sass {
   class Emitter {
 
     public:
-      Emitter(Context* ctx);
+      Emitter(struct Sass_Output_Options& opt);
       virtual ~Emitter() { }
 
     protected:
@@ -31,7 +32,7 @@ namespace Sass {
       ParserState remap(const ParserState& pstate);
 
     public:
-      Context* ctx;
+      struct Sass_Output_Options& opt;
       size_t indentation;
       size_t scheduled_space;
       size_t scheduled_linefeed;

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -50,8 +50,6 @@ namespace Sass {
       // nested lists need parentheses
       bool in_space_array;
       bool in_comma_array;
-      // list separators don't get compressed in @debug
-      bool in_debug;
 
     public:
       // return buffer as std::string

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -24,9 +24,9 @@ namespace Sass {
       // proxy methods for source maps
       void add_source_index(size_t idx);
       void set_filename(const std::string& str);
-      void add_open_mapping(AST_Node* node);
-      void add_close_mapping(AST_Node* node);
-      void schedule_mapping(AST_Node* node);
+      void add_open_mapping(const AST_Node* node);
+      void add_close_mapping(const AST_Node* node);
+      void schedule_mapping(const AST_Node* node);
       std::string render_srcmap(Context &ctx);
       ParserState remap(const ParserState& pstate);
 
@@ -36,7 +36,7 @@ namespace Sass {
       size_t scheduled_space;
       size_t scheduled_linefeed;
       bool scheduled_delimiter;
-      AST_Node* scheduled_mapping;
+      const AST_Node* scheduled_mapping;
 
     public:
       // output strings different in comments
@@ -57,7 +57,7 @@ namespace Sass {
       // return buffer as std::string
       std::string get_buffer(void);
       // flush scheduled space/linefeed
-      Sass_Output_Style output_style(void);
+      Sass_Output_Style output_style(void) const;
       // add outstanding linefeed
       void finalize(bool final = true);
       // flush scheduled space/linefeed
@@ -71,7 +71,7 @@ namespace Sass {
       void append_wspace(const std::string& text);
       // append some text or token to the buffer
       // this adds source-mappings for node start and end
-      void append_token(const std::string& text, AST_Node* node);
+      void append_token(const std::string& text, const AST_Node* node);
 
     public: // syntax sugar
       void append_indentation();

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -26,9 +26,9 @@ namespace Sass {
     : Base(selector->pstate()), parent(parent), selector(selector)
     {
       msg = "Invalid parent selector for \"";
-      msg += selector->to_string(false);
+      msg += selector->to_string(Sass_Inspect_Options());
       msg += "\": \"";
-      msg += parent->to_string(false);;
+      msg += parent->to_string(Sass_Inspect_Options());
       msg += "\"";
     }
 
@@ -36,7 +36,7 @@ namespace Sass {
     : Base(pstate), fn(fn), arg(arg), type(type), value(value)
     {
       msg  = arg + ": \"";
-      msg += value->to_string(true, 5);
+      msg += value->to_string(Sass_Inspect_Options());
       msg += "\" is not a " + type;
       msg += " for `" + fn + "'";
     }
@@ -50,13 +50,13 @@ namespace Sass {
     {
       msg  = def_op_msg + ": \"";
       if (const Value* l = dynamic_cast<const Value*>(lhs)) {
-        msg += l->to_string();
+        msg += l->to_string({ NESTED, 5 });
       } else if (lhs) {
         msg += "[EXPRESSION]";
       }
       msg += " " + op + " ";
       if (const Value* r = dynamic_cast<const Value*>(rhs)) {
-        msg += r->to_string();
+        msg += r->to_string({ NESTED, 5 });
       } else if (rhs) {
         msg += "[EXPRESSION]";
       }
@@ -102,13 +102,13 @@ namespace Sass {
     {
       msg  = "Alpha channels must be equal: ";
       if (const Value* l = dynamic_cast<const Value*>(lhs)) {
-        msg += l->to_string();
+        msg += l->to_string({ NESTED, 5 });
       } else if (lhs) {
         msg += "[EXPRESSION]";
       }
       msg += " " + op + " ";
       if (const Value* r = dynamic_cast<const Value*>(rhs)) {
-        msg += r->to_string();
+        msg += r->to_string({ NESTED, 5 });
       } else if (rhs) {
         msg += "[EXPRESSION]";
       }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -639,7 +639,7 @@ namespace Sass {
     Binary_Expression* b1 = dynamic_cast<Binary_Expression*>(b->left());
     Binary_Expression* b2 = dynamic_cast<Binary_Expression*>(b->right());
 
-    int precision = (int)ctx.c_options->precision;
+    int precision = (int)ctx.c_options.precision;
     bool compressed = ctx.output_style() == SASS_STYLE_COMPRESSED;
 
     bool schema_op = false;
@@ -1094,7 +1094,7 @@ namespace Sass {
   }
 
   void Eval::interpolation(Context& ctx, std::string& res, Expression* ex, bool into_quotes, bool was_itpl) {
-    int precision = (int)ctx.c_options->precision;
+    int precision = (int)ctx.c_options.precision;
     bool compressed = ctx.output_style() == SASS_STYLE_COMPRESSED;
     bool needs_closing_brace = false;
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -43,7 +43,7 @@ namespace Sass {
   Eval::Eval(Expand& exp)
   : exp(exp),
     ctx(exp.ctx),
-    listize(exp.ctx)
+    listize(ctx.mem)
   { }
   Eval::~Eval() { }
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -640,7 +640,7 @@ namespace Sass {
     Binary_Expression* b2 = dynamic_cast<Binary_Expression*>(b->right());
 
     int precision = (int)ctx.c_options.precision;
-    bool compressed = ctx.output_style() == SASS_STYLE_COMPRESSED;
+    bool compressed = ctx.output_style() == COMPRESSED;
 
     bool schema_op = false;
 
@@ -1095,7 +1095,7 @@ namespace Sass {
 
   void Eval::interpolation(Context& ctx, std::string& res, Expression* ex, bool into_quotes, bool was_itpl) {
     int precision = (int)ctx.c_options.precision;
-    bool compressed = ctx.output_style() == SASS_STYLE_COMPRESSED;
+    bool compressed = ctx.output_style() == COMPRESSED;
     bool needs_closing_brace = false;
 
     if (Arguments* args = dynamic_cast<Arguments*>(ex)) {

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -438,10 +438,11 @@ namespace Sass {
         *lm << std::make_pair(key, val);
       }
       if (lm->has_duplicate_key()) {
+        To_String to_string({ INSPECT, 5 }, true);
         if (Color* col = dynamic_cast<Color*>(lm->get_duplicate_key())) {
-          error("Duplicate key " + col->to_hex({ NESTED, 5 }) + " in map (" + l->inspect() + ").", lm->pstate());
+          error("Duplicate key " + col->to_hex({ INSPECT, 5 }) + " in map (" + l->to_string({ INSPECT, 5 }) + ").", lm->pstate());
         } else {
-          error("Duplicate key " + lm->get_duplicate_key()->inspect() + " in map (" + l->inspect() + ").", lm->pstate());
+          error("Duplicate key \"" + lm->get_duplicate_key()->perform(&to_string) + "\" in map (" + l->perform(&to_string) + ").", lm->pstate());
         }
       }
 
@@ -471,7 +472,8 @@ namespace Sass {
     // make sure we're not starting with duplicate keys.
     // the duplicate key state will have been set in the parser phase.
     if (m->has_duplicate_key()) {
-      error("Duplicate key " + m->get_duplicate_key()->inspect() + " in map " + m->inspect() + ".", m->pstate());
+      To_String to_string({ INSPECT, 5 }, false);
+      error("Duplicate key \"" + m->get_duplicate_key()->perform(&to_string) + "\" in map " + m->perform(&to_string) + ".", m->pstate());
     }
 
     Map* mm = SASS_MEMORY_NEW(ctx.mem, Map,
@@ -485,7 +487,8 @@ namespace Sass {
 
     // check the evaluated keys aren't duplicates.
     if (mm->has_duplicate_key()) {
-      error("Duplicate key " + mm->get_duplicate_key()->inspect() + " in map " + m->inspect() + ".", mm->pstate());
+      To_String to_string({ INSPECT, 5 }, false);
+      error("Duplicate key \"" + mm->get_duplicate_key()->perform(&to_string) + "\" in map " + m->perform(&to_string) + ".", mm->pstate());
     }
 
     mm->is_expanded(true);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -1,8 +1,8 @@
 #ifndef SASS_EVAL_H
 #define SASS_EVAL_H
 
+#include "ast.hpp"
 #include "context.hpp"
-#include "listize.hpp"
 #include "operation.hpp"
 #include "environment.hpp"
 
@@ -88,11 +88,11 @@ namespace Sass {
     static bool eq(Expression*, Expression*);
     static bool lt(Expression*, Expression*, std::string op);
     // -- arithmetic on the combinations that matter
-    static Value* op_numbers(Memory_Manager&, enum Sass_OP, const Number&, const Number&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
-    static Value* op_number_color(Memory_Manager&, enum Sass_OP, const Number&, const Color&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
-    static Value* op_color_number(Memory_Manager&, enum Sass_OP, const Color&, const Number&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
-    static Value* op_colors(Memory_Manager&, enum Sass_OP, const Color&, const Color&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
-    static Value* op_strings(Memory_Manager&, Sass::Operand, Value&, Value&, bool compressed = false, int precision = 5, ParserState* pstate = 0, bool interpolant = false);
+    static Value* op_numbers(Memory_Manager&, enum Sass_OP, const Number&, const Number&, struct Sass_Inspect_Options opt, ParserState* pstate = 0);
+    static Value* op_number_color(Memory_Manager&, enum Sass_OP, const Number&, const Color&, struct Sass_Inspect_Options opt, ParserState* pstate = 0);
+    static Value* op_color_number(Memory_Manager&, enum Sass_OP, const Color&, const Number&, struct Sass_Inspect_Options opt, ParserState* pstate = 0);
+    static Value* op_colors(Memory_Manager&, enum Sass_OP, const Color&, const Color&, struct Sass_Inspect_Options opt, ParserState* pstate = 0);
+    static Value* op_strings(Memory_Manager&, Sass::Operand, Value&, Value&, struct Sass_Inspect_Options opt, ParserState* pstate = 0, bool interpolant = false);
 
   private:
     void interpolation(Context& ctx, std::string& res, Expression* ex, bool into_quotes, bool was_itpl = false);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -4,12 +4,12 @@
 #include "context.hpp"
 #include "listize.hpp"
 #include "operation.hpp"
+#include "environment.hpp"
 
 namespace Sass {
 
   class Expand;
   class Context;
-  class Listize;
 
   class Eval : public Operation_CRTP<Expression*, Eval> {
 
@@ -19,7 +19,6 @@ namespace Sass {
    public:
     Expand&  exp;
     Context& ctx;
-    Listize  listize;
     Eval(Expand& exp);
     ~Eval();
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -105,7 +105,7 @@ namespace Sass {
           while (tail) {
             if (tail->head()) for (Simple_Selector* header : tail->head()->elements()) {
               if (dynamic_cast<Parent_Selector*>(header) == NULL) continue; // skip all others
-              To_String to_string(&ctx); std::string sel_str(complex_selector->perform(&to_string));
+              To_String to_string(ctx.c_options); std::string sel_str(complex_selector->perform(&to_string));
               error("Base-level rules cannot contain the parent-selector-referencing character '&'.", header->pstate(), backtrace());
             }
             tail = tail->tail();
@@ -185,7 +185,7 @@ namespace Sass {
 
   Statement* Expand::operator()(Media_Block* m)
   {
-    To_String to_string(&ctx);
+    To_String to_string(ctx.c_options);
     Expression* mq = m->media_queries()->perform(&eval);
     mq = Parser::from_c_str(mq->perform(&to_string).c_str(), ctx, mq->pstate()).parse_media_queries();
     Media_Block* mm = SASS_MEMORY_NEW(ctx.mem, Media_Block,
@@ -558,7 +558,7 @@ namespace Sass {
         while (tail) {
           if (tail->head()) for (Simple_Selector* header : tail->head()->elements()) {
             if (dynamic_cast<Parent_Selector*>(header) == NULL) continue; // skip all others
-            To_String to_string(&ctx); std::string sel_str(complex_selector->perform(&to_string));
+            To_String to_string(ctx.c_options); std::string sel_str(complex_selector->perform(&to_string));
             error("Can't extend " + sel_str + ": can't extend parent selectors", header->pstate(), backtrace());
           }
           tail = tail->tail();
@@ -572,7 +572,7 @@ namespace Sass {
     for (auto complex_sel : contextualized->elements()) {
       Complex_Selector* c = complex_sel;
       if (!c->head() || c->tail()) {
-        To_String to_string(&ctx); std::string sel_str(contextualized->perform(&to_string));
+        To_String to_string(ctx.c_options); std::string sel_str(contextualized->perform(&to_string));
         error("Can't extend " + sel_str + ": can't extend nested selectors", c->pstate(), backtrace());
       }
       Compound_Selector* placeholder = c->head();

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1749,7 +1749,7 @@ namespace Sass {
         for (ExtensionPair ext : entries) {
           // check if both selectors have the same media block parent
           if (ext.first->media_block() == pComplexSelector->media_block()) continue;
-          To_String to_string(&ctx);
+          To_String to_string(ctx.c_options);
           if (ext.second->media_block() == 0) continue;
           if (pComplexSelector->media_block() &&
               ext.second->media_block()->media_queries() &&
@@ -1918,7 +1918,7 @@ namespace Sass {
   */
   Selector_List* Extend::extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething) {
 
-    To_String to_string(&ctx);
+    To_String to_string(ctx.c_options);
 
     Selector_List* pNewSelectors = SASS_MEMORY_NEW(ctx.mem, Selector_List, pSelectorList->pstate(), pSelectorList->length());
 
@@ -2011,7 +2011,7 @@ namespace Sass {
   // Extend a ruleset by extending the selectors and updating them on the ruleset. The block's rules don't need to change.
   template <typename ObjectType>
   static void extendObjectWithSelectorAndBlock(ObjectType* pObject, Context& ctx, ExtensionSubsetMap& subset_map) {
-    To_String to_string(&ctx);
+    To_String to_string(ctx.c_options);
 
     DEBUG_PRINTLN(EXTEND_OBJECT, "FOUND SELECTOR: " << static_cast<Selector_List*>(pObject->selector())->perform(&to_string))
 
@@ -2054,8 +2054,8 @@ namespace Sass {
         Complex_Selector* sel = it.first ? it.first->first() : NULL;
         Compound_Selector* ext = it.second ? it.second : NULL;
         if (ext && (ext->extended() || ext->is_optional())) continue;
-        std::string str_sel(sel->to_string());
-        std::string str_ext(ext->to_string());
+        std::string str_sel(sel->to_string({ NESTED, 5 }));
+        std::string str_ext(ext->to_string({ NESTED, 5 }));
         // debug_ast(sel, "sel: ");
         // debug_ast(ext, "ext: ");
         error("\"" + str_sel + "\" failed to @extend \"" + str_ext + "\".\n"

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1241,7 +1241,7 @@ namespace Sass {
         double index = std::floor(n->value() < 0 ? len + n->value() : n->value() - 1);
         if (index < 0 || index > len - 1) error("index out of bounds for `" + std::string(sig) + "`", pstate);
         // return (*sl)[static_cast<int>(index)];
-        Listize listize(ctx);
+        Listize listize(ctx.mem);
         return (*sl)[static_cast<int>(index)]->perform(&listize);
       }
       List* l = dynamic_cast<List*>(env["$list"]);
@@ -1336,7 +1336,7 @@ namespace Sass {
       List* l = dynamic_cast<List*>(env["$list"]);
       Expression* v = ARG("$val", Expression);
       if (Selector_List* sl = dynamic_cast<Selector_List*>(env["$list"])) {
-        Listize listize(ctx);
+        Listize listize(ctx.mem);
         l = dynamic_cast<List*>(sl->perform(&listize));
       }
       String_Constant* sep = ARG("$separator", String_Constant);
@@ -1741,7 +1741,7 @@ namespace Sass {
         result->elements(exploded);
       }
 
-      Listize listize(ctx);
+      Listize listize(ctx.mem);
       return result->perform(&listize);
     }
 
@@ -1833,7 +1833,7 @@ namespace Sass {
         result->elements(newElements);
       }
 
-      Listize listize(ctx);
+      Listize listize(ctx.mem);
       return result->perform(&listize);
     }
 
@@ -1844,7 +1844,7 @@ namespace Sass {
       Selector_List* selector2 = ARGSEL("$selector2", Selector_List, p_contextualize);
 
       Selector_List* result = selector1->unify_with(selector2, ctx);
-      Listize listize(ctx);
+      Listize listize(ctx.mem);
       return result->perform(&listize);
     }
 
@@ -1879,7 +1879,7 @@ namespace Sass {
       bool extendedSomething;
       Selector_List* result = Extend::extendSelectorList(selector, ctx, subset_map, false, extendedSomething);
 
-      Listize listize(ctx);
+      Listize listize(ctx.mem);
       return result->perform(&listize);
     }
 
@@ -1896,7 +1896,7 @@ namespace Sass {
       bool extendedSomething;
       Selector_List* result = Extend::extendSelectorList(selector, ctx, subset_map, true, extendedSomething);
 
-      Listize listize(ctx);
+      Listize listize(ctx.mem);
       return result->perform(&listize);
     }
 
@@ -1905,7 +1905,7 @@ namespace Sass {
     {
       Selector_List* sel = ARGSEL("$selector", Selector_List, p_contextualize);
 
-      Listize listize(ctx);
+      Listize listize(ctx.mem);
       return sel->perform(&listize);
     }
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -886,9 +886,12 @@ namespace Sass {
         return (Expression*) arg;
       }
       else {
-        To_String to_string(&ctx, false, true);
+        Sass_Output_Style oldstyle = ctx.c_options.output_style;
+        ctx.c_options.output_style = SASS_STYLE_NESTED;
+        To_String to_string(&ctx, false);
         std::string val(arg->perform(&to_string));
         val = dynamic_cast<Null*>(arg) ? "null" : val;
+        ctx.c_options.output_style = oldstyle;
 
         deprecated_function("Passing " + val + ", a non-string value, to unquote()", pstate);
         return (Expression*) arg;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -157,7 +157,7 @@ namespace Sass {
 
     template <>
     Selector_List* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
-      To_String to_string(&ctx, false);
+      To_String to_string(ctx.c_options, false);
       Expression* exp = ARG(argname, Expression);
       if (exp->concrete_type() == Expression::NULL_VAL) {
         std::stringstream msg;
@@ -171,7 +171,7 @@ namespace Sass {
 
     template <>
     Complex_Selector* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
-      To_String to_string(&ctx, false);
+      To_String to_string(ctx.c_options, false);
       Expression* exp = ARG(argname, Expression);
       if (exp->concrete_type() == Expression::NULL_VAL) {
         std::stringstream msg;
@@ -186,7 +186,7 @@ namespace Sass {
 
     template <>
     Compound_Selector* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
-      To_String to_string(&ctx, false);
+      To_String to_string(ctx.c_options, false);
       Expression* exp = ARG(argname, Expression);
       if (exp->concrete_type() == Expression::NULL_VAL) {
         std::stringstream msg;
@@ -512,7 +512,7 @@ namespace Sass {
       // CSS3 filter function overload: pass literal through directly
       Number* amount = dynamic_cast<Number*>(env["$amount"]);
       if (!amount) {
-        To_String to_string(&ctx);
+        To_String to_string(ctx.c_options);
         return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "saturate(" + env["$color"]->perform(&to_string) + ")");
       }
 
@@ -573,7 +573,7 @@ namespace Sass {
       // CSS3 filter function overload: pass literal through directly
       Number* amount = dynamic_cast<Number*>(env["$color"]);
       if (amount) {
-        To_String to_string(&ctx);
+        To_String to_string(ctx.c_options);
         return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "grayscale(" + amount->perform(&to_string) + ")");
       }
 
@@ -610,7 +610,7 @@ namespace Sass {
       // CSS3 filter function overload: pass literal through directly
       Number* amount = dynamic_cast<Number*>(env["$color"]);
       if (amount) {
-        To_String to_string(&ctx);
+        To_String to_string(ctx.c_options);
         return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "invert(" + amount->perform(&to_string) + ")");
       }
 
@@ -638,7 +638,7 @@ namespace Sass {
       // CSS3 filter function overload: pass literal through directly
       Number* amount = dynamic_cast<Number*>(env["$color"]);
       if (amount) {
-        To_String to_string(&ctx);
+        To_String to_string(ctx.c_options);
         return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, "opacity(" + amount->perform(&to_string) + ")");
       }
 
@@ -888,7 +888,7 @@ namespace Sass {
       else {
         Sass_Output_Style oldstyle = ctx.c_options.output_style;
         ctx.c_options.output_style = SASS_STYLE_NESTED;
-        To_String to_string(&ctx, false);
+        To_String to_string(ctx.c_options, false);
         std::string val(arg->perform(&to_string));
         val = dynamic_cast<Null*>(arg) ? "null" : val;
         ctx.c_options.output_style = oldstyle;
@@ -901,7 +901,7 @@ namespace Sass {
     Signature quote_sig = "quote($string)";
     BUILT_IN(sass_quote)
     {
-      To_String to_string(&ctx);
+      To_String to_string(ctx.c_options);
       AST_Node* arg = env["$string"];
       std::string str(quote(arg->perform(&to_string), String_Constant::double_quote()));
       String_Quoted* result = SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, str);
@@ -1130,7 +1130,7 @@ namespace Sass {
     Signature min_sig = "min($numbers...)";
     BUILT_IN(min)
     {
-      To_String to_string(&ctx);
+      To_String to_string(ctx.c_options);
       List* arglist = ARG("$numbers", List);
       Number* least = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
@@ -1149,7 +1149,7 @@ namespace Sass {
     Signature max_sig = "max($numbers...)";
     BUILT_IN(max)
     {
-      To_String to_string(&ctx);
+      To_String to_string(ctx.c_options);
       List* arglist = ARG("$numbers", List);
       Number* greatest = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
@@ -1691,7 +1691,7 @@ namespace Sass {
         Sass_Output_Style old_style;
         old_style = ctx.c_options.output_style;
         ctx.c_options.output_style = NESTED;
-        To_String to_string(&ctx, false);
+        To_String to_string(ctx.c_options, false);
         std::string inspect = v->perform(&to_string);
         if (inspect.empty() && parentheses) inspect = "()";
         ctx.c_options.output_style = old_style;
@@ -1702,7 +1702,7 @@ namespace Sass {
     Signature selector_nest_sig = "selector-nest($selectors...)";
     BUILT_IN(selector_nest)
     {
-      To_String to_string(&ctx, false);
+      To_String to_string(ctx.c_options, false);
       List* arglist = ARG("$selectors", List);
 
       // Not enough parameters
@@ -1915,7 +1915,7 @@ namespace Sass {
     Signature is_superselector_sig = "is-superselector($super, $sub)";
     BUILT_IN(is_superselector)
     {
-      To_String to_string(&ctx, false);
+      To_String to_string(ctx.c_options, false);
       Selector_List*  sel_sup = ARGSEL("$super", Selector_List, p_contextualize);
       Selector_List*  sel_sub = ARGSEL("$sub", Selector_List, p_contextualize);
       bool result = sel_sup->is_superselector_of(sel_sub);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1687,7 +1687,7 @@ namespace Sass {
                            v->concrete_type() == Expression::LIST;
         Sass_Output_Style old_style;
         old_style = ctx.c_options.output_style;
-        ctx.c_options.output_style = SASS_STYLE_NESTED;
+        ctx.c_options.output_style = NESTED;
         To_String to_string(&ctx, false);
         std::string inspect = v->perform(&to_string);
         if (inspect.empty() && parentheses) inspect = "()";

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -313,9 +313,9 @@ namespace Sass {
 
       return SASS_MEMORY_NEW(ctx.mem, Color,
                              pstate,
-                             Sass::round(w1*color1->r() + w2*color2->r(), ctx.c_options->precision),
-                             Sass::round(w1*color1->g() + w2*color2->g(), ctx.c_options->precision),
-                             Sass::round(w1*color1->b() + w2*color2->b(), ctx.c_options->precision),
+                             Sass::round(w1*color1->r() + w2*color2->r(), ctx.c_options.precision),
+                             Sass::round(w1*color1->g() + w2*color2->g(), ctx.c_options.precision),
+                             Sass::round(w1*color1->b() + w2*color2->b(), ctx.c_options.precision),
                              color1->a()*p + color2->a()*(1-p));
     }
 
@@ -856,10 +856,10 @@ namespace Sass {
 
       std::stringstream ss;
       ss << '#' << std::setw(2) << std::setfill('0');
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(a, ctx.c_options->precision));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(r, ctx.c_options->precision));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(g, ctx.c_options->precision));
-      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(b, ctx.c_options->precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(a, ctx.c_options.precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(r, ctx.c_options.precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(g, ctx.c_options.precision));
+      ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(b, ctx.c_options.precision));
 
       std::string result(ss.str());
       for (size_t i = 0, L = result.length(); i < L; ++i) {
@@ -1090,7 +1090,7 @@ namespace Sass {
       Number* n = ARG("$number", Number);
       Number* r = SASS_MEMORY_NEW(ctx.mem, Number, *n);
       r->pstate(pstate);
-      r->value(Sass::round(r->value(), ctx.c_options->precision));
+      r->value(Sass::round(r->value(), ctx.c_options.precision));
       return r;
     }
 
@@ -1686,12 +1686,12 @@ namespace Sass {
         bool parentheses = v->concrete_type() == Expression::MAP ||
                            v->concrete_type() == Expression::LIST;
         Sass_Output_Style old_style;
-        old_style = ctx.c_options->output_style;
-        ctx.c_options->output_style = SASS_STYLE_NESTED;
+        old_style = ctx.c_options.output_style;
+        ctx.c_options.output_style = SASS_STYLE_NESTED;
         To_String to_string(&ctx, false);
         std::string inspect = v->perform(&to_string);
         if (inspect.empty() && parentheses) inspect = "()";
-        ctx.c_options->output_style = old_style;
+        ctx.c_options.output_style = old_style;
         return SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, inspect);
       }
       // return v;

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -1,6 +1,7 @@
 #ifndef SASS_FUNCTIONS_H
 #define SASS_FUNCTIONS_H
 
+#include "listize.hpp"
 #include "position.hpp"
 #include "environment.hpp"
 #include "sass/functions.h"

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -479,29 +479,20 @@ namespace Sass {
 
   void Inspect::operator()(Number* n)
   {
-    // use values to_string facility
-    bool compressed = ctx->output_style() == COMPRESSED;
-    std::string res(n->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
-    append_token(res, n);
+    append_token(n->to_string(opt), n);
   }
 
   void Inspect::operator()(Color* c)
   {
-    // use values to_string facility
-    bool compressed = ctx->output_style() == COMPRESSED;
-    std::string res(c->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
-    append_token(res, c);
+    append_token(c->to_string(opt), c);
   }
 
   void Inspect::operator()(Boolean* b)
   {
-    // use values to_string facility
-    bool compressed = ctx->output_style() == COMPRESSED;
-    std::string res(b->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
-    append_token(res, b);
+    append_token(b->to_string(opt), b);
   }
 
   void Inspect::operator()(String_Schema* ss)
@@ -517,24 +508,14 @@ namespace Sass {
 
   void Inspect::operator()(String_Constant* s)
   {
-    // get options from optional? context
-    int precision = ctx ? (int)ctx->c_options.precision : 5;
-    bool compressed = ctx ? ctx->output_style() == COMPRESSED : false;
-    // use values to_string facility
-    std::string res(s->to_string(compressed, precision));
     // output the final token
-    append_token(res, s);
+    append_token(s->to_string(opt), s);
   }
 
   void Inspect::operator()(String_Quoted* s)
   {
-    // get options from optional? context
-    int precision = ctx ? (int)ctx->c_options.precision : 5;
-    bool compressed = ctx ? ctx->output_style() == COMPRESSED : false;
-    // use values to_string facility
-    std::string res(s->to_string(compressed, precision));
     // output the final token
-    append_token(res, s);
+    append_token(s->to_string(opt), s);
   }
   void Inspect::operator()(Supports_Operator* so)
   {
@@ -632,11 +613,8 @@ namespace Sass {
 
   void Inspect::operator()(Null* n)
   {
-    // use values to_string facility
-    bool compressed = output_style() == COMPRESSED;
-    std::string res(n->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
-    append_token(res, n);
+    append_token(n->to_string(opt), n);
   }
 
   // parameters and arguments

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -412,7 +412,8 @@ namespace Sass {
   void Inspect::operator()(Binary_Expression* expr)
   {
     expr->left()->perform(this);
-    if ( in_media_block || (
+    if ( in_media_block ||
+         (output_style() == INSPECT) || (
           expr->op().ws_before
           && (!expr->is_interpolant())
           && (!expr->is_delayed() ||
@@ -437,7 +438,8 @@ namespace Sass {
       case Sass_OP::MOD: append_string("%");   break;
       default: break; // shouldn't get here
     }
-    if ( in_media_block || (
+    if ( in_media_block ||
+         (output_style() == INSPECT) || (
           expr->op().ws_after
           && (!expr->is_interpolant())
           && (!expr->is_delayed()

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -131,7 +131,8 @@ namespace Sass {
     append_colon_separator();
 
     if (dec->value()->concrete_type() == Expression::SELECTOR) {
-      Listize listize(*ctx);
+      Memory_Manager mem;
+      Listize listize(mem);
       dec->value()->perform(&listize)->perform(this);
     } else {
       dec->value()->perform(this);

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -480,7 +480,7 @@ namespace Sass {
   {
     // use values to_string facility
     bool compressed = ctx->output_style() == SASS_STYLE_COMPRESSED;
-    std::string res(n->to_string(compressed, (int)ctx->c_options->precision));
+    std::string res(n->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
     append_token(res, n);
   }
@@ -489,7 +489,7 @@ namespace Sass {
   {
     // use values to_string facility
     bool compressed = ctx->output_style() == SASS_STYLE_COMPRESSED;
-    std::string res(c->to_string(compressed, (int)ctx->c_options->precision));
+    std::string res(c->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
     append_token(res, c);
   }
@@ -498,7 +498,7 @@ namespace Sass {
   {
     // use values to_string facility
     bool compressed = ctx->output_style() == SASS_STYLE_COMPRESSED;
-    std::string res(b->to_string(compressed, (int)ctx->c_options->precision));
+    std::string res(b->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
     append_token(res, b);
   }
@@ -517,7 +517,7 @@ namespace Sass {
   void Inspect::operator()(String_Constant* s)
   {
     // get options from optional? context
-    int precision = ctx ? (int)ctx->c_options->precision : 5;
+    int precision = ctx ? (int)ctx->c_options.precision : 5;
     bool compressed = ctx ? ctx->output_style() == SASS_STYLE_COMPRESSED : false;
     // use values to_string facility
     std::string res(s->to_string(compressed, precision));
@@ -528,7 +528,7 @@ namespace Sass {
   void Inspect::operator()(String_Quoted* s)
   {
     // get options from optional? context
-    int precision = ctx ? (int)ctx->c_options->precision : 5;
+    int precision = ctx ? (int)ctx->c_options.precision : 5;
     bool compressed = ctx ? ctx->output_style() == SASS_STYLE_COMPRESSED : false;
     // use values to_string facility
     std::string res(s->to_string(compressed, precision));
@@ -633,7 +633,7 @@ namespace Sass {
   {
     // use values to_string facility
     bool compressed = output_style() == SASS_STYLE_COMPRESSED;
-    std::string res(n->to_string(compressed, (int)ctx->c_options->precision));
+    std::string res(n->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
     append_token(res, n);
   }

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -27,11 +27,11 @@ namespace Sass {
       add_open_mapping(block);
       append_scope_opener();
     }
-    if (output_style() == SASS_STYLE_NESTED) indentation += block->tabs();
+    if (output_style() == NESTED) indentation += block->tabs();
     for (size_t i = 0, L = block->length(); i < L; ++i) {
       (*block)[i]->perform(this);
     }
-    if (output_style() == SASS_STYLE_NESTED) indentation -= block->tabs();
+    if (output_style() == NESTED) indentation -= block->tabs();
     if (!block->is_root()) {
       append_scope_closer();
       add_close_mapping(block);
@@ -124,7 +124,7 @@ namespace Sass {
     if (dec->value()->concrete_type() == Expression::NULL_VAL) return;
     bool was_decl = in_declaration;
     in_declaration = true;
-    if (output_style() == SASS_STYLE_NESTED)
+    if (output_style() == NESTED)
       indentation += dec->tabs();
     append_indentation();
     dec->property()->perform(this);
@@ -142,7 +142,7 @@ namespace Sass {
       append_string("!important");
     }
     append_delimiter();
-    if (output_style() == SASS_STYLE_NESTED)
+    if (output_style() == NESTED)
       indentation -= dec->tabs();
     in_declaration = was_decl;
   }
@@ -364,7 +364,7 @@ namespace Sass {
   void Inspect::operator()(List* list)
   {
     std::string sep(list->separator() == SASS_SPACE ? " " : ",");
-    if ((output_style() != SASS_STYLE_COMPRESSED || in_debug) && sep == ",") sep += " ";
+    if ((output_style() != COMPRESSED || in_debug) && sep == ",") sep += " ";
     else if (in_media_block && sep != " ") sep += " "; // verified
     if (list->empty()) return;
     bool items_output = false;
@@ -479,7 +479,7 @@ namespace Sass {
   void Inspect::operator()(Number* n)
   {
     // use values to_string facility
-    bool compressed = ctx->output_style() == SASS_STYLE_COMPRESSED;
+    bool compressed = ctx->output_style() == COMPRESSED;
     std::string res(n->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
     append_token(res, n);
@@ -488,7 +488,7 @@ namespace Sass {
   void Inspect::operator()(Color* c)
   {
     // use values to_string facility
-    bool compressed = ctx->output_style() == SASS_STYLE_COMPRESSED;
+    bool compressed = ctx->output_style() == COMPRESSED;
     std::string res(c->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
     append_token(res, c);
@@ -497,7 +497,7 @@ namespace Sass {
   void Inspect::operator()(Boolean* b)
   {
     // use values to_string facility
-    bool compressed = ctx->output_style() == SASS_STYLE_COMPRESSED;
+    bool compressed = ctx->output_style() == COMPRESSED;
     std::string res(b->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
     append_token(res, b);
@@ -518,7 +518,7 @@ namespace Sass {
   {
     // get options from optional? context
     int precision = ctx ? (int)ctx->c_options.precision : 5;
-    bool compressed = ctx ? ctx->output_style() == SASS_STYLE_COMPRESSED : false;
+    bool compressed = ctx ? ctx->output_style() == COMPRESSED : false;
     // use values to_string facility
     std::string res(s->to_string(compressed, precision));
     // output the final token
@@ -529,7 +529,7 @@ namespace Sass {
   {
     // get options from optional? context
     int precision = ctx ? (int)ctx->c_options.precision : 5;
-    bool compressed = ctx ? ctx->output_style() == SASS_STYLE_COMPRESSED : false;
+    bool compressed = ctx ? ctx->output_style() == COMPRESSED : false;
     // use values to_string facility
     std::string res(s->to_string(compressed, precision));
     // output the final token
@@ -632,7 +632,7 @@ namespace Sass {
   void Inspect::operator()(Null* n)
   {
     // use values to_string facility
-    bool compressed = output_style() == SASS_STYLE_COMPRESSED;
+    bool compressed = output_style() == COMPRESSED;
     std::string res(n->to_string(compressed, (int)ctx->c_options.precision));
     // output the final token
     append_token(res, n);
@@ -772,7 +772,7 @@ namespace Sass {
       (*s)[i]->perform(this);
     }
     if (s->has_line_break()) {
-      if (output_style() != SASS_STYLE_COMPACT) {
+      if (output_style() != COMPACT) {
         append_optional_linefeed();
       }
     }
@@ -794,7 +794,7 @@ namespace Sass {
     if (head && head->length() != 0) head->perform(this);
     bool is_empty = !head || head->length() == 0 || head->is_empty_reference();
     bool is_tail = head && !head->is_empty_reference() && tail;
-    if (output_style() == SASS_STYLE_COMPRESSED && comb != Complex_Selector::ANCESTOR_OF) scheduled_space = 0;
+    if (output_style() == COMPRESSED && comb != Complex_Selector::ANCESTOR_OF) scheduled_space = 0;
 
     switch (comb) {
       case Complex_Selector::ANCESTOR_OF:
@@ -830,7 +830,7 @@ namespace Sass {
     }
     if (tail) tail->perform(this);
     if (!tail && c->has_line_break()) {
-      if (output_style() == SASS_STYLE_COMPACT) {
+      if (output_style() == COMPACT) {
         append_mandatory_space();
       }
     }

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -365,7 +365,7 @@ namespace Sass {
   void Inspect::operator()(List* list)
   {
     std::string sep(list->separator() == SASS_SPACE ? " " : ",");
-    if ((output_style() != COMPRESSED || in_debug) && sep == ",") sep += " ";
+    if ((output_style() != COMPRESSED) && sep == ",") sep += " ";
     else if (in_media_block && sep != " ") sep += " "; // verified
     if (list->empty()) return;
     bool items_output = false;

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -11,19 +11,19 @@
 
 namespace Sass {
 
-  Listize::Listize(Context& ctx)
-  : ctx(ctx)
+  Listize::Listize(Memory_Manager& mem)
+  : mem(mem)
   {  }
 
   Expression* Listize::operator()(Selector_List* sel)
   {
-    List* l = SASS_MEMORY_NEW(ctx.mem, List, sel->pstate(), sel->length(), SASS_COMMA);
+    List* l = SASS_MEMORY_NEW(mem, List, sel->pstate(), sel->length(), SASS_COMMA);
     for (size_t i = 0, L = sel->length(); i < L; ++i) {
       if (!(*sel)[i]) continue;
       *l << (*sel)[i]->perform(this);
     }
     if (l->length()) return l;
-    return SASS_MEMORY_NEW(ctx.mem, Null, l->pstate());
+    return SASS_MEMORY_NEW(mem, Null, l->pstate());
   }
 
   Expression* Listize::operator()(Compound_Selector* sel)
@@ -34,12 +34,12 @@ namespace Sass {
       Expression* e = (*sel)[i]->perform(this);
       if (e) str += e->perform(&to_string);
     }
-    return SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), str);
+    return SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), str);
   }
 
   Expression* Listize::operator()(Complex_Selector* sel)
   {
-    List* l = SASS_MEMORY_NEW(ctx.mem, List, sel->pstate(), 2);
+    List* l = SASS_MEMORY_NEW(mem, List, sel->pstate(), 2);
 
     Compound_Selector* head = sel->head();
     if (head && !head->is_empty_reference())
@@ -54,16 +54,16 @@ namespace Sass {
     switch(sel->combinator())
     {
       case Complex_Selector::PARENT_OF:
-        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), ">");
+        *l << SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), ">");
       break;
       case Complex_Selector::ADJACENT_TO:
-        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), "+");
+        *l << SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), "+");
       break;
       case Complex_Selector::REFERENCE:
-        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), "/" + reference + "/");
+        *l << SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), "/" + reference + "/");
       break;
       case Complex_Selector::PRECEDES:
-        *l << SASS_MEMORY_NEW(ctx.mem, String_Quoted, sel->pstate(), "~");
+        *l << SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), "~");
       break;
       case Complex_Selector::ANCESTOR_OF:
       break;

--- a/src/listize.hpp
+++ b/src/listize.hpp
@@ -16,12 +16,12 @@ namespace Sass {
 
   class Listize : public Operation_CRTP<Expression*, Listize> {
 
-    Context&            ctx;
+    Memory_Manager& mem;
 
     Expression* fallback_impl(AST_Node* n);
 
   public:
-    Listize(Context&);
+    Listize(Memory_Manager&);
     ~Listize() { }
 
     Expression* operator()(Selector_List*);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -134,7 +134,7 @@ namespace Sass {
     if (b->has_non_hoistable()) {
       decls = true;
       if (output_style() == SASS_STYLE_NESTED) indentation += r->tabs();
-      if (ctx && ctx->c_options->source_comments) {
+      if (ctx && ctx->c_options.source_comments) {
         std::stringstream ss;
         append_indentation();
         ss << "/* line " << r->pstate().line + 1 << ", " << r->pstate().path << " */";

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -76,7 +76,7 @@ namespace Sass {
       // skip all ascii chars
       if (chr >= 0) continue;
       // declare the charset
-      if (output_style() != SASS_STYLE_COMPRESSED)
+      if (output_style() != COMPRESSED)
         charset = "@charset \"UTF-8\";"
                   + ctx->linefeed;
       else charset = "\xEF\xBB\xBF";
@@ -97,7 +97,7 @@ namespace Sass {
     std::string txt = c->text()->perform(&to_string);
     // if (indentation && txt == "/**/") return;
     bool important = c->is_important();
-    if (output_style() != SASS_STYLE_COMPRESSED || important) {
+    if (output_style() != COMPRESSED || important) {
       if (buffer().size() == 0) {
         top_nodes.push_back(c);
       } else {
@@ -133,7 +133,7 @@ namespace Sass {
 
     if (b->has_non_hoistable()) {
       decls = true;
-      if (output_style() == SASS_STYLE_NESTED) indentation += r->tabs();
+      if (output_style() == NESTED) indentation += r->tabs();
       if (ctx && ctx->c_options.source_comments) {
         std::stringstream ss;
         append_indentation();
@@ -173,7 +173,7 @@ namespace Sass {
           stm->perform(this);
         }
       }
-      if (output_style() == SASS_STYLE_NESTED) indentation -= r->tabs();
+      if (output_style() == NESTED) indentation -= r->tabs();
       append_scope_closer(b);
     }
 
@@ -240,7 +240,7 @@ namespace Sass {
       return;
     }
 
-    if (output_style() == SASS_STYLE_NESTED) indentation += f->tabs();
+    if (output_style() == NESTED) indentation += f->tabs();
     append_indentation();
     append_token("@supports", f);
     append_mandatory_space();
@@ -276,7 +276,7 @@ namespace Sass {
       }
     }
 
-    if (output_style() == SASS_STYLE_NESTED) indentation -= f->tabs();
+    if (output_style() == NESTED) indentation -= f->tabs();
 
     append_scope_closer();
 
@@ -299,7 +299,7 @@ namespace Sass {
       }
       return;
     }
-    if (output_style() == SASS_STYLE_NESTED) indentation += m->tabs();
+    if (output_style() == NESTED) indentation += m->tabs();
     append_indentation();
     append_token("@media", m);
     append_mandatory_space();
@@ -313,7 +313,7 @@ namespace Sass {
       if (i < L - 1) append_special_linefeed();
     }
 
-    if (output_style() == SASS_STYLE_NESTED) indentation -= m->tabs();
+    if (output_style() == NESTED) indentation -= m->tabs();
     append_scope_closer();
   }
 
@@ -383,7 +383,7 @@ namespace Sass {
   void Output::operator()(String_Constant* s)
   {
     std::string value(s->value());
-    if (s->can_compress_whitespace() && output_style() == SASS_STYLE_COMPRESSED) {
+    if (s->can_compress_whitespace() && output_style() == COMPRESSED) {
       value.erase(std::remove_if(value.begin(), value.end(), ::isspace), value.end());
     }
     if (!in_comment) {

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -23,8 +23,7 @@ namespace Sass {
     using Inspect::operator();
 
   public:
-    // change to Emitter
-    Output(Context* ctx);
+    Output(Sass_Output_Options& opt);
     virtual ~Output();
 
   protected:

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -591,7 +591,7 @@ namespace Sass {
     bool reloop = true;
     bool had_linefeed = false;
     Complex_Selector* sel = 0;
-    To_String to_string(&ctx);
+    To_String to_string(ctx.c_options);
     Selector_List* group = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate);
     group->media_block(last_media_block);
 
@@ -753,8 +753,8 @@ namespace Sass {
           ParserState state(pstate);
           Simple_Selector* cur = (*seq)[seq->length()-1];
           Simple_Selector* prev = (*seq)[seq->length()-2];
-          std::string sel(prev->to_string(false, 5));
-          std::string found(cur->to_string(false, 5));
+          std::string sel(prev->to_string({ NESTED, 5 }));
+          std::string found(cur->to_string({ NESTED, 5 }));
           if (lex < identifier >()) { found += std::string(lexed); }
           error("Invalid CSS after \"" + sel + "\": expected \"{\", was \"" + found + "\"\n\n"
             "\"" + found + "\" may only be used at the beginning of a compound selector.", state);
@@ -1777,7 +1777,7 @@ namespace Sass {
       (*res) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, suffix);
       return res;
     } else {
-      std::string res = prefix + url_string->to_string() + suffix;
+      std::string res = prefix + url_string->to_string({ NESTED, 5 }) + suffix;
       return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, res);
     }
   }

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -45,7 +45,7 @@
 #endif
 
 
-// some syntax sugar
+// output behaviours
 namespace Sass {
 
   // create some C++ aliases for the most used options
@@ -53,6 +53,73 @@ namespace Sass {
   const static Sass_Output_Style COMPACT = SASS_STYLE_COMPACT;
   const static Sass_Output_Style EXPANDED = SASS_STYLE_EXPANDED;
   const static Sass_Output_Style COMPRESSED = SASS_STYLE_COMPRESSED;
+
+};
+
+// input behaviours
+enum Sass_Input_Style {
+  SASS_CONTEXT_NULL,
+  SASS_CONTEXT_FILE,
+  SASS_CONTEXT_DATA,
+  SASS_CONTEXT_FOLDER
+};
+
+// simple linked list
+struct string_list {
+  string_list* next;
+  char* string;
+};
+
+// sass config options structure
+struct Sass_Inspect_Options {
+
+  // Precision for fractional numbers
+  int precision;
+
+  // Output style for the generated css code
+  // A value from above SASS_STYLE_* constants
+  enum Sass_Output_Style output_style;
+
+  // initialization list (constructor with defaults)
+  Sass_Inspect_Options(int precision = 5,
+                       Sass_Output_Style style = Sass::NESTED)
+  : precision(precision), output_style(style)
+  { }
+
+};
+
+// sass config options structure
+struct Sass_Output_Options : Sass_Inspect_Options {
+
+  // String to be used for indentation
+  const char* indent;
+  // String to be used to for line feeds
+  const char* linefeed;
+
+  // Emit comments in the generated CSS indicating
+  // the corresponding source line.
+  bool source_comments;
+
+  // initialization list (constructor with defaults)
+  Sass_Output_Options(struct Sass_Inspect_Options opt,
+                      const char* indent = "  ",
+                      const char* linefeed = "\n",
+                      bool source_comments = false)
+  : Sass_Inspect_Options(opt),
+    indent(indent), linefeed(linefeed),
+    source_comments(source_comments)
+  { }
+
+  // initialization list (constructor with defaults)
+  Sass_Output_Options(int precision = 5,
+                      Sass_Output_Style style = Sass::NESTED,
+                      const char* indent = "  ",
+                      const char* linefeed = "\n",
+                      bool source_comments = false)
+  : Sass_Inspect_Options(precision, style),
+    indent(indent), linefeed(linefeed),
+    source_comments(source_comments)
+  { }
 
 };
 

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -2,9 +2,6 @@
 #ifndef SASS_SASS_H
 #define SASS_SASS_H
 
-// include C-API header
-#include "sass/base.h"
-
 // undefine extensions macro to tell sys includes
 // that we do not want any macros to be exported
 // mainly fixes an issue on SmartOS (SEC macro)
@@ -45,6 +42,9 @@
 #endif
 
 
+// include C-API header
+#include "sass/base.h"
+
 // output behaviours
 namespace Sass {
 
@@ -73,17 +73,17 @@ struct string_list {
 // sass config options structure
 struct Sass_Inspect_Options {
 
-  // Precision for fractional numbers
-  int precision;
-
   // Output style for the generated css code
   // A value from above SASS_STYLE_* constants
   enum Sass_Output_Style output_style;
 
+  // Precision for fractional numbers
+  int precision;
+
   // initialization list (constructor with defaults)
-  Sass_Inspect_Options(int precision = 5,
-                       Sass_Output_Style style = Sass::NESTED)
-  : precision(precision), output_style(style)
+  Sass_Inspect_Options(Sass_Output_Style style = Sass::NESTED,
+                       int precision = 5)
+  : output_style(style), precision(precision)
   { }
 
 };
@@ -111,12 +111,12 @@ struct Sass_Output_Options : Sass_Inspect_Options {
   { }
 
   // initialization list (constructor with defaults)
-  Sass_Output_Options(int precision = 5,
-                      Sass_Output_Style style = Sass::NESTED,
+  Sass_Output_Options(Sass_Output_Style style = Sass::NESTED,
+                      int precision = 5,
                       const char* indent = "  ",
                       const char* linefeed = "\n",
                       bool source_comments = false)
-  : Sass_Inspect_Options(precision, style),
+  : Sass_Inspect_Options(style, precision),
     indent(indent), linefeed(linefeed),
     source_comments(source_comments)
   { }

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -2,6 +2,9 @@
 #ifndef SASS_SASS_H
 #define SASS_SASS_H
 
+// include C-API header
+#include "sass/base.h"
+
 // undefine extensions macro to tell sys includes
 // that we do not want any macros to be exported
 // mainly fixes an issue on SmartOS (SEC macro)
@@ -40,5 +43,17 @@
 #  define PATH_SEP ':'
 # endif
 #endif
+
+
+// some syntax sugar
+namespace Sass {
+
+  // create some C++ aliases for the most used options
+  const static Sass_Output_Style NESTED = SASS_STYLE_NESTED;
+  const static Sass_Output_Style COMPACT = SASS_STYLE_COMPACT;
+  const static Sass_Output_Style EXPANDED = SASS_STYLE_EXPANDED;
+  const static Sass_Output_Style COMPRESSED = SASS_STYLE_COMPRESSED;
+
+};
 
 #endif

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -53,6 +53,8 @@ namespace Sass {
   const static Sass_Output_Style COMPACT = SASS_STYLE_COMPACT;
   const static Sass_Output_Style EXPANDED = SASS_STYLE_EXPANDED;
   const static Sass_Output_Style COMPRESSED = SASS_STYLE_COMPRESSED;
+  // only used internal to trigger ruby inspect behavior
+  const static Sass_Output_Style INSPECT = SASS_STYLE_INSPECT;
 
 };
 

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -410,14 +410,14 @@ extern "C" {
   struct Sass_Compiler* ADDCALL sass_make_data_compiler (struct Sass_Data_Context* data_ctx)
   {
     if (data_ctx == 0) return 0;
-    Context* cpp_ctx = new Data_Context(data_ctx);
+    Context* cpp_ctx = new Data_Context(*data_ctx);
     return sass_prepare_context(data_ctx, cpp_ctx);
   }
 
   struct Sass_Compiler* ADDCALL sass_make_file_compiler (struct Sass_File_Context* file_ctx)
   {
     if (file_ctx == 0) return 0;
-    Context* cpp_ctx = new File_Context(file_ctx);
+    Context* cpp_ctx = new File_Context(*file_ctx);
     return sass_prepare_context(file_ctx, cpp_ctx);
   }
 
@@ -432,7 +432,7 @@ extern "C" {
       // if (*data_ctx->source_string == 0) { throw(std::runtime_error("Data context has empty source string")); }
     }
     catch (...) { return handle_errors(data_ctx) | 1; }
-    Context* cpp_ctx = new Data_Context(data_ctx);
+    Context* cpp_ctx = new Data_Context(*data_ctx);
     return sass_compile_context(data_ctx, cpp_ctx);
   }
 
@@ -446,7 +446,7 @@ extern "C" {
       if (*file_ctx->input_path == 0) { throw(std::runtime_error("File context has empty input path")); }
     }
     catch (...) { return handle_errors(file_ctx) | 1; }
-    Context* cpp_ctx = new File_Context(file_ctx);
+    Context* cpp_ctx = new File_Context(*file_ctx);
     return sass_compile_context(file_ctx, cpp_ctx);
   }
 

--- a/src/sass_context.hpp
+++ b/src/sass_context.hpp
@@ -26,7 +26,7 @@ struct Sass_Options {
   int precision;
 
   // Output style for the generated css code
-  // A value from above SASS_STYLE_* constants
+  // A value from the SASS_STYLE_* constants
   enum Sass_Output_Style output_style;
 
   // Emit comments in the generated CSS indicating

--- a/src/sass_context.hpp
+++ b/src/sass_context.hpp
@@ -2,36 +2,12 @@
 #define SASS_SASS_CONTEXT_H
 
 #include "sass.h"
+#include "sass.hpp"
 #include "context.hpp"
 #include "ast_fwd_decl.hpp"
 
-// Input behaviours
-enum Sass_Input_Style {
-  SASS_CONTEXT_NULL,
-  SASS_CONTEXT_FILE,
-  SASS_CONTEXT_DATA,
-  SASS_CONTEXT_FOLDER
-};
-
-// simple linked list
-struct string_list {
-  string_list* next;
-  char* string;
-};
-
 // sass config options structure
-struct Sass_Options {
-
-  // Precision for fractional numbers
-  int precision;
-
-  // Output style for the generated css code
-  // A value from the SASS_STYLE_* constants
-  enum Sass_Output_Style output_style;
-
-  // Emit comments in the generated CSS indicating
-  // the corresponding source line.
-  bool source_comments;
+struct Sass_Options : Sass_Output_Options {
 
   // embed sourceMappingUrl as data uri
   bool source_map_embed;
@@ -58,11 +34,6 @@ struct Sass_Options {
   // this file, it is just used to create
   // information in source-maps etc.
   char* output_path;
-
-  // String to be used for indentation
-  const char* indent;
-  // String to be used to for line feeds
-  const char* linefeed;
 
   // Colon-separated list of paths
   // Semicolon-separated on Windows

--- a/src/sass_interface.cpp
+++ b/src/sass_interface.cpp
@@ -70,9 +70,8 @@ extern "C" {
       else {
           output_path = c_ctx->output_path;
       }
-      Data_Context cpp_ctx(
-        (Sass_Data_Context*) 0
-      );
+      struct Sass_Data_Context opt;
+      Data_Context cpp_ctx(opt);
       if (c_ctx->c_functions) {
         Sass_Function_List this_func_data = c_ctx->c_functions;
         while ((this_func_data) && (*this_func_data)) {
@@ -146,9 +145,8 @@ extern "C" {
       else {
           output_path = c_ctx->output_path;
       }
-      File_Context cpp_ctx(
-        (Sass_File_Context*) 0
-      );
+      struct Sass_File_Context opt;
+      File_Context cpp_ctx(opt);
       if (c_ctx->c_functions) {
         Sass_Function_List this_func_data = c_ctx->c_functions;
         while ((this_func_data) && (*this_func_data)) {

--- a/src/sass_util.cpp
+++ b/src/sass_util.cpp
@@ -39,7 +39,7 @@ namespace Sass {
     end
   */
   Node paths(const Node& arrs, Context& ctx) {
-    To_String to_string(&ctx);
+    To_String to_string(ctx.c_options);
 
     Node loopStart = Node::createCollection();
     loopStart.collection()->push_back(Node::createCollection());

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -277,7 +277,8 @@ extern "C" {
   {
     Memory_Manager mem;
     Value* val = sass_value_to_ast_node(mem, v);
-    std::string str(val->to_string(compressed, precision));
+    Sass_Inspect_Options options(compressed ? COMPRESSED : NESTED, precision);
+    std::string str(val->to_string(options));
     return sass_make_qstring(str.c_str());
   }
 
@@ -291,6 +292,7 @@ extern "C" {
 
       Value* lhs = sass_value_to_ast_node(mem, a);
       Value* rhs = sass_value_to_ast_node(mem, b);
+      struct Sass_Inspect_Options options(NESTED, 5);
 
       // see if it's a relational expression
       switch(op) {
@@ -306,27 +308,27 @@ extern "C" {
       if (sass_value_is_number(a) && sass_value_is_number(b)) {
         const Number* l_n = dynamic_cast<const Number*>(lhs);
         const Number* r_n = dynamic_cast<const Number*>(rhs);
-        rv = Eval::op_numbers(mem, op, *l_n, *r_n);
+        rv = Eval::op_numbers(mem, op, *l_n, *r_n, options);
       }
       else if (sass_value_is_number(a) && sass_value_is_color(a)) {
         const Number* l_n = dynamic_cast<const Number*>(lhs);
         const Color* r_c = dynamic_cast<const Color*>(rhs);
-        rv = Eval::op_number_color(mem, op, *l_n, *r_c);
+        rv = Eval::op_number_color(mem, op, *l_n, *r_c, options);
       }
       else if (sass_value_is_color(a) && sass_value_is_number(b)) {
         const Color* l_c = dynamic_cast<const Color*>(lhs);
         const Number* r_n = dynamic_cast<const Number*>(rhs);
-        rv = Eval::op_color_number(mem, op, *l_c, *r_n);
+        rv = Eval::op_color_number(mem, op, *l_c, *r_n, options);
       }
       else if (sass_value_is_color(a) && sass_value_is_color(b)) {
         const Color* l_c = dynamic_cast<const Color*>(lhs);
         const Color* r_c = dynamic_cast<const Color*>(rhs);
-        rv = Eval::op_colors(mem, op, *l_c, *r_c);
+        rv = Eval::op_colors(mem, op, *l_c, *r_c, options);
       }
       else /* convert other stuff to string and apply operation */ {
         Value* l_v = dynamic_cast<Value*>(lhs);
         Value* r_v = dynamic_cast<Value*>(rhs);
-        rv = Eval::op_strings(mem, op, *l_v, *r_v);
+        rv = Eval::op_strings(mem, op, *l_v, *r_v, options);
       }
 
       // ToDo: maybe we should should return null value?

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -17,7 +17,7 @@ namespace Sass {
 
   std::string SourceMap::render_srcmap(Context &ctx) {
 
-    const bool include_sources = ctx.c_options->source_map_contents;
+    const bool include_sources = ctx.c_options.source_map_contents;
     const std::vector<std::string> links = ctx.srcmap_links;
     const std::vector<Resource>& sources(ctx.resources);
 

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -160,12 +160,12 @@ namespace Sass {
     current_position += offset;
   }
 
-  void SourceMap::add_open_mapping(AST_Node* node)
+  void SourceMap::add_open_mapping(const AST_Node* node)
   {
     mappings.push_back(Mapping(node->pstate(), current_position));
   }
 
-  void SourceMap::add_close_mapping(AST_Node* node)
+  void SourceMap::add_close_mapping(const AST_Node* node)
   {
     mappings.push_back(Mapping(node->pstate() + node->pstate().offset, current_position));
   }

--- a/src/source_map.hpp
+++ b/src/source_map.hpp
@@ -28,8 +28,8 @@ namespace Sass {
     void prepend(const Offset& offset);
     void append(const OutputBuffer& out);
     void prepend(const OutputBuffer& out);
-    void add_open_mapping(AST_Node* node);
-    void add_close_mapping(AST_Node* node);
+    void add_open_mapping(const AST_Node* node);
+    void add_close_mapping(const AST_Node* node);
 
     std::string render_srcmap(Context &ctx);
     ParserState remap(const ParserState& pstate);

--- a/src/to_string.cpp
+++ b/src/to_string.cpp
@@ -11,13 +11,14 @@
 
 namespace Sass {
 
-  To_String::To_String(Context* ctx, bool in_declaration)
-  : ctx(ctx), in_declaration(in_declaration) { }
+  To_String::To_String(struct Sass_Output_Options opt, bool in_declaration)
+  : opt(opt), in_declaration(in_declaration) { }
+
   To_String::~To_String() { }
 
   inline std::string To_String::fallback_impl(AST_Node* n)
   {
-    Emitter emitter(ctx);
+    Emitter emitter(opt);
     Inspect i(emitter);
     i.in_declaration = in_declaration;
     if (n) n->perform(&i);

--- a/src/to_string.cpp
+++ b/src/to_string.cpp
@@ -11,8 +11,8 @@
 
 namespace Sass {
 
-  To_String::To_String(Context* ctx, bool in_declaration, bool in_debug)
-  : ctx(ctx), in_declaration(in_declaration), in_debug(in_debug) { }
+  To_String::To_String(Context* ctx, bool in_declaration)
+  : ctx(ctx), in_declaration(in_declaration) { }
   To_String::~To_String() { }
 
   inline std::string To_String::fallback_impl(AST_Node* n)
@@ -20,7 +20,6 @@ namespace Sass {
     Emitter emitter(ctx);
     Inspect i(emitter);
     i.in_declaration = in_declaration;
-    i.in_debug = in_debug;
     if (n) n->perform(&i);
     return i.get_buffer();
   }
@@ -44,6 +43,4 @@ namespace Sass {
     return s->value();
   }
 
-  inline std::string To_String::operator()(Null* n)
-  { return in_debug ? "null" : ""; }
 }

--- a/src/to_string.hpp
+++ b/src/to_string.hpp
@@ -16,12 +16,12 @@ namespace Sass {
     // override this to define a catch-all
     std::string fallback_impl(AST_Node* n);
 
-    Context* ctx;
+    struct Sass_Output_Options opt;
     bool in_declaration;
 
   public:
 
-    To_String(Context* ctx = 0, bool in_declaration = true);
+    To_String(struct Sass_Output_Options opt = Sass_Output_Options(), bool in_declaration = true);
     virtual ~To_String();
 
     std::string operator()(String_Schema*);

--- a/src/to_string.hpp
+++ b/src/to_string.hpp
@@ -11,20 +11,19 @@ namespace Sass {
   class Null;
 
   class To_String : public Operation_CRTP<std::string, To_String> {
-
+    // import all the class-specific methods and override as desired
+    using Operation<std::string>::operator();
     // override this to define a catch-all
     std::string fallback_impl(AST_Node* n);
 
     Context* ctx;
     bool in_declaration;
-    bool in_debug;
 
   public:
 
-    To_String(Context* ctx = 0, bool in_declaration = true, bool in_debug = false);
-    ~To_String();
+    To_String(Context* ctx = 0, bool in_declaration = true);
+    virtual ~To_String();
 
-    std::string operator()(Null* n);
     std::string operator()(String_Schema*);
     std::string operator()(String_Quoted*);
     std::string operator()(String_Constant*);

--- a/src/to_value.cpp
+++ b/src/to_value.cpp
@@ -92,7 +92,7 @@ namespace Sass {
   // Selector_List is converted to a string
   Value* To_Value::operator()(Selector_List* s)
   {
-    To_String to_string(&ctx);
+    To_String to_string(ctx.c_options);
     return SASS_MEMORY_NEW(mem, String_Quoted,
                            s->pstate(),
                            s->perform(&to_string));
@@ -101,7 +101,7 @@ namespace Sass {
   // Binary_Expression is converted to a string
   Value* To_Value::operator()(Binary_Expression* s)
   {
-    To_String to_string(&ctx);
+    To_String to_string(ctx.c_options);
     return SASS_MEMORY_NEW(mem, String_Quoted,
                            s->pstate(),
                            s->perform(&to_string));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -474,7 +474,7 @@ namespace Sass {
           }
         } else if (Comment* c = dynamic_cast<Comment*>(stm)) {
           // keep for uncompressed
-          if (style != SASS_STYLE_COMPRESSED) {
+          if (style != COMPRESSED) {
             hasDeclarations = true;
           }
           // output style compressed
@@ -579,7 +579,7 @@ namespace Sass {
         else if (typeid(*stm) == typeid(Comment)) {
           Comment* c = (Comment*) stm;
           // keep for uncompressed
-          if (style != SASS_STYLE_COMPRESSED) {
+          if (style != COMPRESSED) {
             return true;
           }
           // output style compressed

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <assert.h>
+#include "sass.hpp"
 #include "sass/base.h"
 #include "ast_fwd_decl.hpp"
 
@@ -42,13 +43,13 @@ namespace Sass {
     std::string vecJoin(const std::vector<std::string>& vec, const std::string& sep);
     bool containsAnyPrintableStatements(Block* b);
 
-    bool isPrintable(Ruleset* r, Sass_Output_Style style = SASS_STYLE_NESTED);
-    bool isPrintable(Supports_Block* r, Sass_Output_Style style = SASS_STYLE_NESTED);
-    bool isPrintable(Media_Block* r, Sass_Output_Style style = SASS_STYLE_NESTED);
-    bool isPrintable(Block* b, Sass_Output_Style style = SASS_STYLE_NESTED);
-    bool isPrintable(String_Constant* s, Sass_Output_Style style = SASS_STYLE_NESTED);
-    bool isPrintable(String_Quoted* s, Sass_Output_Style style = SASS_STYLE_NESTED);
-    bool isPrintable(Declaration* d, Sass_Output_Style style = SASS_STYLE_NESTED);
+    bool isPrintable(Ruleset* r, Sass_Output_Style style = NESTED);
+    bool isPrintable(Supports_Block* r, Sass_Output_Style style = NESTED);
+    bool isPrintable(Media_Block* r, Sass_Output_Style style = NESTED);
+    bool isPrintable(Block* b, Sass_Output_Style style = NESTED);
+    bool isPrintable(String_Constant* s, Sass_Output_Style style = NESTED);
+    bool isPrintable(String_Quoted* s, Sass_Output_Style style = NESTED);
+    bool isPrintable(Declaration* d, Sass_Output_Style style = NESTED);
     bool isAscii(const char chr);
 
   }


### PR DESCRIPTION
This is a continuation https://github.com/sass/libsass/pull/1736.

Premise: The Context is the main Object which manages and abstracts all internas for parsing and compiling. It takes an option C struct to construct and implements the `parse` and `compile` methods. It also serves as main lifecycle for created objects (as in Ast Nodes).

Currently we have still a lot of places which need the main `Context` (aka `ctx`) instance to be around, which makes it often impossible to call certain functions (like `To_String` visitor) from methods that simply don't have any direct connection to the main `Context` (and therefore don't have access to it).

In the past we mostly just passed around and stored the `ctx` everywhere. This worked as long as we lived inside our own execution path, but this first bit me when I wanted to expose operations and stringification on the C-API. It's absolutely legal to create two Sass Values outside of any actual Context and then call an operation on them. This is just one example where we need the `ctx` for mainly two reasons.

a) accessing the options (output style, precision and others)
b) to create object with a managed life-cycle

This PR will be a first round to finally decouple those two needs from `class Context`. I already have refactored the `Memory_Manager` at an earlier point to make this feasible, since we can now create life-cycles on demand when needed (first use case was the exposure of sass operations). So the second problem is pretty much already solved.

I also made quite a few refactorings to have the options decoupled from context already. The `to_string` methods on Ast Nodes of the base `class Value` takes two arguments (output style and precision), since they never need any other. We also have `To_String` CRTP vistors, which pretty much do the same, but for all Ast Nodes, but as already mentioned they need access to `ctx`.

I hope this explains the motivations behind this refactoring. I'm aware that this will not be the perfect solution and will probably require more refactorings, until also the internal API gets more and more sane.

I will now create meaningfull commits out of my now passing local branch ... could take some time.