### PR TITLE
Refactor value operation error handling

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -910,6 +910,27 @@ namespace Sass {
     ATTACH_OPERATIONS()
   };
 
+  inline static const std::string sass_op_to_name(enum Sass_OP op) {
+    switch (op) {
+      case AND: return "and"; break;
+      case OR: return "or"; break;
+      case EQ: return "eq"; break;
+      case NEQ: return "neq"; break;
+      case GT: return "gt"; break;
+      case GTE: return "gte"; break;
+      case LT: return "lt"; break;
+      case LTE: return "lte"; break;
+      case ADD: return "add"; break;
+      case SUB: return "sub"; break;
+      case MUL: return "times"; break;
+      case DIV: return "div"; break;
+      case MOD: return "mod"; break;
+      // this is only used internally!
+      case NUM_OPS: return "[OPS]"; break;
+      default: return "invalid"; break;
+    }
+  }
+
   //////////////////////////////////////////////////////////////////////////
   // Binary expressions. Represents logical, relational, and arithmetic
   // operations. Templatized to avoid large switch statements and repetitive

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -11,14 +11,9 @@ namespace Sass {
   namespace Exception {
 
     Base::Base(ParserState pstate, std::string msg)
-    : std::runtime_error(msg),
-      msg(msg), pstate(pstate)
+    : std::runtime_error(msg), msg(msg),
+      prefix("Error"), pstate(pstate)
     { }
-
-    const char* Base::what() const throw()
-    {
-      return msg.c_str();
-    }
 
     InvalidSass::InvalidSass(ParserState pstate, std::string msg)
     : Base(pstate, msg)
@@ -47,6 +42,84 @@ namespace Sass {
     InvalidSyntax::InvalidSyntax(ParserState pstate, std::string msg)
     : Base(pstate, msg)
     { }
+
+    UndefinedOperation::UndefinedOperation(const Expression* lhs, const Expression* rhs, const std::string& op)
+    : lhs(lhs), rhs(rhs), op(op)
+    {
+      msg  = def_op_msg + ": \"";
+      if (const Value* l = dynamic_cast<const Value*>(lhs)) {
+        msg += l->to_string();
+      } else if (lhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += " " + op + " ";
+      if (const Value* r = dynamic_cast<const Value*>(rhs)) {
+        msg += r->to_string();
+      } else if (rhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += "\".";
+    }
+
+    InvalidNullOperation::InvalidNullOperation(const Expression* lhs, const Expression* rhs, const std::string& op)
+    : UndefinedOperation(lhs, rhs, op)
+    {
+      msg  = def_op_null_msg + ": \"";
+      if (const Value* l = dynamic_cast<const Value*>(lhs)) {
+        msg += l->to_string();
+      } else if (lhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += " " + op + " ";
+      if (const Value* r = dynamic_cast<const Value*>(rhs)) {
+        msg += r->to_string();
+      } else if (rhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += "\".";
+    }
+
+    ZeroDivisionError::ZeroDivisionError(const Expression& lhs, const Expression& rhs)
+    : lhs(lhs), rhs(rhs)
+    {
+      msg  = "divided by 0";
+    }
+
+    IncompatibleUnits::IncompatibleUnits(const Number& lhs, const Number& rhs)
+    : lhs(lhs), rhs(rhs)
+    {
+      msg  = "Incompatible units: '";
+      msg += rhs.unit();
+      msg += "' and '";
+      msg += lhs.unit();
+      msg += "'.";
+    }
+
+    AlphaChannelsNotEqual::AlphaChannelsNotEqual(const Expression* lhs, const Expression* rhs, const std::string& op)
+    : lhs(lhs), rhs(rhs), op(op)
+    {
+      msg  = "Alpha channels must be equal: ";
+      if (const Value* l = dynamic_cast<const Value*>(lhs)) {
+        msg += l->to_string();
+      } else if (lhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += " " + op + " ";
+      if (const Value* r = dynamic_cast<const Value*>(rhs)) {
+        msg += r->to_string();
+      } else if (rhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += ".";
+    }
+
+
+    SassValueError::SassValueError(ParserState pstate, OperationError& err)
+    : Base(pstate, err.what())
+    {
+      msg = err.what();
+      prefix = err.errtype();
+    }
 
   }
 

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -12,16 +12,20 @@ namespace Sass {
 
   namespace Exception {
 
-    const std::string def_msg = "Invalid sass";
+    const std::string def_msg = "Invalid sass detected";
+    const std::string def_op_msg = "Undefined operation";
+    const std::string def_op_null_msg = "Invalid null operation";
 
     class Base : public std::runtime_error {
       protected:
         std::string msg;
+        std::string prefix;
       public:
         ParserState pstate;
       public:
         Base(ParserState pstate, std::string msg = def_msg);
-        virtual const char* what() const throw();
+        virtual const char* errtype() const { return prefix.c_str(); }
+        virtual const char* what() const throw() { return msg.c_str(); }
         virtual ~Base() throw() {};
     };
 
@@ -55,6 +59,73 @@ namespace Sass {
       public:
         InvalidSyntax(ParserState pstate, std::string msg);
         virtual ~InvalidSyntax() throw() {};
+    };
+
+    /* common virtual base class (has no pstate) */
+    class OperationError : public std::runtime_error {
+      protected:
+        std::string msg;
+      public:
+        OperationError(std::string msg = def_op_msg)
+        : std::runtime_error(msg), msg(msg)
+        {};
+      public:
+        virtual const char* errtype() const { return "Error"; }
+        virtual const char* what() const throw() { return msg.c_str(); }
+        virtual ~OperationError() throw() {};
+    };
+
+    class ZeroDivisionError : public OperationError {
+      protected:
+        const Expression& lhs;
+        const Expression& rhs;
+      public:
+        ZeroDivisionError(const Expression& lhs, const Expression& rhs);
+        virtual const char* errtype() const { return "ZeroDivisionError"; }
+        virtual ~ZeroDivisionError() throw() {};
+    };
+
+    class IncompatibleUnits : public OperationError {
+      protected:
+        const Number& lhs;
+        const Number& rhs;
+      public:
+        IncompatibleUnits(const Number& lhs, const Number& rhs);
+        virtual ~IncompatibleUnits() throw() {};
+    };
+
+    class UndefinedOperation : public OperationError {
+      protected:
+        const Expression* lhs;
+        const Expression* rhs;
+        const std::string op;
+      public:
+        UndefinedOperation(const Expression* lhs, const Expression* rhs, const std::string& op);
+        // virtual const char* errtype() const { return "Error"; }
+        virtual ~UndefinedOperation() throw() {};
+    };
+
+    class InvalidNullOperation : public UndefinedOperation {
+      public:
+        InvalidNullOperation(const Expression* lhs, const Expression* rhs, const std::string& op);
+        virtual ~InvalidNullOperation() throw() {};
+    };
+
+    class AlphaChannelsNotEqual : public OperationError {
+      protected:
+        const Expression* lhs;
+        const Expression* rhs;
+        const std::string op;
+      public:
+        AlphaChannelsNotEqual(const Expression* lhs, const Expression* rhs, const std::string& op);
+        // virtual const char* errtype() const { return "Error"; }
+        virtual ~AlphaChannelsNotEqual() throw() {};
+    };
+
+    class SassValueError : public Base {
+      public:
+        SassValueError(ParserState pstate, OperationError& err);
+        virtual ~SassValueError() throw() {};
     };
 
   }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -509,15 +509,21 @@ namespace Sass {
     }
 
     // see if it's a relational expression
-    switch(op_type) {
-      case Sass_OP::EQ:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), eq(lhs, rhs));
-      case Sass_OP::NEQ: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !eq(lhs, rhs));
-      case Sass_OP::GT:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !lt(lhs, rhs) && !eq(lhs, rhs));
-      case Sass_OP::GTE: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !lt(lhs, rhs));
-      case Sass_OP::LT:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), lt(lhs, rhs));
-      case Sass_OP::LTE: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), lt(lhs, rhs) || eq(lhs, rhs));
-
-      default:                     break;
+    try {
+      switch(op_type) {
+        case Sass_OP::EQ:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), eq(lhs, rhs));
+        case Sass_OP::NEQ: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !eq(lhs, rhs));
+        case Sass_OP::GT:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !lt(lhs, rhs, "gt") && !eq(lhs, rhs));
+        case Sass_OP::GTE: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), !lt(lhs, rhs, "gte"));
+        case Sass_OP::LT:  return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), lt(lhs, rhs, "lt"));
+        case Sass_OP::LTE: return SASS_MEMORY_NEW(ctx.mem, Boolean, b->pstate(), lt(lhs, rhs, "lte") || eq(lhs, rhs));
+        default:                     break;
+      }
+    }
+    catch (Exception::OperationError& err)
+    {
+      // throw Exception::Base(b->pstate(), err.what());
+      throw Exception::SassValueError(b->pstate(), err);
     }
 
 
@@ -572,42 +578,51 @@ namespace Sass {
 
     // ToDo: throw error in op functions
     // ToDo: then catch and re-throw them
-    ParserState pstate(b->pstate());
-    if (l_type == Expression::NUMBER && r_type == Expression::NUMBER) {
-      const Number* l_n = dynamic_cast<const Number*>(lhs);
-      const Number* r_n = dynamic_cast<const Number*>(rhs);
-      return op_numbers(ctx.mem, op_type, *l_n, *r_n, compressed, precision, &pstate);
-    }
-    if (l_type == Expression::NUMBER && r_type == Expression::COLOR) {
-      const Number* l_n = dynamic_cast<const Number*>(lhs);
-      const Color* r_c = dynamic_cast<const Color*>(rhs);
-      return op_number_color(ctx.mem, op_type, *l_n, *r_c, compressed, precision, &pstate);
-    }
-    if (l_type == Expression::COLOR && r_type == Expression::NUMBER) {
-      const Color* l_c = dynamic_cast<const Color*>(lhs);
-      const Number* r_n = dynamic_cast<const Number*>(rhs);
-      return op_color_number(ctx.mem, op_type, *l_c, *r_n, compressed, precision, &pstate);
-    }
-    if (l_type == Expression::COLOR && r_type == Expression::COLOR) {
-      const Color* l_c = dynamic_cast<const Color*>(lhs);
-      const Color* r_c = dynamic_cast<const Color*>(rhs);
-      return op_colors(ctx.mem, op_type, *l_c, *r_c, compressed, precision, &pstate);
-    }
+    try {
+      ParserState pstate(b->pstate());
+      int precision = (int)ctx.c_options->precision;
+      bool compressed = ctx.output_style() == SASS_STYLE_COMPRESSED;
+      if (l_type == Expression::NUMBER && r_type == Expression::NUMBER) {
+        const Number* l_n = dynamic_cast<const Number*>(lhs);
+        const Number* r_n = dynamic_cast<const Number*>(rhs);
+        return op_numbers(ctx.mem, op_type, *l_n, *r_n, compressed, precision, &pstate);
+      }
+      if (l_type == Expression::NUMBER && r_type == Expression::COLOR) {
+        const Number* l_n = dynamic_cast<const Number*>(lhs);
+        const Color* r_c = dynamic_cast<const Color*>(rhs);
+        return op_number_color(ctx.mem, op_type, *l_n, *r_c, compressed, precision, &pstate);
+      }
+      if (l_type == Expression::COLOR && r_type == Expression::NUMBER) {
+        const Color* l_c = dynamic_cast<const Color*>(lhs);
+        const Number* r_n = dynamic_cast<const Number*>(rhs);
+        return op_color_number(ctx.mem, op_type, *l_c, *r_n, compressed, precision, &pstate);
+      }
+      if (l_type == Expression::COLOR && r_type == Expression::COLOR) {
+        const Color* l_c = dynamic_cast<const Color*>(lhs);
+        const Color* r_c = dynamic_cast<const Color*>(rhs);
+        return op_colors(ctx.mem, op_type, *l_c, *r_c, compressed, precision, &pstate);
+      }
 
-    To_Value to_value(ctx, ctx.mem);
-    Value* v_l = dynamic_cast<Value*>(lhs->perform(&to_value));
-    Value* v_r = dynamic_cast<Value*>(rhs->perform(&to_value));
-    Value* ex = op_strings(ctx.mem, op_type, *v_l, *v_r, compressed, precision, &pstate);
-    if (String_Constant* str = dynamic_cast<String_Constant*>(ex))
+      To_Value to_value(ctx, ctx.mem);
+      Value* v_l = dynamic_cast<Value*>(lhs->perform(&to_value));
+      Value* v_r = dynamic_cast<Value*>(rhs->perform(&to_value));
+      Value* ex = op_strings(ctx.mem, op_type, *v_l, *v_r, compressed, precision, &pstate);
+      if (String_Constant* str = dynamic_cast<String_Constant*>(ex))
+      {
+        if (str->concrete_type() != Expression::STRING) return ex;
+        String_Constant* lstr = dynamic_cast<String_Constant*>(lhs);
+        String_Constant* rstr = dynamic_cast<String_Constant*>(rhs);
+        if (String_Constant* org = lstr ? lstr : rstr)
+        { str->quote_mark(org->quote_mark()); }
+      }
+      return ex;
+    }
+    catch (Exception::OperationError& err)
     {
-      if (str->concrete_type() != Expression::STRING) return ex;
-      String_Constant* lstr = dynamic_cast<String_Constant*>(lhs);
-      String_Constant* rstr = dynamic_cast<String_Constant*>(rhs);
-      if (String_Constant* org = lstr ? lstr : rstr)
-      { str->quote_mark(org->quote_mark()); }
+      // throw Exception::Base(b->pstate(), err.what());
+      throw Exception::SassValueError(b->pstate(), err);
     }
-    return ex;
-
+    return 0;
   }
 
   Expression* Eval::operator()(Unary_Expression* u)
@@ -1205,12 +1220,12 @@ namespace Sass {
     return lhs && rhs && *lhs == *rhs;
   }
 
-  bool Eval::lt(Expression* lhs, Expression* rhs)
+  bool Eval::lt(Expression* lhs, Expression* rhs, std::string op)
   {
     Number* l = dynamic_cast<Number*>(lhs);
     Number* r = dynamic_cast<Number*>(rhs);
-    if (!l) error("may only compare numbers", lhs->pstate());
-    if (!r) error("may only compare numbers", rhs->pstate());
+    // we can only compare numbers with numbers here
+    if (!l || !r) throw Exception::UndefinedOperation(lhs, rhs, op);
     // use compare operator from ast node
     return *l < *r;
   }
@@ -1219,11 +1234,11 @@ namespace Sass {
   {
     double lv = l.value();
     double rv = r.value();
-    if (op == Sass_OP::DIV && !rv) {
-      return SASS_MEMORY_NEW(mem, String_Quoted, pstate ? *pstate : l.pstate(), "Infinity");
+    if (op == Sass_OP::DIV && rv == 0) {
+      return SASS_MEMORY_NEW(mem, String_Quoted, pstate ? *pstate : l.pstate(), lv ? "Infinity" : "NaN");
     }
     if (op == Sass_OP::MOD && !rv) {
-      error("division by zero", pstate ? *pstate : r.pstate());
+      throw Exception::ZeroDivisionError(l, r);
     }
 
     Number tmp(r);
@@ -1233,7 +1248,7 @@ namespace Sass {
     std::string r_unit(tmp.unit());
     if (l_unit != r_unit && !l_unit.empty() && !r_unit.empty() &&
         (op == Sass_OP::ADD || op == Sass_OP::SUB)) {
-      error("Incompatible units: '"+r_unit+"' and '"+l_unit+"'.", pstate ? *pstate : r.pstate());
+      throw Exception::IncompatibleUnits(l, r);
     }
     Number* v = SASS_MEMORY_NEW(mem, Number, l);
     v->pstate(pstate ? *pstate : l.pstate());
@@ -1291,7 +1306,7 @@ namespace Sass {
                                + color);
       } break;
       case Sass_OP::MOD: {
-        error("cannot divide a number by a color", pstate ? *pstate : r.pstate());
+        throw Exception::UndefinedOperation(&l, &r, sass_op_to_name(op));
       } break;
       default: break; // caller should ensure that we don't get here
     }
@@ -1302,7 +1317,10 @@ namespace Sass {
   Value* Eval::op_color_number(Memory_Manager& mem, enum Sass_OP op, const Color& l, const Number& r, bool compressed, int precision, ParserState* pstate)
   {
     double rv = r.value();
-    if (op == Sass_OP::DIV && !rv) error("division by zero", pstate ? *pstate : r.pstate());
+    if (op == Sass_OP::DIV && !rv) {
+      // comparison of Fixnum with Float failed?
+      throw Exception::ZeroDivisionError(l, r);
+    }
     return SASS_MEMORY_NEW(mem, Color,
                            pstate ? *pstate : l.pstate(),
                            ops[op](l.r(), rv),
@@ -1314,10 +1332,11 @@ namespace Sass {
   Value* Eval::op_colors(Memory_Manager& mem, enum Sass_OP op, const Color& l, const Color& r, bool compressed, int precision, ParserState* pstate)
   {
     if (l.a() != r.a()) {
-      error("alpha channels must be equal when combining colors", pstate ? *pstate : r.pstate());
+      throw Exception::AlphaChannelsNotEqual(&l, &r, "+");
     }
     if (op == Sass_OP::DIV && (!r.r() || !r.g() ||!r.b())) {
-      error("division by zero", pstate ? *pstate : r.pstate());
+      // comparison of Fixnum with Float failed?
+      throw Exception::ZeroDivisionError(l, r);
     }
     return SASS_MEMORY_NEW(mem, Color,
                            pstate ? *pstate : l.pstate(),
@@ -1368,17 +1387,16 @@ namespace Sass {
       const Color* c_r = name_to_color(rstr);
       return op_number_color(mem, op, *n_l, *c_r, compressed, precision);
     }
-    if (op == Sass_OP::MUL) error("invalid operands for multiplication", lhs.pstate());
-    if (op == Sass_OP::MOD) error("invalid operands for modulo", lhs.pstate());
+    if (ltype == Expression::NULL_VAL) throw Exception::InvalidNullOperation(&lhs, &rhs, sass_op_to_name(op));
+    if (rtype == Expression::NULL_VAL) throw Exception::InvalidNullOperation(&lhs, &rhs, sass_op_to_name(op));
+    if (op == Sass_OP::MOD) throw Exception::UndefinedOperation(&lhs, &rhs, sass_op_to_name(op));
+    if (op == Sass_OP::MUL) throw Exception::UndefinedOperation(&lhs, &rhs, sass_op_to_name(op));
     std::string sep;
     switch (op) {
       case Sass_OP::SUB: sep = "-"; break;
       case Sass_OP::DIV: sep = "/"; break;
       default:                      break;
     }
-    if (ltype == Expression::NULL_VAL) error("Invalid null operation: \"null plus "+quote(unquote(rstr), '"')+"\".", lhs.pstate());
-    if (rtype == Expression::NULL_VAL) error("Invalid null operation: \""+quote(unquote(lstr), '"')+" plus null\".", rhs.pstate());
-
     if (ltype == Expression::NUMBER && sep == "/" && rtype == Expression::STRING)
     {
       return SASS_MEMORY_NEW(mem, String_Constant, lhs.pstate(),

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -87,7 +87,7 @@ namespace Sass {
 
     // -- only need to define two comparisons, and the rest can be implemented in terms of them
     static bool eq(Expression*, Expression*);
-    static bool lt(Expression*, Expression*);
+    static bool lt(Expression*, Expression*, std::string op);
     // -- arithmetic on the combinations that matter
     static Value* op_numbers(Memory_Manager&, enum Sass_OP, const Number&, const Number&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
     static Value* op_number_color(Memory_Manager&, enum Sass_OP, const Number&, const Color&, bool compressed = false, int precision = 5, ParserState* pstate = 0);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1139,7 +1139,7 @@ namespace Sass {
           error("\"" + val->perform(&to_string) + "\" is not a number for `min'", pstate);
         }
         if (least) {
-          if (Eval::lt(xi, least)) least = xi;
+          if (*xi < *least) least = xi;
         } else least = xi;
       }
       return least;
@@ -1158,7 +1158,7 @@ namespace Sass {
           error("\"" + val->perform(&to_string) + "\" is not a number for `max'", pstate);
         }
         if (greatest) {
-          if (Eval::lt(greatest, xi)) greatest = xi;
+          if (*greatest < *xi) greatest = xi;
         } else greatest = xi;
       }
       return greatest;

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -43,9 +43,9 @@ extern "C" {
       std::string cwd(Sass::File::get_cwd());
       std::string rel_path(Sass::File::abs2rel(e.pstate.path, cwd, cwd));
 
-      std::string msg_prefix("Error: ");
+      std::string msg_prefix(e.errtype());
       bool got_newline = false;
-      msg_stream << msg_prefix;
+      msg_stream << msg_prefix << ": ";
       const char* msg = e.what();
       while(msg && *msg) {
         if (*msg == '\r') {
@@ -53,14 +53,14 @@ extern "C" {
         } else if (*msg == '\n') {
           got_newline = true;
         } else if (got_newline) {
-          msg_stream << std::string(msg_prefix.size(), ' ');
+          msg_stream << std::string(msg_prefix.size() + 2, ' ');
           got_newline = false;
         }
         msg_stream << *msg;
         ++ msg;
       }
       if (!got_newline) msg_stream << "\n";
-      msg_stream << std::string(msg_prefix.size(), ' ');
+      msg_stream << std::string(msg_prefix.size() + 2, ' ');
       msg_stream << " on line " << e.pstate.line+1 << " of " << rel_path << "\n";
 
       // now create the code trace (ToDo: maybe have util functions?)

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -295,10 +295,10 @@ extern "C" {
       switch(op) {
         case Sass_OP::EQ:  return sass_make_boolean(Eval::eq(lhs, rhs));
         case Sass_OP::NEQ: return sass_make_boolean(!Eval::eq(lhs, rhs));
-        case Sass_OP::GT:  return sass_make_boolean(!Eval::lt(lhs, rhs) && !Eval::eq(lhs, rhs));
-        case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(lhs, rhs));
-        case Sass_OP::LT:  return sass_make_boolean(Eval::lt(lhs, rhs));
-        case Sass_OP::LTE: return sass_make_boolean(Eval::lt(lhs, rhs) || Eval::eq(lhs, rhs));
+        case Sass_OP::GT:  return sass_make_boolean(!Eval::lt(lhs, rhs, "gt") && !Eval::eq(lhs, rhs));
+        case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(lhs, rhs, "gte"));
+        case Sass_OP::LT:  return sass_make_boolean(Eval::lt(lhs, rhs, "lt"));
+        case Sass_OP::LTE: return sass_make_boolean(Eval::lt(lhs, rhs, "lte") || Eval::eq(lhs, rhs));
         default:           break;
       }
 


### PR DESCRIPTION
Throw native C++ errors inside value operations.
Should now report the correct position, thus fixing #1751