### PR TITLE
Add crutch to help browsers interpreting sourcemaps

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -13,6 +13,7 @@ namespace Sass {
     scheduled_space(0),
     scheduled_linefeed(0),
     scheduled_delimiter(false),
+    scheduled_mapping(0),
     in_comment(false),
     in_wrapped(false),
     in_media_block(false),
@@ -44,6 +45,8 @@ namespace Sass {
   void Emitter::set_filename(const std::string& str)
   { wbuf.smap.file = str; }
 
+  void Emitter::schedule_mapping(AST_Node* node)
+  { scheduled_mapping = node; }
   void Emitter::add_open_mapping(AST_Node* node)
   { wbuf.smap.add_open_mapping(node); }
   void Emitter::add_close_mapping(AST_Node* node)
@@ -137,6 +140,12 @@ namespace Sass {
   {
     flush_schedules();
     add_open_mapping(node);
+    // hotfix for browser issues
+    // this is pretty ugly indeed
+    if (scheduled_mapping) {
+      add_open_mapping(scheduled_mapping);
+      scheduled_mapping = 0;
+    }
     append_string(text);
     add_close_mapping(node);
   }

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -26,6 +26,7 @@ namespace Sass {
       void set_filename(const std::string& str);
       void add_open_mapping(AST_Node* node);
       void add_close_mapping(AST_Node* node);
+      void schedule_mapping(AST_Node* node);
       std::string render_srcmap(Context &ctx);
       ParserState remap(const ParserState& pstate);
 
@@ -35,6 +36,7 @@ namespace Sass {
       size_t scheduled_space;
       size_t scheduled_linefeed;
       bool scheduled_delimiter;
+      AST_Node* scheduled_mapping;
 
     public:
       // output strings different in comments

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -838,7 +838,10 @@ namespace Sass {
     for (size_t i = 0, L = g->length(); i < L; ++i) {
       if (!in_wrapped && i == 0) append_indentation();
       if ((*g)[i] == 0) continue;
+      schedule_mapping((*g)[i]->last());
+      // add_open_mapping((*g)[i]->last());
       (*g)[i]->perform(this);
+      // add_close_mapping((*g)[i]->last());
       if (i < L - 1) {
         scheduled_space = 0;
         append_comma_separator();


### PR DESCRIPTION
They should report where the scope gets opened and not
the position of the first simple selector in the sequence.

Browsers actually report the mapping found most right just before the first selector in the sequence. I first tried to simply wrap each entry in a selector list with a mapping from their last complex selector, but as it turned out browsers wouldn't pick that up, so I had to delay the emmitting of that specific source map entry just before the token for the selector is emitted.

Should fix https://github.com/sass/libsass/issues/1747