### PR TITLE
Fix libsass build for SmartOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
+OS       ?= $(shell uname -s)
 CC       ?= gcc
 CXX      ?= g++
 RM       ?= rm -f
 CP       ?= cp -a
-MKDIR    ?= mkdir
+MKDIR    ?= mkdir -p
 RMDIR    ?= rmdir
 WINDRES  ?= windres
+ifeq ($(OS),SunOS)  # Solaris/Illumos flavors
+INSTALL  = ginstall
+endif
 INSTALL  ?= install
 CFLAGS   ?= -Wall
 CXXFLAGS ?= -Wall

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,12 @@ CC       ?= gcc
 CXX      ?= g++
 RM       ?= rm -f
 CP       ?= cp -a
-MKDIR    ?= mkdir -p
+MKDIR    ?= mkdir
 RMDIR    ?= rmdir
 WINDRES  ?= windres
 ifeq ($(OS),SunOS)  # Solaris/Illumos flavors
 INSTALL  = ginstall
+PREFIX   = /opt/local
 endif
 INSTALL  ?= install
 CFLAGS   ?= -Wall
@@ -132,13 +133,12 @@ ifneq ($(BUILD),shared)
 	BUILD = static
 endif
 
-ifeq (,$(PREFIX))
-	ifeq (,$(TRAVIS_BUILD_DIR))
-		PREFIX = /usr/local
-	else
-		PREFIX = $(TRAVIS_BUILD_DIR)
-	endif
+ifeq (,$(TRAVIS_BUILD_DIR))
+	PREFIX ?= /usr/local
+else
+	PREFIX ?= $(TRAVIS_BUILD_DIR)
 endif
+
 
 SASS_SASSC_PATH ?= sassc
 SASS_SPEC_PATH ?= sass-spec

--- a/src/units.hpp
+++ b/src/units.hpp
@@ -1,5 +1,6 @@
 #ifndef SASS_UNITS_H
 #define SASS_UNITS_H
+#undef SEC
 
 #include <cmath>
 #include <string>
@@ -7,7 +8,7 @@
 
 namespace Sass {
 
-  const double PI = acos(-1);
+  const double PI = std::acos(-1);
 
   enum SassUnitType {
     LENGTH = 0x000,
@@ -58,9 +59,9 @@ namespace Sass {
   extern const double frequency_conversion_factors[2][2];
   extern const double resolution_conversion_factors[3][3];
 
-  enum SassUnit string_to_unit(const std::string&);
-  const char* unit_to_string(SassUnit unit);
-  enum SassUnitType get_unit_type(SassUnit unit);
+  enum Sass::SassUnit string_to_unit(const std::string&);
+  const char* unit_to_string(Sass::SassUnit unit);
+  enum Sass::SassUnitType get_unit_type(Sass::SassUnit unit);
   // throws incompatibleUnits exceptions
   double conversion_factor(const std::string&, const std::string&, bool = true);
 
@@ -68,7 +69,7 @@ namespace Sass {
   {
     public:
       const char* msg;
-      incompatibleUnits(SassUnit a, SassUnit b)
+      incompatibleUnits(Sass::SassUnit a, Sass::SassUnit b)
       : exception()
       {
         std::stringstream ss;


### PR DESCRIPTION
* Use ginstall rather than install for INSTALL variable
* unset `SEC` because it was being used elsewhere
* Use namespacing where there were complaints

Addresses: #1308 

Things I still needed to do to get npm to install node-sass

in libsass:

```
make
make install
make install-headers
```

For npm:

```
export npm_config_libsass_ext=auto
npm install node-sass
```

I don't know where this should be documented, but I thought I'd throw it in there for anyone else who might happen to hit this issue.