### PR TITLE
Be sure to install interface.h

### DIFF
--- a/src/GNUmakefile.am
+++ b/src/GNUmakefile.am
@@ -51,4 +51,5 @@ sass_include_HEADERS = $(top_srcdir)/include/sass/base.h \
                        $(top_srcdir)/include/sass/values.h \
                        $(top_srcdir)/include/sass/version.h \
                        $(top_srcdir)/include/sass/context.h \
-                       $(top_srcdir)/include/sass/functions.h
+                       $(top_srcdir)/include/sass/functions.h \
+                       $(top_srcdir)/include/sass/interface.h


### PR DESCRIPTION
Currently `interface.h` is not being installed by `make install` and is therefore missing from some Linux distros (Arch, in my case).