### PR TITLE
Support multiline url declarations

### DIFF
--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -253,6 +253,7 @@ namespace Sass {
     Function_Call* parse_function_call();
     Function_Call_Schema* parse_function_call_schema();
     String* parse_url_function_string();
+    String* parse_url_function_argument();
     String* parse_interpolated_chunk(Token, bool constant = false);
     String* parse_string();
     String_Constant* parse_static_expression();

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -605,23 +605,6 @@ namespace Sass {
     const char* uri_prefix(const char* src) {
       return exactly<url_kwd>(src);
     }
-    const char* uri_value(const char* src)
-    {
-      return
-      sequence <
-        negate <
-          exactly < '$' >
-        >,
-        zero_plus <
-          alternatives <
-            alnum,
-            interpolant,
-            exactly <'/'>,
-            class_char < uri_chars >
-          >
-        >
-      >(src);
-    }
 
     // TODO: rename the following two functions
     /* no longer used - remove?

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -296,7 +296,6 @@ namespace Sass {
     // const char* rgb_prefix(const char* src);
     // Match CSS uri specifiers.
     const char* uri_prefix(const char* src);
-    const char* uri_value(const char* src);
     // Match CSS "!important" keyword.
     const char* kwd_important(const char* src);
     // Match CSS "!optional" keyword.


### PR DESCRIPTION
This is a continuation of the previous work done to bring our
`url()` parsing up to scratch with Ruby Sass. With this update
we can remove the transitional legacy `url()` parsing logic.

Spec https://github.com/sass/sass-spec/pull/654
Fixes #1096