### PR TITLE
win: VS to emit DLL which exports symbols

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ test_script:
       if ($PRNR) {
         echo "Fetching info for PR $PRNR"
         wget https://api.github.com/repos/sass/libsass/pulls/$PRNR -OutFile pr.json
-        $json = Get-Content pr.json -Raw
+        $json = cat pr.json -Raw
         $SPEC_PR = [regex]::match($json,'sass\/sass-spec(#|\/pull\/)([0-9]+)').Groups[2].Value
         if ($SPEC_PR) {
           echo "Checkout sass spec PR $SPEC_PR"

--- a/win/libsass.vcxproj
+++ b/win/libsass.vcxproj
@@ -6,14 +6,14 @@
     <LIBSASS_HEADERS_DIR>..\src</LIBSASS_HEADERS_DIR>
   </PropertyGroup>
   <Target Name="GitVersion">
-    <Exec Command="git -C .. describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true">
+    <Exec Command="git -C .. describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="LIBSASS_VERSION" />
     </Exec>
   </Target>
   <Target Name="VersionMacros">
     <ItemGroup>
       <ClCompile>
-        <PreprocessorDefinitions>%(PreprocessorDefinitions);LIBSASS_VERSION="$(LIBSASS_VERSION)"</PreprocessorDefinitions>
+        <PreprocessorDefinitions>%(PreprocessorDefinitions);LIBSASS_VERSION="$(LIBSASS_VERSION)";</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>
@@ -54,6 +54,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(LIBSASS_STATIC_LIB) == ''">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <PreprocessorDefinitions>ADD_EXPORTS;$(PreprocessorDefinitions);</PreprocessorDefinitions>
   </PropertyGroup>
   <PropertyGroup Condition="$(LIBSASS_STATIC_LIB) != ''">
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -125,7 +126,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;$(PreprocessorDefinitions);</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -138,7 +139,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;$(PreprocessorDefinitions);</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -153,7 +154,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;$(PreprocessorDefinitions);</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -170,7 +171,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;$(PreprocessorDefinitions);</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
At present if we run `dumpbin /exports win/bin/libsass.dll`, we get:

```ps
C:\Users\Adeel\source\repos\libsass> dumpbin.exe /exports win/bin/libsass.dll
Microsoft (R) COFF/PE Dumper Version 14.00.23506.0
Copyright (C) Microsoft Corporation.  All rights reserved.

Dump of file win/bin/libsass.dll

File Type: DLL

  Summary

        7000 .data
        1000 .gfids
        5000 .rdata
        3000 .reloc
        1000 .rsrc
       13000 .text
```

No exported functions.

With this change, we get the entire set of
exported functions. Note that it only affects the the `DLL` and not
shared `LIB` which we can build as:
`msbuild win/libsass.sln /p:LIBSASS_STATIC_LIB=1`.