### PR TITLE
While loops should release their local env when exiting early

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -294,7 +294,10 @@ namespace Sass {
     exp.env_stack.push_back(&env);
     while (*pred->perform(this)) {
       Expression* val = body->perform(this);
-      if (val) return val;
+      if (val) {
+        exp.env_stack.pop_back();
+        return val;
+      }
     }
     exp.env_stack.pop_back();
     return 0;


### PR DESCRIPTION
While loops can exit early, in which case their environment was not
being release causing local variables in the calling scope to be
lost.

Fixes #1813
Spec sass/sass-spec#662