### PR TITLE
util: Adds CRLF awareness to quote()

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -488,6 +488,12 @@ namespace Sass {
 
       int cp = utf8::next(it, end);
 
+      // in case of \r, check if the next in sequence
+      // is \n and then advance the iterator.
+      if (cp == '\r' && it < end && utf8::peek_next(it, end) == '\n') {
+        cp = utf8::next(it, end);
+      }
+
       if (cp == '\n') {
         quoted.push_back('\\');
         quoted.push_back('a');


### PR DESCRIPTION
Input:

```scss
@import url("a
b");
```

Output on Windows:

```
"@import url(\"a\r\a b\");"
```

Output on Unix (alinged with Ruby Sass, hence the expected output):

```
"@import url(\"a\a b\");"
```

See: https://github.com/sass/libsass/issues/1096#issuecomment-167531680
for details.

Sepc: https://github.com/sass/sass-spec/pull/664.