### PR TITLE
API: Provides a function to clone string

### DIFF
--- a/docs/api-context-internal.md
+++ b/docs/api-context-internal.md
@@ -78,7 +78,7 @@ struct Sass_Options {
   // Directly inserted in source maps
   char* source_map_root;
 
-  // Custom functions that can be called from sccs code
+  // Custom functions that can be called from Sass code
   Sass_C_Function_List c_functions;
 
   // Callback to overload imports

--- a/docs/api-context.md
+++ b/docs/api-context.md
@@ -88,7 +88,7 @@ char* source_map_file;
 char* source_map_root;
 ```
 ```C
-// Custom functions that can be called from sccs code
+// Custom functions that can be called from Sass code
 Sass_C_Function_List c_functions;
 ```
 ```C
@@ -154,6 +154,13 @@ struct Sass_Data_Context; // : Sass_Context
 
 // Create and initialize an option struct
 struct Sass_Options* sass_make_options (void);
+
+// Create a copy of C string
+const char* sass_copy_c_string (const char* input_string);
+
+// Delete a copied C string
+void sass_free_c_string (char* input_string);
+
 // Create and initialize a specific context
 struct Sass_File_Context* sass_make_file_context (const char* input_path);
 struct Sass_Data_Context* sass_make_data_context (char* source_string);
@@ -168,12 +175,12 @@ struct Sass_Compiler* sass_make_data_compiler (struct Sass_Data_Context* data_ct
 
 // Execute the different compilation steps individually
 // Usefull if you only want to query the included files
-int sass_compiler_parse(struct Sass_Compiler* compiler);
-int sass_compiler_execute(struct Sass_Compiler* compiler);
+int sass_compiler_parse (struct Sass_Compiler* compiler);
+int sass_compiler_execute (struct Sass_Compiler* compiler);
 
 // Release all memory allocated with the compiler
 // This does _not_ include any contexts or options
-void sass_delete_compiler(struct Sass_Compiler* compiler);
+void sass_delete_compiler (struct Sass_Compiler* compiler);
 
 // Release all memory allocated and also ourself
 void sass_delete_file_context (struct Sass_File_Context* ctx);

--- a/include/sass/context.h
+++ b/include/sass/context.h
@@ -30,6 +30,13 @@ enum Sass_Compiler_State {
 
 // Create and initialize an option struct
 ADDAPI struct Sass_Options* ADDCALL sass_make_options (void);
+
+// Create a copy of C string
+ADDAPI char* ADDCALL sass_copy_c_string (const char* input_string);
+
+// Delete a copied C string
+ADDAPI void ADDCALL sass_free_c_string (char* input_string);
+
 // Create and initialize a specific context
 ADDAPI struct Sass_File_Context* ADDCALL sass_make_file_context (const char* input_path);
 ADDAPI struct Sass_Data_Context* ADDCALL sass_make_data_context (char* source_string);

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -375,6 +375,16 @@ extern "C" {
     return options;
   }
 
+  char* ADDCALL sass_copy_c_string (const char* input_string)
+  {
+    return sass_strdup(input_string);
+  }
+
+  void ADDCALL sass_free_c_string (char* input_string)
+  {
+    if (input_string)  free(input_string);
+  }
+
   Sass_File_Context* ADDCALL sass_make_file_context(const char* input_path)
   {
     struct Sass_File_Context* ctx = (struct Sass_File_Context*) calloc(1, sizeof(struct Sass_File_Context));

--- a/src/sass_context.hpp
+++ b/src/sass_context.hpp
@@ -54,7 +54,7 @@ struct Sass_Options : Sass_Output_Options {
   // Directly inserted in source maps
   char* source_map_root;
 
-  // Custom functions that can be called from sccs code
+  // Custom functions that can be called from Sass code
   Sass_Function_List c_functions;
 
   // List of custom importers


### PR DESCRIPTION
From the pure API usage (as in FFI), there is a limitation in case of
`sass_make_data_context`, where API requires the caller to allocate the
memory and transfer the ownership to libsass, so libsass will
destroy it afterwards. In case of FFI, despite the provision of
interoperability, the memory allocated by language runtime may not be
deallocatable by CRT, and it corrupts the heap on `free()`ing the
resources.

This utility method equips the caller to get the cloned string ptr back
from CRT and use it to make data context.