### PR TITLE
Implement import recursion check

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -28,6 +28,7 @@
 #include "extend.hpp"
 #include "remove_placeholders.hpp"
 #include "functions.hpp"
+#include "sass_functions.hpp"
 #include "backtrace.hpp"
 #include "sass2scss.h"
 #include "prelexer.hpp"
@@ -254,7 +255,7 @@ namespace Sass {
 
   // register include with resolved path and its content
   // memory of the resources will be freed by us on exit
-  void Context::register_resource(const Include& inc, const Resource& res)
+  void Context::register_resource(const Include& inc, const Resource& res, ParserState* prstate)
   {
 
     // do not parse same resource twice
@@ -297,6 +298,24 @@ namespace Sass {
     strings.push_back(sass_strdup(inc.abs_path.c_str()));
     // create the initial parser state from resource
     ParserState pstate(strings.back(), contents, idx);
+
+    // check existing import stack for possible recursion
+    for (size_t i = 0; i < import_stack.size() - 2; ++i) {
+      auto parent = import_stack[i];
+      if (std::strcmp(parent->abs_path, import->abs_path) == 0) {
+        std::string stack("An @import loop has been found:");
+        for (size_t n = 1; n < i + 2; ++n) {
+          stack += "\n    " + std::string(import_stack[n]->imp_path) +
+            " imports " + std::string(import_stack[n+1]->imp_path);
+        }
+        // implement error throw directly until we
+        // decided how to handle full stack traces
+        ParserState state = prstate ? *prstate : pstate;
+        throw Exception::InvalidSyntax(state, stack, &import_stack);
+        // error(stack, prstate ? *prstate : pstate, import_stack);
+      }
+    }
+
     // create a parser instance from the given c_str buffer
     Parser p(Parser::from_c_str(contents, *this, pstate));
     // do not yet dispose these buffers
@@ -344,7 +363,7 @@ namespace Sass {
       // the memory buffer returned must be freed by us!
       if (char* contents = read_file(resolved[0].abs_path)) {
         // register the newly resolved file resource
-        register_resource(resolved[0], { contents, 0 });
+        register_resource(resolved[0], { contents, 0 }, &pstate);
         // return resolved entry
         return resolved[0];
       }
@@ -433,7 +452,7 @@ namespace Sass {
           // handle error message passed back from custom importer
           // it may (or may not) override the line and column info
           if (const char* err_message = sass_import_get_error_message(include)) {
-            if (source || srcmap) register_resource({ importer, uniq_path }, { source, srcmap });
+            if (source || srcmap) register_resource({ importer, uniq_path }, { source, srcmap }, &pstate);
             if (line == std::string::npos && column == std::string::npos) error(err_message, pstate);
             else error(err_message, ParserState(ctx_path, source, Position(line, column)));
           }
@@ -447,7 +466,7 @@ namespace Sass {
             // attach information to AST node
             imp->incs().push_back(include);
             // register the resource buffers
-            register_resource(include, { source, srcmap });
+            register_resource(include, { source, srcmap }, &pstate);
           }
           // only a path was retuned
           // try to load it like normal
@@ -639,6 +658,7 @@ namespace Sass {
     Expand expand(*this, &global, &backtrace);
     Cssize cssize(*this, &backtrace);
     // expand and eval the tree
+    // debug_ast(root);
     root = root->perform(&expand)->block();
     // merge and bubble certain rules
     root = root->perform(&cssize)->block();

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -92,7 +92,7 @@ namespace Sass {
     virtual char* render(Block* root);
     virtual char* render_srcmap();
 
-    void register_resource(const Include&, const Resource&);
+    void register_resource(const Include&, const Resource&, ParserState* = 0);
     std::vector<Include> find_includes(const Importer& import);
     Include load_import(const Importer&, ParserState pstate);
 

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -10,9 +10,10 @@ namespace Sass {
 
   namespace Exception {
 
-    Base::Base(ParserState pstate, std::string msg)
+    Base::Base(ParserState pstate, std::string msg, std::vector<Sass_Import_Entry>* import_stack)
     : std::runtime_error(msg),
-      msg(msg), pstate(pstate)
+      msg(msg), pstate(pstate),
+      import_stack(import_stack)
     { }
 
     const char* Base::what() const throw()
@@ -44,8 +45,8 @@ namespace Sass {
       msg += " for `" + fn + "'";
     }
 
-    InvalidSyntax::InvalidSyntax(ParserState pstate, std::string msg)
-    : Base(pstate, msg)
+    InvalidSyntax::InvalidSyntax(ParserState pstate, std::string msg, std::vector<Sass_Import_Entry>* import_stack)
+    : Base(pstate, msg, import_stack)
     { }
 
   }

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -19,8 +19,9 @@ namespace Sass {
         std::string msg;
       public:
         ParserState pstate;
+        std::vector<Sass_Import_Entry>* import_stack;
       public:
-        Base(ParserState pstate, std::string msg = def_msg);
+        Base(ParserState pstate, std::string msg = def_msg, std::vector<Sass_Import_Entry>* import_stack = 0);
         virtual const char* what() const throw();
         virtual ~Base() throw() {};
     };
@@ -53,7 +54,7 @@ namespace Sass {
 
     class InvalidSyntax : public Base {
       public:
-        InvalidSyntax(ParserState pstate, std::string msg);
+        InvalidSyntax(ParserState pstate, std::string msg, std::vector<Sass_Import_Entry>* import_stack = 0);
         virtual ~InvalidSyntax() throw() {};
     };
 


### PR DESCRIPTION
Also adds import stack reports on errors.

Fixes https://github.com/sass/libsass/issues/1801
https://github.com/sass/sass-spec/pull/643/files
```
Error: An @import loop has been found:
           index.scss imports _alpha.scss
           _alpha.scss imports _beta.scss
           _beta.scss imports _alpha.scss
        from line 1 of index.scss
        from line 1 of _alpha.scss
        from line 1 of _beta.scss
>> @import 'alpha';
```