### PR TITLE
Implement `extend` for wrapped selectors

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -58,7 +58,10 @@ namespace Sass {
 
   bool Compound_Selector::has_parent_ref()
   {
-    return has_parent_reference();
+    for (Simple_Selector* s : *this) {
+      if (s->has_parent_ref()) return true;
+    }
+    return false;
   }
 
   bool Complex_Selector::has_parent_ref()
@@ -1237,9 +1240,17 @@ namespace Sass {
     }
   }
 
+  bool Selector_List::has_parent_ref()
+  {
+    for (Complex_Selector* s : *this) {
+      if (s->has_parent_ref()) return true;
+    }
+    return false;
+  }
+
   void Selector_List::adjust_after_pushing(Complex_Selector* c)
   {
-    if (c->has_reference())   has_reference(true);
+    // if (c->has_reference())   has_reference(true);
   }
 
   // it's a superselector if every selector of the right side

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1798,7 +1798,7 @@ namespace Sass {
   // Abstract base class for CSS selectors.
   /////////////////////////////////////////
   class Selector : public Expression {
-    ADD_PROPERTY(bool, has_reference)
+    // ADD_PROPERTY(bool, has_reference)
     ADD_PROPERTY(bool, has_placeholder)
     // line break before list separator
     ADD_PROPERTY(bool, has_line_feed)
@@ -1813,7 +1813,7 @@ namespace Sass {
   public:
     Selector(ParserState pstate, bool r = false, bool h = false)
     : Expression(pstate),
-      has_reference_(r),
+      // has_reference_(r),
       has_placeholder_(h),
       has_line_feed_(false),
       has_line_break_(false),
@@ -1823,6 +1823,9 @@ namespace Sass {
     { concrete_type(SELECTOR); }
     virtual ~Selector() = 0;
     virtual size_t hash() = 0;
+    virtual bool has_parent_ref() {
+      return false;
+    }
     virtual unsigned long specificity() {
       return Constants::Specificity_Universal;
     }
@@ -1942,7 +1945,7 @@ namespace Sass {
   public:
     Parent_Selector(ParserState pstate)
     : Simple_Selector(pstate, "&")
-    { has_reference(true); }
+    { /* has_reference(true); */ }
     virtual bool has_parent_ref() { return true; };
     virtual unsigned long specificity()
     {
@@ -2106,6 +2109,11 @@ namespace Sass {
     Wrapped_Selector(ParserState pstate, std::string n, Selector* sel)
     : Simple_Selector(pstate, n), selector_(sel)
     { }
+    virtual bool has_parent_ref() {
+      // if (has_reference()) return true;
+      if (!selector()) return false;
+      return selector()->has_parent_ref();
+    }
     virtual bool is_superselector_of(Wrapped_Selector* sub);
     // Selectors inside the negation pseudo-class are counted like any
     // other, but the negation itself does not count as a pseudo-class.
@@ -2145,7 +2153,7 @@ namespace Sass {
   protected:
     void adjust_after_pushing(Simple_Selector* s)
     {
-      if (s->has_reference())   has_reference(true);
+      // if (s->has_reference())   has_reference(true);
       if (s->has_placeholder()) has_placeholder(true);
     }
   public:
@@ -2253,7 +2261,7 @@ namespace Sass {
       head_(h), tail_(t),
       reference_(r)
     {
-      if ((h && h->has_reference())   || (t && t->has_reference()))   has_reference(true);
+      // if ((h && h->has_reference())   || (t && t->has_reference()))   has_reference(true);
       if ((h && h->has_placeholder()) || (t && t->has_placeholder())) has_placeholder(true);
     }
     virtual bool has_parent_ref();
@@ -2400,6 +2408,7 @@ namespace Sass {
     std::string type() { return "list"; }
     // remove parent selector references
     // basically unwraps parsed selectors
+    virtual bool has_parent_ref();
     void remove_parent_selectors();
     // virtual Selector_Placeholder* find_placeholder();
     Selector_List* parentize(Selector_List* parents, Context& ctx);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -80,6 +80,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " <" << selector->hash() << ">";
     std::cerr << " [@media:" << selector->media_block() << "]";
     std::cerr << (selector->is_optional() ? " [is_optional]": " -");
+    std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
@@ -107,6 +108,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
       << " [weight:" << longToHex(selector->specificity()) << "]"
       << " [@media:" << selector->media_block() << "]"
       << (selector->is_optional() ? " [is_optional]": " -")
+      << (selector->has_parent_ref() ? " [has parent]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << " -- ";
@@ -136,6 +138,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " [weight:" << longToHex(selector->specificity()) << "]";
     std::cerr << " [@media:" << selector->media_block() << "]";
     std::cerr << (selector->is_optional() ? " [is_optional]": " -");
+    std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
@@ -151,35 +154,60 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "Wrapped_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
+    std::cerr << " <<" << selector->ns_name() << ">>";
+    std::cerr << (selector->is_optional() ? " [is_optional]": " -");
+    std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
+    std::cerr << (selector->has_line_break() ? " [line-break]": " -");
+    std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
+    std::cerr << std::endl;
     debug_ast(selector->selector(), ind + " () ", env);
   } else if (dynamic_cast<Pseudo_Selector*>(node)) {
     Pseudo_Selector* selector = dynamic_cast<Pseudo_Selector*>(node);
     std::cerr << ind << "Pseudo_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
+    std::cerr << " <<" << selector->ns_name() << ">>";
+    std::cerr << (selector->is_optional() ? " [is_optional]": " -");
+    std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
+    std::cerr << (selector->has_line_break() ? " [line-break]": " -");
+    std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
+    std::cerr << std::endl;
     debug_ast(selector->expression(), ind + " <= ", env);
   } else if (dynamic_cast<Attribute_Selector*>(node)) {
     Attribute_Selector* selector = dynamic_cast<Attribute_Selector*>(node);
     std::cerr << ind << "Attribute_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
+    std::cerr << " <<" << selector->ns_name() << ">>";
+    std::cerr << (selector->is_optional() ? " [is_optional]": " -");
+    std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
+    std::cerr << (selector->has_line_break() ? " [line-break]": " -");
+    std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
+    std::cerr << std::endl;
     debug_ast(selector->value(), ind + "[" + selector->matcher() + "] ", env);
   } else if (dynamic_cast<Selector_Qualifier*>(node)) {
     Selector_Qualifier* selector = dynamic_cast<Selector_Qualifier*>(node);
     std::cerr << ind << "Selector_Qualifier " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
+    std::cerr << " <<" << selector->ns_name() << ">>";
+    std::cerr << (selector->is_optional() ? " [is_optional]": " -");
+    std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
+    std::cerr << (selector->has_line_break() ? " [line-break]": " -");
+    std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
+    std::cerr << std::endl;
   } else if (dynamic_cast<Type_Selector*>(node)) {
     Type_Selector* selector = dynamic_cast<Type_Selector*>(node);
     std::cerr << ind << "Type_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>" << (selector->has_line_break() ? " [line-break]": " -") <<
-      " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
+    std::cerr << " <<" << selector->ns_name() << ">>";
+    std::cerr << (selector->is_optional() ? " [is_optional]": " -");
+    std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
+    std::cerr << (selector->has_line_break() ? " [line-break]": " -");
+    std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
+    std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">";
+    std::cerr << std::endl;
   } else if (dynamic_cast<Selector_Placeholder*>(node)) {
 
     Selector_Placeholder* selector = dynamic_cast<Selector_Placeholder*>(node);

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -37,6 +37,9 @@ namespace Sass {
 
     Statement* fallback_impl(AST_Node* n);
 
+  private:
+    void expand_selector_list(Selector*, Selector_List* extender);
+
   public:
     Expand(Context&, Env*, Backtrace*);
     virtual ~Expand() { }

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1732,6 +1732,18 @@ namespace Sass {
       Compound_Selector* pHead = pIter->head();
 
       if (pHead) {
+        for (Simple_Selector* pSimple : *pHead) {
+          if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(pSimple)) {
+            if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
+              for (Complex_Selector* cs : sl->elements()) {
+                if (complexSelectorHasExtension(cs, ctx, subset_map)) {
+                  hasExtension = true;
+                  break;
+                }
+              }
+            }
+          }
+        }
         SubsetMapEntries entries = subset_map.get_v(pHead->to_str_vec());
         for (ExtensionPair ext : entries) {
           // check if both selectors have the same media block parent
@@ -1967,6 +1979,21 @@ namespace Sass {
       }
     }
 
+    for (Complex_Selector* cs : *pNewSelectors) {
+      while (cs) {
+        if (cs->head()) {
+        for (Simple_Selector* ss : *cs->head()) {
+          if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(ss)) {
+            if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
+              bool extended = false;
+              ws->selector(extendSelectorList(sl, ctx, subset_map, false, extended));
+            }
+          }
+        }
+        }
+        cs = cs->tail();
+      }
+    }
     return pNewSelectors;
 
   }

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1736,9 +1736,12 @@ namespace Sass {
           if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(pSimple)) {
             if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
               for (Complex_Selector* cs : sl->elements()) {
-                if (complexSelectorHasExtension(cs, ctx, subset_map)) {
-                  hasExtension = true;
-                  break;
+                while (cs) {
+                  if (complexSelectorHasExtension(cs, ctx, subset_map)) {
+                    hasExtension = true;
+                    break;
+                  }
+                  cs = cs->tail();
                 }
               }
             }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -673,14 +673,14 @@ namespace Sass {
       sel->tail(parse_complex_selector(true));
       if (sel->tail()) {
         // ToDo: move this logic below into tail setter
-        if (sel->tail()->has_reference()) sel->has_reference(true);
+        // if (sel->tail()->has_reference()) sel->has_reference(true);
         if (sel->tail()->has_placeholder()) sel->has_placeholder(true);
       }
     }
 
     // add a parent selector if we are not in a root
     // also skip adding parent ref if we only have refs
-    if (!sel->has_reference() && !in_at_root && !in_root) {
+    if (!sel->has_parent_ref() && !in_at_root && !in_root) {
       // create the objects to wrap parent selector reference
       Parent_Selector* parent = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate);
       parent->media_block(last_media_block);

--- a/src/remove_placeholders.cpp
+++ b/src/remove_placeholders.cpp
@@ -16,21 +16,47 @@ namespace Sass {
         }
     }
 
+    Selector_List* Remove_Placeholders::remove_placeholders(Selector_List* sl)
+    {
+      Selector_List* new_sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, sl->pstate());
+
+      for (size_t i = 0, L = sl->length(); i < L; ++i) {
+          if (!(*sl)[i]->contains_placeholder()) {
+              *new_sl << (*sl)[i];
+          }
+      }
+
+      return new_sl;
+
+    }
+
+
     void Remove_Placeholders::operator()(Ruleset* r) {
         // Create a new selector group without placeholders
         Selector_List* sl = static_cast<Selector_List*>(r->selector());
 
         if (sl) {
-            Selector_List* new_sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, sl->pstate());
-
-            for (size_t i = 0, L = sl->length(); i < L; ++i) {
-                if (!(*sl)[i]->contains_placeholder()) {
-                    *new_sl << (*sl)[i];
+          // Set the new placeholder selector list
+          r->selector(remove_placeholders(sl));
+          // Remove placeholders in wrapped selectors
+          for (Complex_Selector* cs : *sl) {
+            while (cs) {
+              if (cs->head()) {
+                for (Simple_Selector* ss : *cs->head()) {
+                  if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(ss)) {
+                    if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
+                      Selector_List* clean = remove_placeholders(sl);
+                      // also clean superflous parent selectors
+                      // probably not really the correct place
+                      clean->remove_parent_selectors();
+                      ws->selector(clean);
+                    }
+                  }
                 }
+              }
+              cs = cs->tail();
             }
-
-            // Set the new placeholder selector list
-            r->selector(new_sl);
+          }
         }
 
         // Iterate into child blocks

--- a/src/remove_placeholders.hpp
+++ b/src/remove_placeholders.hpp
@@ -17,6 +17,9 @@ namespace Sass {
 
         void fallback_impl(AST_Node* n) {}
 
+    private:
+      Selector_List* remove_placeholders(Selector_List*);
+
     public:
         Remove_Placeholders(Context&);
         virtual ~Remove_Placeholders() { }


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1797

A more complete spec test which has some logic I don't yet understand:
```scss
%not {
  color: red;
}
.not {
  @extend %not;
}
div:has(%not) {
  color: black;
}

bar {
  span:not(%not) {
    color: black;
  }
  span:not(&.foo) {
    color: black;
  }
  span:not(&%not) {
    color: black;
  }
}
```

Ruby sass result:
```css
.not {
  color: red; }

div:has(.not) {
  color: black; }

bar span:not(.not) {
  color: black; }
span:not(bar.foo) {
  color: black; }
span:not(bar.not) {
  color: black; }
```

Libsass output with this PR:
```css
.not {
  color: red; }

div:has(.not) {
  color: black; }

bar span:not(.not) {
  color: black; }

bar span:not(bar.foo) {
  color: black; }

bar span:not(bar.not) {
  color: black; }
```

It seems to follow the logic of this sample:
```scss
foo {
  span:not & {
    color: black;
  }
}
```

Which yields in both:
```css
span:not bar {
  color: black; }
```