### PR TITLE
Use Visual Studio 2013 for node/Windows XP compatibility

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2015
+os: Visual Studio 2013
 
 environment:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -14,6 +14,7 @@
 #include "sass/base.h"
 #include "utf8.h"
 
+#include <cstdint>
 #include <cstdlib>
 #include <cmath>
 #include <cctype>


### PR DESCRIPTION
* Use Visual Studio 2013 to ensure the same
  platform as the node engines are currently built

* Include <cstdint> unconditionally to prevent
  missing type declarations. (follow up to https://github.com/sass/libsass/pull/1721)

Fixes: https://github.com/sass/node-sass/issues/1283

More information why we need this change https://github.com/sass/node-sass/issues/1283#issuecomment-169845062

This pull request is against libsass release 3.3.2 (not master)