### PR TITLE
Refactor/milestore 3.4

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2260,9 +2260,10 @@ namespace Sass {
     std::string str("");
     auto end = this->end();
     auto start = this->begin();
+    std::string sep(compressed ? "," : ", ");
     while (start < end && *start) {
       Complex_Selector* sel = *start;
-      if (!str.empty()) str += ", ";
+      if (!str.empty()) str += sep;
       str += sel->to_string(compressed, precision);
       ++ start;
     }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1773,13 +1773,13 @@ namespace Sass {
     return false;
   }
 
-  bool String_Schema::has_left_interpolant(void) const
+  bool String_Schema::is_left_interpolant(void) const
   {
-    return length() && first()->is_interpolant();
+    return length() && first()->is_left_interpolant();
   }
-  bool String_Schema::has_right_interpolant(void) const
+  bool String_Schema::is_right_interpolant(void) const
   {
-    return length() && last()->is_interpolant();
+    return length() && last()->is_right_interpolant();
   }
 
   bool String_Schema::operator== (const Expression& rhs) const
@@ -1937,6 +1937,15 @@ namespace Sass {
   std::string Argument::to_string(bool compressed, int precision) const
   {
     return value()->to_string(compressed, precision);
+  }
+
+  bool Binary_Expression::is_left_interpolant(void) const
+  {
+    return is_interpolant() || (left() && left()->is_left_interpolant());
+  }
+  bool Binary_Expression::is_right_interpolant(void) const
+  {
+    return is_interpolant() || (right() && right()->is_right_interpolant());
   }
 
   std::string Binary_Expression::to_string(bool compressed, int precision) const

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2215,9 +2215,18 @@ namespace Sass {
     }
 
     // some final cosmetics
-    if (res == "-0.0") res.erase(0, 1);
-    else if (res == "-0") res.erase(0, 1);
+    if (res == "0.0") res = "0";
     else if (res == "") res = "0";
+    else if (res == "-0") res = "0";
+    else if (compressed)
+    {
+      if (res == "-0.0") res = ".0";
+      // check if handling negative nr
+      size_t off = res[0] == '-' ? 1 : 0;
+      // remove leading zero from floating point in compressed mode
+      if (res[off] == '0' && res[off+1] == '.') res.erase(off, 1);
+    }
+    else if (res == "-0.0") res = "0.0";
 
     // add unit now
     res += unit();

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2218,15 +2218,14 @@ namespace Sass {
     if (res == "0.0") res = "0";
     else if (res == "") res = "0";
     else if (res == "-0") res = "0";
+    else if (res == "-0.0") res = "0";
     else if (compressed)
     {
-      if (res == "-0.0") res = ".0";
       // check if handling negative nr
       size_t off = res[0] == '-' ? 1 : 0;
       // remove leading zero from floating point in compressed mode
       if (res[off] == '0' && res[off+1] == '.') res.erase(off, 1);
     }
-    else if (res == "-0.0") res = "0.0";
 
     // add unit now
     res += unit();
@@ -2299,6 +2298,7 @@ namespace Sass {
       case ADJACENT_TO: str_op = "+"; break;
       case REFERENCE:   str_op = "/" + str_ref + "/"; break;
     }
+
     // prettify for non ancestors
     if (combinator() != ANCESTOR_OF) {
       // no spaces needed for compressed
@@ -2311,6 +2311,12 @@ namespace Sass {
     // is ancestor with no tail
     else if (str_tail == "") {
       str_op = ""; // superflous
+    }
+    else if (compressed)
+    {
+      if (str_tail[0] == '-') {
+        str_op = ""; // superflous
+      }
     }
     // now build the final result
     return str_head + str_op + str_tail;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1773,6 +1773,15 @@ namespace Sass {
     return false;
   }
 
+  bool String_Schema::has_left_interpolant(void) const
+  {
+    return length() && first()->is_interpolant();
+  }
+  bool String_Schema::has_right_interpolant(void) const
+  {
+    return length() && last()->is_interpolant();
+  }
+
   bool String_Schema::operator== (const Expression& rhs) const
   {
     if (const String_Schema* r = dynamic_cast<const String_Schema*>(&rhs)) {
@@ -2235,9 +2244,19 @@ namespace Sass {
 
   }
 
+  std::string String_Quoted::inspect() const
+  {
+    return quote(value_, '*', true);
+  }
+
   std::string String_Quoted::to_string(bool compressed, int precision) const
   {
     return quote_mark_ ? quote(value_, quote_mark_, true) : value_;
+  }
+
+  std::string String_Constant::inspect() const
+  {
+    return quote(value_, '*', true);
   }
 
   std::string String_Constant::to_string(bool compressed, int precision) const

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1734,6 +1734,12 @@ namespace Sass {
   bool Number::operator== (const Expression& rhs) const
   {
     if (const Number* r = dynamic_cast<const Number*>(&rhs)) {
+      size_t lhs_units = numerator_units_.size() + denominator_units_.size();
+      size_t rhs_units = r->numerator_units_.size() + r->denominator_units_.size();
+      // unitless and only having one unit seems equivalent (will change in future)
+      if (!lhs_units || !rhs_units) {
+        return std::fabs(value() - r->value()) < NUMBER_EPSILON;
+      }
       return (numerator_units_ == r->numerator_units_) &&
              (denominator_units_ == r->denominator_units_) &&
              std::fabs(value() - r->value()) < NUMBER_EPSILON;
@@ -1743,11 +1749,18 @@ namespace Sass {
 
   bool Number::operator< (const Number& rhs) const
   {
+    size_t lhs_units = numerator_units_.size() + denominator_units_.size();
+    size_t rhs_units = rhs.numerator_units_.size() + rhs.denominator_units_.size();
+    // unitless and only having one unit seems equivalent (will change in future)
+    if (!lhs_units || !rhs_units) {
+      return value() < rhs.value();
+    }
+
     Number tmp_r(rhs);
     tmp_r.normalize(find_convertible_unit());
     std::string l_unit(unit());
     std::string r_unit(tmp_r.unit());
-    if (!l_unit.empty() && !r_unit.empty() && unit() != tmp_r.unit()) {
+    if (unit() != tmp_r.unit()) {
       error("cannot compare numbers with incompatible units", pstate());
     }
     return value() < tmp_r.value();

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2255,7 +2255,7 @@ namespace Sass {
       // check if handling negative nr
       size_t off = res[0] == '-' ? 1 : 0;
       // remove leading zero from floating point in compressed mode
-      if (res[off] == '0' && res[off+1] == '.') res.erase(off, 1);
+      if (zero() && res[off] == '0' && res[off+1] == '.') res.erase(off, 1);
     }
 
     // add unit now

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -145,6 +145,9 @@ namespace Sass {
     virtual bool is_false() { return false; }
     virtual bool operator== (const Expression& rhs) const { return false; }
     virtual void set_delayed(bool delayed) { is_delayed(delayed); }
+    virtual bool has_interpolant() const { return is_interpolant(); }
+    virtual bool is_left_interpolant() const { return is_interpolant(); }
+    virtual bool is_right_interpolant() const { return is_interpolant(); }
     virtual std::string inspect() const { return to_string(); } // defaults to to_string
     virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
     virtual size_t hash() { return 0; }
@@ -1002,6 +1005,13 @@ namespace Sass {
         default: return "invalid"; break;
       }
     }
+    bool is_left_interpolant(void) const;
+    bool is_right_interpolant(void) const;
+    bool has_interpolant() const
+    {
+      return is_left_interpolant() ||
+             is_right_interpolant();
+    }
     virtual void set_delayed(bool delayed)
     {
       right()->set_delayed(delayed);
@@ -1470,8 +1480,8 @@ namespace Sass {
     std::string type() { return "string"; }
     static std::string type_name() { return "string"; }
 
-    bool has_left_interpolant(void) const;
-    bool has_right_interpolant(void) const;
+    bool is_left_interpolant(void) const;
+    bool is_right_interpolant(void) const;
     // void has_interpolants(bool tc) { }
     bool has_interpolants() {
       for (auto el : elements()) {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1439,14 +1439,22 @@ namespace Sass {
   // evaluation phase.
   ///////////////////////////////////////////////////////////////////////
   class String_Schema : public String, public Vectorized<Expression*> {
-    ADD_PROPERTY(bool, has_interpolants)
+    // ADD_PROPERTY(bool, has_interpolants)
     size_t hash_;
   public:
     String_Schema(ParserState pstate, size_t size = 0, bool has_interpolants = false)
-    : String(pstate), Vectorized<Expression*>(size), has_interpolants_(has_interpolants), hash_(0)
+    : String(pstate), Vectorized<Expression*>(size), hash_(0)
     { concrete_type(STRING); }
     std::string type() { return "string"; }
     static std::string type_name() { return "string"; }
+
+    void has_interpolants(bool tc) { }
+    bool has_interpolants() {
+      for (auto el : elements()) {
+        if (el->is_interpolant()) return true;
+      }
+      return false;
+    }
 
     virtual size_t hash()
     {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -145,6 +145,7 @@ namespace Sass {
     virtual bool is_false() { return false; }
     virtual bool operator== (const Expression& rhs) const { return false; }
     virtual void set_delayed(bool delayed) { is_delayed(delayed); }
+    virtual std::string inspect() const { return to_string(); } // defaults to to_string
     virtual std::string to_string(bool compressed = false, int precision = 5) const = 0;
     virtual size_t hash() { return 0; }
   };
@@ -924,6 +925,27 @@ namespace Sass {
     ATTACH_OPERATIONS()
   };
 
+  inline static const std::string sass_op_to_name(enum Sass_OP op) {
+    switch (op) {
+      case AND: return "and"; break;
+      case OR: return "or"; break;
+      case EQ: return "eq"; break;
+      case NEQ: return "neq"; break;
+      case GT: return "gt"; break;
+      case GTE: return "gte"; break;
+      case LT: return "lt"; break;
+      case LTE: return "lte"; break;
+      case ADD: return "plus"; break;
+      case SUB: return "sub"; break;
+      case MUL: return "times"; break;
+      case DIV: return "div"; break;
+      case MOD: return "mod"; break;
+      // this is only used internally!
+      case NUM_OPS: return "[OPS]"; break;
+      default: return "invalid"; break;
+    }
+  }
+
   //////////////////////////////////////////////////////////////////////////
   // Binary expressions. Represents logical, relational, and arithmetic
   // operations. Templatized to avoid large switch statements and repetitive
@@ -1448,7 +1470,9 @@ namespace Sass {
     std::string type() { return "string"; }
     static std::string type_name() { return "string"; }
 
-    void has_interpolants(bool tc) { }
+    bool has_left_interpolant(void) const;
+    bool has_right_interpolant(void) const;
+    // void has_interpolants(bool tc) { }
     bool has_interpolants() {
       for (auto el : elements()) {
         if (el->is_interpolant()) return true;
@@ -1505,6 +1529,7 @@ namespace Sass {
     }
 
     virtual bool operator==(const Expression& rhs) const;
+    virtual std::string inspect() const; // quotes are forced on inspection
     virtual std::string to_string(bool compressed = false, int precision = 5) const;
 
     // static char auto_quote() { return '*'; }
@@ -1526,6 +1551,7 @@ namespace Sass {
       if (q && quote_mark_) quote_mark_ = q;
     }
     virtual bool operator==(const Expression& rhs) const;
+    virtual std::string inspect() const; // quotes are forced on inspection
     virtual std::string to_string(bool compressed = false, int precision = 5) const;
     ATTACH_OPERATIONS()
   };

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -125,7 +125,7 @@ namespace Sass {
     extern const char rbrace[]          = "}";
     extern const char rparen[]          = ")";
     extern const char sign_chars[]      = "-+";
-    extern const char op_chars[]        = "-+*/%";
+    extern const char op_chars[]        = "-+";
     extern const char hyphen[]          = "-";
     extern const char ellipsis[]        = "...";
     // extern const char url_space_chars[] = " \t\r\n\f";

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -125,6 +125,7 @@ namespace Sass {
     extern const char rbrace[]          = "}";
     extern const char rparen[]          = ")";
     extern const char sign_chars[]      = "-+";
+    extern const char op_chars[]        = "-+*/%";
     extern const char hyphen[]          = "-";
     extern const char ellipsis[]        = "...";
     // extern const char url_space_chars[] = " \t\r\n\f";

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -87,6 +87,7 @@ namespace Sass {
     extern const char odd_kwd[]          = "odd";
     extern const char progid_kwd[]       = "progid";
     extern const char expression_kwd[]   = "expression";
+    extern const char calc_fn_kwd[]      = "calc";
     extern const char calc_kwd[]         = "calc(";
     extern const char moz_calc_kwd[]     = "-moz-calc(";
     extern const char webkit_calc_kwd[]  = "-webkit-calc(";

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -126,6 +126,7 @@ namespace Sass {
     extern const char rbrace[];
     extern const char rparen[];
     extern const char sign_chars[];
+    extern const char op_chars[];
     extern const char hyphen[];
     extern const char ellipsis[];
     // extern const char url_space_chars[];

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -89,6 +89,7 @@ namespace Sass {
     extern const char progid_kwd[];
     extern const char expression_kwd[];
     extern const char calc_kwd[];
+    extern const char calc_fn_kwd[];
     extern const char moz_calc_kwd[];
     extern const char webkit_calc_kwd[];
     extern const char ms_calc_kwd[];

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -650,7 +650,6 @@ namespace Sass {
     Expand expand(*this, &global, &backtrace);
     Cssize cssize(*this, &backtrace);
     // expand and eval the tree
-    // debug_ast(root);
     root = root->perform(&expand)->block();
     // merge and bubble certain rules
     root = root->perform(&cssize)->block();

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -22,9 +22,7 @@ namespace Sass {
 
   public:
     Cssize(Context&, Backtrace*);
-    virtual ~Cssize() { }
-
-    using Operation<Statement*>::operator();
+    ~Cssize() { }
 
     Statement* operator()(Block*);
     Statement* operator()(Ruleset*);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -453,6 +453,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     else if (expression->type() == Textual::DIMENSION) std::cerr << " [DIMENSION]";
     else if (expression->type() == Textual::HEX) std::cerr << " [HEX]";
     std::cerr << expression << " [" << expression->value() << "]";
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     if (expression->is_delayed()) std::cerr << " [delayed]";
     std::cerr << std::endl;
   } else if (dynamic_cast<Variable*>(node)) {
@@ -562,16 +563,19 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Boolean* expression = dynamic_cast<Boolean*>(node);
     std::cerr << ind << "Boolean " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->value() << "]" << std::endl;
   } else if (dynamic_cast<Color*>(node)) {
     Color* expression = dynamic_cast<Color*>(node);
     std::cerr << ind << "Color " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->r() << ":"  << expression->g() << ":" << expression->b() << "@" << expression->a() << "]" << std::endl;
   } else if (dynamic_cast<Number*>(node)) {
     Number* expression = dynamic_cast<Number*>(node);
     std::cerr << ind << "Number " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->value() << expression->unit() << "]" <<
       " [hash: " << expression->hash() << "] " <<
       std::endl;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -526,7 +526,9 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Binary_Expression*>(node)) {
     Binary_Expression* expression = dynamic_cast<Binary_Expression*>(node);
     std::cerr << ind << "Binary_Expression " << expression;
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
+    if (expression->is_interpolant()) std::cerr << " [is interpolant] ";
+    if (expression->is_left_interpolant()) std::cerr << " [left interpolant] ";
+    if (expression->is_right_interpolant()) std::cerr << " [right interpolant] ";
     std::cerr << " [delayed: " << expression->is_delayed() << "] ";
     std::cerr << " [ws_before: " << expression->op().ws_before << "] ";
     std::cerr << " [ws_after: " << expression->op().ws_after << "] ";
@@ -608,8 +610,10 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "String_Schema " << expression;
     std::cerr << " " << expression->concrete_type();
     if (expression->is_delayed()) std::cerr << " [delayed]";
-    if (expression->has_interpolants()) std::cerr << " [has_interpolants]";
-    if (expression->is_interpolant()) std::cerr << " [interpolant]";
+    if (expression->is_interpolant()) std::cerr << " [is interpolant]";
+    if (expression->has_interpolant()) std::cerr << " [has interpolant]";
+    if (expression->is_left_interpolant()) std::cerr << " [left interpolant] ";
+    if (expression->is_right_interpolant()) std::cerr << " [right interpolant] ";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
     for(auto i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<String*>(node)) {

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -528,6 +528,8 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "Binary_Expression " << expression;
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [delayed: " << expression->is_delayed() << "] ";
+    std::cerr << " [ws_before: " << expression->op().ws_before << "] ";
+    std::cerr << " [ws_after: " << expression->op().ws_after << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->type_name() << "]" << std::endl;
     debug_ast(expression->left(), ind + " left:  ", env);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -458,6 +458,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Variable*>(node)) {
     Variable* expression = dynamic_cast<Variable*>(node);
     std::cerr << ind << "Variable " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->name() << "]" << std::endl;
     std::string name(expression->name());
@@ -465,6 +466,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Function_Call_Schema*>(node)) {
     Function_Call_Schema* expression = dynamic_cast<Function_Call_Schema*>(node);
     std::cerr << ind << "Function_Call_Schema " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << "" << std::endl;
     debug_ast(expression->name(), ind + "name: ", env);
@@ -472,6 +474,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Function_Call*>(node)) {
     Function_Call* expression = dynamic_cast<Function_Call*>(node);
     std::cerr << ind << "Function_Call " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->name() << "]";
     if (expression->is_delayed()) std::cerr << " [delayed]";
@@ -515,12 +518,14 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Unary_Expression*>(node)) {
     Unary_Expression* expression = dynamic_cast<Unary_Expression*>(node);
     std::cerr << ind << "Unary_Expression " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->type() << "]" << std::endl;
     debug_ast(expression->operand(), ind + " operand: ", env);
   } else if (dynamic_cast<Binary_Expression*>(node)) {
     Binary_Expression* expression = dynamic_cast<Binary_Expression*>(node);
     std::cerr << ind << "Binary_Expression " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [delayed: " << expression->is_delayed() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->type_name() << "]" << std::endl;
@@ -529,6 +534,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   } else if (dynamic_cast<Map*>(node)) {
     Map* expression = dynamic_cast<Map*>(node);
     std::cerr << ind << "Map " << expression;
+    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [Hashed]" << std::endl;
     for (auto i : expression->elements()) {

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -109,6 +109,7 @@ namespace Sass {
   // append some text or token to the buffer
   void Emitter::append_string(const std::string& text)
   {
+
     // write space/lf
     flush_schedules();
 

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -58,9 +58,11 @@ namespace Sass {
   // MAIN BUFFER MANIPULATION
 
   // add outstanding delimiter
-  void Emitter::finalize(void)
+  void Emitter::finalize(bool final)
   {
     scheduled_space = 0;
+    if (output_style() == SASS_STYLE_COMPRESSED)
+      if (final) scheduled_delimiter = false;
     if (scheduled_linefeed)
       scheduled_linefeed = 1;
     flush_schedules();

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -59,7 +59,7 @@ namespace Sass {
       // flush scheduled space/linefeed
       Sass_Output_Style output_style(void);
       // add outstanding linefeed
-      void finalize(void);
+      void finalize(bool final = true);
       // flush scheduled space/linefeed
       void flush_schedules(void);
       // prepend some text or token to the buffer

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -50,6 +50,84 @@ namespace Sass {
     : Base(pstate, msg, import_stack)
     { }
 
+    UndefinedOperation::UndefinedOperation(const Expression* lhs, const Expression* rhs, const std::string& op)
+    : lhs(lhs), rhs(rhs), op(op)
+    {
+      msg  = def_op_msg + ": \"";
+      if (const Value* l = dynamic_cast<const Value*>(lhs)) {
+        msg += l->inspect();
+      } else if (lhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += " " + op + " ";
+      if (const Value* r = dynamic_cast<const Value*>(rhs)) {
+        msg += r->inspect();
+      } else if (rhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += "\".";
+    }
+
+    InvalidNullOperation::InvalidNullOperation(const Expression* lhs, const Expression* rhs, const std::string& op)
+    : UndefinedOperation(lhs, rhs, op)
+    {
+      msg  = def_op_null_msg + ": \"";
+      if (const Value* l = dynamic_cast<const Value*>(lhs)) {
+        msg += l->inspect();
+      } else if (lhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += " " + op + " ";
+      if (const Value* r = dynamic_cast<const Value*>(rhs)) {
+        msg += r->inspect();
+      } else if (rhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += "\".";
+    }
+
+    ZeroDivisionError::ZeroDivisionError(const Expression& lhs, const Expression& rhs)
+    : lhs(lhs), rhs(rhs)
+    {
+      msg  = "divided by 0";
+    }
+
+    IncompatibleUnits::IncompatibleUnits(const Number& lhs, const Number& rhs)
+    : lhs(lhs), rhs(rhs)
+    {
+      msg  = "Incompatible units: '";
+      msg += rhs.unit();
+      msg += "' and '";
+      msg += lhs.unit();
+      msg += "'.";
+    }
+
+    AlphaChannelsNotEqual::AlphaChannelsNotEqual(const Expression* lhs, const Expression* rhs, const std::string& op)
+    : lhs(lhs), rhs(rhs), op(op)
+    {
+      msg  = "Alpha channels must be equal: ";
+      if (const Value* l = dynamic_cast<const Value*>(lhs)) {
+        msg += l->to_string();
+      } else if (lhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += " " + op + " ";
+      if (const Value* r = dynamic_cast<const Value*>(rhs)) {
+        msg += r->to_string();
+      } else if (rhs) {
+        msg += "[EXPRESSION]";
+      }
+      msg += ".";
+    }
+
+
+    SassValueError::SassValueError(ParserState pstate, OperationError& err)
+    : Base(pstate, err.what())
+    {
+      msg = err.what();
+      prefix = err.errtype();
+    }
+
   }
 
 

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -12,15 +12,10 @@ namespace Sass {
   namespace Exception {
 
     Base::Base(ParserState pstate, std::string msg, std::vector<Sass_Import_Entry>* import_stack)
-    : std::runtime_error(msg),
-      msg(msg), pstate(pstate),
+    : std::runtime_error(msg), msg(msg),
+      prefix("Error"), pstate(pstate),
       import_stack(import_stack)
     { }
-
-    const char* Base::what() const throw()
-    {
-      return msg.c_str();
-    }
 
     InvalidSass::InvalidSass(ParserState pstate, std::string msg)
     : Base(pstate, msg)

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -50,13 +50,13 @@ namespace Sass {
     {
       msg  = def_op_msg + ": \"";
       if (const Value* l = dynamic_cast<const Value*>(lhs)) {
-        msg += l->inspect();
+        msg += l->to_string();
       } else if (lhs) {
         msg += "[EXPRESSION]";
       }
       msg += " " + op + " ";
       if (const Value* r = dynamic_cast<const Value*>(rhs)) {
-        msg += r->inspect();
+        msg += r->to_string();
       } else if (rhs) {
         msg += "[EXPRESSION]";
       }

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -12,17 +12,21 @@ namespace Sass {
 
   namespace Exception {
 
-    const std::string def_msg = "Invalid sass";
+    const std::string def_msg = "Invalid sass detected";
+    const std::string def_op_msg = "Undefined operation";
+    const std::string def_op_null_msg = "Invalid null operation";
 
     class Base : public std::runtime_error {
       protected:
         std::string msg;
+        std::string prefix;
       public:
         ParserState pstate;
         std::vector<Sass_Import_Entry>* import_stack;
       public:
         Base(ParserState pstate, std::string msg = def_msg, std::vector<Sass_Import_Entry>* import_stack = 0);
-        virtual const char* what() const throw();
+        virtual const char* errtype() const { return prefix.c_str(); }
+        virtual const char* what() const throw() { return msg.c_str(); }
         virtual ~Base() throw() {};
     };
 
@@ -56,6 +60,73 @@ namespace Sass {
       public:
         InvalidSyntax(ParserState pstate, std::string msg, std::vector<Sass_Import_Entry>* import_stack = 0);
         virtual ~InvalidSyntax() throw() {};
+    };
+
+    /* common virtual base class (has no pstate) */
+    class OperationError : public std::runtime_error {
+      protected:
+        std::string msg;
+      public:
+        OperationError(std::string msg = def_op_msg)
+        : std::runtime_error(msg), msg(msg)
+        {};
+      public:
+        virtual const char* errtype() const { return "Error"; }
+        virtual const char* what() const throw() { return msg.c_str(); }
+        virtual ~OperationError() throw() {};
+    };
+
+    class ZeroDivisionError : public OperationError {
+      protected:
+        const Expression& lhs;
+        const Expression& rhs;
+      public:
+        ZeroDivisionError(const Expression& lhs, const Expression& rhs);
+        virtual const char* errtype() const { return "ZeroDivisionError"; }
+        virtual ~ZeroDivisionError() throw() {};
+    };
+
+    class IncompatibleUnits : public OperationError {
+      protected:
+        const Number& lhs;
+        const Number& rhs;
+      public:
+        IncompatibleUnits(const Number& lhs, const Number& rhs);
+        virtual ~IncompatibleUnits() throw() {};
+    };
+
+    class UndefinedOperation : public OperationError {
+      protected:
+        const Expression* lhs;
+        const Expression* rhs;
+        const std::string op;
+      public:
+        UndefinedOperation(const Expression* lhs, const Expression* rhs, const std::string& op);
+        // virtual const char* errtype() const { return "Error"; }
+        virtual ~UndefinedOperation() throw() {};
+    };
+
+    class InvalidNullOperation : public UndefinedOperation {
+      public:
+        InvalidNullOperation(const Expression* lhs, const Expression* rhs, const std::string& op);
+        virtual ~InvalidNullOperation() throw() {};
+    };
+
+    class AlphaChannelsNotEqual : public OperationError {
+      protected:
+        const Expression* lhs;
+        const Expression* rhs;
+        const std::string op;
+      public:
+        AlphaChannelsNotEqual(const Expression* lhs, const Expression* rhs, const std::string& op);
+        // virtual const char* errtype() const { return "Error"; }
+        virtual ~AlphaChannelsNotEqual() throw() {};
+    };
+
+    class SassValueError : public Base {
+      public:
+        SassValueError(ParserState pstate, OperationError& err);
+        virtual ~SassValueError() throw() {};
     };
 
   }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -497,7 +497,7 @@ namespace Sass {
       return b;
     }
 
-    // if we have a schema on the left side, we also return a string
+    // only the last item will be used to eval the binary expression
     if (String_Schema* s_1 = dynamic_cast<String_Schema*>(b->left())) {
       if (!s_1->is_right_interpolant()) {
         ret_schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, s_1->pstate());
@@ -1002,8 +1002,12 @@ namespace Sass {
   {
     using Prelexer::number;
     Expression* result = 0;
-    bool zero = !( t->value().substr(0, 1) == "." ||
-                   t->value().substr(0, 2) == "-." );
+    size_t L = t->value().length();
+    bool zero = !( (L > 0 && t->value().substr(0, 1) == ".") ||
+                   (L > 1 && t->value().substr(0, 2) == "0.") ||
+                   (L > 1 && t->value().substr(0, 2) == "-.")  ||
+                   (L > 2 && t->value().substr(0, 3) == "-0.")
+                 );
 
     const std::string& text = t->value();
     size_t num_pos = text.find_first_not_of(" \n\r\t");
@@ -1026,7 +1030,7 @@ namespace Sass {
                                  t->pstate(),
                                  sass_atof(num.c_str()),
                                  "%",
-                                 zero);
+                                 true);
         break;
       case Textual::DIMENSION:
         result = SASS_MEMORY_NEW(ctx.mem, Number,

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -521,6 +521,9 @@ namespace Sass {
         op_type == Sass_OP::LT ||
         op_type == Sass_OP::LTE)
     {
+      lhs->is_expanded(false);
+      lhs->set_delayed(false);
+      lhs = lhs->perform(this);
       rhs->is_expanded(false);
       rhs->set_delayed(false);
       rhs = rhs->perform(this);
@@ -1008,6 +1011,8 @@ namespace Sass {
 
     if (List* l = dynamic_cast<List*>(ex)) {
       List* ll = SASS_MEMORY_NEW(ctx.mem, List, l->pstate(), 0, l->separator());
+      // this fixes an issue with bourbon sample, not really sure why
+      if (l->size() && dynamic_cast<Null*>((*l)[0])) { res += " "; }
       for(auto item : *l) {
         item->is_interpolant(l->is_interpolant());
         std::string rl(""); interpolation(ctx, rl, item, into_quotes, l->is_interpolant());

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -882,10 +882,9 @@ namespace Sass {
       bind(std::string("Function"), c->name(), params, args, &ctx, &fn_env, this);
       Backtrace here(backtrace(), c->pstate(), ", in function `" + c->name() + "`");
       exp.backtrace_stack.push_back(&here);
-      // if it's user-defined, eval the body
-      if (body) { result = body->perform(this); }
-      // if it's native, invoke the underlying CPP function
-      else { result = func(fn_env, *env, ctx, def->signature(), c->pstate(), backtrace()); }
+      // eval the body if user-defined or special, invoke underlying CPP function if native
+      if (body && !Prelexer::re_special_fun(c->name().c_str())) { result = body->perform(this); }
+      else if (func) { result = func(fn_env, *env, ctx, def->signature(), c->pstate(), backtrace()); }
       if (!result) error(std::string("Function ") + c->name() + " did not return a value", c->pstate());
       exp.backtrace_stack.pop_back();
     }

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -93,7 +93,7 @@ namespace Sass {
     static Value* op_number_color(Memory_Manager&, enum Sass_OP, const Number&, const Color&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
     static Value* op_color_number(Memory_Manager&, enum Sass_OP, const Color&, const Number&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
     static Value* op_colors(Memory_Manager&, enum Sass_OP, const Color&, const Color&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
-    static Value* op_strings(Memory_Manager&, Sass::Operand, Value&, Value&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
+    static Value* op_strings(Memory_Manager&, Sass::Operand, Value&, Value&, bool compressed = false, int precision = 5, ParserState* pstate = 0, bool interpolant = false);
 
   private:
     void interpolation(Context& ctx, std::string& res, Expression* ex, bool into_quotes, bool was_itpl = false);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -93,7 +93,7 @@ namespace Sass {
     static Value* op_number_color(Memory_Manager&, enum Sass_OP, const Number&, const Color&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
     static Value* op_color_number(Memory_Manager&, enum Sass_OP, const Color&, const Number&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
     static Value* op_colors(Memory_Manager&, enum Sass_OP, const Color&, const Color&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
-    static Value* op_strings(Memory_Manager&, enum Sass_OP, Value&, Value&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
+    static Value* op_strings(Memory_Manager&, Sass::Operand, Value&, Value&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
 
   private:
     void interpolation(Context& ctx, std::string& res, Expression* ex, bool into_quotes, bool was_itpl = false);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -87,7 +87,7 @@ namespace Sass {
 
     // -- only need to define two comparisons, and the rest can be implemented in terms of them
     static bool eq(Expression*, Expression*);
-    static bool lt(Expression*, Expression*);
+    static bool lt(Expression*, Expression*, std::string op);
     // -- arithmetic on the combinations that matter
     static Value* op_numbers(Memory_Manager&, enum Sass_OP, const Number&, const Number&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
     static Value* op_number_color(Memory_Manager&, enum Sass_OP, const Number&, const Color&, bool compressed = false, int precision = 5, ParserState* pstate = 0);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -23,6 +23,8 @@ namespace Sass {
     Eval(Expand& exp);
     ~Eval();
 
+    bool is_in_comment;
+
     Env* environment();
     Context& context();
     Selector_List* selector();
@@ -94,7 +96,7 @@ namespace Sass {
     static Value* op_strings(Memory_Manager&, enum Sass_OP, Value&, Value&, bool compressed = false, int precision = 5, ParserState* pstate = 0);
 
   private:
-    std::string interpolation(Expression* s, bool into_quotes = false);
+    void interpolation(Context& ctx, std::string& res, Expression* ex, bool into_quotes, bool was_itpl = false);
 
   };
 

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -21,14 +21,12 @@ namespace Sass {
     Context& ctx;
     Listize  listize;
     Eval(Expand& exp);
-    virtual ~Eval();
+    ~Eval();
 
     Env* environment();
     Context& context();
     Selector_List* selector();
     Backtrace* backtrace();
-
-    using Operation<Expression*>::operator();
 
     // for evaluating function bodies
     Expression* operator()(Block*);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -368,8 +368,11 @@ namespace Sass {
 
   Statement* Expand::operator()(Comment* c)
   {
+    eval.is_in_comment = true;
+    auto rv = SASS_MEMORY_NEW(ctx.mem, Comment, c->pstate(), static_cast<String*>(c->text()->perform(&eval)), c->is_important());
+    eval.is_in_comment = false;
     // TODO: eval the text, once we're parsing/storing it as a String_Schema
-    return SASS_MEMORY_NEW(ctx.mem, Comment, c->pstate(), static_cast<String*>(c->text()->perform(&eval)), c->is_important());
+    return rv;
   }
 
   Statement* Expand::operator()(If* i)

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -43,9 +43,7 @@ namespace Sass {
 
   public:
     Expand(Context&, Env*, Backtrace*);
-    virtual ~Expand() { }
-
-    using Operation<Statement*>::operator();
+    ~Expand() { }
 
     Statement* operator()(Block*);
     Statement* operator()(Ruleset*);

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -25,9 +25,7 @@ namespace Sass {
     static Node subweave(Node& one, Node& two, Context& ctx);
     static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething);
     Extend(Context&, ExtensionSubsetMap&);
-    virtual ~Extend() { }
-
-    using Operation<void>::operator();
+    ~Extend() { }
 
     void operator()(Block*);
     void operator()(Ruleset*);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1137,7 +1137,7 @@ namespace Sass {
           error("\"" + val->perform(&to_string) + "\" is not a number for `min'", pstate);
         }
         if (least) {
-          if (Eval::lt(xi, least)) least = xi;
+          if (*xi < *least) least = xi;
         } else least = xi;
       }
       return least;
@@ -1156,7 +1156,7 @@ namespace Sass {
           error("\"" + val->perform(&to_string) + "\" is not a number for `max'", pstate);
         }
         if (greatest) {
-          if (Eval::lt(greatest, xi)) greatest = xi;
+          if (*greatest < *xi) greatest = xi;
         } else greatest = xi;
       }
       return greatest;

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -413,7 +413,12 @@ namespace Sass {
     expr->left()->perform(this);
     if ( in_media_block || (
           expr->op().ws_before
-          && !expr->is_delayed()
+          && (!expr->is_interpolant())
+          && (!expr->is_delayed() ||
+          expr->is_left_interpolant() ||
+          expr->is_right_interpolant()
+          )
+
     )) append_string(" ");
     switch (expr->type()) {
       case Sass_OP::AND: append_string("&&"); break;
@@ -433,7 +438,11 @@ namespace Sass {
     }
     if ( in_media_block || (
           expr->op().ws_after
-          && !expr->is_delayed()
+          && (!expr->is_interpolant())
+          && (!expr->is_delayed()
+              || expr->is_left_interpolant()
+              || expr->is_right_interpolant()
+          )
     )) append_string(" ");
     expr->right()->perform(this);
   }

--- a/src/listize.hpp
+++ b/src/listize.hpp
@@ -22,9 +22,7 @@ namespace Sass {
 
   public:
     Listize(Context&);
-    virtual ~Listize() { }
-
-    using Operation<Expression*>::operator();
+    ~Listize() { }
 
     Expression* operator()(Selector_List*);
     Expression* operator()(Complex_Selector*);

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -88,84 +88,83 @@ namespace Sass {
   template <typename T, typename D>
   class Operation_CRTP : public Operation<T> {
   public:
-    virtual T operator()(AST_Node* x)               { return static_cast<D*>(this)->fallback(x); }
-    virtual ~Operation_CRTP()                       = 0;
+    D& impl() { return static_cast<D&>(*this); }
+  public:
+    T operator()(AST_Node* x)               { return static_cast<D*>(this)->fallback(x); }
     // statements
-    virtual T operator()(Block* x)                  { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Ruleset* x)                { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Propset* x)                { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Bubble* x)                 { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Supports_Block* x)          { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Media_Block* x)            { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(At_Root_Block* x)          { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(At_Rule* x)                { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Keyframe_Rule* x)          { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Declaration* x)            { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Assignment* x)             { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Import* x)                 { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Import_Stub* x)            { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Warning* x)                { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Error* x)                  { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Debug* x)                  { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Comment* x)                { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(If* x)                     { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(For* x)                    { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Each* x)                   { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(While* x)                  { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Return* x)                 { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Content* x)                { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Extension* x)              { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Definition* x)             { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Mixin_Call* x)             { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Block* x)                  { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Ruleset* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Propset* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Bubble* x)                 { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Supports_Block* x)         { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Media_Block* x)            { return static_cast<D*>(this)->fallback(x); }
+    T operator()(At_Root_Block* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(At_Rule* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Keyframe_Rule* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Declaration* x)            { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Assignment* x)             { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Import* x)                 { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Import_Stub* x)            { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Warning* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Error* x)                  { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Debug* x)                  { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Comment* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(If* x)                     { return static_cast<D*>(this)->fallback(x); }
+    T operator()(For* x)                    { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Each* x)                   { return static_cast<D*>(this)->fallback(x); }
+    T operator()(While* x)                  { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Return* x)                 { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Content* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Extension* x)              { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Definition* x)             { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Mixin_Call* x)             { return static_cast<D*>(this)->fallback(x); }
     // expressions
-    virtual T operator()(List* x)                   { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Map* x)                    { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Binary_Expression* x)      { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Unary_Expression* x)       { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Function_Call* x)          { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Function_Call_Schema* x)   { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Custom_Warning* x)         { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Custom_Error* x)           { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Variable* x)               { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Textual* x)                { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Number* x)                 { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Color* x)                  { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Boolean* x)                { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(String_Schema* x)          { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(String_Constant* x)        { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(String_Quoted* x)          { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Supports_Condition* x)     { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Supports_Operator* x)      { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Supports_Negation* x)      { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Supports_Declaration* x)   { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Supports_Interpolation* x) { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Media_Query* x)            { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Media_Query_Expression* x) { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(At_Root_Expression* x)     { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Null* x)                   { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Parent_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
+    T operator()(List* x)                   { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Map* x)                    { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Binary_Expression* x)      { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Unary_Expression* x)       { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Function_Call* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Function_Call_Schema* x)   { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Custom_Warning* x)         { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Custom_Error* x)           { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Variable* x)               { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Textual* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Number* x)                 { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Color* x)                  { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Boolean* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(String_Schema* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(String_Constant* x)        { return static_cast<D*>(this)->fallback(x); }
+    T operator()(String_Quoted* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Supports_Condition* x)     { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Supports_Operator* x)      { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Supports_Negation* x)      { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Supports_Declaration* x)   { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Supports_Interpolation* x) { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Media_Query* x)            { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Media_Query_Expression* x) { return static_cast<D*>(this)->fallback(x); }
+    T operator()(At_Root_Expression* x)     { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Null* x)                   { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Parent_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
     // parameters and arguments
-    virtual T operator()(Parameter* x)              { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Parameters* x)             { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Argument* x)               { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Arguments* x)              { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Parameter* x)              { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Parameters* x)             { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Argument* x)               { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Arguments* x)              { return static_cast<D*>(this)->fallback(x); }
     // selectors
-    virtual T operator()(Selector_Schema* x)        { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Selector_Placeholder* x)   { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Type_Selector* x)          { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Selector_Qualifier* x)     { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Attribute_Selector* x)     { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Pseudo_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Wrapped_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Compound_Selector* x)      { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Complex_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
-    virtual T operator()(Selector_List* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Selector_Schema* x)        { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Selector_Placeholder* x)   { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Type_Selector* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Selector_Qualifier* x)     { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Attribute_Selector* x)     { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Pseudo_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Wrapped_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Compound_Selector* x)      { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Complex_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Selector_List* x)          { return static_cast<D*>(this)->fallback(x); }
 
     template <typename U>
     T fallback(U x)                                 { return T(); }
   };
-  template<typename T, typename D>
-  inline Operation_CRTP<T, D>::~Operation_CRTP()    { }
 
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -61,7 +61,8 @@ namespace Sass {
     }
 
     // flush scheduled outputs
-    inspect.finalize();
+    // maybe omit semicolon if possible
+    inspect.finalize(wbuf.buffer.size() == 0);
     // prepend buffer on top
     prepend_output(inspect.output());
     // make sure we end with a linefeed

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -341,7 +341,8 @@ namespace Sass {
     }
 
     if (b->is_invisible() || b->length() == 0) {
-      return append_string(" {}");
+      append_optional_space();
+      return append_string("{}");
     }
 
     append_scope_opener();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2306,9 +2306,10 @@ namespace Sass {
                     quoted_string,
                     interpolant,
                     identifier,
-                    percentage,
-                    dimension,
                     variable,
+                    percentage,
+                    binomial,
+                    dimension,
                     alnum
                   >
                 > >,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1430,6 +1430,7 @@ namespace Sass {
     }
 
     String_Schema* schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, pstate);
+    schema->is_interpolant(true);
     while (i < chunk.end) {
       p = constant ? find_first_in_interval< exactly<hash_lbrace> >(i, chunk.end) :
           find_first_in_interval< exactly<hash_lbrace>, block_comment >(i, chunk.end);
@@ -1578,11 +1579,14 @@ namespace Sass {
         if (peek< exactly< rbrace > >()) {
           css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
         }
+        Expression* ex = 0;
         if (lex< re_static_expression >()) {
-          (*schema) << SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
+          ex = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
         } else {
-          (*schema) << parse_list();
+          ex = parse_list();
         }
+        ex->is_interpolant(true);
+        (*schema) << ex;
         // ToDo: no error check here?
         lex < exactly < rbrace > >();
       }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1360,7 +1360,11 @@ namespace Sass {
     if (lex< kwd_important >())
     { return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, "!important"); }
 
-    if (lex< sequence < number, lookahead< exactly<'+'> > > >())
+    // parse `10%4px` into separated items and not a schema
+    if (lex< sequence < percentage, lookahead < number > > >())
+    { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::PERCENTAGE, lexed); }
+
+    if (lex< sequence < number, lookahead< sequence < op, number > > > >())
     { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::NUMBER, lexed); }
 
     if (const char* stop = peek< value_schema >())

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2624,8 +2624,10 @@ namespace Sass {
 
     std::string left(pos_left, end_left);
     std::string right(pos_right, end_right);
-    if (ellipsis_left) left = ellipsis + left.substr(left.size() - 15);
-    if (ellipsis_right) right = right.substr(right.size() - 15) + ellipsis;
+    size_t left_subpos = left.size() > 15 ? left.size() - 15 : 0;
+    size_t right_subpos = right.size() > 15 ? right.size() - 15 : 0;
+    if (left_subpos && ellipsis_left) left = ellipsis + left.substr(left_subpos);
+    if (right_subpos && ellipsis_right) right = right.substr(right_subpos) + ellipsis;
     // now pass new message to the more generic error function
     error(msg + prefix + quote(left) + middle + quote(right), pstate);
   }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1422,7 +1422,7 @@ namespace Sass {
 
     // also handle the 10em- foo special case
     // alternatives < exactly < '.' >, .. > -- `1.5em-.75em` is split into a list, not a binary expression
-    if (lex< sequence< dimension, optional< sequence< exactly<'-'>, lookahead< alternatives < exactly < '.' >, space > > > > > >())
+    if (lex< sequence< dimension, optional< sequence< exactly<'-'>, lookahead< alternatives < space > > > > > >())
     { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::DIMENSION, lexed); }
 
     if (lex< sequence< static_component, one_plus< strict_identifier > > >())

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -525,7 +525,7 @@ namespace Sass {
         Expression* interpolant = Parser::from_c_str(p+2, j, ctx, pstate).parse_list();
         // set status on the list expression
         interpolant->is_interpolant(true);
-        schema->has_interpolants(true);
+        // schema->has_interpolants(true);
         // add to the string schema
         (*schema) << interpolant;
         // advance position
@@ -1682,7 +1682,7 @@ namespace Sass {
           Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, pstate).parse_list();
           interp_node->is_interpolant(true);
           (*schema) << interp_node;
-          schema->has_interpolants(true);
+          // schema->has_interpolants(true);
           i = j;
         }
         else {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1291,8 +1291,8 @@ namespace Sass {
       value->is_delayed(false);
       // make sure wrapped lists and division expressions are non-delayed within parentheses
       if (value->concrete_type() == Expression::LIST) {
-        List* l = static_cast<List*>(value);
-        if (!l->empty()) (*l)[0]->is_delayed(false);
+        // List* l = static_cast<List*>(value);
+        // if (!l->empty()) (*l)[0]->is_delayed(false);
       } else if (typeid(*value) == typeid(Binary_Expression)) {
         Binary_Expression* b = static_cast<Binary_Expression*>(value);
         Binary_Expression* lhs = static_cast<Binary_Expression*>(b->left());
@@ -1359,6 +1359,9 @@ namespace Sass {
 
     if (lex< kwd_important >())
     { return SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, "!important"); }
+
+    if (lex< sequence < number, lookahead< exactly<'+'> > > >())
+    { return SASS_MEMORY_NEW(ctx.mem, Textual, pstate, Textual::NUMBER, lexed); }
 
     if (const char* stop = peek< value_schema >())
     { return parse_value_schema(stop); }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -300,7 +300,7 @@ namespace Sass {
     Lookahead lookahead_for_include(const char* start = 0);
 
     Expression* fold_operands(Expression* base, std::vector<Expression*>& operands, Operand op);
-    Expression* fold_operands(Expression* base, std::vector<Expression*>& operands, std::vector<Operand>& ops);
+    Expression* fold_operands(Expression* base, std::vector<Expression*>& operands, std::vector<Operand>& ops, size_t i = 0);
 
     void throw_syntax_error(std::string message, size_t ln = 0);
     void throw_read_error(std::string message, size_t ln = 0);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -47,11 +47,11 @@ namespace Sass {
     { in_at_root = false; stack.push_back(Scope::Root); }
 
     // static Parser from_string(const std::string& src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
-    static Parser from_c_str(const char* src, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));
-    static Parser from_c_str(const char* beg, const char* end, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));
-    static Parser from_token(Token t, Context& ctx, ParserState pstate = ParserState("[TOKEN]"));
+    static Parser from_c_str(const char* src, Context& ctx, ParserState pstate = ParserState("[CSTRING]"), const char* source = 0);
+    static Parser from_c_str(const char* beg, const char* end, Context& ctx, ParserState pstate = ParserState("[CSTRING]"), const char* source = 0);
+    static Parser from_token(Token t, Context& ctx, ParserState pstate = ParserState("[TOKEN]"), const char* source = 0);
     // special static parsers to convert strings into certain selectors
-    static Selector_List* parse_selector(const char* src, Context& ctx, ParserState pstate = ParserState("[SELECTOR]"));
+    static Selector_List* parse_selector(const char* src, Context& ctx, ParserState pstate = ParserState("[SELECTOR]"), const char* source = 0);
 
 #ifdef __clang__
 

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -205,7 +205,6 @@ namespace Sass {
                        digits,
                        identifier,
                        quoted_string,
-                       exactly<'+'>,
                        exactly<'-'>
                      >
                    >

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -540,6 +540,9 @@ namespace Sass {
     }
     // Match CSS numeric constants.
 
+    const char* op(const char* src) {
+      return class_char<op_chars>(src);
+    }
     const char* sign(const char* src) {
       return class_char<sign_chars>(src);
     }

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -296,7 +296,7 @@ namespace Sass {
       bool was_number = false;
       const char* pos = src;
       while (src) {
-        if (pos = alternatives < quoted_string, identifier, percentage, hex >(src)) {
+        if ((pos = alternatives < quoted_string, identifier, percentage, hex >(src))) {
           was_number = false;
           src = pos;
         } else if (!was_number && !exactly<'+'>(src) && (pos = alternatives < dimension, number >(src))) {
@@ -1129,6 +1129,41 @@ namespace Sass {
       return sequence< number, optional_spaces, exactly<'/'>, optional_spaces, number >(src);
     }
 
+    // lexer special_fn: these functions cannot be overloaded
+    // (/((-[\w-]+-)?(calc|element)|expression|progid:[a-z\.]*)\(/i)
+    const char* re_special_fun(const char* src) {
+      return sequence <
+        optional <
+          sequence <
+            exactly <'-'>,
+            one_plus <
+              alternatives <
+                alpha,
+                exactly <'+'>,
+                exactly <'-'>
+              >
+            >
+          >
+        >,
+        alternatives <
+          exactly < calc_fn_kwd >,
+          exactly < expression_kwd >,
+          sequence <
+            sequence <
+              exactly < progid_kwd >,
+              exactly <':'>
+            >,
+            zero_plus <
+              alternatives <
+                char_range <'a', 'z'>,
+                exactly <'.'>
+              >
+            >
+          >
+        >
+      >(src);
+    }
+
     template <size_t size, prelexer mx, prelexer pad>
     const char* padded_token(const char* src)
     {
@@ -1157,6 +1192,14 @@ namespace Sass {
       if (got < min) return 0;
       if (got > max) return 0;
       return pos;
+    }
+
+    template <char min, char max>
+    const char* char_range(const char* src)
+    {
+      if (*src < min) return 0;
+      if (*src > max) return 0;
+      return src + 1;
     }
 
   }

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -253,6 +253,7 @@ namespace Sass {
     const char* re_nothing(const char* src);
     const char* re_type_selector2(const char* src);
 
+    const char* re_special_fun(const char* src);
 
     const char* kwd_warn(const char* src);
     const char* kwd_err(const char* src);
@@ -422,6 +423,9 @@ namespace Sass {
 
     template <size_t min, size_t max, prelexer mx>
     const char* minmax_range(const char* src);
+
+    template <char min, char max>
+    const char* char_range(const char* src);
 
   }
 }

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -210,6 +210,7 @@ namespace Sass {
     // Match interpolant schemas
     const char* identifier_schema(const char* src);
     const char* value_schema(const char* src);
+    const char* sass_value(const char* src);
     // const char* filename(const char* src);
     // const char* filename_schema(const char* src);
     // const char* url_schema(const char* src);

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -282,6 +282,7 @@ namespace Sass {
     // Match placeholder selectors.
     const char* placeholder(const char* src);
     // Match CSS numeric constants.
+    const char* op(const char* src);
     const char* sign(const char* src);
     const char* unsigned_number(const char* src);
     const char* number(const char* src);

--- a/src/remove_placeholders.hpp
+++ b/src/remove_placeholders.hpp
@@ -22,9 +22,7 @@ namespace Sass {
 
     public:
         Remove_Placeholders(Context&);
-        virtual ~Remove_Placeholders() { }
-
-        using Operation<void>::operator();
+        ~Remove_Placeholders() { }
 
         void operator()(Block*);
         void operator()(Ruleset*);

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -44,9 +44,9 @@ extern "C" {
       std::stringstream msg_stream;
       std::string cwd(Sass::File::get_cwd());
 
-      std::string msg_prefix("Error: ");
+      std::string msg_prefix(e.errtype());
       bool got_newline = false;
-      msg_stream << msg_prefix;
+      msg_stream << msg_prefix << ": ";
       const char* msg = e.what();
       while(msg && *msg) {
         if (*msg == '\r') {
@@ -54,7 +54,7 @@ extern "C" {
         } else if (*msg == '\n') {
           got_newline = true;
         } else if (got_newline) {
-          msg_stream << std::string(msg_prefix.size(), ' ');
+          msg_stream << std::string(msg_prefix.size() + 2, ' ');
           got_newline = false;
         }
         msg_stream << *msg;
@@ -65,13 +65,13 @@ extern "C" {
         for (size_t i = 1; i < e.import_stack->size() - 1; ++i) {
           std::string path((*e.import_stack)[i]->imp_path);
           std::string rel_path(Sass::File::abs2rel(path, cwd, cwd));
-          msg_stream << std::string(msg_prefix.size(), ' ');
+          msg_stream << std::string(msg_prefix.size() + 2, ' ');
           msg_stream << (i == 1 ? " on line " : " from line ");
           msg_stream << e.pstate.line+1 << " of " << rel_path << "\n";
         }
       } else {
         std::string rel_path(Sass::File::abs2rel(e.pstate.path, cwd, cwd));
-        msg_stream << std::string(msg_prefix.size(), ' ');
+        msg_stream << std::string(msg_prefix.size() + 2, ' ');
         msg_stream << " on line " << e.pstate.line+1 << " of " << rel_path << "\n";
       }
 

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -296,10 +296,10 @@ extern "C" {
       switch(op) {
         case Sass_OP::EQ:  return sass_make_boolean(Eval::eq(lhs, rhs));
         case Sass_OP::NEQ: return sass_make_boolean(!Eval::eq(lhs, rhs));
-        case Sass_OP::GT:  return sass_make_boolean(!Eval::lt(lhs, rhs) && !Eval::eq(lhs, rhs));
-        case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(lhs, rhs));
-        case Sass_OP::LT:  return sass_make_boolean(Eval::lt(lhs, rhs));
-        case Sass_OP::LTE: return sass_make_boolean(Eval::lt(lhs, rhs) || Eval::eq(lhs, rhs));
+        case Sass_OP::GT:  return sass_make_boolean(!Eval::lt(lhs, rhs, "gt") && !Eval::eq(lhs, rhs));
+        case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(lhs, rhs, "gte"));
+        case Sass_OP::LT:  return sass_make_boolean(Eval::lt(lhs, rhs, "lt"));
+        case Sass_OP::LTE: return sass_make_boolean(Eval::lt(lhs, rhs, "lte") || Eval::eq(lhs, rhs));
         default:           break;
       }
 

--- a/src/to_c.hpp
+++ b/src/to_c.hpp
@@ -8,15 +8,13 @@
 namespace Sass {
 
   class To_C : public Operation_CRTP<union Sass_Value*, To_C> {
-    // import all the class-specific methods and override as desired
-    using Operation<union Sass_Value*>::operator();
     // override this to define a catch-all
     union Sass_Value* fallback_impl(AST_Node* n);
 
   public:
 
     To_C() { }
-    virtual ~To_C() { }
+    ~To_C() { }
 
     union Sass_Value* operator()(Boolean*);
     union Sass_Value* operator()(Number*);

--- a/src/to_string.hpp
+++ b/src/to_string.hpp
@@ -11,8 +11,7 @@ namespace Sass {
   class Null;
 
   class To_String : public Operation_CRTP<std::string, To_String> {
-    // import all the class-specific methods and override as desired
-    using Operation<std::string>::operator();
+
     // override this to define a catch-all
     std::string fallback_impl(AST_Node* n);
 
@@ -23,7 +22,7 @@ namespace Sass {
   public:
 
     To_String(Context* ctx = 0, bool in_declaration = true, bool in_debug = false);
-    virtual ~To_String();
+    ~To_String();
 
     std::string operator()(Null* n);
     std::string operator()(String_Schema*);

--- a/src/to_value.hpp
+++ b/src/to_value.hpp
@@ -21,7 +21,7 @@ namespace Sass {
     To_Value(Context& ctx, Memory_Manager& mem)
     : ctx(ctx), mem(mem)
     { }
-    virtual ~To_Value() { }
+    ~To_Value() { }
     using Operation<Value*>::operator();
 
     Value* operator()(Argument*);

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -17,15 +17,10 @@ namespace Sass {
   const char* safe_str(const char *, const char* = "");
   void free_string_array(char **);
   char **copy_strings(const std::vector<std::string>&, char ***, int = 0);
-  std::string string_escape(const std::string& str);
-  std::string string_unescape(const std::string& str);
-  std::string string_eval_escapes(const std::string& str);
   std::string read_css_string(const std::string& str);
-  std::string evacuate_quotes(const std::string& str);
   std::string evacuate_escapes(const std::string& str);
   std::string string_to_output(const std::string& str);
   std::string comment_to_string(const std::string& text);
-  std::string normalize_wspace(const std::string& str);
 
   std::string quote(const std::string&, char q = 0, bool keep_linefeed_whitespace = false);
   std::string unquote(const std::string&, char* q = 0, bool keep_utf8_sequences = false);


### PR DESCRIPTION
Should pass https://github.com/sass/sass-spec/pull/669

@xzyfer I'm pushing this here, since I had to fix some stuff in parser for the binary expression handling and could no longer wait. I consider the code base of this branch stable, but its need some more cleaning up. I'm also pretty sure that a few flags and ifs are no longer needed with this refactor.

Beside the fixes that are open in the other PRs, this mainly improves and fixes how we parse values and value schemas. I also added a pretty extensive test suite for this. It passes all expected tests against 3.4.21, minus the open sass bugs, plus the new extended test suite.