### PR TITLE
Fix SmartOS compilation once and for all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ CP       ?= cp -a
 MKDIR    ?= mkdir
 RMDIR    ?= rmdir
 WINDRES  ?= windres
-ifeq ($(OS),SunOS)  # Solaris/Illumos flavors
+# Solaris/Illumos flavors
+# ginstall from coreutils
+ifeq ($(OS),SunOS)
 INSTALL  ?= ginstall
-PREFIX   ?= /opt/local
 endif
 INSTALL  ?= install
 CFLAGS   ?= -Wall
@@ -134,7 +135,11 @@ ifneq ($(BUILD),shared)
 endif
 
 ifeq (,$(TRAVIS_BUILD_DIR))
-	PREFIX ?= /usr/local
+	ifeq ($(OS),SunOS)
+		PREFIX ?= /opt/local
+	else
+		PREFIX ?= /usr/local
+	endif
 else
 	PREFIX ?= $(TRAVIS_BUILD_DIR)
 endif

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ MKDIR    ?= mkdir
 RMDIR    ?= rmdir
 WINDRES  ?= windres
 ifeq ($(OS),SunOS)  # Solaris/Illumos flavors
-INSTALL  = ginstall
-PREFIX   = /opt/local
+INSTALL  ?= ginstall
+PREFIX   ?= /opt/local
 endif
 INSTALL  ?= install
 CFLAGS   ?= -Wall

--- a/docs/build-with-autotools.md
+++ b/docs/build-with-autotools.md
@@ -7,6 +7,16 @@ git clone https://github.com/sass/sassc.git libsass/sassc
 git clone https://github.com/sass/sass-spec.git libsass/sass-spec
 ```
 
+### Prerequisites
+
+In order to run autotools you need a few tools installed on your system.
+```bash
+yum install automake libtool # RedHat Linux
+emerge -a automake libtool # Gentoo Linux
+pkgin install automake libtool # SmartOS
+```
+
+
 ### Create configure script
 ```bash
 cd libsass

--- a/docs/build-with-makefiles.md
+++ b/docs/build-with-makefiles.md
@@ -32,6 +32,24 @@ $ ls libsass/lib
 libsass.a libsass.so
 ```
 
+### Install onto the system
+
+We recommend to use [autotools to install](build-with-autotools.md) libsass onto the
+system, since that brings all the benefits of using libtools as the main install method.
+If you still want to install libsass via the makefile, you need to make sure that gnu
+`install` utility (or compatible) is installed on your system.
+```bash
+yum install coreutils # RedHat Linux
+emerge -a coreutils # Gentoo Linux
+pkgin install coreutils # SmartOS
+```
+
+You can set the install location by setting `PREFIX`
+```bash
+PREFIX="/opt/local" make install
+```
+
+
 ### Compling sassc
 
 ```bash

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "ast.hpp"
 #include "context.hpp"
 #include "node.hpp"

--- a/src/base64vlq.cpp
+++ b/src/base64vlq.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "base64vlq.hpp"
 
 namespace Sass {

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "bind.hpp"
 #include "ast.hpp"
 #include "context.hpp"

--- a/src/color_maps.cpp
+++ b/src/color_maps.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "ast.hpp"
 #include "color_maps.hpp"
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "constants.hpp"
 
 namespace Sass {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,9 +1,3 @@
-#ifdef _WIN32
-#define PATH_SEP ';'
-#else
-#define PATH_SEP ':'
-#endif
-
 #include "sass.hpp"
 #include <string>
 #include <cstdlib>

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -4,6 +4,7 @@
 #define PATH_SEP ':'
 #endif
 
+#include "sass.hpp"
 #include <string>
 #include <cstdlib>
 #include <cstring>

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <iostream>
 #include <typeinfo>
 #include <vector>

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "util.hpp"
 #include "context.hpp"
 #include "output.hpp"

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "ast.hpp"
 #include "environment.hpp"
 

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "ast.hpp"
 #include "prelexer.hpp"
 #include "backtrace.hpp"

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cstdlib>
 #include <cmath>
 #include <iostream>

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -1,7 +1,3 @@
-#ifdef _MSC_VER
-#pragma warning(disable : 4503)
-#endif
-
 #include "sass.hpp"
 #include <iostream>
 #include <typeinfo>

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -2,6 +2,7 @@
 #pragma warning(disable : 4503)
 #endif
 
+#include "sass.hpp"
 #include <iostream>
 #include <typeinfo>
 

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -2,6 +2,7 @@
 #pragma warning(disable : 4503)
 #endif
 
+#include "sass.hpp"
 #include "extend.hpp"
 #include "context.hpp"
 #include "to_string.hpp"

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1,7 +1,3 @@
-#ifdef _MSC_VER
-#pragma warning(disable : 4503)
-#endif
-
 #include "sass.hpp"
 #include "extend.hpp"
 #include "context.hpp"

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -13,6 +13,7 @@
 #define NOMINMAX
 #endif
 
+#include "sass.hpp"
 #include <iostream>
 #include <fstream>
 #include <cctype>

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -1,18 +1,14 @@
 #ifdef _WIN32
-#ifdef __MINGW32__
-#ifndef off64_t
-#define off64_t _off64_t    /* Workaround for http://sourceforge.net/p/mingw/bugs/2024/ */
-#endif
-#endif
-#include <direct.h>
-#define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
+# ifdef __MINGW32__
+#  ifndef off64_t
+#   define off64_t _off64_t    /* Workaround for http://sourceforge.net/p/mingw/bugs/2024/ */
+#  endif
+# endif
+# include <direct.h>
+# define S_ISDIR(mode) (((mode) & S_IFMT) == S_IFDIR)
 #else
-#include <unistd.h>
+# include <unistd.h>
 #endif
-#ifdef _MSC_VER
-#define NOMINMAX
-#endif
-
 #include "sass.hpp"
 #include <iostream>
 #include <fstream>
@@ -27,16 +23,16 @@
 #include "sass2scss.h"
 
 #ifdef _WIN32
-#include <windows.h>
+# include <windows.h>
 
-#ifdef _MSC_VER
-#include <codecvt>
+# ifdef _MSC_VER
+# include <codecvt>
 inline static std::string wstring_to_string(const std::wstring& wstr)
 {
     std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> wchar_converter;
     return wchar_converter.to_bytes(wstr);
 }
-#else // mingw(/gcc) does not support C++11's codecvt yet.
+# else // mingw(/gcc) does not support C++11's codecvt yet.
 inline static std::string wstring_to_string(const std::wstring &wstr)
 {
     int size_needed = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), NULL, 0, NULL, NULL);
@@ -44,15 +40,7 @@ inline static std::string wstring_to_string(const std::wstring &wstr)
     WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)wstr.size(), &strTo[0], size_needed, NULL, NULL);
     return strTo;
 }
-#endif
-#endif
-
-#ifndef FS_CASE_SENSITIVE
-#ifdef _WIN32
-#define FS_CASE_SENSITIVE 0
-#else
-#define FS_CASE_SENSITIVE 1
-#endif
+# endif
 #endif
 
 namespace Sass {

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "functions.hpp"
 #include "ast.hpp"
 #include "context.hpp"

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cmath>
 #include <string>
 #include <iostream>

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cctype>
 #include <cstddef>
 #include <iostream>

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <iostream>
 #include <typeinfo>
 #include <string>

--- a/src/memory_manager.cpp
+++ b/src/memory_manager.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "ast.hpp"
 #include "memory_manager.hpp"
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <vector>
 
 #include "node.hpp"

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "ast.hpp"
 #include "output.hpp"
 #include "to_string.hpp"

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1199,7 +1199,7 @@ namespace Sass {
           > >(position)))
     { return lhs; }
     // parse the operator
-    bool left_ws = peek < css_comments >();
+    const char* left_ws = peek < css_comments >();
     // parse the operator
     enum Sass_OP op
     = lex<kwd_eq>()  ? Sass_OP::EQ
@@ -1211,11 +1211,11 @@ namespace Sass {
     // we checked the possibilites on top of fn
     :                  Sass_OP::EQ;
     // parse the right hand side expression
-    bool right_ws = peek < css_comments >();
+    const char* right_ws = peek < css_comments >();
     // parse the right hand side expression
     Expression* rhs = parse_expression();
     // return binary expression with a left and a right hand side
-    return SASS_MEMORY_NEW(ctx.mem, Binary_Expression, lhs->pstate(), { op, left_ws, right_ws }, lhs, rhs);
+    return SASS_MEMORY_NEW(ctx.mem, Binary_Expression, lhs->pstate(), { op, left_ws != 0, right_ws != 0 }, lhs, rhs);
   }
   // parse_relation
 
@@ -1237,10 +1237,10 @@ namespace Sass {
 
     std::vector<Expression*> operands;
     std::vector<Operand> operators;
-    bool left_ws = peek < css_comments >();
+    const char* left_ws = peek < css_comments >();
     while (lex_css< exactly<'+'> >() || lex< sequence< negate< digit >, exactly<'-'> > >()) {
-      bool right_ws = peek < css_comments >();
-      operators.push_back({ lexed.to_string() == "+" ? Sass_OP::ADD : Sass_OP::SUB, left_ws, right_ws });
+      const char* right_ws = peek < css_comments >();
+      operators.push_back({ lexed.to_string() == "+" ? Sass_OP::ADD : Sass_OP::SUB, left_ws != 0, right_ws != 0 });
       operands.push_back(parse_operators());
       left_ws = peek < css_comments >();
     }
@@ -1259,13 +1259,13 @@ namespace Sass {
     std::vector<Expression*> operands; // factors
     std::vector<Operand> operators; // ops
     // lex operations to apply to lhs
-    bool left_ws = peek < css_comments >();
+    const char* left_ws = peek < css_comments >();
     while (lex_css< class_char< static_ops > >()) {
-      bool right_ws = peek < css_comments >();
+      const char* right_ws = peek < css_comments >();
       switch(*lexed.begin) {
-        case '*': operators.push_back({ Sass_OP::MUL, left_ws, right_ws }); break;
-        case '/': operators.push_back({ Sass_OP::DIV, left_ws, right_ws }); break;
-        case '%': operators.push_back({ Sass_OP::MOD, left_ws, right_ws }); break;
+        case '*': operators.push_back({ Sass_OP::MUL, left_ws != 0, right_ws != 0 }); break;
+        case '/': operators.push_back({ Sass_OP::DIV, left_ws != 0, right_ws != 0 }); break;
+        case '%': operators.push_back({ Sass_OP::MOD, left_ws != 0, right_ws != 0 }); break;
         default: throw std::runtime_error("unknown static op parsed"); break;
       }
       operands.push_back(parse_factor());
@@ -1903,7 +1903,7 @@ namespace Sass {
     call->predicate(predicate);
     // parse mandatory block
     call->block(parse_block());
-    // remove from stack
+    // return ast node
     stack.pop_back();
     // return ast node
     return call;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cstdlib>
 #include <iostream>
 #include <vector>

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -7,6 +7,7 @@
 #include <dlfcn.h>
 #endif
 
+#include "sass.hpp"
 #include <iostream>
 #include "output.hpp"
 #include "plugins.hpp"

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "position.hpp"
 
 namespace Sass {

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cctype>
 #include <cstddef>
 #include <iostream>

--- a/src/remove_placeholders.cpp
+++ b/src/remove_placeholders.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "remove_placeholders.hpp"
 #include "context.hpp"
 #include "inspect.hpp"

--- a/src/sass.cpp
+++ b/src/sass.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cstdlib>
 #include <cstring>
 #include <vector>

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -1,0 +1,5 @@
+// must be the first include in all compile units
+#ifndef SASS_SASS_H
+#define SASS_SASS_H
+
+#endif

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -4,7 +4,38 @@
 
 // undefine extensions macro to tell sys includes
 // that we do not want any macros to be exported
-// this mainly fixes issues on smartos (SEC)
+// mainly fixes an issue on SmartOS (SEC macro)
 #undef __EXTENSIONS__
+
+#ifdef _MSC_VER
+#pragma warning(disable : 4005)
+#endif
+
+// aplies to MSVC and MinGW
+#ifdef _WIN32
+// we do not want the ERROR macro
+# define NOGDI
+// we do not want the min/max macro
+# define NOMINMAX
+#endif
+
+// should we be case insensitive
+// when dealing with files or paths
+#ifndef FS_CASE_SENSITIVE
+# ifdef _WIN32
+#  define FS_CASE_SENSITIVE 0
+# else
+#  define FS_CASE_SENSITIVE 1
+# endif
+#endif
+
+// path separation char
+#ifndef PATH_SEP
+# ifdef _WIN32
+#  define PATH_SEP ';'
+# else
+#  define PATH_SEP ':'
+# endif
+#endif
 
 #endif

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -2,4 +2,9 @@
 #ifndef SASS_SASS_H
 #define SASS_SASS_H
 
+// undefine extensions macro to tell sys includes
+// that we do not want any macros to be exported
+// this mainly fixes issues on smartos (SEC)
+#undef __EXTENSIONS__
+
 #endif

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cstring>
 #include <stdexcept>
 #include <sstream>

--- a/src/sass_functions.cpp
+++ b/src/sass_functions.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cstring>
 #include "util.hpp"
 #include "context.hpp"

--- a/src/sass_interface.cpp
+++ b/src/sass_interface.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <string>
 #include <cstdlib>
 #include <cstring>

--- a/src/sass_util.cpp
+++ b/src/sass_util.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "node.hpp"
 #include "to_string.hpp"
 

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cstdlib>
 #include <cstring>
 #include "util.hpp"

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <string>
 #include <sstream>
 #include <iostream>

--- a/src/to_c.cpp
+++ b/src/to_c.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "to_c.hpp"
 #include "ast.hpp"
 

--- a/src/to_string.cpp
+++ b/src/to_string.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <cmath>
 #include <sstream>
 #include <iomanip>

--- a/src/to_value.cpp
+++ b/src/to_value.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "ast.hpp"
 #include "to_value.hpp"
 #include "to_string.hpp"

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -2,10 +2,6 @@
 #include <stdexcept>
 #include "units.hpp"
 
-#ifdef IN
-#undef IN
-#endif
-
 namespace Sass {
 
   /* the conversion matrix can be readed the following way */

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -49,72 +49,72 @@ namespace Sass {
     /* dppx */ { 1/96.0,    2.54/96,   1        }
   };
 
-  SassUnitType get_unit_type(SassUnit unit)
+  UnitClass get_unit_type(UnitType unit)
   {
     switch (unit & 0xFF00)
     {
-      case SassUnitType::LENGTH:      return SassUnitType::LENGTH; break;
-      case SassUnitType::ANGLE:       return SassUnitType::ANGLE; break;
-      case SassUnitType::TIME:        return SassUnitType::TIME; break;
-      case SassUnitType::FREQUENCY:   return SassUnitType::FREQUENCY; break;
-      case SassUnitType::RESOLUTION:  return SassUnitType::RESOLUTION; break;
-      default:                        return SassUnitType::INCOMMENSURABLE; break;
+      case UnitClass::LENGTH:      return UnitClass::LENGTH; break;
+      case UnitClass::ANGLE:       return UnitClass::ANGLE; break;
+      case UnitClass::TIME:        return UnitClass::TIME; break;
+      case UnitClass::FREQUENCY:   return UnitClass::FREQUENCY; break;
+      case UnitClass::RESOLUTION:  return UnitClass::RESOLUTION; break;
+      default:                     return UnitClass::INCOMMENSURABLE; break;
     }
   };
 
-  SassUnit string_to_unit(const std::string& s)
+  UnitType string_to_unit(const std::string& s)
   {
     // size units
-    if      (s == "px")   return SassUnit::PX;
-    else if (s == "pt")   return SassUnit::PT;
-    else if (s == "pc")   return SassUnit::PC;
-    else if (s == "mm")   return SassUnit::MM;
-    else if (s == "cm")   return SassUnit::CM;
-    else if (s == "in")   return SassUnit::IN;
+    if      (s == "px")   return UnitType::PX;
+    else if (s == "pt")   return UnitType::PT;
+    else if (s == "pc")   return UnitType::PC;
+    else if (s == "mm")   return UnitType::MM;
+    else if (s == "cm")   return UnitType::CM;
+    else if (s == "in")   return UnitType::IN;
     // angle units
-    else if (s == "deg")  return SassUnit::DEG;
-    else if (s == "grad") return SassUnit::GRAD;
-    else if (s == "rad")  return SassUnit::RAD;
-    else if (s == "turn") return SassUnit::TURN;
+    else if (s == "deg")  return UnitType::DEG;
+    else if (s == "grad") return UnitType::GRAD;
+    else if (s == "rad")  return UnitType::RAD;
+    else if (s == "turn") return UnitType::TURN;
     // time units
-    else if (s == "s")    return SassUnit::SEC;
-    else if (s == "ms")   return SassUnit::MSEC;
+    else if (s == "s")    return UnitType::SEC;
+    else if (s == "ms")   return UnitType::MSEC;
     // frequency units
-    else if (s == "Hz")   return SassUnit::HERTZ;
-    else if (s == "kHz")  return SassUnit::KHERTZ;
+    else if (s == "Hz")   return UnitType::HERTZ;
+    else if (s == "kHz")  return UnitType::KHERTZ;
     // resolutions units
-    else if (s == "dpi")  return SassUnit::DPI;
-    else if (s == "dpcm") return SassUnit::DPCM;
-    else if (s == "dppx") return SassUnit::DPPX;
+    else if (s == "dpi")  return UnitType::DPI;
+    else if (s == "dpcm") return UnitType::DPCM;
+    else if (s == "dppx") return UnitType::DPPX;
     // for unknown units
-    else return SassUnit::UNKNOWN;
+    else return UnitType::UNKNOWN;
   }
 
-  const char* unit_to_string(SassUnit unit)
+  const char* unit_to_string(UnitType unit)
   {
     switch (unit) {
       // size units
-      case SassUnit::PX:      return "px"; break;
-      case SassUnit::PT:      return "pt"; break;
-      case SassUnit::PC:      return "pc"; break;
-      case SassUnit::MM:      return "mm"; break;
-      case SassUnit::CM:      return "cm"; break;
-      case SassUnit::IN:      return "in"; break;
+      case UnitType::PX:      return "px"; break;
+      case UnitType::PT:      return "pt"; break;
+      case UnitType::PC:      return "pc"; break;
+      case UnitType::MM:      return "mm"; break;
+      case UnitType::CM:      return "cm"; break;
+      case UnitType::IN:      return "in"; break;
       // angle units
-      case SassUnit::DEG:     return "deg"; break;
-      case SassUnit::GRAD:    return "grad"; break;
-      case SassUnit::RAD:     return "rad"; break;
-      case SassUnit::TURN:    return "turn"; break;
+      case UnitType::DEG:     return "deg"; break;
+      case UnitType::GRAD:    return "grad"; break;
+      case UnitType::RAD:     return "rad"; break;
+      case UnitType::TURN:    return "turn"; break;
       // time units
-      case SassUnit::SEC:     return "s"; break;
-      case SassUnit::MSEC:    return "ms"; break;
+      case UnitType::SEC:     return "s"; break;
+      case UnitType::MSEC:    return "ms"; break;
       // frequency units
-      case SassUnit::HERTZ:   return "Hz"; break;
-      case SassUnit::KHERTZ:  return "kHz"; break;
+      case UnitType::HERTZ:   return "Hz"; break;
+      case UnitType::KHERTZ:  return "kHz"; break;
       // resolutions units
-      case SassUnit::DPI:     return "dpi"; break;
-      case SassUnit::DPCM:    return "dpcm"; break;
-      case SassUnit::DPPX:    return "dppx"; break;
+      case UnitType::DPI:     return "dpi"; break;
+      case UnitType::DPCM:    return "dpcm"; break;
+      case UnitType::DPPX:    return "dppx"; break;
       // for unknown units
       default:                return ""; break;
     }
@@ -126,11 +126,11 @@ namespace Sass {
     // assert for same units
     if (s1 == s2) return 1;
     // get unit enum from string
-    SassUnit u1 = string_to_unit(s1);
-    SassUnit u2 = string_to_unit(s2);
+    UnitType u1 = string_to_unit(s1);
+    UnitType u2 = string_to_unit(s2);
     // query unit group types
-    SassUnitType t1 = get_unit_type(u1);
-    SassUnitType t2 = get_unit_type(u2);
+    UnitClass t1 = get_unit_type(u1);
+    UnitClass t2 = get_unit_type(u2);
     // get absolute offset
     // used for array acces
     size_t i1 = u1 - t1;
@@ -141,13 +141,13 @@ namespace Sass {
     // only process known units
     if (u1 != UNKNOWN && u2 != UNKNOWN) {
       switch (t1) {
-        case SassUnitType::LENGTH:              return size_conversion_factors[i1][i2]; break;
-        case SassUnitType::ANGLE:             return angle_conversion_factors[i1][i2]; break;
-        case SassUnitType::TIME:              return time_conversion_factors[i1][i2]; break;
-        case SassUnitType::FREQUENCY:         return frequency_conversion_factors[i1][i2]; break;
-        case SassUnitType::RESOLUTION:        return resolution_conversion_factors[i1][i2]; break;
+        case UnitClass::LENGTH:            return size_conversion_factors[i1][i2]; break;
+        case UnitClass::ANGLE:             return angle_conversion_factors[i1][i2]; break;
+        case UnitClass::TIME:              return time_conversion_factors[i1][i2]; break;
+        case UnitClass::FREQUENCY:         return frequency_conversion_factors[i1][i2]; break;
+        case UnitClass::RESOLUTION:        return resolution_conversion_factors[i1][i2]; break;
         // ToDo: should we throw error here?
-        case SassUnitType::INCOMMENSURABLE:   return 0; break;
+        case UnitClass::INCOMMENSURABLE:   return 0; break;
       }
     }
     // fallback

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <stdexcept>
 #include "units.hpp"
 

--- a/src/units.hpp
+++ b/src/units.hpp
@@ -9,7 +9,7 @@ namespace Sass {
 
   const double PI = std::acos(-1);
 
-  enum SassUnitType {
+  enum UnitClass {
     LENGTH = 0x000,
     ANGLE = 0x100,
     TIME = 0x200,
@@ -18,10 +18,10 @@ namespace Sass {
     INCOMMENSURABLE = 0x500
   };
 
-  enum SassUnit {
+  enum UnitType {
 
     // size units
-    IN = SassUnitType::LENGTH,
+    IN = UnitClass::LENGTH,
     CM,
     PC,
     MM,
@@ -58,9 +58,9 @@ namespace Sass {
   extern const double frequency_conversion_factors[2][2];
   extern const double resolution_conversion_factors[3][3];
 
-  enum Sass::SassUnit string_to_unit(const std::string&);
-  const char* unit_to_string(Sass::SassUnit unit);
-  enum Sass::SassUnitType get_unit_type(Sass::SassUnit unit);
+  enum Sass::UnitType string_to_unit(const std::string&);
+  const char* unit_to_string(Sass::UnitType unit);
+  enum Sass::UnitClass get_unit_type(Sass::UnitType unit);
   // throws incompatibleUnits exceptions
   double conversion_factor(const std::string&, const std::string&, bool = true);
 
@@ -68,7 +68,7 @@ namespace Sass {
   {
     public:
       const char* msg;
-      incompatibleUnits(Sass::SassUnit a, Sass::SassUnit b)
+      incompatibleUnits(Sass::UnitType a, Sass::UnitType b)
       : exception()
       {
         std::stringstream ss;

--- a/src/units.hpp
+++ b/src/units.hpp
@@ -1,6 +1,5 @@
 #ifndef SASS_UNITS_H
 #define SASS_UNITS_H
-#undef SEC
 
 #include <cmath>
 #include <string>

--- a/src/utf8_string.cpp
+++ b/src/utf8_string.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include <string>
 #include <vector>
 #include <cstdlib>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "sass.h"
 #include "ast.hpp"
 #include "util.hpp"

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -1,3 +1,4 @@
+#include "sass.hpp"
 #include "sass.h"
 #include "values.hpp"
 

--- a/win/libsass.vcxproj.filters
+++ b/win/libsass.vcxproj.filters
@@ -27,9 +27,6 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_fwd_decl.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\b64\cencode.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\backtrace.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -177,6 +174,12 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\values.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\sass.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\b64\cencode.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup Label="Sources">
     <ClCompile Include="$(LIBSASS_SRC_DIR)\ast.cpp">
@@ -306,6 +309,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\values.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\c99func.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Verified by compiling inside VMWare image (the problems with `SEC` were present):
```
SunOS smartos 5.11 joyent_20160108T173524Z i86pc i386 i86pc
```

Let's see what CI thinks ... https://github.com/sass/libsass/issues/1802