### PR TITLE
Implement missing error checks

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1168,6 +1168,7 @@ namespace Sass {
   Complex_Selector* Complex_Selector::clone(Context& ctx) const
   {
     Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, *this);
+    cpy->is_optional(this->is_optional());
     cpy->media_block(this->media_block());
     if (tail()) cpy->tail(tail()->clone(ctx));
     return cpy;
@@ -1176,7 +1177,8 @@ namespace Sass {
   Complex_Selector* Complex_Selector::cloneFully(Context& ctx) const
   {
     Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, *this);
-
+    cpy->is_optional(this->is_optional());
+    cpy->media_block(this->media_block());
     if (head()) {
       cpy->head(head()->clone(ctx));
     }
@@ -1191,13 +1193,16 @@ namespace Sass {
   Compound_Selector* Compound_Selector::clone(Context& ctx) const
   {
     Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *this);
+    cpy->is_optional(this->is_optional());
     cpy->media_block(this->media_block());
+    cpy->extended(this->extended());
     return cpy;
   }
 
   Selector_List* Selector_List::clone(Context& ctx) const
   {
     Selector_List* cpy = SASS_MEMORY_NEW(ctx.mem, Selector_List, *this);
+    cpy->is_optional(this->is_optional());
     cpy->media_block(this->media_block());
     return cpy;
   }
@@ -1205,6 +1210,8 @@ namespace Sass {
   Selector_List* Selector_List::cloneFully(Context& ctx) const
   {
     Selector_List* cpy = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
+    cpy->is_optional(this->is_optional());
+    cpy->media_block(this->media_block());
     for (size_t i = 0, L = length(); i < L; ++i) {
       *cpy << (*this)[i]->cloneFully(ctx);
     }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2177,6 +2177,7 @@ namespace Sass {
   class Compound_Selector : public Selector, public Vectorized<Simple_Selector*> {
   private:
     SourcesSet sources_;
+    ADD_PROPERTY(bool, extended);
     ADD_PROPERTY(bool, has_parent_reference);
   protected:
     void adjust_after_pushing(Simple_Selector* s)
@@ -2188,6 +2189,7 @@ namespace Sass {
     Compound_Selector(ParserState pstate, size_t s = 0)
     : Selector(pstate),
       Vectorized<Simple_Selector*>(s),
+      extended_(false),
       has_parent_reference_(false)
     { }
     bool contains_placeholder() {

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -384,10 +384,7 @@ namespace Sass {
     if (const char* proto = sequence< identifier, exactly<':'>, exactly<'/'>, exactly<'/'> >(imp_path.c_str())) {
 
       protocol = std::string(imp_path.c_str(), proto - 3);
-      // std::cerr << "==================== " << protocol << "\n";
-      if (protocol.compare("file") && true) {
-
-      }
+      // if (protocol.compare("file") && true) { }
     }
 
     // add urls (protocol other than file) and urls without procotol to `urls` member

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -137,6 +137,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " <" << selector->hash() << ">";
     std::cerr << " [weight:" << longToHex(selector->specificity()) << "]";
     std::cerr << " [@media:" << selector->media_block() << "]";
+    std::cerr << (selector->extended() ? " [extended]": " -");
     std::cerr << (selector->is_optional() ? " [is_optional]": " -");
     std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -30,6 +30,7 @@ namespace Sass {
     // it's easier to work with vectors
     std::vector<Env*>      env_stack;
     std::vector<Block*>    block_stack;
+    std::vector<AST_Node*> call_stack;
     std::vector<String*>   property_stack;
     std::vector<Selector_List*> selector_stack;
     std::vector<Backtrace*>backtrace_stack;

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -15,7 +15,7 @@ namespace Sass {
     virtual T operator()(Ruleset* x)                = 0;
     virtual T operator()(Propset* x)                = 0;
     virtual T operator()(Bubble* x)                 = 0;
-    virtual T operator()(Supports_Block* x)          = 0;
+    virtual T operator()(Supports_Block* x)         = 0;
     virtual T operator()(Media_Block* x)            = 0;
     virtual T operator()(At_Root_Block* x)          = 0;
     virtual T operator()(At_Rule* x)                = 0;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -205,7 +205,7 @@ namespace Sass {
 
     // parse imports to process later
     else if (lex < kwd_import >(true)) {
-      Scope parent = stack.back();
+      Scope parent = stack.empty() ? Scope::Other : stack.back();
       if (parent != Scope::Function && parent != Scope::Root && parent != Scope::Media) {
         if (! peek_css< uri_prefix >(position)) { // this seems to go in ruby sass 3.4.20
           error("Import directives may not be used within control directives or mixins.", pstate);
@@ -340,6 +340,10 @@ namespace Sass {
 
   Definition* Parser::parse_definition(Definition::Type which_type)
   {
+    Scope parent = stack.empty() ? Scope::Other : stack.back();
+    if (parent != Scope::Root && parent != Scope::Function) {
+      error("Functions may not be defined within control directives or other mixins.", pstate);
+    }
     std::string which_str(lexed);
     if (!lex< identifier >()) error("invalid name in " + which_str + " definition", pstate);
     std::string name(Util::normalize_underscores(lexed));

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -23,11 +23,11 @@ namespace Sass {
   class Parser : public ParserState {
   public:
 
-    enum Syntactic_Context { nothing, mixin_def, function_def };
+    enum Scope { Root, Mixin, Function, Media, Other };
 
     Context& ctx;
     std::vector<Block*> block_stack;
-    std::vector<Syntactic_Context> stack;
+    std::vector<Scope> stack;
     Media_Block* last_media_block;
     const char* source;
     const char* position;
@@ -44,7 +44,7 @@ namespace Sass {
     Parser(Context& ctx, const ParserState& pstate)
     : ParserState(pstate), ctx(ctx), block_stack(0), stack(0), last_media_block(0),
       source(0), position(0), end(0), before_token(pstate), after_token(pstate), pstate(pstate), indentation(0)
-    { in_at_root = false; stack.push_back(nothing); }
+    { in_at_root = false; stack.push_back(Scope::Root); }
 
     // static Parser from_string(const std::string& src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
     static Parser from_c_str(const char* src, Context& ctx, ParserState pstate = ParserState("[CSTRING]"));

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -23,7 +23,7 @@ namespace Sass {
   class Parser : public ParserState {
   public:
 
-    enum Scope { Root, Mixin, Function, Media, Other };
+    enum Scope { Root, Mixin, Function, Media, Control, Properties, Rules };
 
     Context& ctx;
     std::vector<Block*> block_stack;


### PR DESCRIPTION
Should pass specs https://github.com/sass/sass-spec/pull/680

- Fixes: https://github.com/sass/libsass/issues/1724
- Fixes https://github.com/sass/libsass/issues/1550
- Fixes https://github.com/sass/libsass/issues/871
- Fixes https://github.com/sass/libsass/issues/1670
- Fixes https://github.com/sass/libsass/issues/1653

One minor issue not on par with ruby sass, but that will change once we switch sass specs to 3.4.20.