### PR TITLE
undefine conflicting mingw pseudo headers fixes sass/libsass#1851

### DIFF
--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -1,3 +1,5 @@
+#define _NO_W32_PSEUDO_MODIFIERS
+
 // must be the first include in all compile units
 #ifndef SASS_SASS_H
 #define SASS_SASS_H


### PR DESCRIPTION
Handles an issue with conflicting headers on windows.

Reproduced here: https://ci.appveyor.com/project/drewwells/go-libsass/build/424