### PR TITLE
Improve url parsing for functions with suffixes

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -79,7 +79,7 @@ namespace Sass {
     extern const char keyframes_kwd[]    = "keyframes";
     extern const char only_kwd[]         = "only";
     extern const char rgb_kwd[]          = "rgb(";
-    extern const char url_kwd[]          = "url(";
+    extern const char url_kwd[]          = "url";
     // extern const char url_prefix_kwd[]   = "url-prefix(";
     extern const char important_kwd[]    = "important";
     extern const char pseudo_not_kwd[]   = ":not(";

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -81,7 +81,6 @@ namespace Sass {
     extern const char rgb_kwd[];
     extern const char url_kwd[];
     // extern const char url_prefix_kwd[];
-    extern const char image_url_kwd[];
     extern const char important_kwd[];
     extern const char pseudo_not_kwd[];
     extern const char even_kwd[];

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -642,7 +642,20 @@ namespace Sass {
     // Match CSS uri specifiers.
 
     const char* uri_prefix(const char* src) {
-      return exactly<url_kwd>(src);
+      return sequence <
+        exactly <
+          url_kwd
+        >,
+        zero_plus <
+          sequence <
+            exactly <'-'>,
+            one_plus <
+              alpha
+            >
+          >
+        >,
+        exactly <'('>
+      >(src);
     }
 
     // TODO: rename the following two functions


### PR DESCRIPTION
Allows to parse:
```
@document url(http://www.w3.org/),
               url-prefix(http://www.w3.org/Style/)
```

Still not perfect, but a slight improvement