### PR TITLE
Implement css linefeed `\a` handling better

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2040,12 +2040,12 @@ namespace Sass {
 
   std::string String_Quoted::inspect() const
   {
-    return quote(value_, '*', true);
+    return quote(value_, '*');
   }
 
   std::string String_Constant::inspect() const
   {
-    return quote(value_, '*', true);
+    return quote(value_, '*');
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -709,7 +709,7 @@ namespace Sass {
   void Inspect::operator()(String_Quoted* s)
   {
     if (const char q = s->quote_mark()) {
-      append_token(quote(s->value(), q, true), s);
+      append_token(quote(s->value(), q), s);
     } else {
       append_token(s->value(), s);
     }

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1215,43 +1215,5 @@ namespace Sass {
       >(src);
     }
 
-    template <size_t size, prelexer mx, prelexer pad>
-    const char* padded_token(const char* src)
-    {
-      size_t got = 0;
-      const char* pos = src;
-      while (got < size) {
-        if (!mx(pos)) break;
-        ++ pos; ++ got;
-      }
-      while (got < size) {
-        if (!pad(pos)) break;
-        ++ pos; ++ got;
-      }
-      return got ? pos : 0;
-    }
-
-    template <size_t min, size_t max, prelexer mx>
-    const char* minmax_range(const char* src)
-    {
-      size_t got = 0;
-      const char* pos = src;
-      while (got < max) {
-        if (!mx(pos)) break;
-        ++ pos; ++ got;
-      }
-      if (got < min) return 0;
-      if (got > max) return 0;
-      return pos;
-    }
-
-    template <char min, char max>
-    const char* char_range(const char* src)
-    {
-      if (*src < min) return 0;
-      if (*src > max) return 0;
-      return src + 1;
-    }
-
   }
 }

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -421,13 +421,42 @@ namespace Sass {
     }
 
     template <size_t size, prelexer mx, prelexer pad>
-    const char* padded_token(const char* src);
+    const char* padded_token(const char* src)
+    {
+      size_t got = 0;
+      const char* pos = src;
+      while (got < size) {
+        if (!mx(pos)) break;
+        ++ pos; ++ got;
+      }
+      while (got < size) {
+        if (!pad(pos)) break;
+        ++ pos; ++ got;
+      }
+      return got ? pos : 0;
+    }
 
     template <size_t min, size_t max, prelexer mx>
-    const char* minmax_range(const char* src);
+    const char* minmax_range(const char* src)
+    {
+      size_t got = 0;
+      const char* pos = src;
+      while (got < max) {
+        if (!mx(pos)) break;
+        ++ pos; ++ got;
+      }
+      if (got < min) return 0;
+      if (got > max) return 0;
+      return pos;
+    }
 
     template <char min, char max>
-    const char* char_range(const char* src);
+    const char* char_range(const char* src)
+    {
+      if (*src < min) return 0;
+      if (*src > max) return 0;
+      return src + 1;
+    }
 
   }
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -315,7 +315,7 @@ namespace Sass {
 
   }
 
-  std::string quote(const std::string& s, char q, bool keep_linefeed_whitespace)
+  std::string quote(const std::string& s, char q)
   {
 
     // autodetect with fallback to given quote
@@ -352,8 +352,16 @@ namespace Sass {
         quoted.push_back('a');
         // we hope we can remove this flag once we figure out
         // why ruby sass has these different output behaviors
-        if (keep_linefeed_whitespace)
+        // gsub(/\n(?![a-fA-F0-9\s])/, "\\a").gsub("\n", "\\a ")
+        using namespace Prelexer;
+        if (alternatives <
+          Prelexer::char_range<'a', 'f'>,
+          Prelexer::char_range<'A', 'F'>,
+          Prelexer::char_range<'0', '9'>,
+          space
+        >(it) != NULL) {
           quoted.push_back(' ');
+        }
       } else if (cp < 127) {
         quoted.push_back((char) cp);
       } else {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -23,7 +23,7 @@ namespace Sass {
   std::string string_to_output(const std::string& str);
   std::string comment_to_string(const std::string& text);
 
-  std::string quote(const std::string&, char q = 0, bool keep_linefeed_whitespace = false);
+  std::string quote(const std::string&, char q = 0);
   std::string unquote(const std::string&, char* q = 0, bool keep_utf8_sequences = false);
   char detect_best_quotemark(const char* s, char qm = '"');
 


### PR DESCRIPTION
Removes obsolete `keep_linefeed_whitespace` on quote function. Also moves implementation of some prelexer function into header, since otherwise implementation is not seen in other compile units.