### PR TITLE
Change default from `scss` to `sass` syntax

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -404,7 +404,7 @@ namespace Sass {
       }
       for(size_t i=0; i<extension.size();++i)
         extension[i] = tolower(extension[i]);
-      if (extension == ".sass" && contents != 0) {
+      if (extension != ".scss" && contents != 0) {
         char * converted = sass2scss(contents, SASS2SCSS_PRETTIFY_1 | SASS2SCSS_KEEP_COMMENT);
         free(contents); // free the indented contents
         return converted; // should be freed by caller


### PR DESCRIPTION
- https://github.com/sass/libsass/pull/1341
- https://github.com/sass/sass/issues/1726

Ruby sass uses the extension, so to be on par we must too. Auto-detection of the format may be fancier, but it's not what ruby sass does AFAIK. Personally I think think this should be changed with sass 4.0 (//CC @chriseppstein) and scss should be the defaut, if extensions doesn't explicitly match .sass.

Otherwise https://github.com/sass/libsass/issues/1219 will stay open forever!