### PR TITLE
Handle signed char when considering @charset

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -67,7 +67,8 @@ namespace Sass {
     // search for unicode char
     for(const char& chr : wbuf.buffer) {
       // skip all ascii chars
-      if (chr >= 0) continue;
+      // static cast to unsigned to handle `char` being signed / unsigned
+      if (static_cast<unsigned>(chr) < 128) continue;
       // declare the charset
       if (output_style() != COMPRESSED)
         charset = "@charset \"UTF-8\";"


### PR DESCRIPTION
Resolves dahlia/libsass-python#117

On platforms where `char` is unsigned the `@charset` (or UTF-8 BOM) was not present in the output.  This seems to fix it.