### PR TITLE
Fix import resolution order changing with custom importers

### DIFF
--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -357,6 +357,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Import_Stub* block = dynamic_cast<Import_Stub*>(node);
     std::cerr << ind << "Import_Stub " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [" << block->imp_path() << "] ";
     std::cerr << " " << block->tabs() << std::endl;
   } else if (dynamic_cast<Import*>(node)) {
     Import* block = dynamic_cast<Import*>(node);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -290,12 +290,7 @@ namespace Sass {
     do {
       while (lex< block_comment >());
       if (lex< quoted_string >()) {
-        if (!ctx.call_importers(unquote(std::string(lexed)), path, pstate, imp))
-        {
-          // push single file import
-          // import_single_file(imp, lexed);
-          to_import.push_back(std::pair<std::string,Function_Call*>(std::string(lexed), 0));
-        }
+        to_import.push_back(std::pair<std::string,Function_Call*>(std::string(lexed), 0));
       }
       else if (lex< uri_prefix >()) {
         Arguments* args = SASS_MEMORY_NEW(ctx.mem, Arguments, pstate);
@@ -333,7 +328,7 @@ namespace Sass {
     for(auto location : to_import) {
       if (location.second) {
         imp->urls().push_back(location.second);
-      } else {
+      } else if (!ctx.call_importers(unquote(location.first), path, pstate, imp)) {
         ctx.import_url(imp, location.first, path);
       }
     }


### PR DESCRIPTION
When using the following syntax with a custom importer

```css
@import "foo", "bar";
```

Paths that are matched by a custom importer get pushed into the
queue ahead of those that don't. This means if `bar` is matched
by a custom importer the import order will be changed to
`"bar", "foo"` instead of the intended `"foo", "bar"`. This can
easily break user code.

See sass/node-sass#1381 for an example

/cc @nowells

/cc @mgreter does this look sane to you? Passes the Node Sass tests.