### PR TITLE
Don't use import resource cache if there are custom importers

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -351,8 +351,9 @@ namespace Sass {
 
     // process the resolved entry
     else if (resolved.size() == 1) {
+      bool use_cache = c_importers.size() == 0;
       // use cache for the resource loading
-      if (sheets.count(resolved[0].abs_path)) return resolved[0];
+      if (use_cache && sheets.count(resolved[0].abs_path)) return resolved[0];
       // try to read the content of the resolved file entry
       // the memory buffer returned must be freed by us!
       if (char* contents = read_file(resolved[0].abs_path)) {


### PR DESCRIPTION
The import resource cache prevent custom importers from being
called for all imports.

This happens because we during the import resolution we cache
the resources parsed AST tree and simply substitute it for future
reference to that resource.

If that resource has it's own imports those imports are only
resolved the first time the file is parsed. Although this is a
nice optimisation, it does negatively affect custom importers.

Rather than disabling the resource caching wholesale, this patch
disables it only if a custom importer has been registered.

/cc @mgreter 