### PR TITLE
Revert "Disable error check for extend placement check"

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -221,8 +221,7 @@ namespace Sass {
     }
 
     else if (lex < kwd_extend >(true)) {
-      Scope parent = stack.empty() ? Scope::Rules : stack.back();
-      if (parent == Scope::Root) {
+      if (block->is_root()) {
         error("Extend directives may only be used within rules.", pstate);
       }
 
@@ -2145,7 +2144,6 @@ namespace Sass {
     Block* body = 0;
     At_Root_Expression* expr = 0;
     Lookahead lookahead_result;
-    // stack.push_back(Scope::Root);
     LOCAL_FLAG(in_at_root, true);
     if (lex< exactly<'('> >()) {
       expr = parse_at_root_expression();
@@ -2160,7 +2158,6 @@ namespace Sass {
     }
     At_Root_Block* at_root = SASS_MEMORY_NEW(ctx.mem, At_Root_Block, at_source_position, body);
     if (expr) at_root->expression(expr);
-    // stack.pop_back();
     return at_root;
   }
 


### PR DESCRIPTION
Reverts sass/libsass#1870

This patch was originally a placebo for #1651 but has caused a real regression (#1915). 

Spec https://github.com/sass/sass-spec/pull/740