### PR TITLE
Fix import file resolution to match Ruby Sass

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -305,7 +305,7 @@ namespace Sass {
       std::string filename = join_paths(root, file);
       // supported extensions
       const std::vector<std::string> exts = {
-        ".scss", ".sass", ".css"
+        ".sass", ".scss"
       };
       // split the filename
       std::string base(dir_name(file));


### PR DESCRIPTION
This patch address two inconsistencies with how `@import` is
resolved compared to Ruby Sass.
- `.css` should not be `@import`able
- `.sass` should take precedence over `.scss` files

Fixes #1656