### PR TITLE
[RFC] Add an option for allowing the old .css import behaviour

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -77,6 +77,8 @@ namespace Sass {
     c_importers             (std::vector<Sass_Importer_Entry>()),
     c_functions             (std::vector<Sass_Function_Entry>()),
 
+    css_imports             (false),
+
     indent                  (safe_str(c_options.indent, "  ")),
     linefeed                (safe_str(c_options.linefeed, "\n")),
 
@@ -239,7 +241,7 @@ namespace Sass {
     for (size_t i = 0, S = include_paths.size(); vec.size() == 0 && i < S; ++i)
     {
       // call resolve_includes and individual base path and append all results
-      std::vector<Include> resolved(resolve_includes(include_paths[i], import.imp_path));
+      std::vector<Include> resolved(resolve_includes(include_paths[i], import.imp_path, c_options.css_imports));
       if (resolved.size()) vec.insert(vec.end(), resolved.begin(), resolved.end());
     }
     // return vector

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -78,6 +78,7 @@ namespace Sass {
     void add_c_importer(Sass_Importer_Entry importer);
     void add_c_function(Sass_Function_Entry function);
 
+    const bool css_imports; // should @import consider .css files
     const std::string indent; // String to be used for indentation
     const std::string linefeed; // String to be used for line feeds
     const std::string input_path; // for relative paths in src-map

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -300,13 +300,18 @@ namespace Sass {
     // (2) underscore + given
     // (3) underscore + given + extension
     // (4) given + extension
-    std::vector<Include> resolve_includes(const std::string& root, const std::string& file)
+    std::vector<Include> resolve_includes(const std::string& root, const std::string& file, const bool css_imports)
     {
       std::string filename = join_paths(root, file);
       // supported extensions
-      const std::vector<std::string> exts = {
-        ".scss", ".sass", ".css"
+      std::vector<std::string> exts = {
+        ".sass", ".scss"
       };
+
+      if (css_imports) {
+        exts.push_back(".css");
+      }
+
       // split the filename
       std::string base(dir_name(file));
       std::string name(base_name(file));

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -114,7 +114,7 @@ namespace Sass {
 
   namespace File {
 
-    std::vector<Include> resolve_includes(const std::string& root, const std::string& file);
+    std::vector<Include> resolve_includes(const std::string& root, const std::string& file, const bool css_imports = false);
 
   }
 

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -372,6 +372,7 @@ extern "C" {
     options->precision = 5;
     options->indent = "  ";
     options->linefeed = LFEED;
+    options->css_imports = false;
   }
 
   Sass_Options* ADDCALL sass_make_options (void)
@@ -655,6 +656,7 @@ extern "C" {
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, source_map_contents);
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, omit_source_map_url);
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, is_indented_syntax_src);
+  IMPLEMENT_SASS_OPTION_ACCESSOR(bool, css_imports);
   IMPLEMENT_SASS_OPTION_ACCESSOR(Sass_Function_List, c_functions);
   IMPLEMENT_SASS_OPTION_ACCESSOR(Sass_Importer_List, c_importers);
   IMPLEMENT_SASS_OPTION_ACCESSOR(Sass_Importer_List, c_headers);

--- a/src/sass_context.hpp
+++ b/src/sass_context.hpp
@@ -21,6 +21,10 @@ struct Sass_Options : Sass_Output_Options {
   // Treat source_string as sass (as opposed to scss)
   bool is_indented_syntax_src;
 
+  // Whether .css files should be considered
+  // when resolving @import
+  bool css_imports;
+
   // The input path is used for source map
   // generation. It can be used to define
   // something with string compilation or to


### PR DESCRIPTION
The broken behaviour was removed in #1963. There appears to be some support for this, although I'm very much against it. Additionally we have no way presently to test flags like this.
