### PR TITLE
Ensure sass spec is using specs for 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
     - os: osx
       compiler: gcc
     - os: osx
-      env: AUTOTOOLS=no COVERAGE=yes BUILD=static
+      env: AUTOTOOLS=no BUILD=static
 
 script: ./script/ci-build-libsass
 before_install: ./script/ci-install-deps

--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -57,7 +57,7 @@ TESTS = \
 	$(SASS_SPEC_PATH)/spec/scss-tests \
 	$(SASS_SPEC_PATH)/spec/types
 
-SASS_TEST_FLAGS =
+SASS_TEST_FLAGS = -V 3.4
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) ./script/tap-driver
 AM_LOG_FLAGS = -c ./tester --ignore-todo $(LOG_FLAGS)
 if USE_TAP

--- a/Makefile
+++ b/Makefile
@@ -300,13 +300,13 @@ version: $(SASSC_BIN)
 	$(SASSC_BIN) -v
 
 test: $(SASSC_BIN)
-	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) -s $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
+	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -V 3.4 -c $(SASSC_BIN) -s $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
 
 test_build: $(SASSC_BIN)
-	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) -s --ignore-todo $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
+	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -V 3.4 -c $(SASSC_BIN) -s --ignore-todo $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
 
 test_issues: $(SASSC_BIN)
-	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) $(LOG_FLAGS) $(SASS_SPEC_PATH)/spec/issues
+	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -V 3.4 -c $(SASSC_BIN) $(LOG_FLAGS) $(SASS_SPEC_PATH)/spec/issues
 
 clean-objects: lib
 	-$(RM) lib/*.a lib/*.so lib/*.dll lib/*.la

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ test_script:
           git -C sass-spec checkout -q --force ci-spec-pr-$SPEC_PR
         }
       }
-      ruby sass-spec/sass-spec.rb -c $env:TargetPath -s --ignore-todo sass-spec/spec
+      ruby sass-spec/sass-spec.rb -V 3.4 -c $env:TargetPath -s --ignore-todo sass-spec/spec
 
       Write-Host "Explicitly testing the case when cwd has Cyrillic characters: " -nonewline
       # See comments in gh-1774 for details.


### PR DESCRIPTION
Sass spec has been updated to support specs for multiple versions
of Sass in sass/sass-spec#745. It currently defaults to 4.0 but we
want to run against 3.4.