### PR TITLE
Fix prelexer to match calc signature more strictly

### DIFF
--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1197,8 +1197,8 @@ namespace Sass {
           >
         >,
         alternatives <
-          exactly < calc_fn_kwd >,
-          exactly < expression_kwd >,
+          word < calc_fn_kwd >,
+          word < expression_kwd >,
           sequence <
             sequence <
               exactly < progid_kwd >,


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1969 - Spec test https://github.com/sass/sass-spec/pull/756