### PR TITLE
Add sass_string_alloc public API function to allow to allocate a string owned by libsass

### DIFF
--- a/include/sass/base.h
+++ b/include/sass/base.h
@@ -63,6 +63,7 @@ enum Sass_Output_Style {
 };
 
 // Some convenient string helper function
+ADDAPI char* ADDCALL sass_string_alloc(size_t length); // Allocates a string of length+1 (terminated by zero)
 ADDAPI char* ADDCALL sass_string_quote (const char* str, const char quote_mark);
 ADDAPI char* ADDCALL sass_string_unquote (const char* str);
 

--- a/src/sass.cpp
+++ b/src/sass.cpp
@@ -11,6 +11,12 @@
 extern "C" {
   using namespace Sass;
 
+  // Allocates a string owned by libsass
+  char* ADDCALL sass_string_alloc(size_t length)
+  {
+	  return sass_stralloc(length);
+  }
+
   // caller must free the returned memory
   char* ADDCALL sass_string_quote (const char *str, const char quote_mark)
   {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,11 +29,18 @@ namespace Sass {
   }
 
   /* Sadly, sass_strdup is not portable. */
+  char *sass_stralloc(size_t length)
+  {
+	  char *ret = (char*)malloc(length + 1);
+	  if (ret == NULL)
+		  out_of_memory();
+	  return ret;
+  }
+
+  /* Sadly, sass_strdup is not portable. */
   char *sass_strdup(const char *str)
   {
-    char *ret = (char*) malloc(strlen(str) + 1);
-    if (ret == NULL)
-      out_of_memory();
+    char *ret = sass_stralloc(strlen(str));
     strcpy(ret, str);
     return ret;
   }

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -13,6 +13,7 @@
 namespace Sass {
 
   double round(double val, size_t precision = 0);
+  char* sass_stralloc(size_t length);
   char* sass_strdup(const char* str);
   double sass_atof(const char* str);
   const char* safe_str(const char *, const char* = "");


### PR DESCRIPTION
Hi there!

While developing a wrapper of libsass for .NET (I can't use [libsass.net](https://github.com/darrenkopp/libsass-net) as it is using a wrapping technique that is not portable on Linux...etc.), I had to add a new function API `sass_string_alloc` in order to be able to allocate a string that I have to pass to libsass (and owned by libsass)

From a public API point of view, there is currently no way to do this. Typically, when wrapping libsass in C#, I can only access the DLL and don't have access to any C function like `malloc`. Also, it might be good to enforce a public API for this, so that you can hide the internals about requiring malloc or not, track allocated strings...etc.

Hope this can make it, as I don't have any workaround for this, let me know if there is any issues (when I saw the comment `Sadly, sass_strdup is not portable`, I was unsure about this problem)

Thanks!