### PR TITLE
Fix sass_option_push_include_path / sass_option_push_plugin_path 

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -92,9 +92,9 @@ namespace Sass {
 
     // collect more paths from different options
     collect_include_paths(c_options.include_path);
-    // collect_include_paths(c_options.include_paths);
+    collect_include_paths(c_options.include_paths);
     collect_plugin_paths(c_options.plugin_path);
-    // collect_plugin_paths(c_options.plugin_paths);
+    collect_plugin_paths(c_options.plugin_paths);
 
     // load plugins and register custom behaviors
     for(auto plug : plugin_paths) plugins.load_plugins(plug);
@@ -162,7 +162,6 @@ namespace Sass {
 
   void Context::collect_include_paths(const char* paths_str)
   {
-
     if (paths_str) {
       const char* beg = paths_str;
       const char* end = Prelexer::find_first<PATH_SEP>(beg);
@@ -185,17 +184,17 @@ namespace Sass {
     }
   }
 
-  void Context::collect_include_paths(const char** paths_array)
+  void Context::collect_include_paths(string_list* paths_array)
   {
-    if (!paths_array) return;
-    for (size_t i = 0; paths_array[i]; i++) {
-      collect_include_paths(paths_array[i]);
+    while (paths_array)
+    {
+      collect_include_paths(paths_array->string);
+      paths_array = paths_array->next;
     }
   }
 
   void Context::collect_plugin_paths(const char* paths_str)
   {
-
     if (paths_str) {
       const char* beg = paths_str;
       const char* end = Prelexer::find_first<PATH_SEP>(beg);
@@ -218,14 +217,14 @@ namespace Sass {
     }
   }
 
-  void Context::collect_plugin_paths(const char** paths_array)
+  void Context::collect_plugin_paths(string_list* paths_array)
   {
-    if (!paths_array) return;
-    for (size_t i = 0; paths_array[i]; i++) {
-      collect_plugin_paths(paths_array[i]);
+    while (paths_array)
+    {
+      collect_plugin_paths(paths_array->string);
+      paths_array = paths_array->next;
     }
   }
-
 
   // resolve the imp_path in base_path or include_paths
   // looks for alternatives and returns a list from one directory

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -101,9 +101,9 @@ namespace Sass {
 
   private:
     void collect_plugin_paths(const char* paths_str);
-    void collect_plugin_paths(const char** paths_array);
+    void collect_plugin_paths(string_list* paths_array);
     void collect_include_paths(const char* paths_str);
-    void collect_include_paths(const char** paths_array);
+    void collect_include_paths(string_list* paths_array);
     std::string format_embedded_source_map();
     std::string format_source_mapping_url(const std::string& out_path);
 

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -198,44 +198,6 @@ extern "C" {
   static Sass_Compiler* sass_prepare_context (Sass_Context* c_ctx, Context* cpp_ctx) throw()
   {
     try {
-
-      // convert include path linked list to static array
-      struct string_list* inc = c_ctx->include_paths;
-      // very poor loop to get the length of the linked list
-      size_t inc_size = 0; while (inc) { inc_size ++; inc = inc->next; }
-      // create char* array to hold all paths plus null terminator
-      const char** include_paths = (const char**) calloc(inc_size + 1, sizeof(char*));
-      if (include_paths == 0) throw(std::bad_alloc());
-      // reset iterator
-      inc = c_ctx->include_paths;
-      // copy over the paths
-      for (size_t i = 0; inc; i++) {
-        include_paths[i] = inc->string;
-        inc = inc->next;
-      }
-
-      // convert plugin path linked list to static array
-      struct string_list* imp = c_ctx->plugin_paths;
-      // very poor loop to get the length of the linked list
-      size_t imp_size = 0; while (imp) { imp_size ++; imp = imp->next; }
-      // create char* array to hold all paths plus null terminator
-      const char** plugin_paths = (const char**) calloc(imp_size + 1, sizeof(char*));
-      if (plugin_paths == 0) {
-          free(include_paths); //free include_paths before throw
-          throw(std::bad_alloc());
-      }
-      // reset iterator
-      imp = c_ctx->plugin_paths;
-      // copy over the paths
-      for (size_t i = 0; imp; i++) {
-        plugin_paths[i] = imp->string;
-        imp = imp->next;
-      }
-
-      // free intermediate data
-      free(include_paths);
-      free(plugin_paths);
-
       // register our custom functions
       if (c_ctx->c_functions) {
         auto this_func_data = c_ctx->c_functions;


### PR DESCRIPTION
This is a fix for #1871 

Trying to use `sass_option_push_include_path` / `sass_option_push_plugin_path` I discovered that they were completely unplugged, while these APIs are useful to push path when the list is already prepared on the user side and we don't want to concatenate the includes (that will be splitted anyway by libsass)