### PR TITLE
Avoid a segfault when selector would be set to NULL

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1233,7 +1233,9 @@ namespace Sass {
           if ((*this)[i]->tail() && (*this)[i]->has_line_feed()) {
             (*this)[i]->tail()->has_line_feed(true);
           }
-          (*this)[i] = (*this)[i]->tail();
+          if ((*this)[i]->tail() != NULL) {
+            (*this)[i] = (*this)[i]->tail();
+          }
         }
         // otherwise remove the first item from head
         else {


### PR DESCRIPTION
Really just a hotfix since there is still an underlying
bug when extending inner of :not pseudo selector. Mostly
showing when parent selectors are involved.

IMHO still better than segfaulting -> https://github.com/sass/libsass/issues/1960