### PR TITLE
Fix issue with (too strict) assertion in MSVC debug mode

### DIFF
--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -204,7 +204,7 @@ namespace Sass {
   void Emitter::append_optional_space()
   {
     if ((output_style() != COMPRESSED) && buffer().size()) {
-      char lst = buffer().at(buffer().length() - 1);
+      unsigned char lst = buffer().at(buffer().length() - 1);
       if (!isspace(lst) || scheduled_delimiter) {
         append_mandatory_space();
       }


### PR DESCRIPTION
A newly activated spec test triggered a debug assertion with MSVC and `isspace`.
The char in question was an `ö` which as `char` seems to have the value `-4`.
Therefore the assertion was triggered (IMO MSVC should know how to deal with chars).
Anyway, changing it to `unsigned char` fixed the issue (hope that works with gcc too).

http://stackoverflow.com/questions/28513332/debug-assertation-failed-c-1-c-255