### PR TITLE
Expose the libsass language version via API.

### DIFF
--- a/include/sass/base.h
+++ b/include/sass/base.h
@@ -79,6 +79,9 @@ ADDAPI char* ADDCALL sass_resolve_file (const char* path, const char* incs[]);
 // Get compiled libsass version
 ADDAPI const char* ADDCALL libsass_version(void);
 
+// Get compiled libsass language
+ADDAPI const char* ADDCALL libsass_language_version(void);
+
 #ifdef __cplusplus
 } // __cplusplus defined.
 #endif

--- a/include/sass/version.h
+++ b/include/sass/version.h
@@ -5,4 +5,8 @@
 #define LIBSASS_VERSION "[NA]"
 #endif
 
+#ifndef LIBSASS_LANGUAGE_VERSION
+#define LIBSASS_LANGUAGE_VERSION "[NA]"
+#endif
+
 #endif

--- a/include/sass/version.h.in
+++ b/include/sass/version.h.in
@@ -5,4 +5,8 @@
 #define LIBSASS_VERSION "@PACKAGE_VERSION@"
 #endif
 
+#ifndef LIBSASS_LANGUAGE_VERSION
+#define LIBSASS_LANGUAGE_VERSION "3.4"
+#endif
+
 #endif

--- a/src/sass.cpp
+++ b/src/sass.cpp
@@ -63,4 +63,10 @@ extern "C" {
     return LIBSASS_VERSION;
   }
 
+  // Get compiled libsass version
+  const char* ADDCALL libsass_language_version(void)
+  {
+    return LIBSASS_LANGUAGE_VERSION;
+  }
+
 }


### PR DESCRIPTION
I'm not sure if this 100% right. I can't seem to make autoconf work on my local env. But it builds and prints "[NA]" in the patched version of sassc that I will also submit.

Reason: Tracking the sass language version explicitly helps users correctly understand which version of the language they are using, it will also help sass-spec automatically derive the version of the tests to run without requiring `-V` all the time.