### PR TITLE
Improve class selector parsing

### DIFF
--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -600,7 +600,7 @@ namespace Sass {
     }
     // Match CSS class names.
     const char* class_name(const char* src) {
-      return sequence<exactly<'.'>, identifier_alnums >(src);
+      return sequence<exactly<'.'>, identifier >(src);
     }
     // Attribute name in an attribute selector.
     const char* attribute_name(const char* src) {


### PR DESCRIPTION
`.1a` is not a valid selector in sass

A spec exists already but does not yet pass. Probably due to selector lookahead regex. Anyway this seems to be correct and I need something to test CI :wink: 