### PR TITLE
Remove a warning under MSVC (x86_64)

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -172,7 +172,7 @@ namespace Sass {
           break;
         } else {
           if (arglist->length() > LP - ip && !ps->has_rest_parameter()) {
-            int arg_count = (arglist->length() + LA - 1);
+            size_t arg_count = (arglist->length() + LA - 1);
             std::stringstream msg;
             msg << callee << " takes " << LP;
             msg << (LP == 1 ? " argument" : " arguments");


### PR DESCRIPTION
Before I was getting this:

```
src/bind.cpp(175): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data
```