### PR TITLE
Fix issue with extend and recursions

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1889,6 +1889,9 @@ namespace Sass {
     virtual void set_media_block(Media_Block* mb) {
       media_block(mb);
     }
+    virtual bool has_wrapped_selector() {
+      return false;
+    }
   };
   inline Selector::~Selector() { }
 
@@ -2185,6 +2188,10 @@ namespace Sass {
       }
       return hash_;
     }
+    virtual bool has_wrapped_selector()
+    {
+      return true;
+    }
     virtual unsigned long specificity()
     {
       return selector_ ? selector_->specificity() : 0;
@@ -2268,6 +2275,15 @@ namespace Sass {
       for (size_t i = 0, L = length(); i < L; ++i)
       { sum += (*this)[i]->specificity(); }
       return sum;
+    }
+
+    virtual bool has_wrapped_selector()
+    {
+      if (length() == 0) return false;
+      if (Simple_Selector* ss = elements().front()) {
+        if (ss->has_wrapped_selector()) return true;
+      }
+      return false;
     }
 
     bool is_empty_reference()
@@ -2398,6 +2414,11 @@ namespace Sass {
       if (tail_) tail_->set_media_block(mb);
       if (head_) head_->set_media_block(mb);
     }
+    virtual bool has_wrapped_selector() {
+      if (head_ && head_->has_wrapped_selector()) return true;
+      if (tail_ && tail_->has_wrapped_selector()) return true;
+      return false;
+    }
     bool operator<(const Complex_Selector& rhs) const;
     bool operator==(const Complex_Selector& rhs) const;
     inline bool operator!=(const Complex_Selector& rhs) const { return !(*this == rhs); }
@@ -2505,6 +2526,12 @@ namespace Sass {
       for (Complex_Selector* cs : elements()) {
         cs->set_media_block(mb);
       }
+    }
+    virtual bool has_wrapped_selector() {
+      for (Complex_Selector* cs : elements()) {
+        if (cs->has_wrapped_selector()) return true;
+      }
+      return false;
     }
     Selector_List* clone(Context&) const;      // does not clone Compound_Selector*s
     Selector_List* cloneFully(Context&) const; // clones Compound_Selector*s

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1942,6 +1942,7 @@ namespace Sass {
       if (!pSelector->has_placeholder()) {
         if (!extendedSelectors.contains(complexSelectorToNode(pSelector, ctx), true /*simpleSelectorOrderDependent*/)) {
           *pNewSelectors << pSelector;
+          continue;
         }
       }
 
@@ -1987,7 +1988,12 @@ namespace Sass {
                       Wrapped_Selector* cpy_ws = SASS_MEMORY_NEW(ctx.mem, Wrapped_Selector, *ws);
                       Selector_List* cpy_ws_sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, sl->pstate());
                       // remove parent selectors from inner selector
-                      if (ext_cs->first()) *cpy_ws_sl << ext_cs->first();
+                      if (ext_cs->first()) {
+                        if (ext_cs->first()->has_wrapped_selector()) {
+                          continue; // ignore this case for now
+                        }
+                        *cpy_ws_sl << ext_cs->first();
+                      }
                       // assign list to clone
                       cpy_ws->selector(cpy_ws_sl);
                       // append the clone

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -2,6 +2,7 @@
 #define SASS_EXTEND_H
 
 #include <string>
+#include <set>
 
 #include "ast.hpp"
 #include "operation.hpp"
@@ -23,10 +24,16 @@ namespace Sass {
 
   public:
     static Node subweave(Node& one, Node& two, Context& ctx);
+    static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
     static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething);
     static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace = false) {
       bool extendedSomething = false;
       return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething);
+    }
+    static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, std::set<Compound_Selector>& seen) {
+      bool isReplace = false;
+      bool extendedSomething = false;
+      return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething, seen);
     }
     Extend(Context&, ExtensionSubsetMap&);
     ~Extend() { }


### PR DESCRIPTION
Addresses https://github.com/sass/libsass/issues/2051 (and should fix https://github.com/sass/libsass/issues/2054)

I tried to re-use the existing approach with `std::set<Compound_Selector> seen`. But I have no idea how the extend code overall is supposed to work, since the implementation is pretty hairy. I guess this case was simply not implemented. I recently introduced changes to allow extending of wrapped selectors. This lead to a new code path to call `extendSelectorList`, which lead to more exposure of this issue.

used test case:
```scss
:not(.thing) {
    color: red;
}
:not(.thing[disabled]) {
    @extend .thing;
    background: blue;
}
```

now produces:
```css
:not(.thing) {
  color: red; }
:not(.thing[disabled]):not([disabled]:not(.thing[disabled])) {
  background: blue; }
```

So it fixes the segfault and the output is correct.
Specs still pass, but implications for this change are unknown.