### PR TITLE
Fix and refactor delayed evaluation flag

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -74,6 +74,21 @@ namespace Sass {
     ltrim();
   }
 
+  void Argument::set_delayed(bool delayed)
+  {
+    if (value_) value_->set_delayed(delayed);
+    is_delayed(delayed);
+  }
+
+  void Arguments::set_delayed(bool delayed)
+  {
+    for (Argument* arg : elements()) {
+      if (arg) arg->set_delayed(delayed);
+    }
+    is_delayed(delayed);
+  }
+
+
   bool At_Root_Query::exclude(std::string str)
   {
     bool with = feature() && unquote(feature()->to_string()).compare("with") == 0;
@@ -2147,29 +2162,6 @@ namespace Sass {
   bool Binary_Expression::is_right_interpolant(void) const
   {
     return is_interpolant() || (right() && right()->is_right_interpolant());
-  }
-
-  // delay binary expressions in function arguments
-  // https://github.com/sass/libsass/issues/1417
-  bool Binary_Expression::can_delay(void) const
-  {
-    bool l_delay = false;
-    bool r_delay = false;
-    if (op().operand == Sass_OP::DIV) {
-      if (Textual* tl = dynamic_cast<Textual*>(left())) {
-        l_delay = tl->type() == Textual::NUMBER ||
-                  tl->type() == Textual::DIMENSION;
-      } else {
-        l_delay = dynamic_cast<Number*>(left()) != NULL;
-      }
-      if (Textual* tr = dynamic_cast<Textual*>(right())) {
-        r_delay = tr->type() == Textual::NUMBER ||
-                  tr->type() == Textual::DIMENSION;
-      } else {
-        r_delay = dynamic_cast<Number*>(right()) != NULL;
-      }
-    }
-    return l_delay && r_delay;
   }
 
   std::string AST_Node::to_string(Sass_Inspect_Options opt) const

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -396,7 +396,7 @@ namespace Sass {
     ADD_PROPERTY(bool, group_end)
   public:
     Statement(ParserState pstate, Statement_Type st = NONE, size_t t = 0)
-    : AST_Node(pstate), statement_type_(st), tabs_(t), group_end_(false)
+    : AST_Node(pstate), block_(0), statement_type_(st), tabs_(t), group_end_(false)
      { }
     virtual ~Statement() = 0;
     // needed for rearranging nested rulesets during CSS emission

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -50,6 +50,9 @@
 
 namespace Sass {
 
+  // easier to search with name
+  const bool DELAYED = true;
+
   // ToDo: should this really be hardcoded
   // Note: most methods follow precision option
   const double NUMBER_EPSILON = 0.00000000000001;
@@ -67,7 +70,8 @@ namespace Sass {
       bool ws_after;
   };
 
-  // from boost (functional/hash):
+  //////////////////////////////////////////////////////////
+  // `hash_combine` comes from boost (functional/hash):
   // http://www.boost.org/doc/libs/1_35_0/doc/html/hash/combine.html
   // Boost Software License - Version 1.0
   // http://www.boost.org/users/license.html
@@ -77,6 +81,7 @@ namespace Sass {
     seed ^= std::hash<T>()(val) + 0x9e3779b9
              + (seed<<6) + (seed>>2);
   }
+  //////////////////////////////////////////////////////////
 
   //////////////////////////////////////////////////////////
   // Abstract base class for all abstract syntax tree nodes.
@@ -905,9 +910,8 @@ namespace Sass {
 
     virtual void set_delayed(bool delayed)
     {
-      for (size_t i = 0, L = length(); i < L; ++i)
-        (elements()[i])->set_delayed(delayed);
       is_delayed(delayed);
+      // don't set children
     }
 
     virtual bool operator== (const Expression& rhs) const;
@@ -1031,12 +1035,6 @@ namespace Sass {
       return is_left_interpolant() ||
              is_right_interpolant();
     }
-    virtual bool can_delay() const;
-    void reset_whitespace()
-    {
-      op_.ws_before = false;
-      op_.ws_after = false;
-    }
     virtual void set_delayed(bool delayed)
     {
       right()->set_delayed(delayed);
@@ -1138,6 +1136,7 @@ namespace Sass {
       }
     }
 
+    virtual void set_delayed(bool delayed);
     virtual bool operator==(const Expression& rhs) const
     {
       try
@@ -1184,6 +1183,8 @@ namespace Sass {
       has_rest_argument_(false),
       has_keyword_argument_(false)
     { }
+
+    virtual void set_delayed(bool delayed);
 
     Argument* get_rest_argument();
     Argument* get_keyword_argument();
@@ -1296,7 +1297,7 @@ namespace Sass {
     size_t hash_;
   public:
     Textual(ParserState pstate, Type t, std::string val)
-    : Expression(pstate, true), type_(t), value_(val),
+    : Expression(pstate, DELAYED), type_(t), value_(val),
       hash_(0)
     { }
 
@@ -1466,10 +1467,9 @@ namespace Sass {
   // "flat" strings.
   ////////////////////////////////////////////////////////////////////////
   class String : public Value {
-    ADD_PROPERTY(bool, sass_fix_1291)
   public:
-    String(ParserState pstate, bool delayed = false, bool sass_fix_1291 = false)
-    : Value(pstate, delayed), sass_fix_1291_(sass_fix_1291)
+    String(ParserState pstate, bool delayed = false)
+    : Value(pstate, delayed)
     { concrete_type(STRING); }
     static std::string type_name() { return "string"; }
     virtual ~String() = 0;
@@ -1515,6 +1515,10 @@ namespace Sass {
           hash_combine(hash_, string->hash());
       }
       return hash_;
+    }
+
+    virtual void set_delayed(bool delayed) {
+      is_delayed(delayed);
     }
 
     virtual bool operator==(const Expression& rhs) const;

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -21,7 +21,6 @@ namespace Sass {
         // force optional quotes (only if needed)
         if (str->quote_mark()) {
           str->quote_mark('*');
-          str->is_delayed(true);
         }
       }
     }

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -102,10 +102,20 @@ namespace Sass {
   {
     p_stack.push_back(r);
     s_stack.push_back(dynamic_cast<Selector_List*>(r->selector()));
+    // this can return a string schema
+    // string schema is not a statement!
+    // r->block() is already a string schema
+    // and that is comming from propset expand
+    Statement* stmt = r->block()->perform(this);
+    // this should protect us (at least a bit) from our mess
+    // fixing this properly is harder that it should be ...
+    if (dynamic_cast<Statement*>((AST_Node*)stmt) == NULL) {
+      error("Illegal nesting: Only properties may be nested beneath properties.", r->block()->pstate());
+    }
     Ruleset* rr = SASS_MEMORY_NEW(ctx.mem, Ruleset,
                                   r->pstate(),
                                   r->selector(),
-                                  r->block()->perform(this)->block());
+                                  stmt->block());
     rr->is_root(r->is_root());
     // rr->tabs(r->block()->tabs());
     s_stack.pop_back();

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -311,6 +311,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "Warning " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
+    debug_ast(block->message(), ind + " : ");
   } else if (dynamic_cast<Error*>(node)) {
     Error* block = dynamic_cast<Error*>(node);
     std::cerr << ind << "Error " << block;
@@ -578,6 +579,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Color* expression = dynamic_cast<Color*>(node);
     std::cerr << ind << "Color " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [delayed: " << expression->is_delayed() << "] ";
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->r() << ":"  << expression->g() << ":" << expression->b() << "@" << expression->a() << "]" << std::endl;
   } else if (dynamic_cast<Number*>(node)) {
@@ -594,7 +596,6 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << prettyprint(expression->value()) << "]";
     if (expression->is_delayed()) std::cerr << " [delayed]";
-    if (expression->sass_fix_1291()) std::cerr << " [sass_fix_1291]";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     if (expression->quote_mark()) std::cerr << " [quote_mark: " << expression->quote_mark() << "]";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
@@ -607,7 +608,6 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << prettyprint(expression->value()) << "]";
     if (expression->is_delayed()) std::cerr << " [delayed]";
-    if (expression->sass_fix_1291()) std::cerr << " [sass_fix_1291]";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
   } else if (dynamic_cast<String_Schema*>(node)) {
@@ -626,7 +626,6 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "String " << expression;
     std::cerr << " " << expression->concrete_type();
     std::cerr << " (" << pstate_source_position(node) << ")";
-    if (expression->sass_fix_1291()) std::cerr << " [sass_fix_1291]";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
   } else if (dynamic_cast<Expression*>(node)) {

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -74,7 +74,6 @@ namespace Sass {
     : Base(org.pstate()), dup(dup), org(org)
     {
       msg  = "Duplicate key ";
-      dup.get_duplicate_key()->is_delayed(false);
       msg += dup.get_duplicate_key()->inspect();
       msg += " in map (";
       msg += org.inspect();

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -22,6 +22,7 @@ namespace Sass {
     Eval(Expand& exp);
     ~Eval();
 
+    bool force;
     bool is_in_comment;
 
     Env* environment();
@@ -50,6 +51,7 @@ namespace Sass {
     Expression* operator()(Variable*);
     Expression* operator()(Textual*);
     Expression* operator()(Number*);
+    Expression* operator()(Color*);
     Expression* operator()(Boolean*);
     Expression* operator()(String_Schema*);
     Expression* operator()(String_Quoted*);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -153,20 +153,24 @@ namespace Sass {
     return rr;
   }
 
+  // this is not properly implemented
+  // mixes string_schema and statement
   Statement* Expand::operator()(Propset* p)
   {
     property_stack.push_back(p->property_fragment());
     Block* expanded_block = p->block()->perform(this)->block();
-
     for (size_t i = 0, L = expanded_block->length(); i < L; ++i) {
       Statement* stm = (*expanded_block)[i];
       if (Declaration* dec = static_cast<Declaration*>(stm)) {
+        // dec = SASS_MEMORY_NEW(ctx.mem, Declaration, *dec);
         String_Schema* combined_prop = SASS_MEMORY_NEW(ctx.mem, String_Schema, p->pstate());
         if (!property_stack.empty()) {
-          *combined_prop << property_stack.back()->perform(&eval)
-                         << SASS_MEMORY_NEW(ctx.mem, String_Quoted,
-             p->pstate(), "-")
-             << dec->property(); // TODO: eval the prop into a string constant
+          *combined_prop << property_stack.back()->perform(&eval);
+          *combined_prop << SASS_MEMORY_NEW(ctx.mem, String_Quoted, p->pstate(), "-");
+          if (dec->property()) {
+            // we cannot directly add block (from dec->property()) to string schema (combined_prop)
+            *combined_prop << SASS_MEMORY_NEW(ctx.mem, String_Quoted, dec->pstate(), dec->property()->to_string());
+          }
         }
         else {
           *combined_prop << dec->property();

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -166,10 +166,6 @@ namespace Sass {
       append_token("@import", import);
       append_mandatory_space();
 
-      if (String_Quoted* strq = dynamic_cast<String_Quoted*>(import->urls().front())) {
-        strq->is_delayed(false);
-      }
-
       import->urls().front()->perform(this);
       if (import->urls().size() == 1) {
         if (import->media_queries()) {
@@ -182,10 +178,6 @@ namespace Sass {
         append_mandatory_linefeed();
         append_token("@import", import);
         append_mandatory_space();
-
-        if (String_Quoted* strq = dynamic_cast<String_Quoted*>(import->urls()[i])) {
-          strq->is_delayed(false);
-        }
 
         import->urls()[i]->perform(this);
         if (import->urls().size() - 1 == i) {
@@ -451,10 +443,8 @@ namespace Sass {
          (output_style() == INSPECT) || (
           expr->op().ws_before
           && (!expr->is_interpolant())
-          && (!expr->is_delayed() ||
-          expr->is_left_interpolant() ||
-          expr->is_right_interpolant()
-          )
+          && (expr->is_left_interpolant() ||
+              expr->is_right_interpolant())
 
     )) append_string(" ");
     switch (expr->type()) {
@@ -477,10 +467,8 @@ namespace Sass {
          (output_style() == INSPECT) || (
           expr->op().ws_after
           && (!expr->is_interpolant())
-          && (!expr->is_delayed()
-              || expr->is_left_interpolant()
-              || expr->is_right_interpolant()
-          )
+          && (expr->is_left_interpolant() ||
+              expr->is_right_interpolant())
     )) append_string(" ");
     expr->right()->perform(this);
   }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -12,6 +12,18 @@
 #include "sass/functions.h"
 #include "error_handling.hpp"
 
+// Notes about delayed: some ast nodes can have delayed evaluation so
+// they can preserve their original semantics if needed. This is most
+// prominently exhibited by the division operation, since it is not
+// only a valid operation, but also a valid css statement (i.e. for
+// fonts, as in `16px/24px`). When parsing lists and expression we
+// unwrap single items from lists and other operations. A nested list
+// must not be delayed, only the items of the first level sometimes
+// are delayed (as with argument lists). To achieve this we need to
+// pass status to the list parser, so this can be set correctly.
+// Another case with delayed values are colors. In compressed mode
+// only processed values get compressed (other are left as written).
+
 #include <typeinfo>
 #include <tuple>
 
@@ -391,7 +403,6 @@ namespace Sass {
     if (lex< exactly<':'> >()) { // there's a default value
       while (lex< block_comment >());
       val = parse_space_list();
-      val->is_delayed(false);
     }
     else if (lex< exactly< ellipsis > >()) {
       is_rest = true;
@@ -430,14 +441,12 @@ namespace Sass {
       ParserState p = pstate;
       lex_css< exactly<':'> >();
       Expression* val = parse_space_list();
-      val->is_delayed(false);
       arg = SASS_MEMORY_NEW(ctx.mem, Argument, p, val, name);
     }
     else {
       bool is_arglist = false;
       bool is_keyword = false;
       Expression* val = parse_space_list();
-      val->is_delayed(false);
       List* l = dynamic_cast<List*>(val);
       if (lex_css< exactly< ellipsis > >()) {
         if (val->concrete_type() == Expression::MAP || (
@@ -462,7 +471,6 @@ namespace Sass {
     } else {
       val = parse_list();
     }
-    val->is_delayed(false);
     bool is_default = false;
     bool is_global = false;
     while (peek< alternatives < default_flag, global_flag > >()) {
@@ -938,7 +946,6 @@ namespace Sass {
     }
     else if (lex< sequence< optional< exactly<'*'> >, identifier, zero_plus< block_comment > > >()) {
       prop = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
-      prop->is_delayed(true);
     }
     else {
       css_error("Invalid CSS", " after ", ": expected \"}\", was ");
@@ -959,11 +966,11 @@ namespace Sass {
         if (lookahead.has_interpolants) {
           value = parse_value_schema(lookahead.found);
         } else {
-          value = parse_list();
+          value = parse_list(DELAYED);
         }
       }
       else {
-        value = parse_list();
+        value = parse_list(DELAYED);
         if (List* list = dynamic_cast<List*>(value)) {
           if (list->length() == 0 && !peek< exactly <'{'> >()) {
             css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
@@ -1052,14 +1059,13 @@ namespace Sass {
   // parse list returns either a space separated list,
   // a comma separated list or any bare expression found.
   // so to speak: we unwrap items from lists if possible here!
-  Expression* Parser::parse_list()
+  Expression* Parser::parse_list(bool delayed)
   {
-    // parse list is relly just an alias
-    return parse_comma_list();
+    return parse_comma_list(delayed);
   }
 
   // will return singletons unwrapped
-  Expression* Parser::parse_comma_list()
+  Expression* Parser::parse_comma_list(bool delayed)
   {
     // check if we have an empty list
     // return the empty list as such
@@ -1075,12 +1081,20 @@ namespace Sass {
           default_flag,
           global_flag
         > >(position))
-    { return SASS_MEMORY_NEW(ctx.mem, List, pstate, 0); }
+    {
+      // return an empty list (nothing to delay)
+      return SASS_MEMORY_NEW(ctx.mem, List, pstate, 0);
+    }
 
     // now try to parse a space list
     Expression* list = parse_space_list();
     // if it's a singleton, return it (don't wrap it)
-    if (!peek_css< exactly<','> >(position)) return list;
+    if (!peek_css< exactly<','> >(position)) {
+      // set_delay doesn't apply to list children
+      // so this will only undelay single values
+      if (!delayed) list->set_delayed(false);
+      return list;
+    }
 
     // if we got so far, we actually do have a comma list
     List* comma_list = SASS_MEMORY_NEW(ctx.mem, List, pstate, 2, SASS_COMMA);
@@ -1222,7 +1236,11 @@ namespace Sass {
       operands.push_back(parse_expression());
       left_ws = peek < css_comments >() != NULL;
     }
-    // parse the operator
+    // we are called recursively for list, so we first
+    // fold inner binary expression which has delayed
+    // correctly set to zero. After folding we also unwrap
+    // single nested items. So we cannot set delay on the
+    // returned result here, as we have lost nestings ...
     return fold_operands(lhs, operands, operators);
   }
   // parse_relation
@@ -1258,7 +1276,6 @@ namespace Sass {
       )
 
     ) {
-
 
       bool right_ws = peek < css_comments >() != NULL;
       operators.push_back({ lexed.to_string() == "+" ? Sass_OP::ADD : Sass_OP::SUB, left_ws, right_ws });
@@ -1307,14 +1324,6 @@ namespace Sass {
       // lex the expected closing parenthesis
       if (!lex_css< exactly<')'> >()) error("unclosed parenthesis", pstate);
       // expression can be evaluated
-      // make sure wrapped lists and division expressions are non-delayed within parentheses
-      if (value->concrete_type() == Expression::LIST) {
-        // List* l = static_cast<List*>(value);
-        // if (!l->empty()) (*l)[0]->is_delayed(false);
-      } else if (typeid(*value) == typeid(Binary_Expression)) {
-        Binary_Expression* b = static_cast<Binary_Expression*>(value);
-        if (b && b->type() == Sass_OP::DIV) b->set_delayed(false);
-      }
       return value;
     }
     // string may be interpolated
@@ -1455,7 +1464,6 @@ namespace Sass {
     if (!p) {
       String_Quoted* str_quoted = SASS_MEMORY_NEW(ctx.mem, String_Quoted, pstate, std::string(i, chunk.end));
       if (!constant && str_quoted->quote_mark()) str_quoted->quote_mark('*');
-      str_quoted->is_delayed(true);
       return str_quoted;
     }
 
@@ -1514,7 +1522,6 @@ namespace Sass {
     --position;
 
     String_Constant* str_node = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, str.time_wspace());
-    str_node->is_delayed(true);
     return str_node;
   }
 
@@ -1720,7 +1727,7 @@ namespace Sass {
         const char* j = skip_over_scopes< exactly<hash_lbrace>, exactly<rbrace> >(p+2, id.end); // find the closing brace
         if (j) {
           // parse the interpolant and accumulate it
-          Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, pstate, source).parse_list();
+          Expression* interp_node = Parser::from_token(Token(p+2, j), ctx, pstate, source).parse_list(DELAYED);
           interp_node->is_interpolant(true);
           (*schema) << interp_node;
           // schema->has_interpolants(true);
@@ -1862,7 +1869,6 @@ namespace Sass {
     stack.push_back(Scope::Control);
     ParserState if_source_position = pstate;
     Expression* predicate = parse_list();
-    predicate->is_delayed(false);
     Block* block = parse_block();
     Block* alternative = 0;
 
@@ -1887,13 +1893,11 @@ namespace Sass {
     std::string var(Util::normalize_underscores(lexed));
     if (!lex< kwd_from >()) error("expected 'from' keyword in @for directive", pstate);
     Expression* lower_bound = parse_expression();
-    lower_bound->is_delayed(false);
     bool inclusive = false;
     if (lex< kwd_through >()) inclusive = true;
     else if (lex< kwd_to >()) inclusive = false;
     else                  error("expected 'through' or 'to' keyword in @for directive", pstate);
     Expression* upper_bound = parse_expression();
-    upper_bound->is_delayed(false);
     Block* body = parse_block();
     stack.pop_back();
     return SASS_MEMORY_NEW(ctx.mem, For, for_source_position, var, lower_bound, upper_bound, body, inclusive);
@@ -1938,13 +1942,6 @@ namespace Sass {
     }
     if (!lex< kwd_in >()) error("expected 'in' keyword in @each directive", pstate);
     Expression* list = parse_list();
-    list->is_delayed(false);
-    if (list->concrete_type() == Expression::LIST) {
-      List* l = static_cast<List*>(list);
-      for (size_t i = 0, L = l->length(); i < L; ++i) {
-        (*l)[i]->is_delayed(false);
-      }
-    }
     Block* body = parse_block();
     stack.pop_back();
     return SASS_MEMORY_NEW(ctx.mem, Each, each_source_position, vars, list, body);
@@ -1958,7 +1955,6 @@ namespace Sass {
     While* call = SASS_MEMORY_NEW(ctx.mem, While, pstate, 0, 0);
     // parse mandatory predicate
     Expression* predicate = parse_list();
-    predicate->is_delayed(false);
     call->predicate(predicate);
     // parse mandatory block
     call->block(parse_block());
@@ -2033,7 +2029,7 @@ namespace Sass {
     feature = parse_expression();
     Expression* expression = 0;
     if (lex_css< exactly<':'> >()) {
-      expression = parse_list();
+      expression = parse_list(DELAYED);
     }
     if (!lex_css< exactly<')'> >()) {
       error("unclosed parenthesis in media query expression", pstate);
@@ -2252,8 +2248,6 @@ namespace Sass {
     Directive* directive = SASS_MEMORY_NEW(ctx.mem, Directive, pstate, lexed);
     Expression* val = parse_almost_any_value();
     // strip left and right if they are of type string
-    // debug_ast(val);
-    // std::cerr << "HAASDASD\n";
     directive->value(val);
     if (peek< exactly<'{'> >()) {
       directive->block(parse_block());
@@ -2386,7 +2380,7 @@ namespace Sass {
         stack.back() != Scope::Rules) {
       error("Illegal nesting: Only properties may be nested beneath properties.", pstate);
     }
-    return SASS_MEMORY_NEW(ctx.mem, Warning, pstate, parse_list());
+    return SASS_MEMORY_NEW(ctx.mem, Warning, pstate, parse_list(DELAYED));
   }
 
   Error* Parser::parse_error()
@@ -2398,7 +2392,7 @@ namespace Sass {
         stack.back() != Scope::Rules) {
       error("Illegal nesting: Only properties may be nested beneath properties.", pstate);
     }
-    return SASS_MEMORY_NEW(ctx.mem, Error, pstate, parse_list());
+    return SASS_MEMORY_NEW(ctx.mem, Error, pstate, parse_list(DELAYED));
   }
 
   Debug* Parser::parse_debug()
@@ -2410,7 +2404,7 @@ namespace Sass {
         stack.back() != Scope::Rules) {
       error("Illegal nesting: Only properties may be nested beneath properties.", pstate);
     }
-    return SASS_MEMORY_NEW(ctx.mem, Debug, pstate, parse_list());
+    return SASS_MEMORY_NEW(ctx.mem, Debug, pstate, parse_list(DELAYED));
   }
 
   Return* Parser::parse_return_directive()
@@ -2624,21 +2618,12 @@ namespace Sass {
   {
     for (size_t i = 0, S = operands.size(); i < S; ++i) {
       base = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, pstate, op, base, operands[i]);
-      Binary_Expression* b = static_cast<Binary_Expression*>(base);
-      if (op.operand == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
-        base->is_delayed(true);
-      }
-      else if (b && b->op().operand != Sass_OP::DIV) {
-        b->left()->is_delayed(false);
-        b->right()->is_delayed(false);
-      }
     }
     return base;
   }
 
   Expression* Parser::fold_operands(Expression* base, std::vector<Expression*>& operands, std::vector<Operand>& ops, size_t i)
   {
-
     if (String_Schema* schema = dynamic_cast<String_Schema*>(base)) {
       // return schema;
       if (schema->has_interpolants()) {
@@ -2655,8 +2640,6 @@ namespace Sass {
         )) {
           Expression* rhs = fold_operands(operands[0], operands, ops, 1);
           rhs = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, base->pstate(), ops[0], schema, rhs);
-          rhs->set_delayed(false);
-          rhs->is_delayed(true);
           return rhs;
         }
         // return schema;
@@ -2670,12 +2653,9 @@ namespace Sass {
             Expression* rhs = fold_operands(operands[i+1], operands, ops, i + 2);
             rhs = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, base->pstate(), ops[i], schema, rhs);
             base = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, base->pstate(), ops[i], base, rhs);
-            rhs->is_delayed(true);
-            base->is_delayed(true);
             return base;
           }
           base = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, base->pstate(), ops[i], base, operands[i]);
-          if (ops[i].operand != Sass_OP::DIV) base->is_delayed(true);
           return base;
         } else {
           base = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, base->pstate(), ops[i], base, operands[i]);
@@ -2687,11 +2667,11 @@ namespace Sass {
       if (b && ops[i].operand == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
         base->is_delayed(true);
       }
-      else if (b) {
-        b->left()->is_delayed(false);
-        b->right()->is_delayed(false);
-      }
-
+    }
+    // nested binary expression are never to be delayed
+    if (Binary_Expression* b = dynamic_cast<Binary_Expression*>(base)) {
+      if (dynamic_cast<Binary_Expression*>(b->left())) base->set_delayed(false);
+      if (dynamic_cast<Binary_Expression*>(b->right())) base->set_delayed(false);
     }
     return base;
   }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -255,8 +255,8 @@ namespace Sass {
     Declaration* parse_declaration();
     Expression* parse_map_value();
     Expression* parse_map();
-    Expression* parse_list();
-    Expression* parse_comma_list();
+    Expression* parse_list(bool delayed = false);
+    Expression* parse_comma_list(bool delayed = false);
     Expression* parse_space_list();
     Expression* parse_disjunction();
     Expression* parse_conjunction();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -151,7 +151,7 @@ namespace Sass {
     std::string out("");
     bool lf = false;
     for (auto i : str) {
-      if (i == 10) {
+      if (i == '\n') {
         out += ' ';
         lf = true;
       } else if (!(lf && isspace(i))) {
@@ -267,7 +267,7 @@ namespace Sass {
           // assert invalid code points
           if (cp == 0) cp = 0xFFFD;
           // replace bell character
-          // if (cp == 10) cp = 32;
+          // if (cp == '\n') cp = 32;
 
           // use a very simple approach to convert via utf8 lib
           // maybe there is a more elegant way; maybe we shoud
@@ -330,7 +330,7 @@ namespace Sass {
       int cp = utf8::next(it, end);
 
       // in case of \r, check if the next in sequence
-      // is \n and then advance the iterator.
+      // is \n and then advance the iterator and skip \r
       if (cp == '\r' && it < end && utf8::peek_next(it, end) == '\n') {
         cp = utf8::next(it, end);
       }


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/2042, https://github.com/sass/libsass/issues/2034 and https://github.com/sass/libsass/issues/2057 (Spec tests https://github.com/sass/sass-spec/pull/856).

This is pretty much a complete rewrite of how we handle delayed values:

```c++
// Notes about delayed: some ast nodes can have delayed evaluation so
// they can preserve their original semantics if needed. This is most
// prominently exhibited by the division operation, since it is not
// only a valid operation, but also a valid css statement (i.e. for
// fonts, as in `16px/24px`). When parsing lists and expression we
// unwrap single items from lists and other operations. A nested list
// must not be delayed, only the items of the first level sometimes
// are delayed (as with argument lists). To achieve this we need to
// pass status to the list parser, so this can be set correctly.
// Another case with delayed values are colors. In compressed mode
// only processed values get compressed (other are left as written).
```

Issue #2042 was never fully working, but its behavior was changed with #1986 from undelayed to delayed. From my experience libsass struggled to emulate these behaviors from the beginning. First I figured out why #2042 was never working. It turns out that we have to only set delayed on certain parsed ast nodes. And whoever calls parse_list must tell it if values on the first level must be delayed (//CC @xzyfer). This is the case for declarations and argument lists (and others), but not for nested lists (with exceptions).

Once implemented pretty much all other stuff related to delayed values broke. So I set out to fix them one by one, and most were easy. The trickiest one revealed itself in the following sass:

```scss
.foo {
  eval: foobar(true, ((yellow 3) red), 1/2);
}  
```

This compiles to (in compressed :exclamation:  mode):
```css
.foo{eval:foobar(true, #ff0 3 red, 1/2)}
```

It shows that undelaying colors vs divisions are really two different things. Because in the sample above the color got undelayed, while the division did not. Another key code in the PR is that binary expression never get delayed when they contain nested binary expressions. With this logic in place I was able to remove most of the complicated code regarding delayed value handling.