### PR TITLE
Error when declarations are printed without ruleset

### DIFF
--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -493,6 +493,15 @@ namespace Sass {
     return flatten(result);
   }
 
+  Statement* Cssize::operator()(Declaration* d)
+  {
+    if (block_stack.size() < 2) {
+      throw Exception::InvalidSass(d->pstate(), "Properties are only allowed "
+        "within rules, directives, mixin includes, or other properties.");
+    }
+    return static_cast<Statement*>(d);
+  }
+
   Statement* Cssize::fallback_impl(AST_Node* n)
   {
     return static_cast<Statement*>(n);

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -36,7 +36,7 @@ namespace Sass {
     Statement* operator()(At_Root_Block*);
     Statement* operator()(Directive*);
     Statement* operator()(Keyframe_Rule*);
-    // Statement* operator()(Declaration*);
+    Statement* operator()(Declaration*);
     // Statement* operator()(Assignment*);
     // Statement* operator()(Import*);
     // Statement* operator()(Import_Stub*);

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -20,7 +20,6 @@ namespace Sass {
     : Base(pstate, msg)
     { }
 
-
     InvalidParent::InvalidParent(Selector* parent, Selector* selector)
     : Base(selector->pstate()), parent(parent), selector(selector)
     {


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1732 - Another one of the category "should error" :exclamation: 

`Properties are only allowed within rules, directives, mixin includes, or other properties.`