### PR TITLE
Error when declarations are printed without ruleset

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -4,6 +4,7 @@ SOURCES = \
 	ast.cpp \
 	base64vlq.cpp \
 	bind.cpp \
+	check_nesting.cpp \
 	color_maps.cpp \
 	constants.cpp \
 	context.cpp \

--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -1,0 +1,66 @@
+#include "sass.hpp"
+#include <vector>
+
+#include "check_nesting.hpp"
+#include "context.hpp"
+// #include "debugger.hpp"
+
+namespace Sass {
+
+  CheckNesting::CheckNesting(Context& ctx)
+  : ctx(ctx),
+    parent_stack(std::vector<AST_Node*>())
+  { }
+
+  AST_Node* CheckNesting::parent()
+  {
+    if (parent_stack.size() > 0)
+      return parent_stack.back();
+    return 0;
+  }
+
+  Statement* CheckNesting::operator()(Block* b)
+  {
+    parent_stack.push_back(b);
+    append_block(b);
+    parent_stack.pop_back();
+    return b;
+  }
+
+  Statement* CheckNesting::operator()(Declaration* d)
+  {
+    if (!is_valid_prop_parent(parent())) {
+      throw Exception::InvalidSass(d->pstate(), "Properties are only allowed "
+        "within rules, directives, mixin includes, or other properties.");
+    }
+    return static_cast<Statement*>(d);
+  }
+
+  Statement* CheckNesting::fallback_impl(AST_Node* n)
+  {
+    return static_cast<Statement*>(n);
+  }
+
+  bool CheckNesting::is_valid_prop_parent(AST_Node* p) 
+  {
+    if (Definition* def = dynamic_cast<Definition*>(p)) {
+      return def->type() == Definition::MIXIN;
+    }
+
+    return dynamic_cast<Ruleset*>(p) ||
+           dynamic_cast<Keyframe_Rule*>(p) ||
+           dynamic_cast<Propset*>(p) ||
+           dynamic_cast<Directive*>(p) ||
+           dynamic_cast<Mixin_Call*>(p);
+  }
+
+  void CheckNesting::append_block(Block* b)
+  {
+    for (size_t i = 0, L = b->length(); i < L; ++i) {
+      Statement* ith = (*b)[i]->perform(this);
+      if (ith) {
+        (*b)[i] = ith;
+      }
+    }
+  }
+}

--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -22,7 +22,11 @@ namespace Sass {
   Statement* CheckNesting::operator()(Block* b)
   {
     parent_stack.push_back(b);
-    append_block(b);
+
+    for (auto n : *b) {
+      n->perform(this);
+    }
+
     parent_stack.pop_back();
     return b;
   }
@@ -52,15 +56,5 @@ namespace Sass {
            dynamic_cast<Propset*>(p) ||
            dynamic_cast<Directive*>(p) ||
            dynamic_cast<Mixin_Call*>(p);
-  }
-
-  void CheckNesting::append_block(Block* b)
-  {
-    for (size_t i = 0, L = b->length(); i < L; ++i) {
-      Statement* ith = (*b)[i]->perform(this);
-      if (ith) {
-        (*b)[i] = ith;
-      }
-    }
   }
 }

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -1,0 +1,38 @@
+#ifndef SASS_CHECK_NESTING_H
+#define SASS_CHECK_NESTING_H
+
+#include "ast.hpp"
+#include "context.hpp"
+#include "operation.hpp"
+
+namespace Sass {
+
+  typedef Environment<AST_Node*> Env;
+
+  class CheckNesting : public Operation_CRTP<Statement*, CheckNesting> {
+
+    Context&                 ctx;
+    std::vector<Block*>      block_stack;
+    std::vector<AST_Node*>   parent_stack;
+
+    AST_Node* parent();
+
+    Statement* fallback_impl(AST_Node* n);
+
+  public:
+    CheckNesting(Context&);
+    ~CheckNesting() { }
+
+    Statement* operator()(Block*);
+    Statement* operator()(Declaration*);
+
+    template <typename U>
+    Statement* fallback(U x) { return fallback_impl(x); }
+
+    bool is_valid_prop_parent(AST_Node*);
+    void append_block(Block*);
+  };
+
+}
+
+#endif

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -30,7 +30,6 @@ namespace Sass {
     Statement* fallback(U x) { return fallback_impl(x); }
 
     bool is_valid_prop_parent(AST_Node*);
-    void append_block(Block*);
   };
 
 }

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -18,6 +18,7 @@
 #include "output.hpp"
 #include "expand.hpp"
 #include "eval.hpp"
+#include "check_nesting.hpp"
 #include "cssize.hpp"
 #include "listize.hpp"
 #include "extend.hpp"
@@ -648,8 +649,13 @@ namespace Sass {
     // create crtp visitor objects
     Expand expand(*this, &global, &backtrace);
     Cssize cssize(*this, &backtrace);
+    CheckNesting check_nesting(*this);
+    // check nesting
+    root = root->perform(&check_nesting)->block();
     // expand and eval the tree
     root = root->perform(&expand)->block();
+    // check nesting
+    root = root->perform(&check_nesting)->block();
     // merge and bubble certain rules
     root = root->perform(&cssize)->block();
     // should we extend something?

--- a/win/libsass.targets
+++ b/win/libsass.targets
@@ -18,6 +18,7 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\base64vlq.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\bind.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\b64\cencode.h" />
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\check_nesting.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\color_maps.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\constants.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\context.hpp" />
@@ -71,6 +72,7 @@
     <ClCompile Include="$(LIBSASS_SRC_DIR)\bind.cpp" />
     <ClCompile Condition="$(VisualStudioVersion) &lt; 14.0" Include="$(LIBSASS_SRC_DIR)\c99func.c" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\cencode.c" />
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\check_nesting.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\color_maps.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\constants.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\context.cpp" />

--- a/win/libsass.vcxproj.filters
+++ b/win/libsass.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\bind.hpp">
       <Filter>Headers</Filter>
     </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\check_nesting.hpp">
+      <Filter>Headers</Filter>
+    </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\color_maps.hpp">
       <Filter>Headers</Filter>
     </ClInclude>
@@ -222,6 +225,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\cencode.c">
+      <Filter>Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\check_nesting.cpp">
       <Filter>Sources</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\color_maps.cpp">


### PR DESCRIPTION
This is introduces a vastly reduced `CheckNesting` visitor from Ruby
Sass as discussed in #2061. Doing this properly will require some
small changes to the parser, and probably eval, which currently try
to do some nesting checking of their own.

This is just first step to properly introducing the proper nesting
checking.

Spec sass/sass-spec#857
Closes #2061
Fixes #1732