### PR TITLE
Clean up some dead code in check nesting

### DIFF
--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -2,14 +2,11 @@
 #include <vector>
 
 #include "check_nesting.hpp"
-#include "context.hpp"
-// #include "debugger.hpp"
 
 namespace Sass {
 
-  CheckNesting::CheckNesting(Context& ctx)
-  : ctx(ctx),
-    parent_stack(std::vector<AST_Node*>())
+  CheckNesting::CheckNesting()
+  : parent_stack(std::vector<AST_Node*>())
   { }
 
   AST_Node* CheckNesting::parent()

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -2,7 +2,6 @@
 #define SASS_CHECK_NESTING_H
 
 #include "ast.hpp"
-#include "context.hpp"
 #include "operation.hpp"
 
 namespace Sass {
@@ -11,8 +10,6 @@ namespace Sass {
 
   class CheckNesting : public Operation_CRTP<Statement*, CheckNesting> {
 
-    Context&                 ctx;
-    std::vector<Block*>      block_stack;
     std::vector<AST_Node*>   parent_stack;
 
     AST_Node* parent();
@@ -20,7 +17,7 @@ namespace Sass {
     Statement* fallback_impl(AST_Node* n);
 
   public:
-    CheckNesting(Context&);
+    CheckNesting();
     ~CheckNesting() { }
 
     Statement* operator()(Block*);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -649,7 +649,7 @@ namespace Sass {
     // create crtp visitor objects
     Expand expand(*this, &global, &backtrace);
     Cssize cssize(*this, &backtrace);
-    CheckNesting check_nesting(*this);
+    CheckNesting check_nesting;
     // check nesting
     root = root->perform(&check_nesting)->block();
     // expand and eval the tree

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -651,11 +651,11 @@ namespace Sass {
     Cssize cssize(*this, &backtrace);
     CheckNesting check_nesting;
     // check nesting
-    root = root->perform(&check_nesting)->block();
+    root->perform(&check_nesting)->block();
     // expand and eval the tree
     root = root->perform(&expand)->block();
     // check nesting
-    root = root->perform(&check_nesting)->block();
+    root->perform(&check_nesting)->block();
     // merge and bubble certain rules
     root = root->perform(&cssize)->block();
     // should we extend something?


### PR DESCRIPTION
- fix warning about unused `ctx`
- remove commented out code
- don't reassign root to the check nesting visitor