### PR TITLE
Fix minor issue with handling "\a" in interpolations

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1078,7 +1078,16 @@ namespace Sass {
         bool is_null = dynamic_cast<Null*>(item) != 0; // rl != ""
         if (!is_null) *ll << SASS_MEMORY_NEW(ctx.mem, String_Quoted, item->pstate(), rl);
       }
-      res += (ll->to_string(ctx.c_options));
+      // Check indicates that we probably should not get a list
+      // here. Normally single list items are already unwrapped.
+      if (l->size() > 1) {
+        // string_to_output would fail "#{'_\a' '_\a'}";
+        std::string str(ll->to_string(ctx.c_options));
+        newline_to_space(str); // replace directly
+        res += str; // append to result string
+      } else {
+        res += (ll->to_string(ctx.c_options));
+      }
       ll->is_interpolant(l->is_interpolant());
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -145,7 +145,14 @@ namespace Sass {
     return out;
   }
 
-  // bell character is replaces with space
+  // bell characters are replaced with spaces
+  void newline_to_space(std::string& str)
+  {
+    std::replace(str.begin(), str.end(), '\n', ' ');
+  }
+
+  // bell characters are replaced with spaces
+  // also eats spaces after line-feeds (ltrim)
   std::string string_to_output(const std::string& str)
   {
     std::string out("");

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -26,6 +26,7 @@ namespace Sass {
   std::string evacuate_escapes(const std::string& str);
   std::string string_to_output(const std::string& str);
   std::string comment_to_string(const std::string& text);
+  void newline_to_space(std::string& str);
 
   std::string quote(const std::string&, char q = 0);
   std::string unquote(const std::string&, char* q = 0, bool keep_utf8_sequences = false);


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1786

The check currently needed in interpolation indicates that we probably should not get a list
there in the first place. Normally single list items are not wrapped in a list container.