### PR TITLE
Fix error message for missing arguments

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -275,10 +275,7 @@ namespace Sass {
         }
         else {
           // param is unbound and has no default value -- error
-          std::stringstream msg;
-          msg << "required parameter " << leftover->name()
-              << " is missing in call to " << callee;
-          error(msg.str(), as->pstate());
+          throw Exception::MissingArgument(as->pstate(), name, leftover->name(), type);
         }
       }
     }

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -35,9 +35,17 @@ namespace Sass {
     : Base(pstate), fn(fn), arg(arg), type(type), value(value)
     {
       msg  = arg + ": \"";
-      msg += value->to_string(Sass_Inspect_Options());
+      if (value) msg += value->to_string(Sass_Inspect_Options());
       msg += "\" is not a " + type;
       msg += " for `" + fn + "'";
+    }
+
+    MissingArgument::MissingArgument(ParserState pstate, std::string fn, std::string arg, std::string fntype)
+    : Base(pstate), fn(fn), arg(arg), fntype(fntype)
+    {
+      msg  = fntype + " " + fn;
+      msg += " is missing argument ";
+      msg += arg + ".";
     }
 
     InvalidSyntax::InvalidSyntax(ParserState pstate, std::string msg, std::vector<Sass_Import_Entry>* import_stack)

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -45,6 +45,16 @@ namespace Sass {
         virtual ~InvalidParent() throw() {};
     };
 
+    class MissingArgument : public Base {
+      protected:
+        std::string fn;
+        std::string arg;
+        std::string fntype;
+      public:
+        MissingArgument(ParserState pstate, std::string fn, std::string arg, std::string fntype);
+        virtual ~MissingArgument() throw() {};
+    };
+
     class InvalidArgumentType : public Base {
       protected:
         std::string fn;


### PR DESCRIPTION
Updates one error message from bind class to conform to ruby sass:

```
Error: Mixin colors is missing argument $color.
        on line 7 of foo.scss
```

Interestingly we already have a case for this in todo-issues/83