### PR TITLE
Implement indexed map access (incubating feature)

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -303,6 +303,7 @@ namespace Sass {
     std::vector<Expression*> list_;
   protected:
     size_t hash_;
+    std::deque<Expression*> ordered;
     Expression* duplicate_key_;
     void reset_hash() { hash_ = 0; }
     void reset_duplicate_key() { duplicate_key_ = 0; }
@@ -321,14 +322,23 @@ namespace Sass {
     Hashed& operator<<(std::pair<Expression*, Expression*> p)
     {
       reset_hash();
-
+      ordered.push_back(p.first);
+      ordered.push_back(p.second);
       if (!has(p.first)) list_.push_back(p.first);
       else if (!duplicate_key_) duplicate_key_ = p.first;
-
       elements_[p.first] = p.second;
-
       adjust_after_pushing(p);
       return *this;
+    }
+    Expression* key(size_t i) {
+      return ordered.at(i * 2);
+    }
+    Expression* value(size_t i) {
+      return ordered.at(i * 2 + 1);
+    }
+    Expression* value(size_t i, Expression* v) {
+      ordered[i * 2 + 1] = v;
+      return v;
     }
     Hashed& operator+=(Hashed* h)
     {

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -14,6 +14,17 @@ namespace Sass {
   : mem(mem)
   {  }
 
+  Expression* Listize::operator()(Map* m)
+  {
+    List* l = SASS_MEMORY_NEW(mem, List, m->pstate(), m->length(), SASS_COMMA);
+    for (size_t i = 0, L = m->length(); i < L; i++) {
+      List* il = SASS_MEMORY_NEW(mem, List, m->pstate(), 2, SASS_SPACE);
+      *il << m->key(i) << m->value(i);
+      *l << il;
+    }
+    return l;
+  }
+
   Expression* Listize::operator()(Selector_List* sel)
   {
     List* l = SASS_MEMORY_NEW(mem, List, sel->pstate(), sel->length(), SASS_COMMA);

--- a/src/listize.hpp
+++ b/src/listize.hpp
@@ -24,6 +24,7 @@ namespace Sass {
     Listize(Memory_Manager&);
     ~Listize() { }
 
+    Expression* operator()(Map*);
     Expression* operator()(Selector_List*);
     Expression* operator()(Complex_Selector*);
     Expression* operator()(Compound_Selector*);


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1930

Was even simpler than anticipated. Had to add a `deque` object to the hash map implementation. I also tried to switch to a `std::map`, but it doesn't seem to support a custom hasher and only works with compare operator (which is not good, since we cannot really compare different types of ast nodes). It wouldn't had much benefit anyway (we would only get an ordered iterator over all pairs). As always with hash maps, it more of a guess which implementation would lead to the best performance.

IMO this implementation is pretty close to being optimal (in terms of performance). Random/Indexed access is constant `O(1)` due to the use of `deque`. I didn't put too much thought into the API, but it should be straight forward to use. You can fetch key or value by index. As I already wrote in other threads, the list/map interfaces/types/classes should be refactored and unified at some point (basically hiding all the logic currently implemented in functions.cpp and elsewhere).

If you can point me to other functions that allow random/indexed access to maps, please add them in this thread. Will see if I can also implement them. And yes, this is still missing proper spec test coverage.