### PR TITLE
Remove placeholder for Sass lang version

### DIFF
--- a/include/sass/version.h
+++ b/include/sass/version.h
@@ -6,7 +6,7 @@
 #endif
 
 #ifndef LIBSASS_LANGUAGE_VERSION
-#define LIBSASS_LANGUAGE_VERSION "[NA]"
+#define LIBSASS_LANGUAGE_VERSION "3.4"
 #endif
 
 #endif


### PR DESCRIPTION
Based on the commentary in PR #2021, there is no need to define
a placeholder for language version in `version.h.in` file. Instead we
define the constant in `version.h` for non-gcc compilers.

With this change MSVC and clang compiled outputs will not show [NA]
anymore.