### PR TITLE
Export memory allocator functions to public API

### DIFF
--- a/include/sass/base.h
+++ b/include/sass/base.h
@@ -63,11 +63,11 @@ enum Sass_Output_Style {
 };
 
 // to allocate buffer to be filled
-void* sass_alloc_memory(size_t size);
+ADDAPI void* ADDCALL sass_alloc_memory(size_t size);
 // to allocate a buffer from existing string
-char* sass_copy_c_string(const char* str);
+ADDAPI char* ADDCALL sass_copy_c_string(const char* str);
 // to free overtaken memory when done
-void sass_free_memory(void* ptr);
+ADDAPI void ADDCALL sass_free_memory(void* ptr);
 
 // Some convenient string helper function
 ADDAPI char* ADDCALL sass_string_quote (const char* str, const char quote_mark);


### PR DESCRIPTION
There functions were missing __cdecl (required by FFI consumption).

cc @mgreter 