### PR TITLE
[DNM] Consolidate the Declaration and Propset AST nodes

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -481,18 +481,6 @@ namespace Sass {
     ATTACH_OPERATIONS()
   };
 
-  /////////////////////////////////////////////////////////
-  // Nested declaration sets (i.e., namespaced properties).
-  /////////////////////////////////////////////////////////
-  class Propset : public Has_Block {
-    ADD_PROPERTY(String*, property_fragment)
-  public:
-    Propset(ParserState pstate, String* pf, Block* b = 0)
-    : Has_Block(pstate, b), property_fragment_(pf)
-    { }
-    ATTACH_OPERATIONS()
-  };
-
   /////////////////
   // Bubble.
   /////////////////

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -580,15 +580,15 @@ namespace Sass {
   ////////////////////////////////////////////////////////////////////////
   // Declarations -- style rules consisting of a property name and values.
   ////////////////////////////////////////////////////////////////////////
-  class Declaration : public Statement {
+  class Declaration : public Has_Block {
     ADD_PROPERTY(String*, property)
     ADD_PROPERTY(Expression*, value)
     ADD_PROPERTY(bool, is_important)
     ADD_PROPERTY(bool, is_indented)
   public:
     Declaration(ParserState pstate,
-                String* prop, Expression* val, bool i = false)
-    : Statement(pstate), property_(prop), value_(val), is_important_(i), is_indented_(false)
+                String* prop, Expression* val, bool i = false, Block* b = 0)
+    : Has_Block(pstate, b), property_(prop), value_(val), is_important_(i), is_indented_(false)
     { statement_type(DECLARATION); }
     ATTACH_OPERATIONS()
   };

--- a/src/ast_factory.hpp
+++ b/src/ast_factory.hpp
@@ -19,7 +19,7 @@ namespace Sass {
     At_Root_Block* new_At_Root_Block(std::string p, size_t l, Selector* sel, Block* b);
     Directive* new_At_Rule(std::string p, size_t l, std::string kwd, Selector* sel, Block* b);
     Keyframe_Rule* new_Keyframe_Rule(std::string p, size_t l, Block* b);
-    Declaration* new_Declaration(std::string p, size_t l, String* prop, List* vals);
+    Declaration* new_Declaration(std::string p, size_t l, String* prop, List* vals, Block* b);
     Assignment* new_Assignment(std::string p, size_t l, std::string var, Expression* val, bool guarded = false);
     Import<Function_Call*>* new_CSS_Import(std::string p, size_t l, Function_Call* loc);
     Import<String*>* new_SASS_Import(std::string p, size_t l, String* loc);

--- a/src/ast_factory.hpp
+++ b/src/ast_factory.hpp
@@ -13,7 +13,6 @@ namespace Sass {
     // statements
     Block* new_Block(std::string p, size_t l, size_t s = 0, bool r = false);
     Ruleset* new_Ruleset(std::string p, size_t l, Selector* s, Block* b);
-    Propset* new_Propset(std::string p, size_t l, String* pf, Block* b);
     Supports_Query* new_Supports_Query(std::string p, size_t l, Supports_Query* f, Block* b);
     Media_Query* new_Media_Query(std::string p, size_t l, List* q, Block* b);
     At_Root_Block* new_At_Root_Block(std::string p, size_t l, Selector* sel, Block* b);

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -11,7 +11,6 @@ namespace Sass {
   class Statement;
   class Block;
   class Ruleset;
-  class Propset;
   class Bubble;
   class Trace;
   class Media_Block;

--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -42,7 +42,7 @@ namespace Sass {
     return static_cast<Statement*>(n);
   }
 
-  bool CheckNesting::is_valid_prop_parent(AST_Node* p) 
+  bool CheckNesting::is_valid_prop_parent(AST_Node* p)
   {
     if (Definition* def = dynamic_cast<Definition*>(p)) {
       return def->type() == Definition::MIXIN;
@@ -50,7 +50,7 @@ namespace Sass {
 
     return dynamic_cast<Ruleset*>(p) ||
            dynamic_cast<Keyframe_Rule*>(p) ||
-           dynamic_cast<Propset*>(p) ||
+           dynamic_cast<Declaration*>(p) ||
            dynamic_cast<Directive*>(p) ||
            dynamic_cast<Mixin_Call*>(p);
   }

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -29,7 +29,6 @@ namespace Sass {
 
     Statement* operator()(Block*);
     Statement* operator()(Ruleset*);
-    // Statement* operator()(Propset*);
     // Statement* operator()(Bubble*);
     Statement* operator()(Media_Block*);
     Statement* operator()(Supports_Block*);

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -13,11 +13,11 @@ namespace Sass {
 
   class Cssize : public Operation_CRTP<Statement*, Cssize> {
 
-    Context&                 ctx;
-    std::vector<Block*>      block_stack;
-    std::vector<Statement*>  p_stack;
+    Context&                    ctx;
+    std::vector<Block*>         block_stack;
+    std::vector<Statement*>     p_stack;
     std::vector<Selector_List*> s_stack;
-    Backtrace*               backtrace;
+    Backtrace*                  backtrace;
 
     Statement* fallback_impl(AST_Node* n);
 
@@ -37,7 +37,7 @@ namespace Sass {
     Statement* operator()(Directive*);
     Statement* operator()(Keyframe_Rule*);
     Statement* operator()(Trace*);
-    // Statement* operator()(Declaration*);
+    Statement* operator()(Declaration*);
     // Statement* operator()(Assignment*);
     // Statement* operator()(Import*);
     // Statement* operator()(Import_Stub*);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -151,13 +151,6 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
     for(auto i : selector->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Propset*>(node)) {
-    Propset* selector = dynamic_cast<Propset*>(node);
-    std::cerr << ind << "Propset " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << dynamic_cast<String_Constant*>(selector->property_fragment())->value() << ">";
-    std::cerr << " " << selector->tabs() << std::endl;
-    if (selector->block()) for(auto i : selector->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Wrapped_Selector*>(node)) {
     Wrapped_Selector* selector = dynamic_cast<Wrapped_Selector*>(node);
     std::cerr << ind << "Wrapped_Selector " << selector;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -155,6 +155,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Propset* selector = dynamic_cast<Propset*>(node);
     std::cerr << ind << "Propset " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << dynamic_cast<String_Constant*>(selector->property_fragment())->value() << ">";
     std::cerr << " " << selector->tabs() << std::endl;
     if (selector->block()) for(auto i : selector->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Wrapped_Selector*>(node)) {
@@ -389,6 +390,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->property(), ind + " prop: ", env);
     debug_ast(block->value(), ind + " value: ", env);
+    debug_ast(block->block(), ind + " ", env);
   } else if (dynamic_cast<Keyframe_Rule*>(node)) {
     Keyframe_Rule* has_block = dynamic_cast<Keyframe_Rule*>(node);
     std::cerr << ind << "Keyframe_Rule " << has_block;

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -153,53 +153,6 @@ namespace Sass {
     return rr;
   }
 
-  // this is not properly implemented
-  // mixes string_schema and statement
-  Statement* Expand::operator()(Propset* p)
-  {
-    String* fragment = dynamic_cast<String*>(p->property_fragment()->perform(&eval));
-    Propset* prop = SASS_MEMORY_NEW(ctx.mem, Propset,
-                                        p->pstate(),
-                                        fragment,
-                                        p->block()->perform(this)->block());
-    prop->tabs(p->tabs());
-    return prop;
-
-
-    property_stack.push_back(p->property_fragment());
-    Block* expanded_block = p->block()->perform(this)->block();
-    for (size_t i = 0, L = expanded_block->length(); i < L; ++i) {
-      Statement* stm = (*expanded_block)[i];
-      if (Declaration* dec = static_cast<Declaration*>(stm)) {
-        // dec = SASS_MEMORY_NEW(ctx.mem, Declaration, *dec);
-        String_Schema* combined_prop = SASS_MEMORY_NEW(ctx.mem, String_Schema, p->pstate());
-        if (!property_stack.empty()) {
-          *combined_prop << property_stack.back()->perform(&eval);
-          *combined_prop << SASS_MEMORY_NEW(ctx.mem, String_Quoted, p->pstate(), "-");
-          if (dec->property()) {
-            // we cannot directly add block (from dec->property()) to string schema (combined_prop)
-            *combined_prop << SASS_MEMORY_NEW(ctx.mem, String_Quoted, dec->pstate(), dec->property()->to_string());
-          }
-        }
-        else {
-          *combined_prop << dec->property();
-        }
-        dec->property(combined_prop);
-        *block_stack.back() << dec;
-      }
-      else if (typeid(*stm) == typeid(Comment)) {
-        // drop comments in propsets
-      }
-      else {
-        error("contents of namespaced properties must result in style declarations only", stm->pstate(), backtrace());
-      }
-    }
-
-    property_stack.pop_back();
-
-    return 0;
-  }
-
   Statement* Expand::operator()(Supports_Block* f)
   {
     Expression* condition = f->condition()->perform(&eval);

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -48,7 +48,6 @@ namespace Sass {
 
     Statement* operator()(Block*);
     Statement* operator()(Ruleset*);
-    Statement* operator()(Propset*);
     Statement* operator()(Media_Block*);
     Statement* operator()(Supports_Block*);
     Statement* operator()(At_Root_Block*);

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -51,13 +51,6 @@ namespace Sass {
     if (rule->block()) rule->block()->perform(this);
   }
 
-  void Inspect::operator()(Propset* propset)
-  {
-    propset->property_fragment()->perform(this);
-    append_colon_separator();
-    propset->block()->perform(this);
-  }
-
   void Inspect::operator()(Bubble* bubble)
   {
     append_indentation();

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -23,7 +23,6 @@ namespace Sass {
     // statements
     virtual void operator()(Block*);
     virtual void operator()(Ruleset*);
-    virtual void operator()(Propset*);
     virtual void operator()(Bubble*);
     virtual void operator()(Supports_Block*);
     virtual void operator()(Media_Block*);

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -13,7 +13,6 @@ namespace Sass {
     // statements
     virtual T operator()(Block* x)                  = 0;
     virtual T operator()(Ruleset* x)                = 0;
-    virtual T operator()(Propset* x)                = 0;
     virtual T operator()(Bubble* x)                 = 0;
     virtual T operator()(Trace* x)                  = 0;
     virtual T operator()(Supports_Block* x)         = 0;
@@ -95,7 +94,6 @@ namespace Sass {
     // statements
     T operator()(Block* x)                  { return static_cast<D*>(this)->fallback(x); }
     T operator()(Ruleset* x)                { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Propset* x)                { return static_cast<D*>(this)->fallback(x); }
     T operator()(Bubble* x)                 { return static_cast<D*>(this)->fallback(x); }
     T operator()(Trace* x)                  { return static_cast<D*>(this)->fallback(x); }
     T operator()(Supports_Block* x)         { return static_cast<D*>(this)->fallback(x); }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -118,7 +118,9 @@ namespace Sass {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement* stm = (*b)[i];
         if (dynamic_cast<Has_Block*>(stm)) {
-          stm->perform(this);
+          if (typeid(*stm) != typeid(Declaration)) {
+            stm->perform(this);
+          }
         }
       }
       return;

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -35,7 +35,6 @@ namespace Sass {
 
     virtual void operator()(Map*);
     virtual void operator()(Ruleset*);
-    // virtual void operator()(Propset*);
     virtual void operator()(Supports_Block*);
     virtual void operator()(Media_Block*);
     virtual void operator()(Directive*);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -284,7 +284,7 @@ namespace Sass {
         if (decl->is_indented()) ++ indentation;
         // parse a propset that rides on the declaration's property
         stack.push_back(Scope::Properties);
-        (*block) << SASS_MEMORY_NEW(ctx.mem, Propset, pstate, decl->property(), parse_block());
+        decl->block(parse_block());
         stack.pop_back();
         if (decl->is_indented()) -- indentation;
       }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -236,7 +236,6 @@ namespace Sass {
     Arguments* parse_arguments();
     Argument* parse_argument();
     Assignment* parse_assignment();
-    // Propset* parse_propset();
     Ruleset* parse_ruleset(Lookahead lookahead, bool is_root = false);
     Selector_Schema* parse_selector_schema(const char* end_of_selector);
     Selector_List* parse_selector_list(bool at_root = false);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -470,6 +470,8 @@ namespace Sass {
         Statement* stm = (*b)[i];
         if (dynamic_cast<Directive*>(stm)) {
           return true;
+        } else if (Declaration* d = dynamic_cast<Declaration*>(stm)) {
+          return isPrintable(d, style);
         } else if (dynamic_cast<Has_Block*>(stm)) {
           Block* pChildBlock = ((Has_Block*)stm)->block();
           if (isPrintable(pChildBlock, style)) {
@@ -484,8 +486,6 @@ namespace Sass {
           if (c->is_important()) {
             hasDeclarations = c->is_important();
           }
-        } else if (Declaration* d = dynamic_cast<Declaration*>(stm)) {
-          return isPrintable(d, style);
         } else {
           hasDeclarations = true;
         }


### PR DESCRIPTION
In order to fix #1585 we need to introduce the `Trace` node from
Ruby Sass. This node interacts with propsets in an interesting way.
Have two node to represent the single Ruby `Prop` node caused a
lot of trouble with correct implementing check nesting logic for
`Trace`.

The trouble with implementing `Trace` were exaggerated by us
incorrectly eval propsets into declarations in the expand step.
This PR moves the de-nesting of prop nodes the cssize step to
[better match Ruby Sass][1].

Later we should rename this node `Prop` but it's out of scope of
this PR. This should allow my work on porting the `Trace` node over
from Ruby Sass to fix #1585.

[1]: https://github.com/sass/sass/blob/63586f1e51c0aec47a7afcc8cd17aa03f32f0a29/lib/sass/tree/visitors/cssize.rb#L149-L166