### PR TITLE
[DNM] Implement the Trace node

### DIFF
--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -6,52 +6,374 @@
 namespace Sass {
 
   CheckNesting::CheckNesting()
-  : parent_stack(std::vector<AST_Node*>())
+  : parents(std::vector<Statement*>()),
+    parent(0),
+    current_mixin_definition(0)
   { }
 
-  AST_Node* CheckNesting::parent()
-  {
-    if (parent_stack.size() > 0)
-      return parent_stack.back();
-    return 0;
+  Statement* CheckNesting::before(Statement* s) {
+      if (this->should_visit(s)) return s;
+      return 0;
   }
 
-  Statement* CheckNesting::operator()(Block* b)
-  {
-    parent_stack.push_back(b);
+  Statement* CheckNesting::visit_children(Statement* parent) {
 
-    for (auto n : *b) {
-      n->perform(this);
+    Statement* old_parent = this->parent;
+
+    if (dynamic_cast<At_Root_Block*>(parent)) {
+      std::vector<Statement*> old_parents = this->parents;
+      std::vector<Statement*> new_parents;
+
+      for (size_t i = 0, L = this->parents.size(); i < L; i++) {
+        Statement* p = this->parents.at(i);
+        if (!dynamic_cast<At_Root_Block*>(parent)->exclude_node(p)) {
+          new_parents.push_back(p);
+        }
+      }
+      this->parents = new_parents;
+
+      for (size_t i = this->parents.size(); i > 0; i--) {
+        Statement* p = 0;
+        Statement* gp = 0;
+        if (i > 0) p = this->parents.at(i - 1);
+        if (i > 1) gp = this->parents.at(i - 2);
+
+        if (!this->is_transparent_parent(p, gp)) {
+          this->parent = p;
+          break;
+        }
+      }
+
+      At_Root_Block* ar = dynamic_cast<At_Root_Block*>(parent);
+      Statement* ret = this->visit_children(ar->block());
+
+      this->parent = old_parent;
+      this->parents = old_parents;
+
+      return ret;
     }
 
-    parent_stack.pop_back();
+
+    if (!this->is_transparent_parent(parent, old_parent)) {
+      this->parent = parent;
+    }
+
+    this->parents.push_back(parent);
+
+    Block* b = dynamic_cast<Block*>(parent);
+
+    if (!b) {
+      if (Has_Block* bb = dynamic_cast<Has_Block*>(parent)) {
+        b = bb->block();
+      }
+    }
+
+    if (b) {
+      for (auto n : *b) {
+        n->perform(this);
+      }
+    }
+
+    this->parent = old_parent;
+    this->parents.pop_back();
+
     return b;
   }
 
-  Statement* CheckNesting::operator()(Declaration* d)
+
+  Statement* CheckNesting::operator()(Block* b)
   {
-    if (!is_valid_prop_parent(parent())) {
-      throw Exception::InvalidSass(d->pstate(), "Properties are only allowed "
-        "within rules, directives, mixin includes, or other properties.");
-    }
-    return static_cast<Statement*>(d);
+    return this->visit_children(b);
   }
 
-  Statement* CheckNesting::fallback_impl(AST_Node* n)
+  Statement* CheckNesting::operator()(Definition* n)
   {
-    return static_cast<Statement*>(n);
+    if (!is_mixin(n)) return n;
+
+    Definition* old_mixin_definition = this->current_mixin_definition;
+    this->current_mixin_definition = n;
+
+    visit_children(n);
+
+    this->current_mixin_definition = old_mixin_definition;
+
+    return n;
   }
 
-  bool CheckNesting::is_valid_prop_parent(AST_Node* p) 
+  Statement* CheckNesting::fallback_impl(Statement* s)
   {
-    if (Definition* def = dynamic_cast<Definition*>(p)) {
-      return def->type() == Definition::MIXIN;
+    if (dynamic_cast<Block*>(s) || dynamic_cast<Has_Block*>(s)) {
+      return visit_children(s);
     }
+    return s;
+  }
 
-    return dynamic_cast<Ruleset*>(p) ||
-           dynamic_cast<Keyframe_Rule*>(p) ||
-           dynamic_cast<Propset*>(p) ||
-           dynamic_cast<Directive*>(p) ||
-           dynamic_cast<Mixin_Call*>(p);
+  bool CheckNesting::should_visit(Statement* node)
+  {
+    if (!this->parent) return true;
+
+    if (dynamic_cast<Content*>(node))
+    { this->invalid_content_parent(this->parent); }
+
+    if (is_charset(node))
+    { this->invalid_charset_parent(this->parent); }
+
+    if (dynamic_cast<Extension*>(node))
+    { this->invalid_extend_parent(this->parent); }
+
+    // if (dynamic_cast<Import*>(node))
+    // { this->invalid_import_parent(this->parent); }
+
+    if (this->is_mixin(node))
+    { this->invalid_mixin_definition_parent(this->parent); }
+
+    if (this->is_function(node))
+    { this->invalid_function_parent(this->parent); }
+
+    if (this->is_function(this->parent))
+    { this->invalid_function_child(node); }
+
+    if (dynamic_cast<Declaration*>(node))
+    { this->invalid_prop_parent(this->parent); }
+
+    if (
+      dynamic_cast<Declaration*>(this->parent)
+    ) { this->invalid_prop_child(node); }
+
+    if (dynamic_cast<Return*>(node))
+    { this->invalid_return_parent(this->parent); }
+
+    return true;
+  }
+
+  void CheckNesting::invalid_content_parent(Statement* parent)
+  {
+    if (!this->current_mixin_definition) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "@content may only be used within a mixin."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_charset_parent(Statement* parent)
+  {
+    if (!(
+        is_root_node(parent)
+    )) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "@charset may only be used at the root of a document."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_extend_parent(Statement* parent)
+  {
+    if (!(
+        dynamic_cast<Ruleset*>(parent) ||
+        dynamic_cast<Mixin_Call*>(parent) ||
+        is_mixin(parent)
+    )) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "Extend directives may only be used within rules."
+      );
+    }
+  }
+
+  // void CheckNesting::invalid_import_parent(Statement* parent)
+  // {
+  //   for (auto pp : this->parents) {
+  //     if (
+  //         dynamic_cast<Each*>(pp) ||
+  //         dynamic_cast<For*>(pp) ||
+  //         dynamic_cast<If*>(pp) ||
+  //         dynamic_cast<While*>(pp) ||
+  //         dynamic_cast<Trace*>(pp) ||
+  //         dynamic_cast<Mixin_Call*>(pp) ||
+  //         is_mixin(pp)
+  //     ) {
+  //       throw Exception::InvalidSass(
+  //         parent->pstate(),
+  //         "Import directives may not be defined within control directives or other mixins."
+  //       );
+  //     }
+  //   }
+
+  //   if (this->is_root_node(parent)) {
+  //     return;
+  //   }
+
+  //   if (false/*n.css_import?*/) {
+  //     throw Exception::InvalidSass(
+  //       parent->pstate(),
+  //       "CSS import directives may only be used at the root of a document."
+  //     );
+  //   }
+  // }
+
+  void CheckNesting::invalid_mixin_definition_parent(Statement* parent)
+  {
+    for (auto pp : this->parents) {
+      if (
+          dynamic_cast<Each*>(pp) ||
+          dynamic_cast<For*>(pp) ||
+          dynamic_cast<If*>(pp) ||
+          dynamic_cast<While*>(pp) ||
+          dynamic_cast<Trace*>(pp) ||
+          dynamic_cast<Mixin_Call*>(pp) ||
+          is_mixin(pp)
+      ) {
+        throw Exception::InvalidSass(
+          parent->pstate(),
+          "Mixins may not be defined within control directives or other mixins."
+        );
+      }
+    }
+  }
+
+  void CheckNesting::invalid_function_parent(Statement* parent)
+  {
+    for (auto pp : this->parents) {
+      if (
+          dynamic_cast<Each*>(pp) ||
+          dynamic_cast<For*>(pp) ||
+          dynamic_cast<If*>(pp) ||
+          dynamic_cast<While*>(pp) ||
+          dynamic_cast<Trace*>(pp) ||
+          dynamic_cast<Mixin_Call*>(pp) ||
+          is_mixin(pp)
+      ) {
+        throw Exception::InvalidSass(
+          parent->pstate(),
+          "Functions may not be defined within control directives or other mixins."
+        );
+      }
+    }
+  }
+
+  void CheckNesting::invalid_function_child(Statement* child)
+  {
+    if (!(
+        dynamic_cast<Each*>(child) ||
+        dynamic_cast<For*>(child) ||
+        dynamic_cast<If*>(child) ||
+        dynamic_cast<While*>(child) ||
+        dynamic_cast<Trace*>(child) ||
+        dynamic_cast<Comment*>(child) ||
+        dynamic_cast<Debug*>(child) ||
+        dynamic_cast<Return*>(child) ||
+        dynamic_cast<Variable*>(child) ||
+        dynamic_cast<Warning*>(child) ||
+        dynamic_cast<Error*>(child)
+    )) {
+      throw Exception::InvalidSass(
+        child->pstate(),
+        "Functions can only contain variable declarations and control directives."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_prop_child(Statement* child)
+  {
+    if (!(
+        dynamic_cast<Each*>(child) ||
+        dynamic_cast<For*>(child) ||
+        dynamic_cast<If*>(child) ||
+        dynamic_cast<While*>(child) ||
+        dynamic_cast<Trace*>(child) ||
+        dynamic_cast<Comment*>(child) ||
+        dynamic_cast<Propset*>(child) ||
+        dynamic_cast<Mixin_Call*>(child)
+    )) {
+      throw Exception::InvalidSass(
+        child->pstate(),
+        "Illegal nesting: Only properties may be nested beneath properties."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_prop_parent(Statement* parent)
+  {
+    if (!(
+        is_mixin(parent) ||
+        is_directive_node(parent) ||
+        dynamic_cast<Ruleset*>(parent) ||
+        dynamic_cast<Keyframe_Rule*>(parent) ||
+        dynamic_cast<Propset*>(parent) ||
+        dynamic_cast<Mixin_Call*>(parent)
+    )) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "Properties are only allowed within rules, directives, mixin includes, or other properties."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_return_parent(Statement* parent)
+  {
+    if (!this->is_function(parent)) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "@return may only be used within a function."
+      );
+    }
+  }
+
+  bool CheckNesting::is_transparent_parent(Statement* parent, Statement* grandparent)
+  {
+    bool parent_bubbles = parent && parent->bubbles();
+
+    bool valid_bubble_node = parent_bubbles &&
+                             !is_root_node(grandparent) &&
+                             !is_at_root_node(grandparent);
+
+    return dynamic_cast<Import*>(parent) ||
+           dynamic_cast<Each*>(parent) ||
+           dynamic_cast<For*>(parent) ||
+           dynamic_cast<If*>(parent) ||
+           dynamic_cast<While*>(parent) ||
+           dynamic_cast<Trace*>(parent) ||
+           valid_bubble_node;
+  }
+
+  bool CheckNesting::is_charset(Statement* n)
+  {
+    Directive* d = dynamic_cast<Directive*>(n);
+    return d && d->keyword() == "charset";
+  }
+
+  bool CheckNesting::is_mixin(Statement* n)
+  {
+    Definition* def = dynamic_cast<Definition*>(n);
+    return def && def->type() == Definition::MIXIN;
+  }
+
+  bool CheckNesting::is_function(Statement* n)
+  {
+    Definition* def = dynamic_cast<Definition*>(n);
+    return def && def->type() == Definition::FUNCTION;
+  }
+
+  bool CheckNesting::is_root_node(Statement* n)
+  {
+    if (dynamic_cast<Ruleset*>(n)) return false;
+
+    Block* b = dynamic_cast<Block*>(n);
+    return b && b->is_root();
+  }
+
+  bool CheckNesting::is_at_root_node(Statement* n)
+  {
+    return dynamic_cast<At_Root_Block*>(n);
+  }
+
+  bool CheckNesting::is_directive_node(Statement* n)
+  {
+    return dynamic_cast<Directive*>(n) ||
+           dynamic_cast<Import*>(n) ||
+           dynamic_cast<Media_Block*>(n) ||
+           dynamic_cast<Supports_Block*>(n);
   }
 }

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -10,23 +10,49 @@ namespace Sass {
 
   class CheckNesting : public Operation_CRTP<Statement*, CheckNesting> {
 
-    std::vector<AST_Node*>   parent_stack;
+    std::vector<Statement*>  parents;
+    Statement*               parent;
+    Definition*              current_mixin_definition;
 
-    AST_Node* parent();
-
-    Statement* fallback_impl(AST_Node* n);
+    Statement* fallback_impl(Statement*);
+    Statement* before(Statement*);
+    Statement* visit_children(Statement*);
 
   public:
     CheckNesting();
     ~CheckNesting() { }
 
     Statement* operator()(Block*);
-    Statement* operator()(Declaration*);
+    Statement* operator()(Definition*);
 
     template <typename U>
-    Statement* fallback(U x) { return fallback_impl(x); }
+    Statement* fallback(U x) {
+        return fallback_impl(this->before(dynamic_cast<Statement*>(x)));
+    }
 
-    bool is_valid_prop_parent(AST_Node*);
+  private:
+    void invalid_content_parent(Statement*);
+    void invalid_charset_parent(Statement*);
+    void invalid_extend_parent(Statement*);
+    // void invalid_import_parent(Statement*);
+    void invalid_mixin_definition_parent(Statement*);
+    void invalid_function_parent(Statement*);
+
+    void invalid_function_child(Statement*);
+    void invalid_prop_child(Statement*);
+    void invalid_prop_parent(Statement*);
+    void invalid_return_parent(Statement*);
+
+    bool is_transparent_parent(Statement*, Statement*);
+
+    bool should_visit(Statement*);
+
+    bool is_charset(Statement*);
+    bool is_mixin(Statement*);
+    bool is_function(Statement*);
+    bool is_root_node(Statement*);
+    bool is_at_root_node(Statement*);
+    bool is_directive_node(Statement*);
   };
 
 }

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -28,14 +28,15 @@ namespace Sass {
     Eval              eval;
 
     // it's easier to work with vectors
-    std::vector<Env*>      env_stack;
-    std::vector<Block*>    block_stack;
-    std::vector<AST_Node*> call_stack;
-    std::vector<String*>   property_stack;
+    std::vector<Env*>           env_stack;
+    std::vector<Block*>         block_stack;
+    std::vector<AST_Node*>      call_stack;
+    std::vector<String*>        property_stack;
     std::vector<Selector_List*> selector_stack;
-    std::vector<Media_Block*> media_block_stack;
-    std::vector<Backtrace*>backtrace_stack;
-    bool              in_keyframes;
+    std::vector<Media_Block*>   media_block_stack;
+    std::vector<Backtrace*>     backtrace_stack;
+    bool                        in_keyframes;
+    bool                        at_root_without_rule;
 
     Statement* fallback_impl(AST_Node* n);
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1851,16 +1851,6 @@ namespace Sass {
 
   Content* Parser::parse_content_directive()
   {
-    bool missing_mixin_parent = true;
-    for (auto parent : stack) {
-      if (parent == Scope::Mixin) {
-        missing_mixin_parent = false;
-        break;
-      }
-    }
-    if (missing_mixin_parent) {
-      error("@content may only be used within a mixin", pstate);
-    }
     return SASS_MEMORY_NEW(ctx.mem, Content, pstate);
   }
 


### PR DESCRIPTION
The Trace node is a simple wrapper around the result of a mixin call 
and `@content`. It exists as a way to group the resulting properties
as a block but maintain some metadata about the initiating mixin call 
or `@content` block.

It also plays an important rule is bubble those blocks with `@at-root` 
and nested property sets. This required implementing the final
 missing `cssize` methods. As a result we should a complete `@at-root` 
implementation.

`Trace` "wrapping" other nodes didn't play nice with the naive check
nesting implementation I lazily wrote so I also implemented 99% of the 
check nesting visitor like-for-like with Ruby Sass. The missing piece is 
handling `@imports` which is the only part I didn't need to touch in this 
work.

Spec sass/sass-spec#868
Fixes #1585 

## TODO
- [ ] blocked on #2085
- [x] enable specs (sass/sass-spec#868)