### PR TITLE
Add the Trace AST node

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -508,6 +508,18 @@ namespace Sass {
   };
 
   /////////////////
+  // Trace.
+  /////////////////
+  class Trace : public Has_Block {
+    ADD_PROPERTY(std::string, name)
+  public:
+    Trace(ParserState pstate, std::string n, Block* b = 0)
+    : Has_Block(pstate, b), name_(n)
+    { }
+    ATTACH_OPERATIONS()
+  };
+
+  /////////////////
   // Media queries.
   /////////////////
   class Media_Block : public Has_Block {

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -13,6 +13,7 @@ namespace Sass {
   class Ruleset;
   class Propset;
   class Bubble;
+  class Trace;
   class Media_Block;
   class Supports_Block;
   class Directive;

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -39,6 +39,11 @@ namespace Sass {
     return bb;
   }
 
+  Statement* Cssize::operator()(Trace* t)
+  {
+    return t->block()->perform(this);
+  }
+
   Statement* Cssize::operator()(Directive* r)
   {
     if (!r->block() || !r->block()->length()) return r;

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -36,6 +36,7 @@ namespace Sass {
     Statement* operator()(At_Root_Block*);
     Statement* operator()(Directive*);
     Statement* operator()(Keyframe_Rule*);
+    Statement* operator()(Trace*);
     // Statement* operator()(Declaration*);
     // Statement* operator()(Assignment*);
     // Statement* operator()(Import*);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -65,6 +65,13 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << bubble->tabs();
     std::cerr << std::endl;
+  } else if (dynamic_cast<Trace*>(node)) {
+    Trace* trace = dynamic_cast<Trace*>(node);
+    std::cerr << ind << "Trace " << trace;
+    std::cerr << " (" << pstate_source_position(node) << ")"
+    << " [name:" << trace->name() << "]"
+    << std::endl;
+    debug_ast(trace->block(), ind + " ", env);
   } else if (dynamic_cast<At_Root_Block*>(node)) {
     At_Root_Block* root_block = dynamic_cast<At_Root_Block*>(node);
     std::cerr << ind << "At_Root_Block " << root_block;
@@ -426,14 +433,14 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " [native: " << block->native_function() << "] ";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->parameters(), ind + " params: ", env);
-    if (block->block()) for(auto i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
+    if (block->block()) debug_ast(block->block(), ind + " ", env);
   } else if (dynamic_cast<Mixin_Call*>(node)) {
     Mixin_Call* block = dynamic_cast<Mixin_Call*>(node);
     std::cerr << ind << "Mixin_Call " << block << " " << block->tabs();
     std::cerr << " [" <<  block->name() << "]";
     std::cerr << " [has_content: " << block->has_content() << "] " << std::endl;
     debug_ast(block->arguments(), ind + " args: ");
-    if (block->block()) for(auto i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
+    if (block->block()) debug_ast(block->block(), ind + " ", env);
   } else if (Ruleset* ruleset = dynamic_cast<Ruleset*>(node)) {
     std::cerr << ind << "Ruleset " << ruleset;
     std::cerr << " (" << pstate_source_position(node) << ")";

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -15,10 +15,11 @@ namespace Sass {
     virtual T operator()(Ruleset* x)                = 0;
     virtual T operator()(Propset* x)                = 0;
     virtual T operator()(Bubble* x)                 = 0;
+    virtual T operator()(Trace* x)                  = 0;
     virtual T operator()(Supports_Block* x)         = 0;
     virtual T operator()(Media_Block* x)            = 0;
     virtual T operator()(At_Root_Block* x)          = 0;
-    virtual T operator()(Directive* x)                = 0;
+    virtual T operator()(Directive* x)              = 0;
     virtual T operator()(Keyframe_Rule* x)          = 0;
     virtual T operator()(Declaration* x)            = 0;
     virtual T operator()(Assignment* x)             = 0;
@@ -61,7 +62,7 @@ namespace Sass {
     virtual T operator()(Supports_Interpolation* x) = 0;
     virtual T operator()(Media_Query* x)            = 0;
     virtual T operator()(Media_Query_Expression* x) = 0;
-    virtual T operator()(At_Root_Query* x)     = 0;
+    virtual T operator()(At_Root_Query* x)          = 0;
     virtual T operator()(Null* x)                   = 0;
     virtual T operator()(Parent_Selector* x)        = 0;
     // parameters and arguments
@@ -96,10 +97,11 @@ namespace Sass {
     T operator()(Ruleset* x)                { return static_cast<D*>(this)->fallback(x); }
     T operator()(Propset* x)                { return static_cast<D*>(this)->fallback(x); }
     T operator()(Bubble* x)                 { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Trace* x)                  { return static_cast<D*>(this)->fallback(x); }
     T operator()(Supports_Block* x)         { return static_cast<D*>(this)->fallback(x); }
     T operator()(Media_Block* x)            { return static_cast<D*>(this)->fallback(x); }
     T operator()(At_Root_Block* x)          { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Directive* x)                { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Directive* x)              { return static_cast<D*>(this)->fallback(x); }
     T operator()(Keyframe_Rule* x)          { return static_cast<D*>(this)->fallback(x); }
     T operator()(Declaration* x)            { return static_cast<D*>(this)->fallback(x); }
     T operator()(Assignment* x)             { return static_cast<D*>(this)->fallback(x); }
@@ -142,7 +144,7 @@ namespace Sass {
     T operator()(Supports_Interpolation* x) { return static_cast<D*>(this)->fallback(x); }
     T operator()(Media_Query* x)            { return static_cast<D*>(this)->fallback(x); }
     T operator()(Media_Query_Expression* x) { return static_cast<D*>(this)->fallback(x); }
-    T operator()(At_Root_Query* x)     { return static_cast<D*>(this)->fallback(x); }
+    T operator()(At_Root_Query* x)          { return static_cast<D*>(this)->fallback(x); }
     T operator()(Null* x)                   { return static_cast<D*>(this)->fallback(x); }
     T operator()(Parent_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
     // parameters and arguments
@@ -163,7 +165,7 @@ namespace Sass {
     T operator()(Selector_List* x)          { return static_cast<D*>(this)->fallback(x); }
 
     template <typename U>
-    T fallback(U x)                                 { return T(); }
+    T fallback(U x)                         { return T(); }
   };
 
 }


### PR DESCRIPTION
Extracted from #2086. This PR adds the `Trace` AST node but doesn't
implement any of it's usage. This change is a noop. It's intended
simply to reduce the noise in #2086.

The Trace node is a simple wrapper around the result of a mixin call
and `@content`. It exists as a way to group the resulting properties
as a block but maintain some metadata about the initiating mixin call
or `@content` block.