### PR TITLE
Implement the Trace AST node

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -481,18 +481,6 @@ namespace Sass {
     ATTACH_OPERATIONS()
   };
 
-  /////////////////////////////////////////////////////////
-  // Nested declaration sets (i.e., namespaced properties).
-  /////////////////////////////////////////////////////////
-  class Propset : public Has_Block {
-    ADD_PROPERTY(String*, property_fragment)
-  public:
-    Propset(ParserState pstate, String* pf, Block* b = 0)
-    : Has_Block(pstate, b), property_fragment_(pf)
-    { }
-    ATTACH_OPERATIONS()
-  };
-
   /////////////////
   // Bubble.
   /////////////////

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -580,15 +580,15 @@ namespace Sass {
   ////////////////////////////////////////////////////////////////////////
   // Declarations -- style rules consisting of a property name and values.
   ////////////////////////////////////////////////////////////////////////
-  class Declaration : public Statement {
+  class Declaration : public Has_Block {
     ADD_PROPERTY(String*, property)
     ADD_PROPERTY(Expression*, value)
     ADD_PROPERTY(bool, is_important)
     ADD_PROPERTY(bool, is_indented)
   public:
     Declaration(ParserState pstate,
-                String* prop, Expression* val, bool i = false)
-    : Statement(pstate), property_(prop), value_(val), is_important_(i), is_indented_(false)
+                String* prop, Expression* val, bool i = false, Block* b = 0)
+    : Has_Block(pstate, b), property_(prop), value_(val), is_important_(i), is_indented_(false)
     { statement_type(DECLARATION); }
     ATTACH_OPERATIONS()
   };

--- a/src/ast_factory.hpp
+++ b/src/ast_factory.hpp
@@ -19,7 +19,7 @@ namespace Sass {
     At_Root_Block* new_At_Root_Block(std::string p, size_t l, Selector* sel, Block* b);
     Directive* new_At_Rule(std::string p, size_t l, std::string kwd, Selector* sel, Block* b);
     Keyframe_Rule* new_Keyframe_Rule(std::string p, size_t l, Block* b);
-    Declaration* new_Declaration(std::string p, size_t l, String* prop, List* vals);
+    Declaration* new_Declaration(std::string p, size_t l, String* prop, List* vals, Block* b);
     Assignment* new_Assignment(std::string p, size_t l, std::string var, Expression* val, bool guarded = false);
     Import<Function_Call*>* new_CSS_Import(std::string p, size_t l, Function_Call* loc);
     Import<String*>* new_SASS_Import(std::string p, size_t l, String* loc);

--- a/src/ast_factory.hpp
+++ b/src/ast_factory.hpp
@@ -13,7 +13,6 @@ namespace Sass {
     // statements
     Block* new_Block(std::string p, size_t l, size_t s = 0, bool r = false);
     Ruleset* new_Ruleset(std::string p, size_t l, Selector* s, Block* b);
-    Propset* new_Propset(std::string p, size_t l, String* pf, Block* b);
     Supports_Query* new_Supports_Query(std::string p, size_t l, Supports_Query* f, Block* b);
     Media_Query* new_Media_Query(std::string p, size_t l, List* q, Block* b);
     At_Root_Block* new_At_Root_Block(std::string p, size_t l, Selector* sel, Block* b);

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -11,7 +11,6 @@ namespace Sass {
   class Statement;
   class Block;
   class Ruleset;
-  class Propset;
   class Bubble;
   class Trace;
   class Media_Block;

--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -42,7 +42,7 @@ namespace Sass {
     return static_cast<Statement*>(n);
   }
 
-  bool CheckNesting::is_valid_prop_parent(AST_Node* p) 
+  bool CheckNesting::is_valid_prop_parent(AST_Node* p)
   {
     if (Definition* def = dynamic_cast<Definition*>(p)) {
       return def->type() == Definition::MIXIN;
@@ -50,7 +50,7 @@ namespace Sass {
 
     return dynamic_cast<Ruleset*>(p) ||
            dynamic_cast<Keyframe_Rule*>(p) ||
-           dynamic_cast<Propset*>(p) ||
+           dynamic_cast<Declaration*>(p) ||
            dynamic_cast<Directive*>(p) ||
            dynamic_cast<Mixin_Call*>(p);
   }

--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -6,52 +6,374 @@
 namespace Sass {
 
   CheckNesting::CheckNesting()
-  : parent_stack(std::vector<AST_Node*>())
+  : parents(std::vector<Statement*>()),
+    parent(0),
+    current_mixin_definition(0)
   { }
 
-  AST_Node* CheckNesting::parent()
-  {
-    if (parent_stack.size() > 0)
-      return parent_stack.back();
-    return 0;
+  Statement* CheckNesting::before(Statement* s) {
+      if (this->should_visit(s)) return s;
+      return 0;
   }
 
-  Statement* CheckNesting::operator()(Block* b)
-  {
-    parent_stack.push_back(b);
+  Statement* CheckNesting::visit_children(Statement* parent) {
 
-    for (auto n : *b) {
-      n->perform(this);
+    Statement* old_parent = this->parent;
+
+    if (dynamic_cast<At_Root_Block*>(parent)) {
+      std::vector<Statement*> old_parents = this->parents;
+      std::vector<Statement*> new_parents;
+
+      for (size_t i = 0, L = this->parents.size(); i < L; i++) {
+        Statement* p = this->parents.at(i);
+        if (!dynamic_cast<At_Root_Block*>(parent)->exclude_node(p)) {
+          new_parents.push_back(p);
+        }
+      }
+      this->parents = new_parents;
+
+      for (size_t i = this->parents.size(); i > 0; i--) {
+        Statement* p = 0;
+        Statement* gp = 0;
+        if (i > 0) p = this->parents.at(i - 1);
+        if (i > 1) gp = this->parents.at(i - 2);
+
+        if (!this->is_transparent_parent(p, gp)) {
+          this->parent = p;
+          break;
+        }
+      }
+
+      At_Root_Block* ar = dynamic_cast<At_Root_Block*>(parent);
+      Statement* ret = this->visit_children(ar->block());
+
+      this->parent = old_parent;
+      this->parents = old_parents;
+
+      return ret;
     }
 
-    parent_stack.pop_back();
+
+    if (!this->is_transparent_parent(parent, old_parent)) {
+      this->parent = parent;
+    }
+
+    this->parents.push_back(parent);
+
+    Block* b = dynamic_cast<Block*>(parent);
+
+    if (!b) {
+      if (Has_Block* bb = dynamic_cast<Has_Block*>(parent)) {
+        b = bb->block();
+      }
+    }
+
+    if (b) {
+      for (auto n : *b) {
+        n->perform(this);
+      }
+    }
+
+    this->parent = old_parent;
+    this->parents.pop_back();
+
     return b;
   }
 
-  Statement* CheckNesting::operator()(Declaration* d)
+
+  Statement* CheckNesting::operator()(Block* b)
   {
-    if (!is_valid_prop_parent(parent())) {
-      throw Exception::InvalidSass(d->pstate(), "Properties are only allowed "
-        "within rules, directives, mixin includes, or other properties.");
-    }
-    return static_cast<Statement*>(d);
+    return this->visit_children(b);
   }
 
-  Statement* CheckNesting::fallback_impl(AST_Node* n)
+  Statement* CheckNesting::operator()(Definition* n)
   {
-    return static_cast<Statement*>(n);
+    if (!is_mixin(n)) return n;
+
+    Definition* old_mixin_definition = this->current_mixin_definition;
+    this->current_mixin_definition = n;
+
+    visit_children(n);
+
+    this->current_mixin_definition = old_mixin_definition;
+
+    return n;
   }
 
-  bool CheckNesting::is_valid_prop_parent(AST_Node* p)
+  Statement* CheckNesting::fallback_impl(Statement* s)
   {
-    if (Definition* def = dynamic_cast<Definition*>(p)) {
-      return def->type() == Definition::MIXIN;
+    if (dynamic_cast<Block*>(s) || dynamic_cast<Has_Block*>(s)) {
+      return visit_children(s);
     }
+    return s;
+  }
 
-    return dynamic_cast<Ruleset*>(p) ||
-           dynamic_cast<Keyframe_Rule*>(p) ||
-           dynamic_cast<Declaration*>(p) ||
-           dynamic_cast<Directive*>(p) ||
-           dynamic_cast<Mixin_Call*>(p);
+  bool CheckNesting::should_visit(Statement* node)
+  {
+    if (!this->parent) return true;
+
+    if (dynamic_cast<Content*>(node))
+    { this->invalid_content_parent(this->parent); }
+
+    if (is_charset(node))
+    { this->invalid_charset_parent(this->parent); }
+
+    if (dynamic_cast<Extension*>(node))
+    { this->invalid_extend_parent(this->parent); }
+
+    // if (dynamic_cast<Import*>(node))
+    // { this->invalid_import_parent(this->parent); }
+
+    if (this->is_mixin(node))
+    { this->invalid_mixin_definition_parent(this->parent); }
+
+    if (this->is_function(node))
+    { this->invalid_function_parent(this->parent); }
+
+    if (this->is_function(this->parent))
+    { this->invalid_function_child(node); }
+
+    if (dynamic_cast<Declaration*>(node))
+    { this->invalid_prop_parent(this->parent); }
+
+    if (
+      dynamic_cast<Declaration*>(this->parent)
+    ) { this->invalid_prop_child(node); }
+
+    if (dynamic_cast<Return*>(node))
+    { this->invalid_return_parent(this->parent); }
+
+    return true;
+  }
+
+  void CheckNesting::invalid_content_parent(Statement* parent)
+  {
+    if (!this->current_mixin_definition) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "@content may only be used within a mixin."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_charset_parent(Statement* parent)
+  {
+    if (!(
+        is_root_node(parent)
+    )) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "@charset may only be used at the root of a document."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_extend_parent(Statement* parent)
+  {
+    if (!(
+        dynamic_cast<Ruleset*>(parent) ||
+        dynamic_cast<Mixin_Call*>(parent) ||
+        is_mixin(parent)
+    )) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "Extend directives may only be used within rules."
+      );
+    }
+  }
+
+  // void CheckNesting::invalid_import_parent(Statement* parent)
+  // {
+  //   for (auto pp : this->parents) {
+  //     if (
+  //         dynamic_cast<Each*>(pp) ||
+  //         dynamic_cast<For*>(pp) ||
+  //         dynamic_cast<If*>(pp) ||
+  //         dynamic_cast<While*>(pp) ||
+  //         dynamic_cast<Trace*>(pp) ||
+  //         dynamic_cast<Mixin_Call*>(pp) ||
+  //         is_mixin(pp)
+  //     ) {
+  //       throw Exception::InvalidSass(
+  //         parent->pstate(),
+  //         "Import directives may not be defined within control directives or other mixins."
+  //       );
+  //     }
+  //   }
+
+  //   if (this->is_root_node(parent)) {
+  //     return;
+  //   }
+
+  //   if (false/*n.css_import?*/) {
+  //     throw Exception::InvalidSass(
+  //       parent->pstate(),
+  //       "CSS import directives may only be used at the root of a document."
+  //     );
+  //   }
+  // }
+
+  void CheckNesting::invalid_mixin_definition_parent(Statement* parent)
+  {
+    for (auto pp : this->parents) {
+      if (
+          dynamic_cast<Each*>(pp) ||
+          dynamic_cast<For*>(pp) ||
+          dynamic_cast<If*>(pp) ||
+          dynamic_cast<While*>(pp) ||
+          dynamic_cast<Trace*>(pp) ||
+          dynamic_cast<Mixin_Call*>(pp) ||
+          is_mixin(pp)
+      ) {
+        throw Exception::InvalidSass(
+          parent->pstate(),
+          "Mixins may not be defined within control directives or other mixins."
+        );
+      }
+    }
+  }
+
+  void CheckNesting::invalid_function_parent(Statement* parent)
+  {
+    for (auto pp : this->parents) {
+      if (
+          dynamic_cast<Each*>(pp) ||
+          dynamic_cast<For*>(pp) ||
+          dynamic_cast<If*>(pp) ||
+          dynamic_cast<While*>(pp) ||
+          dynamic_cast<Trace*>(pp) ||
+          dynamic_cast<Mixin_Call*>(pp) ||
+          is_mixin(pp)
+      ) {
+        throw Exception::InvalidSass(
+          parent->pstate(),
+          "Functions may not be defined within control directives or other mixins."
+        );
+      }
+    }
+  }
+
+  void CheckNesting::invalid_function_child(Statement* child)
+  {
+    if (!(
+        dynamic_cast<Each*>(child) ||
+        dynamic_cast<For*>(child) ||
+        dynamic_cast<If*>(child) ||
+        dynamic_cast<While*>(child) ||
+        dynamic_cast<Trace*>(child) ||
+        dynamic_cast<Comment*>(child) ||
+        dynamic_cast<Debug*>(child) ||
+        dynamic_cast<Return*>(child) ||
+        dynamic_cast<Variable*>(child) ||
+        dynamic_cast<Warning*>(child) ||
+        dynamic_cast<Error*>(child)
+    )) {
+      throw Exception::InvalidSass(
+        child->pstate(),
+        "Functions can only contain variable declarations and control directives."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_prop_child(Statement* child)
+  {
+    if (!(
+        dynamic_cast<Each*>(child) ||
+        dynamic_cast<For*>(child) ||
+        dynamic_cast<If*>(child) ||
+        dynamic_cast<While*>(child) ||
+        dynamic_cast<Trace*>(child) ||
+        dynamic_cast<Comment*>(child) ||
+        dynamic_cast<Declaration*>(child) ||
+        dynamic_cast<Mixin_Call*>(child)
+    )) {
+      throw Exception::InvalidSass(
+        child->pstate(),
+        "Illegal nesting: Only properties may be nested beneath properties."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_prop_parent(Statement* parent)
+  {
+    if (!(
+        is_mixin(parent) ||
+        is_directive_node(parent) ||
+        dynamic_cast<Ruleset*>(parent) ||
+        dynamic_cast<Keyframe_Rule*>(parent) ||
+        dynamic_cast<Declaration*>(parent) ||
+        dynamic_cast<Mixin_Call*>(parent)
+    )) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "Properties are only allowed within rules, directives, mixin includes, or other properties."
+      );
+    }
+  }
+
+  void CheckNesting::invalid_return_parent(Statement* parent)
+  {
+    if (!this->is_function(parent)) {
+      throw Exception::InvalidSass(
+        parent->pstate(),
+        "@return may only be used within a function."
+      );
+    }
+  }
+
+  bool CheckNesting::is_transparent_parent(Statement* parent, Statement* grandparent)
+  {
+    bool parent_bubbles = parent && parent->bubbles();
+
+    bool valid_bubble_node = parent_bubbles &&
+                             !is_root_node(grandparent) &&
+                             !is_at_root_node(grandparent);
+
+    return dynamic_cast<Import*>(parent) ||
+           dynamic_cast<Each*>(parent) ||
+           dynamic_cast<For*>(parent) ||
+           dynamic_cast<If*>(parent) ||
+           dynamic_cast<While*>(parent) ||
+           dynamic_cast<Trace*>(parent) ||
+           valid_bubble_node;
+  }
+
+  bool CheckNesting::is_charset(Statement* n)
+  {
+    Directive* d = dynamic_cast<Directive*>(n);
+    return d && d->keyword() == "charset";
+  }
+
+  bool CheckNesting::is_mixin(Statement* n)
+  {
+    Definition* def = dynamic_cast<Definition*>(n);
+    return def && def->type() == Definition::MIXIN;
+  }
+
+  bool CheckNesting::is_function(Statement* n)
+  {
+    Definition* def = dynamic_cast<Definition*>(n);
+    return def && def->type() == Definition::FUNCTION;
+  }
+
+  bool CheckNesting::is_root_node(Statement* n)
+  {
+    if (dynamic_cast<Ruleset*>(n)) return false;
+
+    Block* b = dynamic_cast<Block*>(n);
+    return b && b->is_root();
+  }
+
+  bool CheckNesting::is_at_root_node(Statement* n)
+  {
+    return dynamic_cast<At_Root_Block*>(n);
+  }
+
+  bool CheckNesting::is_directive_node(Statement* n)
+  {
+    return dynamic_cast<Directive*>(n) ||
+           dynamic_cast<Import*>(n) ||
+           dynamic_cast<Media_Block*>(n) ||
+           dynamic_cast<Supports_Block*>(n);
   }
 }

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -10,23 +10,49 @@ namespace Sass {
 
   class CheckNesting : public Operation_CRTP<Statement*, CheckNesting> {
 
-    std::vector<AST_Node*>   parent_stack;
+    std::vector<Statement*>  parents;
+    Statement*               parent;
+    Definition*              current_mixin_definition;
 
-    AST_Node* parent();
-
-    Statement* fallback_impl(AST_Node* n);
+    Statement* fallback_impl(Statement*);
+    Statement* before(Statement*);
+    Statement* visit_children(Statement*);
 
   public:
     CheckNesting();
     ~CheckNesting() { }
 
     Statement* operator()(Block*);
-    Statement* operator()(Declaration*);
+    Statement* operator()(Definition*);
 
     template <typename U>
-    Statement* fallback(U x) { return fallback_impl(x); }
+    Statement* fallback(U x) {
+        return fallback_impl(this->before(dynamic_cast<Statement*>(x)));
+    }
 
-    bool is_valid_prop_parent(AST_Node*);
+  private:
+    void invalid_content_parent(Statement*);
+    void invalid_charset_parent(Statement*);
+    void invalid_extend_parent(Statement*);
+    // void invalid_import_parent(Statement*);
+    void invalid_mixin_definition_parent(Statement*);
+    void invalid_function_parent(Statement*);
+
+    void invalid_function_child(Statement*);
+    void invalid_prop_child(Statement*);
+    void invalid_prop_parent(Statement*);
+    void invalid_return_parent(Statement*);
+
+    bool is_transparent_parent(Statement*, Statement*);
+
+    bool should_visit(Statement*);
+
+    bool is_charset(Statement*);
+    bool is_mixin(Statement*);
+    bool is_function(Statement*);
+    bool is_root_node(Statement*);
+    bool is_at_root_node(Statement*);
+    bool is_directive_node(Statement*);
   };
 
 }

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -29,7 +29,6 @@ namespace Sass {
 
     Statement* operator()(Block*);
     Statement* operator()(Ruleset*);
-    // Statement* operator()(Propset*);
     // Statement* operator()(Bubble*);
     Statement* operator()(Media_Block*);
     Statement* operator()(Supports_Block*);

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -13,11 +13,11 @@ namespace Sass {
 
   class Cssize : public Operation_CRTP<Statement*, Cssize> {
 
-    Context&                 ctx;
-    std::vector<Block*>      block_stack;
-    std::vector<Statement*>  p_stack;
+    Context&                    ctx;
+    std::vector<Block*>         block_stack;
+    std::vector<Statement*>     p_stack;
     std::vector<Selector_List*> s_stack;
-    Backtrace*               backtrace;
+    Backtrace*                  backtrace;
 
     Statement* fallback_impl(AST_Node* n);
 
@@ -37,7 +37,7 @@ namespace Sass {
     Statement* operator()(Directive*);
     Statement* operator()(Keyframe_Rule*);
     Statement* operator()(Trace*);
-    // Statement* operator()(Declaration*);
+    Statement* operator()(Declaration*);
     // Statement* operator()(Assignment*);
     // Statement* operator()(Import*);
     // Statement* operator()(Import_Stub*);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -151,13 +151,6 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
     for(auto i : selector->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Propset*>(node)) {
-    Propset* selector = dynamic_cast<Propset*>(node);
-    std::cerr << ind << "Propset " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << dynamic_cast<String_Constant*>(selector->property_fragment())->value() << ">";
-    std::cerr << " " << selector->tabs() << std::endl;
-    if (selector->block()) for(auto i : selector->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Wrapped_Selector*>(node)) {
     Wrapped_Selector* selector = dynamic_cast<Wrapped_Selector*>(node);
     std::cerr << ind << "Wrapped_Selector " << selector;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -155,6 +155,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Propset* selector = dynamic_cast<Propset*>(node);
     std::cerr << ind << "Propset " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << dynamic_cast<String_Constant*>(selector->property_fragment())->value() << ">";
     std::cerr << " " << selector->tabs() << std::endl;
     if (selector->block()) for(auto i : selector->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Wrapped_Selector*>(node)) {
@@ -389,6 +390,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->property(), ind + " prop: ", env);
     debug_ast(block->value(), ind + " value: ", env);
+    debug_ast(block->block(), ind + " ", env);
   } else if (dynamic_cast<Keyframe_Rule*>(node)) {
     Keyframe_Rule* has_block = dynamic_cast<Keyframe_Rule*>(node);
     std::cerr << ind << "Keyframe_Rule " << has_block;

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -87,9 +87,6 @@ namespace Sass {
 
   Statement* Expand::operator()(Ruleset* r)
   {
-    bool old_at_root_without_rule = this->at_root_without_rule;
-    // reset when leaving scope
-
     if (in_keyframes) {
       Keyframe_Rule* k = SASS_MEMORY_NEW(ctx.mem, Keyframe_Rule, r->pstate(), r->block()->perform(this)->block());
       if (r->selector()) {
@@ -100,7 +97,8 @@ namespace Sass {
       return k;
     }
 
-    this->at_root_without_rule = false;
+    // reset when leaving scope
+    LOCAL_FLAG(at_root_without_rule, false);
 
     // do some special checks for the base level rules
     if (r->is_root()) {
@@ -153,8 +151,6 @@ namespace Sass {
     }
     rr->is_root(r->is_root());
     rr->tabs(r->tabs());
-
-    this->at_root_without_rule = old_at_root_without_rule;
 
     return rr;
   }

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -192,21 +192,14 @@ namespace Sass {
     if (ae) ae = ae->perform(&eval);
     else ae = SASS_MEMORY_NEW(ctx.mem, At_Root_Query, a->pstate());
 
-    bool old_at_root_without_rule = this->at_root_without_rule;
-    bool old_in_keyframes = this->in_keyframes;
-
-    this->at_root_without_rule = true;
-    this->in_keyframes = false;
+    LOCAL_FLAG(at_root_without_rule, true);
+    LOCAL_FLAG(in_keyframes, false);
 
     Block* bb = ab ? ab->perform(this)->block() : 0;
     At_Root_Block* aa = SASS_MEMORY_NEW(ctx.mem, At_Root_Block,
                                         a->pstate(),
                                         bb,
                                         static_cast<At_Root_Query*>(ae));
-
-    this->at_root_without_rule = old_at_root_without_rule;
-    this->in_keyframes = old_in_keyframes;
-
     return aa;
   }
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -153,53 +153,6 @@ namespace Sass {
     return rr;
   }
 
-  // this is not properly implemented
-  // mixes string_schema and statement
-  Statement* Expand::operator()(Propset* p)
-  {
-    String* fragment = dynamic_cast<String*>(p->property_fragment()->perform(&eval));
-    Propset* prop = SASS_MEMORY_NEW(ctx.mem, Propset,
-                                        p->pstate(),
-                                        fragment,
-                                        p->block()->perform(this)->block());
-    prop->tabs(p->tabs());
-    return prop;
-
-
-    property_stack.push_back(p->property_fragment());
-    Block* expanded_block = p->block()->perform(this)->block();
-    for (size_t i = 0, L = expanded_block->length(); i < L; ++i) {
-      Statement* stm = (*expanded_block)[i];
-      if (Declaration* dec = static_cast<Declaration*>(stm)) {
-        // dec = SASS_MEMORY_NEW(ctx.mem, Declaration, *dec);
-        String_Schema* combined_prop = SASS_MEMORY_NEW(ctx.mem, String_Schema, p->pstate());
-        if (!property_stack.empty()) {
-          *combined_prop << property_stack.back()->perform(&eval);
-          *combined_prop << SASS_MEMORY_NEW(ctx.mem, String_Quoted, p->pstate(), "-");
-          if (dec->property()) {
-            // we cannot directly add block (from dec->property()) to string schema (combined_prop)
-            *combined_prop << SASS_MEMORY_NEW(ctx.mem, String_Quoted, dec->pstate(), dec->property()->to_string());
-          }
-        }
-        else {
-          *combined_prop << dec->property();
-        }
-        dec->property(combined_prop);
-        *block_stack.back() << dec;
-      }
-      else if (typeid(*stm) == typeid(Comment)) {
-        // drop comments in propsets
-      }
-      else {
-        error("contents of namespaced properties must result in style declarations only", stm->pstate(), backtrace());
-      }
-    }
-
-    property_stack.pop_back();
-
-    return 0;
-  }
-
   Statement* Expand::operator()(Supports_Block* f)
   {
     Expression* condition = f->condition()->perform(&eval);

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -28,14 +28,15 @@ namespace Sass {
     Eval              eval;
 
     // it's easier to work with vectors
-    std::vector<Env*>      env_stack;
-    std::vector<Block*>    block_stack;
-    std::vector<AST_Node*> call_stack;
-    std::vector<String*>   property_stack;
+    std::vector<Env*>           env_stack;
+    std::vector<Block*>         block_stack;
+    std::vector<AST_Node*>      call_stack;
+    std::vector<String*>        property_stack;
     std::vector<Selector_List*> selector_stack;
-    std::vector<Media_Block*> media_block_stack;
-    std::vector<Backtrace*>backtrace_stack;
-    bool              in_keyframes;
+    std::vector<Media_Block*>   media_block_stack;
+    std::vector<Backtrace*>     backtrace_stack;
+    bool                        in_keyframes;
+    bool                        at_root_without_rule;
 
     Statement* fallback_impl(AST_Node* n);
 

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -48,7 +48,6 @@ namespace Sass {
 
     Statement* operator()(Block*);
     Statement* operator()(Ruleset*);
-    Statement* operator()(Propset*);
     Statement* operator()(Media_Block*);
     Statement* operator()(Supports_Block*);
     Statement* operator()(At_Root_Block*);

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -51,13 +51,6 @@ namespace Sass {
     if (rule->block()) rule->block()->perform(this);
   }
 
-  void Inspect::operator()(Propset* propset)
-  {
-    propset->property_fragment()->perform(this);
-    append_colon_separator();
-    propset->block()->perform(this);
-  }
-
   void Inspect::operator()(Bubble* bubble)
   {
     append_indentation();

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -23,7 +23,6 @@ namespace Sass {
     // statements
     virtual void operator()(Block*);
     virtual void operator()(Ruleset*);
-    virtual void operator()(Propset*);
     virtual void operator()(Bubble*);
     virtual void operator()(Supports_Block*);
     virtual void operator()(Media_Block*);

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -13,7 +13,6 @@ namespace Sass {
     // statements
     virtual T operator()(Block* x)                  = 0;
     virtual T operator()(Ruleset* x)                = 0;
-    virtual T operator()(Propset* x)                = 0;
     virtual T operator()(Bubble* x)                 = 0;
     virtual T operator()(Trace* x)                  = 0;
     virtual T operator()(Supports_Block* x)         = 0;
@@ -95,7 +94,6 @@ namespace Sass {
     // statements
     T operator()(Block* x)                  { return static_cast<D*>(this)->fallback(x); }
     T operator()(Ruleset* x)                { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Propset* x)                { return static_cast<D*>(this)->fallback(x); }
     T operator()(Bubble* x)                 { return static_cast<D*>(this)->fallback(x); }
     T operator()(Trace* x)                  { return static_cast<D*>(this)->fallback(x); }
     T operator()(Supports_Block* x)         { return static_cast<D*>(this)->fallback(x); }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -118,7 +118,9 @@ namespace Sass {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement* stm = (*b)[i];
         if (dynamic_cast<Has_Block*>(stm)) {
-          stm->perform(this);
+          if (typeid(*stm) != typeid(Declaration)) {
+            stm->perform(this);
+          }
         }
       }
       return;

--- a/src/output.hpp
+++ b/src/output.hpp
@@ -35,7 +35,6 @@ namespace Sass {
 
     virtual void operator()(Map*);
     virtual void operator()(Ruleset*);
-    // virtual void operator()(Propset*);
     virtual void operator()(Supports_Block*);
     virtual void operator()(Media_Block*);
     virtual void operator()(Directive*);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1851,16 +1851,6 @@ namespace Sass {
 
   Content* Parser::parse_content_directive()
   {
-    bool missing_mixin_parent = true;
-    for (auto parent : stack) {
-      if (parent == Scope::Mixin) {
-        missing_mixin_parent = false;
-        break;
-      }
-    }
-    if (missing_mixin_parent) {
-      error("@content may only be used within a mixin", pstate);
-    }
     return SASS_MEMORY_NEW(ctx.mem, Content, pstate);
   }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -284,7 +284,7 @@ namespace Sass {
         if (decl->is_indented()) ++ indentation;
         // parse a propset that rides on the declaration's property
         stack.push_back(Scope::Properties);
-        (*block) << SASS_MEMORY_NEW(ctx.mem, Propset, pstate, decl->property(), parse_block());
+        decl->block(parse_block());
         stack.pop_back();
         if (decl->is_indented()) -- indentation;
       }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -236,7 +236,6 @@ namespace Sass {
     Arguments* parse_arguments();
     Argument* parse_argument();
     Assignment* parse_assignment();
-    // Propset* parse_propset();
     Ruleset* parse_ruleset(Lookahead lookahead, bool is_root = false);
     Selector_Schema* parse_selector_schema(const char* end_of_selector);
     Selector_List* parse_selector_list(bool at_root = false);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -470,6 +470,8 @@ namespace Sass {
         Statement* stm = (*b)[i];
         if (dynamic_cast<Directive*>(stm)) {
           return true;
+        } else if (Declaration* d = dynamic_cast<Declaration*>(stm)) {
+          return isPrintable(d, style);
         } else if (dynamic_cast<Has_Block*>(stm)) {
           Block* pChildBlock = ((Has_Block*)stm)->block();
           if (isPrintable(pChildBlock, style)) {
@@ -484,8 +486,6 @@ namespace Sass {
           if (c->is_important()) {
             hasDeclarations = c->is_important();
           }
-        } else if (Declaration* d = dynamic_cast<Declaration*>(stm)) {
-          return isPrintable(d, style);
         } else {
           hasDeclarations = true;
         }


### PR DESCRIPTION
This PR is the combination of #2085 and #2086. 
They have their own detailed descriptions I wont repeat here.

Unfortunately those two PRs each have a single failing spec
which is due to a missing implementation provided by the
alternative PR. Those PRs have been marked as DNM and
will closed by this PR. I'm doing this so that master stays green
in case a revert is required.

Spec sass/sass-spec#868
Closes #2085 
Closes #2086
Fixes #1585