### PR TITLE
Revert "Change default from `scss` to `sass` syntax"

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -404,7 +404,7 @@ namespace Sass {
       }
       for(size_t i=0; i<extension.size();++i)
         extension[i] = tolower(extension[i]);
-      if (extension != ".scss" && contents != 0) {
+      if (extension == ".sass" && contents != 0) {
         char * converted = sass2scss(contents, SASS2SCSS_PRETTIFY_1 | SASS2SCSS_KEEP_COMMENT);
         free(contents); // free the indented contents
         return converted; // should be freed by caller


### PR DESCRIPTION
Reverts sass/libsass#1893