### PR TITLE
Fix default at-root behaviour

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1737,7 +1737,7 @@ namespace Sass {
     bool exclude_node(Statement* s) {
       if (expression() == 0)
       {
-        return true;
+        return s->statement_type() == Statement::RULESET;
       }
 
       if (s->statement_type() == Statement::DIRECTIVE)


### PR DESCRIPTION
a condition was not supplied. This changed was incorrectly excluded
all parent instead of just rules. As it stands this condition is
unreachable but that could change in the future so this logic
should be correct.