### PR TITLE
Fix specificity for Simple_Selectors

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1893,7 +1893,7 @@ namespace Sass {
       return false;
     }
     virtual unsigned long specificity() {
-      return Constants::Specificity_Universal;
+      return 0;
     }
     virtual void set_media_block(Media_Block* mb) {
       media_block(mb);
@@ -2034,6 +2034,10 @@ namespace Sass {
     Selector_Placeholder(ParserState pstate, std::string n)
     : Simple_Selector(pstate, n)
     { has_placeholder(true); }
+    virtual unsigned long specificity()
+    {
+      return Constants::Specificity_Base;
+    }
     // virtual Selector_Placeholder* find_placeholder();
     virtual ~Selector_Placeholder() {};
     ATTACH_OPERATIONS()
@@ -2049,8 +2053,7 @@ namespace Sass {
     { }
     virtual unsigned long specificity()
     {
-      // ToDo: What is the specificity of the star selector?
-      if (name() == "*") return Constants::Specificity_Universal;
+      if (name() == "*") return 0;
       else               return Constants::Specificity_Type;
     }
     virtual Simple_Selector* unify_with(Simple_Selector*, Context&);

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -10,12 +10,13 @@ namespace Sass {
     // https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity
     // https://github.com/sass/sass/issues/1495#issuecomment-61189114
     extern const unsigned long Specificity_Star = 0;
-    extern const unsigned long Specificity_Universal = 1 << 0;
-    extern const unsigned long Specificity_Type = 1 << 8;
-    extern const unsigned long Specificity_Class = 1 << 16;
-    extern const unsigned long Specificity_Attr = 1 << 16;
-    extern const unsigned long Specificity_Pseudo = 1 << 16;
-    extern const unsigned long Specificity_ID = 1 << 24;
+    extern const unsigned long Specificity_Universal = 0;
+    extern const unsigned long Specificity_Type = 1;
+    extern const unsigned long Specificity_Base = 1000;
+    extern const unsigned long Specificity_Class = 1000;
+    extern const unsigned long Specificity_Attr = 1000;
+    extern const unsigned long Specificity_Pseudo = 1000;
+    extern const unsigned long Specificity_ID = 1000000;
 
     // sass keywords
     extern const char at_root_kwd[]       = "@at-root";

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -12,6 +12,7 @@ namespace Sass {
     extern const unsigned long Specificity_Star;
     extern const unsigned long Specificity_Universal;
     extern const unsigned long Specificity_Type;
+    extern const unsigned long Specificity_Base;
     extern const unsigned long Specificity_Class;
     extern const unsigned long Specificity_Attr;
     extern const unsigned long Specificity_Pseudo;


### PR DESCRIPTION
This better matches the Ruby Sass implementation.