### PR TITLE
Rename parentize to resolve_parent_refs

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1084,28 +1084,28 @@ namespace Sass {
 
   }
 
-  Selector_List* Selector_List::parentize(Selector_List* ps, Context& ctx)
+  Selector_List* Selector_List::parentize(Selector_List* ps, Context& ctx, bool implicit_parent = true)
   {
-    if (!this->has_parent_ref()) return this;
     Selector_List* ss = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
     for (size_t pi = 0, pL = ps->length(); pi < pL; ++pi) {
       Selector_List* list = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
       *list << (*ps)[pi];
       for (size_t si = 0, sL = this->length(); si < sL; ++si) {
-        *ss += (*this)[si]->parentize(list, ctx);
+        *ss += (*this)[si]->parentize(list, ctx, implicit_parent);
       }
     }
     return ss;
   }
 
-  Selector_List* Complex_Selector::parentize(Selector_List* parents, Context& ctx)
+  Selector_List* Complex_Selector::parentize(Selector_List* parents, Context& ctx, bool implicit_parent)
   {
+    if (!this->has_parent_ref()/* && !implicit_parent*/) return this;
 
     Complex_Selector* tail = this->tail();
     Compound_Selector* head = this->head();
 
     // first parentize the tail (which may return an expanded list)
-    Selector_List* tails = tail ? tail->parentize(parents, ctx) : 0;
+    Selector_List* tails = tail ? tail->parentize(parents, ctx, implicit_parent) : 0;
 
     if (head && head->length() > 0) {
 
@@ -1186,7 +1186,7 @@ namespace Sass {
       for (Simple_Selector* ss : *head) {
         if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(ss)) {
           if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
-            if (parents) ws->selector(sl->parentize(parents, ctx));
+            if (parents) ws->selector(sl->parentize(parents, ctx, implicit_parent));
           }
         }
       }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2404,7 +2404,7 @@ namespace Sass {
     Complex_Selector* innermost() { return last(); };
 
     size_t length() const;
-    Selector_List* parentize(Selector_List* parents, Context& ctx, bool implicit_parent = true);
+    Selector_List* resolve_parent_refs(Context& ctx, Selector_List* parents, bool implicit_parent);
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Selector_List* sub, std::string wrapping = "");
@@ -2517,7 +2517,7 @@ namespace Sass {
     virtual bool has_parent_ref();
     void remove_parent_selectors();
     // virtual Selector_Placeholder* find_placeholder();
-    Selector_List* parentize(Selector_List* parents, Context& ctx, bool implicit_parent);
+    Selector_List* resolve_parent_refs(Context& ctx, Selector_List* parents, bool implicit_parent = true);
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Selector_List* sub, std::string wrapping = "");

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2404,7 +2404,7 @@ namespace Sass {
     Complex_Selector* innermost() { return last(); };
 
     size_t length() const;
-    Selector_List* parentize(Selector_List* parents, Context& ctx);
+    Selector_List* parentize(Selector_List* parents, Context& ctx, bool implicit_parent = true);
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Selector_List* sub, std::string wrapping = "");
@@ -2517,7 +2517,7 @@ namespace Sass {
     virtual bool has_parent_ref();
     void remove_parent_selectors();
     // virtual Selector_Placeholder* find_placeholder();
-    Selector_List* parentize(Selector_List* parents, Context& ctx);
+    Selector_List* parentize(Selector_List* parents, Context& ctx, bool implicit_parent);
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Selector_List* sub, std::string wrapping = "");

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1647,7 +1647,7 @@ namespace Sass {
   Selector_List* Eval::operator()(Complex_Selector* s)
   {
     bool implicit_parent = !exp.old_at_root_without_rule;
-    return s->parentize(selector(), ctx, implicit_parent);
+    return s->resolve_parent_refs(ctx, selector(), implicit_parent);
 
   }
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1646,7 +1646,8 @@ namespace Sass {
 
   Selector_List* Eval::operator()(Complex_Selector* s)
   {
-    return s->parentize(selector(), ctx);
+    bool implicit_parent = !exp.old_at_root_without_rule;
+    return s->parentize(selector(), ctx, implicit_parent);
 
   }
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -22,7 +22,8 @@ namespace Sass {
     media_block_stack(std::vector<Media_Block*>()),
     backtrace_stack(std::vector<Backtrace*>()),
     in_keyframes(false),
-    at_root_without_rule(false)
+    at_root_without_rule(false),
+    old_at_root_without_rule(false)
   {
     env_stack.push_back(0);
     env_stack.push_back(env);
@@ -87,6 +88,8 @@ namespace Sass {
 
   Statement* Expand::operator()(Ruleset* r)
   {
+    LOCAL_FLAG(old_at_root_without_rule, at_root_without_rule);
+
     if (in_keyframes) {
       Keyframe_Rule* k = SASS_MEMORY_NEW(ctx.mem, Keyframe_Rule, r->pstate(), r->block()->perform(this)->block());
       if (r->selector()) {

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -37,6 +37,7 @@ namespace Sass {
     std::vector<Backtrace*>     backtrace_stack;
     bool                        in_keyframes;
     bool                        at_root_without_rule;
+    bool                        old_at_root_without_rule;
 
     Statement* fallback_impl(AST_Node* n);
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1745,7 +1745,7 @@ namespace Sass {
       for(;itr != parsedSelectors.end(); ++itr) {
         Selector_List* child = *itr;
         std::vector<Complex_Selector*> exploded;
-        Selector_List* rv = child->parentize(result, ctx, true);
+        Selector_List* rv = child->resolve_parent_refs(ctx, result);
         for (size_t m = 0, mLen = rv->length(); m < mLen; ++m) {
           exploded.push_back((*rv)[m]);
         }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1745,7 +1745,7 @@ namespace Sass {
       for(;itr != parsedSelectors.end(); ++itr) {
         Selector_List* child = *itr;
         std::vector<Complex_Selector*> exploded;
-        Selector_List* rv = child->parentize(result, ctx);
+        Selector_List* rv = child->parentize(result, ctx, true);
         for (size_t m = 0, mLen = rv->length(); m < mLen; ++m) {
           exploded.push_back((*rv)[m]);
         }


### PR DESCRIPTION
This better matches the Ruby Sass implementation.

Also update the function signature. Add missing `implicit_parent` flag.

This is required to prevent some instances of parentizing when we
shouldn't like #2006. This isn't a complete fix because we incorrectly
add parent refs during parsing which also needs to be addressed.