### PR TITLE
Rename some selector AST nodes

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -411,7 +411,7 @@ namespace Sass {
     return cpy;
   }
 
-  Simple_Selector* Type_Selector::unify_with(Simple_Selector* rhs, Context& ctx)
+  Simple_Selector* Element_Selector::unify_with(Simple_Selector* rhs, Context& ctx)
   {
     // check if ns can be extended
     // true for no ns or universal
@@ -422,7 +422,7 @@ namespace Sass {
       if (!rhs->is_universal_ns())
       {
         // creaty the copy inside (avoid unnecessary copies)
-        Type_Selector* ts = SASS_MEMORY_NEW(ctx.mem, Type_Selector, *this);
+        Element_Selector* ts = SASS_MEMORY_NEW(ctx.mem, Element_Selector, *this);
         // overwrite the name if star is given as name
         if (ts->name() == "*") { ts->name(rhs->name()); }
         // now overwrite the namespace name and flag
@@ -436,7 +436,7 @@ namespace Sass {
     if (name() == "*" && rhs->name() != "*")
     {
       // creaty the copy inside (avoid unnecessary copies)
-      Type_Selector* ts = SASS_MEMORY_NEW(ctx.mem, Type_Selector, *this);
+      Element_Selector* ts = SASS_MEMORY_NEW(ctx.mem, Element_Selector, *this);
       // simply set the new name
       ts->name(rhs->name());
       // return copy
@@ -446,7 +446,7 @@ namespace Sass {
     return this;
   }
 
-  Compound_Selector* Type_Selector::unify_with(Compound_Selector* rhs, Context& ctx)
+  Compound_Selector* Element_Selector::unify_with(Compound_Selector* rhs, Context& ctx)
   {
     // TODO: handle namespaces
 
@@ -461,11 +461,11 @@ namespace Sass {
     // otherwise, this is a tag name
     if (name() == "*")
     {
-      if (typeid(*rhs_0) == typeid(Type_Selector))
+      if (typeid(*rhs_0) == typeid(Element_Selector))
       {
         // if rhs is universal, just return this tagname + rhs's qualifiers
         Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *rhs);
-        Type_Selector* ts = static_cast<Type_Selector*>(rhs_0);
+        Element_Selector* ts = static_cast<Element_Selector*>(rhs_0);
         (*cpy)[0] = this->unify_with(ts, ctx);
         return cpy;
       }
@@ -484,7 +484,7 @@ namespace Sass {
       return rhs;
     }
 
-    if (typeid(*rhs_0) == typeid(Type_Selector))
+    if (typeid(*rhs_0) == typeid(Element_Selector))
     {
       // if rhs is universal, just return this tagname + rhs's qualifiers
       if (rhs_0->name() != "*" && rhs_0->ns() != "*" && rhs_0->name() != name()) return 0;
@@ -1036,14 +1036,14 @@ namespace Sass {
       } else if (last()->head_ && last()->head_->length()) {
         Compound_Selector* rh = last()->head();
         size_t i = 0, L = h->length();
-        if (dynamic_cast<Type_Selector*>(h->first())) {
+        if (dynamic_cast<Element_Selector*>(h->first())) {
           if (Selector_Qualifier* sq = dynamic_cast<Selector_Qualifier*>(rh->last())) {
             Selector_Qualifier* sqs = new Selector_Qualifier(*sq);
             sqs->name(sqs->name() + (*h)[0]->name());
             (*rh)[rh->length()-1] = sqs;
             for (i = 1; i < L; ++i) *rh << (*h)[i];
-          } else if (Type_Selector* ts = dynamic_cast<Type_Selector*>(rh->last())) {
-            Type_Selector* tss = new Type_Selector(*ts);
+          } else if (Element_Selector* ts = dynamic_cast<Element_Selector*>(rh->last())) {
+            Element_Selector* tss = new Element_Selector(*ts);
             tss->name(tss->name() + (*h)[0]->name());
             (*rh)[rh->length()-1] = tss;
             for (i = 1; i < L; ++i) *rh << (*h)[i];

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -319,10 +319,10 @@ namespace Sass {
     return ns() < rhs.ns();
   }
 
-  bool Selector_List::operator== (const Selector& rhs) const
+  bool CommaSequence_Selector::operator== (const Selector& rhs) const
   {
     // solve the double dispatch problem by using RTTI information via dynamic cast
-    if (const Selector_List* ls = dynamic_cast<const Selector_List*>(&rhs)) { return *this == *ls; }
+    if (const CommaSequence_Selector* ls = dynamic_cast<const CommaSequence_Selector*>(&rhs)) { return *this == *ls; }
     else if (const Complex_Selector* ls = dynamic_cast<const Complex_Selector*>(&rhs)) { return *this == *ls; }
     else if (const Compound_Selector* ls = dynamic_cast<const Compound_Selector*>(&rhs)) { return *this == *ls; }
     // no compare method
@@ -330,7 +330,7 @@ namespace Sass {
   }
 
   // Selector lists can be compared to comma lists
-  bool Selector_List::operator==(const Expression& rhs) const
+  bool CommaSequence_Selector::operator==(const Expression& rhs) const
   {
     // solve the double dispatch problem by using RTTI information via dynamic cast
     if (const List* ls = dynamic_cast<const List*>(&rhs)) { return *this == *ls; }
@@ -339,7 +339,7 @@ namespace Sass {
     return false;
   }
 
-  bool Selector_List::operator== (const Selector_List& rhs) const
+  bool CommaSequence_Selector::operator== (const CommaSequence_Selector& rhs) const
   {
     // for array access
     size_t i = 0, n = 0;
@@ -660,18 +660,18 @@ namespace Sass {
   {
     if (this->name() != sub->name()) return false;
     if (this->name() == ":current") return false;
-    if (Selector_List* rhs_list = dynamic_cast<Selector_List*>(sub->selector())) {
-      if (Selector_List* lhs_list = dynamic_cast<Selector_List*>(selector())) {
+    if (CommaSequence_Selector* rhs_list = dynamic_cast<CommaSequence_Selector*>(sub->selector())) {
+      if (CommaSequence_Selector* lhs_list = dynamic_cast<CommaSequence_Selector*>(selector())) {
         return lhs_list->is_superselector_of(rhs_list);
       }
-      error("is_superselector expected a Selector_List", sub->pstate());
+      error("is_superselector expected a CommaSequence_Selector", sub->pstate());
     } else {
-      error("is_superselector expected a Selector_List", sub->pstate());
+      error("is_superselector expected a CommaSequence_Selector", sub->pstate());
     }
     return false;
   }
 
-  bool Compound_Selector::is_superselector_of(Selector_List* rhs, std::string wrapped)
+  bool Compound_Selector::is_superselector_of(CommaSequence_Selector* rhs, std::string wrapped)
   {
     for (Complex_Selector* item : rhs->elements()) {
       if (is_superselector_of(item, wrapped)) return true;
@@ -734,7 +734,7 @@ namespace Sass {
       // very special case for wrapped matches selector
       if (Wrapped_Selector* wrapped = dynamic_cast<Wrapped_Selector*>(lhs)) {
         if (wrapped->name() == ":not") {
-          if (Selector_List* not_list = dynamic_cast<Selector_List*>(wrapped->selector())) {
+          if (CommaSequence_Selector* not_list = dynamic_cast<CommaSequence_Selector*>(wrapped->selector())) {
             if (not_list->is_superselector_of(rhs, wrapped->name())) return false;
           } else {
             throw std::runtime_error("wrapped not selector is not a list");
@@ -742,7 +742,7 @@ namespace Sass {
         }
         if (wrapped->name() == ":matches" || wrapped->name() == ":-moz-any") {
           lhs = wrapped->selector();
-          if (Selector_List* list = dynamic_cast<Selector_List*>(wrapped->selector())) {
+          if (CommaSequence_Selector* list = dynamic_cast<CommaSequence_Selector*>(wrapped->selector())) {
             if (Compound_Selector* comp = dynamic_cast<Compound_Selector*>(rhs)) {
               if (!wrapping.empty() && wrapping != wrapped->name()) return false;
               if (wrapping.empty() || wrapping != wrapped->name()) {;
@@ -770,7 +770,7 @@ namespace Sass {
       auto r = (*rhs)[n];
       if (Wrapped_Selector* wrapped = dynamic_cast<Wrapped_Selector*>(r)) {
         if (wrapped->name() == ":not") {
-          if (Selector_List* ls = dynamic_cast<Selector_List*>(wrapped->selector())) {
+          if (CommaSequence_Selector* ls = dynamic_cast<CommaSequence_Selector*>(wrapped->selector())) {
             ls->remove_parent_selectors();
             if (is_superselector_of(ls, wrapped->name())) return false;
           }
@@ -779,7 +779,7 @@ namespace Sass {
           if (!wrapping.empty()) {
             if (wrapping != wrapped->name()) return false;
           }
-          if (Selector_List* ls = dynamic_cast<Selector_List*>(wrapped->selector())) {
+          if (CommaSequence_Selector* ls = dynamic_cast<CommaSequence_Selector*>(wrapped->selector())) {
             ls->remove_parent_selectors();
             return (is_superselector_of(ls, wrapped->name()));
           }
@@ -808,7 +808,7 @@ namespace Sass {
                            0);
   }
 
-  Selector_List* Complex_Selector::unify_with(Complex_Selector* other, Context& ctx)
+  CommaSequence_Selector* Complex_Selector::unify_with(Complex_Selector* other, Context& ctx)
   {
 
     // get last tails (on the right side)
@@ -866,7 +866,7 @@ namespace Sass {
 
     // do some magic we inherit from node and extend
     Node node = Extend::subweave(lhsNode, rhsNode, ctx);
-    Selector_List* result = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
+    CommaSequence_Selector* result = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate());
     NodeDequePtr col = node.collection(); // move from collection to list
     for (NodeDeque::iterator it = col->begin(), end = col->end(); it != end; it++)
     { (*result) << nodeToComplexSelector(Node::naiveTrim(*it, ctx), ctx); }
@@ -1084,12 +1084,12 @@ namespace Sass {
 
   }
 
-  Selector_List* Selector_List::resolve_parent_refs(Context& ctx, Selector_List* ps, bool implicit_parent)
+  CommaSequence_Selector* CommaSequence_Selector::resolve_parent_refs(Context& ctx, CommaSequence_Selector* ps, bool implicit_parent)
   {
     if (!this->has_parent_ref()/* && !implicit_parent*/) return this;
-    Selector_List* ss = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
+    CommaSequence_Selector* ss = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate());
     for (size_t pi = 0, pL = ps->length(); pi < pL; ++pi) {
-      Selector_List* list = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
+      CommaSequence_Selector* list = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate());
       *list << (*ps)[pi];
       for (size_t si = 0, sL = this->length(); si < sL; ++si) {
         *ss += (*this)[si]->resolve_parent_refs(ctx, list, implicit_parent);
@@ -1098,21 +1098,21 @@ namespace Sass {
     return ss;
   }
 
-  Selector_List* Complex_Selector::resolve_parent_refs(Context& ctx, Selector_List* parents, bool implicit_parent)
+  CommaSequence_Selector* Complex_Selector::resolve_parent_refs(Context& ctx, CommaSequence_Selector* parents, bool implicit_parent)
   {
     Complex_Selector* tail = this->tail();
     Compound_Selector* head = this->head();
 
     // first resolve_parent_refs the tail (which may return an expanded list)
-    Selector_List* tails = tail ? tail->resolve_parent_refs(ctx, parents, implicit_parent) : 0;
+    CommaSequence_Selector* tails = tail ? tail->resolve_parent_refs(ctx, parents, implicit_parent) : 0;
 
     if (head && head->length() > 0) {
 
-      Selector_List* retval = 0;
+      CommaSequence_Selector* retval = 0;
       // we have a parent selector in a simple compound list
       // mix parent complex selector into the compound list
       if (dynamic_cast<Parent_Selector*>((*head)[0])) {
-        retval = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
+        retval = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate());
         if (parents && parents->length()) {
           if (tails && tails->length() > 0) {
             for (size_t n = 0, nL = tails->length(); n < nL; ++n) {
@@ -1184,7 +1184,7 @@ namespace Sass {
 
       for (Simple_Selector* ss : *head) {
         if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(ss)) {
-          if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
+          if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(ws->selector())) {
             if (parents) ws->selector(sl->resolve_parent_refs(ctx, parents, implicit_parent));
           }
         }
@@ -1202,9 +1202,9 @@ namespace Sass {
     return 0;
   }
 
-  Selector_List* Complex_Selector::tails(Context& ctx, Selector_List* tails)
+  CommaSequence_Selector* Complex_Selector::tails(Context& ctx, CommaSequence_Selector* tails)
   {
-    Selector_List* rv = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate_);
+    CommaSequence_Selector* rv = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate_);
     if (tails && tails->length()) {
       for (size_t i = 0, iL = tails->length(); i < iL; ++i) {
         Complex_Selector* pr = this->clone(ctx);
@@ -1331,17 +1331,17 @@ namespace Sass {
     return cpy;
   }
 
-  Selector_List* Selector_List::clone(Context& ctx) const
+  CommaSequence_Selector* CommaSequence_Selector::clone(Context& ctx) const
   {
-    Selector_List* cpy = SASS_MEMORY_NEW(ctx.mem, Selector_List, *this);
+    CommaSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, *this);
     cpy->is_optional(this->is_optional());
     cpy->media_block(this->media_block());
     return cpy;
   }
 
-  Selector_List* Selector_List::cloneFully(Context& ctx) const
+  CommaSequence_Selector* CommaSequence_Selector::cloneFully(Context& ctx) const
   {
-    Selector_List* cpy = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
+    CommaSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate());
     cpy->is_optional(this->is_optional());
     cpy->media_block(this->media_block());
     for (size_t i = 0, L = length(); i < L; ++i) {
@@ -1358,7 +1358,7 @@ namespace Sass {
 
   // remove parent selector references
   // basically unwraps parsed selectors
-  void Selector_List::remove_parent_selectors()
+  void CommaSequence_Selector::remove_parent_selectors()
   {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = length(); i < L; ++i) {
@@ -1381,7 +1381,7 @@ namespace Sass {
     }
   }
 
-  bool Selector_List::has_parent_ref()
+  bool CommaSequence_Selector::has_parent_ref()
   {
     for (Complex_Selector* s : *this) {
       if (s && s->has_parent_ref()) return true;
@@ -1397,14 +1397,14 @@ namespace Sass {
     return false;
   }
 
-  void Selector_List::adjust_after_pushing(Complex_Selector* c)
+  void CommaSequence_Selector::adjust_after_pushing(Complex_Selector* c)
   {
     // if (c->has_reference())   has_reference(true);
   }
 
   // it's a superselector if every selector of the right side
   // list is a superselector of the given left side selector
-  bool Complex_Selector::is_superselector_of(Selector_List *sub, std::string wrapping)
+  bool Complex_Selector::is_superselector_of(CommaSequence_Selector *sub, std::string wrapping)
   {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = sub->length(); i < L; ++i) {
@@ -1415,7 +1415,7 @@ namespace Sass {
 
   // it's a superselector if every selector of the right side
   // list is a superselector of the given left side selector
-  bool Selector_List::is_superselector_of(Selector_List *sub, std::string wrapping)
+  bool CommaSequence_Selector::is_superselector_of(CommaSequence_Selector *sub, std::string wrapping)
   {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = sub->length(); i < L; ++i) {
@@ -1426,7 +1426,7 @@ namespace Sass {
 
   // it's a superselector if every selector on the right side
   // is a superselector of any one of the left side selectors
-  bool Selector_List::is_superselector_of(Compound_Selector *sub, std::string wrapping)
+  bool CommaSequence_Selector::is_superselector_of(Compound_Selector *sub, std::string wrapping)
   {
     // Check every lhs selector against right hand
     for(size_t i = 0, L = length(); i < L; ++i) {
@@ -1437,7 +1437,7 @@ namespace Sass {
 
   // it's a superselector if every selector on the right side
   // is a superselector of any one of the left side selectors
-  bool Selector_List::is_superselector_of(Complex_Selector *sub, std::string wrapping)
+  bool CommaSequence_Selector::is_superselector_of(Complex_Selector *sub, std::string wrapping)
   {
     // Check every lhs selector against right hand
     for(size_t i = 0, L = length(); i < L; ++i) {
@@ -1446,7 +1446,7 @@ namespace Sass {
     return false;
   }
 
-  Selector_List* Selector_List::unify_with(Selector_List* rhs, Context& ctx) {
+  CommaSequence_Selector* CommaSequence_Selector::unify_with(CommaSequence_Selector* rhs, Context& ctx) {
     std::vector<Complex_Selector*> unified_complex_selectors;
     // Unify all of children with RHS's children, storing the results in `unified_complex_selectors`
     for (size_t lhs_i = 0, lhs_L = length(); lhs_i < lhs_L; ++lhs_i) {
@@ -1454,7 +1454,7 @@ namespace Sass {
       for(size_t rhs_i = 0, rhs_L = rhs->length(); rhs_i < rhs_L; ++rhs_i) {
         Complex_Selector* seq2 = (*rhs)[rhs_i];
 
-        Selector_List* result = seq1->unify_with(seq2, ctx);
+        CommaSequence_Selector* result = seq1->unify_with(seq2, ctx);
         if( result ) {
           for(size_t i = 0, L = result->length(); i < L; ++i) {
             unified_complex_selectors.push_back( (*result)[i] );
@@ -1463,18 +1463,18 @@ namespace Sass {
       }
     }
 
-    // Creates the final Selector_List by combining all the complex selectors
-    Selector_List* final_result = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate());
+    // Creates the final CommaSequence_Selector by combining all the complex selectors
+    CommaSequence_Selector* final_result = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate());
     for (auto itr = unified_complex_selectors.begin(); itr != unified_complex_selectors.end(); ++itr) {
       *final_result << *itr;
     }
     return final_result;
   }
 
-  void Selector_List::populate_extends(Selector_List* extendee, Context& ctx, ExtensionSubsetMap& extends)
+  void CommaSequence_Selector::populate_extends(CommaSequence_Selector* extendee, Context& ctx, ExtensionSubsetMap& extends)
   {
 
-    Selector_List* extender = this;
+    CommaSequence_Selector* extender = this;
     for (auto complex_sel : extendee->elements()) {
       Complex_Selector* c = complex_sel;
 
@@ -1608,7 +1608,7 @@ namespace Sass {
   }
 
   bool Ruleset::is_invisible() const {
-    Selector_List* sl = static_cast<Selector_List*>(selector());
+    CommaSequence_Selector* sl = static_cast<CommaSequence_Selector*>(selector());
     for (size_t i = 0, L = sl->length(); i < L; ++i)
       if (!(*sl)[i]->has_placeholder()) return false;
     return true;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -157,17 +157,17 @@ namespace Sass {
     return false;
   }
 
-  bool Complex_Selector::has_parent_ref()
+  bool Sequence_Selector::has_parent_ref()
   {
     return (head() && head()->has_parent_ref()) ||
            (tail() && tail()->has_parent_ref());
   }
 
-  bool Complex_Selector::operator< (const Complex_Selector& rhs) const
+  bool Sequence_Selector::operator< (const Sequence_Selector& rhs) const
   {
     // const iterators for tails
-    const Complex_Selector* l = this;
-    const Complex_Selector* r = &rhs;
+    const Sequence_Selector* l = this;
+    const Sequence_Selector* r = &rhs;
     Compound_Selector* l_h = l ? l->head() : 0;
     Compound_Selector* r_h = r ? r->head() : 0;
     // process all tails
@@ -225,11 +225,11 @@ namespace Sass {
     return true;
   }
 
-  bool Complex_Selector::operator== (const Complex_Selector& rhs) const
+  bool Sequence_Selector::operator== (const Sequence_Selector& rhs) const
   {
     // const iterators for tails
-    const Complex_Selector* l = this;
-    const Complex_Selector* r = &rhs;
+    const Sequence_Selector* l = this;
+    const Sequence_Selector* r = &rhs;
     Compound_Selector* l_h = l ? l->head() : 0;
     Compound_Selector* r_h = r ? r->head() : 0;
     // process all tails
@@ -323,7 +323,7 @@ namespace Sass {
   {
     // solve the double dispatch problem by using RTTI information via dynamic cast
     if (const CommaSequence_Selector* ls = dynamic_cast<const CommaSequence_Selector*>(&rhs)) { return *this == *ls; }
-    else if (const Complex_Selector* ls = dynamic_cast<const Complex_Selector*>(&rhs)) { return *this == *ls; }
+    else if (const Sequence_Selector* ls = dynamic_cast<const Sequence_Selector*>(&rhs)) { return *this == *ls; }
     else if (const Compound_Selector* ls = dynamic_cast<const Compound_Selector*>(&rhs)) { return *this == *ls; }
     // no compare method
     return this == &rhs;
@@ -346,8 +346,8 @@ namespace Sass {
     size_t iL = length();
     size_t nL = rhs.length();
     // create temporary vectors and sort them
-    std::vector<Complex_Selector*> l_lst = this->elements();
-    std::vector<Complex_Selector*> r_lst = rhs.elements();
+    std::vector<Sequence_Selector*> l_lst = this->elements();
+    std::vector<Sequence_Selector*> r_lst = rhs.elements();
     std::sort(l_lst.begin(), l_lst.end(), cmp_complex_selector());
     std::sort(r_lst.begin(), r_lst.end(), cmp_complex_selector());
     // process loop
@@ -357,8 +357,8 @@ namespace Sass {
       if (i == iL) return iL == nL;
       else if (n == nL) return iL == nL;
       // the access the vector items
-      Complex_Selector* l = l_lst[i];
-      Complex_Selector* r = r_lst[n];
+      Sequence_Selector* l = l_lst[i];
+      Sequence_Selector* r = r_lst[n];
       // skip nulls
       if (!l) ++i;
       else if (!r) ++n;
@@ -673,13 +673,13 @@ namespace Sass {
 
   bool Compound_Selector::is_superselector_of(CommaSequence_Selector* rhs, std::string wrapped)
   {
-    for (Complex_Selector* item : rhs->elements()) {
+    for (Sequence_Selector* item : rhs->elements()) {
       if (is_superselector_of(item, wrapped)) return true;
     }
     return false;
   }
 
-  bool Compound_Selector::is_superselector_of(Complex_Selector* rhs, std::string wrapped)
+  bool Compound_Selector::is_superselector_of(Sequence_Selector* rhs, std::string wrapped)
   {
     if (rhs->head()) return is_superselector_of(rhs->head(), wrapped);
     return false;
@@ -798,22 +798,22 @@ namespace Sass {
   }
 
   // create complex selector (ancestor of) from compound selector
-  Complex_Selector* Compound_Selector::to_complex(Memory_Manager& mem)
+  Sequence_Selector* Compound_Selector::to_complex(Memory_Manager& mem)
   {
     // create an intermediate complex selector
-    return SASS_MEMORY_NEW(mem, Complex_Selector,
+    return SASS_MEMORY_NEW(mem, Sequence_Selector,
                            pstate(),
-                           Complex_Selector::ANCESTOR_OF,
+                           Sequence_Selector::ANCESTOR_OF,
                            this,
                            0);
   }
 
-  CommaSequence_Selector* Complex_Selector::unify_with(Complex_Selector* other, Context& ctx)
+  CommaSequence_Selector* Sequence_Selector::unify_with(Sequence_Selector* other, Context& ctx)
   {
 
     // get last tails (on the right side)
-    Complex_Selector* l_last = this->last();
-    Complex_Selector* r_last = other->last();
+    Sequence_Selector* l_last = this->last();
+    Sequence_Selector* r_last = other->last();
 
     // check valid pointers (assertion)
     SASS_ASSERT(l_last, "lhs is null");
@@ -858,7 +858,7 @@ namespace Sass {
     if (!is_universal)
     {
       // create some temporaries to convert to node
-      Complex_Selector* fake = unified->to_complex(ctx.mem);
+      Sequence_Selector* fake = unified->to_complex(ctx.mem);
       Node unified_node = complexSelectorToNode(fake, ctx);
       // add to permutate the list?
       rhsNode.plus(unified_node);
@@ -909,26 +909,26 @@ namespace Sass {
     return true;
   }
 
-  bool Complex_Selector_Pointer_Compare::operator() (const Complex_Selector* const pLeft, const Complex_Selector* const pRight) const {
+  bool Sequence_Selector_Pointer_Compare::operator() (const Sequence_Selector* const pLeft, const Sequence_Selector* const pRight) const {
     return *pLeft < *pRight;
   }
 
-  bool Complex_Selector::is_superselector_of(Compound_Selector* rhs, std::string wrapping)
+  bool Sequence_Selector::is_superselector_of(Compound_Selector* rhs, std::string wrapping)
   {
     return last()->head() && last()->head()->is_superselector_of(rhs, wrapping);
   }
 
-  bool Complex_Selector::is_superselector_of(Complex_Selector* rhs, std::string wrapping)
+  bool Sequence_Selector::is_superselector_of(Sequence_Selector* rhs, std::string wrapping)
   {
-    Complex_Selector* lhs = this;
+    Sequence_Selector* lhs = this;
     // check for selectors with leading or trailing combinators
     if (!lhs->head() || !rhs->head())
     { return false; }
-    const Complex_Selector* l_innermost = lhs->innermost();
-    if (l_innermost->combinator() != Complex_Selector::ANCESTOR_OF)
+    const Sequence_Selector* l_innermost = lhs->innermost();
+    if (l_innermost->combinator() != Sequence_Selector::ANCESTOR_OF)
     { return false; }
-    const Complex_Selector* r_innermost = rhs->innermost();
-    if (r_innermost->combinator() != Complex_Selector::ANCESTOR_OF)
+    const Sequence_Selector* r_innermost = rhs->innermost();
+    if (r_innermost->combinator() != Sequence_Selector::ANCESTOR_OF)
     { return false; }
     // more complex (i.e., longer) selectors are always more specific
     size_t l_len = lhs->length(), r_len = rhs->length();
@@ -940,9 +940,9 @@ namespace Sass {
 
     // we have to look one tail deeper, since we cary the
     // combinator around for it (which is important here)
-    if (rhs->tail() && lhs->tail() && combinator() != Complex_Selector::ANCESTOR_OF) {
-      Complex_Selector* lhs_tail = lhs->tail();
-      Complex_Selector* rhs_tail = rhs->tail();
+    if (rhs->tail() && lhs->tail() && combinator() != Sequence_Selector::ANCESTOR_OF) {
+      Sequence_Selector* lhs_tail = lhs->tail();
+      Sequence_Selector* rhs_tail = rhs->tail();
       if (lhs_tail->combinator() != rhs_tail->combinator()) return false;
       if (lhs_tail->head() && !rhs_tail->head()) return false;
       if (!lhs_tail->head() && rhs_tail->head()) return false;
@@ -952,7 +952,7 @@ namespace Sass {
     }
 
     bool found = false;
-    Complex_Selector* marker = rhs;
+    Sequence_Selector* marker = rhs;
     for (size_t i = 0, L = rhs->length(); i < L; ++i) {
       if (i == L-1)
       { return false; }
@@ -976,17 +976,17 @@ namespace Sass {
       else
         return lhs.tail.is_superselector_of(marker.tail)
     */
-    if (lhs->combinator() != Complex_Selector::ANCESTOR_OF)
+    if (lhs->combinator() != Sequence_Selector::ANCESTOR_OF)
     {
-      if (marker->combinator() == Complex_Selector::ANCESTOR_OF)
+      if (marker->combinator() == Sequence_Selector::ANCESTOR_OF)
       { return false; }
-      if (!(lhs->combinator() == Complex_Selector::PRECEDES ? marker->combinator() != Complex_Selector::PARENT_OF : lhs->combinator() == marker->combinator()))
+      if (!(lhs->combinator() == Sequence_Selector::PRECEDES ? marker->combinator() != Sequence_Selector::PARENT_OF : lhs->combinator() == marker->combinator()))
       { return false; }
       return lhs->tail()->is_superselector_of(marker->tail());
     }
-    else if (marker->combinator() != Complex_Selector::ANCESTOR_OF)
+    else if (marker->combinator() != Sequence_Selector::ANCESTOR_OF)
     {
-      if (marker->combinator() != Complex_Selector::PARENT_OF)
+      if (marker->combinator() != Sequence_Selector::PARENT_OF)
       { return false; }
       return lhs->tail()->is_superselector_of(marker->tail());
     }
@@ -998,18 +998,18 @@ namespace Sass {
     return false;
   }
 
-  size_t Complex_Selector::length() const
+  size_t Sequence_Selector::length() const
   {
     // TODO: make this iterative
     if (!tail()) return 1;
     return 1 + tail()->length();
   }
 
-  Complex_Selector* Complex_Selector::context(Context& ctx)
+  Sequence_Selector* Sequence_Selector::context(Context& ctx)
   {
     if (!tail()) return 0;
     if (!head()) return tail()->context(ctx);
-    Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pstate(), combinator(), head(), tail()->context(ctx));
+    Sequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, pstate(), combinator(), head(), tail()->context(ctx));
     cpy->media_block(media_block());
     return cpy;
   }
@@ -1018,10 +1018,10 @@ namespace Sass {
   // check if we need to append some headers
   // then we need to check for the combinator
   // only then we can safely set the new tail
-  void Complex_Selector::append(Context& ctx, Complex_Selector* ss)
+  void Sequence_Selector::append(Context& ctx, Sequence_Selector* ss)
   {
 
-    Complex_Selector* t = ss->tail();
+    Sequence_Selector* t = ss->tail();
     Combinator c = ss->combinator();
     String* r = ss->reference();
     Compound_Selector* h = ss->head();
@@ -1067,7 +1067,7 @@ namespace Sass {
 
     if (last()) {
       if (last()->combinator() != ANCESTOR_OF && c != ANCESTOR_OF) {
-        Complex_Selector* inter = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pstate());
+        Sequence_Selector* inter = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, pstate());
         inter->reference(r);
         inter->combinator(c);
         inter->tail(t);
@@ -1098,9 +1098,9 @@ namespace Sass {
     return ss;
   }
 
-  CommaSequence_Selector* Complex_Selector::resolve_parent_refs(Context& ctx, CommaSequence_Selector* parents, bool implicit_parent)
+  CommaSequence_Selector* Sequence_Selector::resolve_parent_refs(Context& ctx, CommaSequence_Selector* parents, bool implicit_parent)
   {
-    Complex_Selector* tail = this->tail();
+    Sequence_Selector* tail = this->tail();
     Compound_Selector* head = this->head();
 
     // first resolve_parent_refs the tail (which may return an expanded list)
@@ -1117,10 +1117,10 @@ namespace Sass {
           if (tails && tails->length() > 0) {
             for (size_t n = 0, nL = tails->length(); n < nL; ++n) {
               for (size_t i = 0, iL = parents->length(); i < iL; ++i) {
-                Complex_Selector* t = (*tails)[n];
-                Complex_Selector* parent = (*parents)[i];
-                Complex_Selector* s = parent->cloneFully(ctx);
-                Complex_Selector* ss = this->clone(ctx);
+                Sequence_Selector* t = (*tails)[n];
+                Sequence_Selector* parent = (*parents)[i];
+                Sequence_Selector* s = parent->cloneFully(ctx);
+                Sequence_Selector* ss = this->clone(ctx);
                 ss->tail(t ? t->clone(ctx) : 0);
                 Compound_Selector* h = head_->clone(ctx);
                 if (h->length()) h->erase(h->begin());
@@ -1134,9 +1134,9 @@ namespace Sass {
           // loop above is inside out
           else {
             for (size_t i = 0, iL = parents->length(); i < iL; ++i) {
-              Complex_Selector* parent = (*parents)[i];
-              Complex_Selector* s = parent->cloneFully(ctx);
-              Complex_Selector* ss = this->clone(ctx);
+              Sequence_Selector* parent = (*parents)[i];
+              Sequence_Selector* s = parent->cloneFully(ctx);
+              Sequence_Selector* ss = this->clone(ctx);
               // this is only if valid if the parent has no trailing op
               // otherwise we cannot append more simple selectors to head
               if (parent->last()->combinator() != ANCESTOR_OF) {
@@ -1157,7 +1157,7 @@ namespace Sass {
         else {
           if (tails && tails->length() > 0) {
             for (size_t n = 0, nL = tails->length(); n < nL; ++n) {
-              Complex_Selector* cpy = this->clone(ctx);
+              Sequence_Selector* cpy = this->clone(ctx);
               cpy->tail((*tails)[n]->cloneFully(ctx));
               cpy->head(SASS_MEMORY_NEW(ctx.mem, Compound_Selector, head->pstate()));
               for (size_t i = 1, L = this->head()->length(); i < L; ++i)
@@ -1168,7 +1168,7 @@ namespace Sass {
           }
           // have no parent nor tails
           else {
-            Complex_Selector* cpy = this->clone(ctx);
+            Sequence_Selector* cpy = this->clone(ctx);
             cpy->head(SASS_MEMORY_NEW(ctx.mem, Compound_Selector, head->pstate()));
             for (size_t i = 1, L = this->head()->length(); i < L; ++i)
               *cpy->head() << (*this->head())[i];
@@ -1202,12 +1202,12 @@ namespace Sass {
     return 0;
   }
 
-  CommaSequence_Selector* Complex_Selector::tails(Context& ctx, CommaSequence_Selector* tails)
+  CommaSequence_Selector* Sequence_Selector::tails(Context& ctx, CommaSequence_Selector* tails)
   {
     CommaSequence_Selector* rv = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate_);
     if (tails && tails->length()) {
       for (size_t i = 0, iL = tails->length(); i < iL; ++i) {
-        Complex_Selector* pr = this->clone(ctx);
+        Sequence_Selector* pr = this->clone(ctx);
         pr->tail((*tails)[i]);
         *rv << pr;
       }
@@ -1219,10 +1219,10 @@ namespace Sass {
   }
 
   // return the last tail that is defined
-  Complex_Selector* Complex_Selector::first()
+  Sequence_Selector* Sequence_Selector::first()
   {
     // declare variables used in loop
-    Complex_Selector* cur = this;
+    Sequence_Selector* cur = this;
     const Compound_Selector* head;
     // processing loop
     while (cur)
@@ -1241,10 +1241,10 @@ namespace Sass {
   }
 
   // return the last tail that is defined
-  const Complex_Selector* Complex_Selector::first() const
+  const Sequence_Selector* Sequence_Selector::first() const
   {
     // declare variables used in loop
-    const Complex_Selector* cur = this->tail_;
+    const Sequence_Selector* cur = this->tail_;
     const Compound_Selector* head = head_;
     // processing loop
     while (cur)
@@ -1265,21 +1265,21 @@ namespace Sass {
   }
 
   // return the last tail that is defined
-  Complex_Selector* Complex_Selector::last()
+  Sequence_Selector* Sequence_Selector::last()
   {
     // ToDo: implement with a while loop
     return tail_? tail_->last() : this;
   }
 
   // return the last tail that is defined
-  const Complex_Selector* Complex_Selector::last() const
+  const Sequence_Selector* Sequence_Selector::last() const
   {
     // ToDo: implement with a while loop
     return tail_? tail_->last() : this;
   }
 
 
-  Complex_Selector::Combinator Complex_Selector::clear_innermost()
+  Sequence_Selector::Combinator Sequence_Selector::clear_innermost()
   {
     Combinator c;
     if (!tail() || tail()->tail() == 0)
@@ -1289,7 +1289,7 @@ namespace Sass {
     return c;
   }
 
-  void Complex_Selector::set_innermost(Complex_Selector* val, Combinator c)
+  void Sequence_Selector::set_innermost(Sequence_Selector* val, Combinator c)
   {
     if (!tail())
     { tail(val); combinator(c); }
@@ -1297,18 +1297,18 @@ namespace Sass {
     { tail()->set_innermost(val, c); }
   }
 
-  Complex_Selector* Complex_Selector::clone(Context& ctx) const
+  Sequence_Selector* Sequence_Selector::clone(Context& ctx) const
   {
-    Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, *this);
+    Sequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, *this);
     cpy->is_optional(this->is_optional());
     cpy->media_block(this->media_block());
     if (tail()) cpy->tail(tail()->clone(ctx));
     return cpy;
   }
 
-  Complex_Selector* Complex_Selector::cloneFully(Context& ctx) const
+  Sequence_Selector* Sequence_Selector::cloneFully(Context& ctx) const
   {
-    Complex_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, *this);
+    Sequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, *this);
     cpy->is_optional(this->is_optional());
     cpy->media_block(this->media_block());
     if (head()) {
@@ -1365,7 +1365,7 @@ namespace Sass {
       if (!(*this)[i]->head()) continue;
       if ((*this)[i]->head()->is_empty_reference()) {
         // simply move to the next tail if we have "no" combinator
-        if ((*this)[i]->combinator() == Complex_Selector::ANCESTOR_OF) {
+        if ((*this)[i]->combinator() == Sequence_Selector::ANCESTOR_OF) {
           if ((*this)[i]->tail() != NULL) {
             if ((*this)[i]->has_line_feed()) {
               (*this)[i]->tail()->has_line_feed(true);
@@ -1383,7 +1383,7 @@ namespace Sass {
 
   bool CommaSequence_Selector::has_parent_ref()
   {
-    for (Complex_Selector* s : *this) {
+    for (Sequence_Selector* s : *this) {
       if (s && s->has_parent_ref()) return true;
     }
     return false;
@@ -1397,14 +1397,14 @@ namespace Sass {
     return false;
   }
 
-  void CommaSequence_Selector::adjust_after_pushing(Complex_Selector* c)
+  void CommaSequence_Selector::adjust_after_pushing(Sequence_Selector* c)
   {
     // if (c->has_reference())   has_reference(true);
   }
 
   // it's a superselector if every selector of the right side
   // list is a superselector of the given left side selector
-  bool Complex_Selector::is_superselector_of(CommaSequence_Selector *sub, std::string wrapping)
+  bool Sequence_Selector::is_superselector_of(CommaSequence_Selector *sub, std::string wrapping)
   {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = sub->length(); i < L; ++i) {
@@ -1437,7 +1437,7 @@ namespace Sass {
 
   // it's a superselector if every selector on the right side
   // is a superselector of any one of the left side selectors
-  bool CommaSequence_Selector::is_superselector_of(Complex_Selector *sub, std::string wrapping)
+  bool CommaSequence_Selector::is_superselector_of(Sequence_Selector *sub, std::string wrapping)
   {
     // Check every lhs selector against right hand
     for(size_t i = 0, L = length(); i < L; ++i) {
@@ -1447,12 +1447,12 @@ namespace Sass {
   }
 
   CommaSequence_Selector* CommaSequence_Selector::unify_with(CommaSequence_Selector* rhs, Context& ctx) {
-    std::vector<Complex_Selector*> unified_complex_selectors;
+    std::vector<Sequence_Selector*> unified_complex_selectors;
     // Unify all of children with RHS's children, storing the results in `unified_complex_selectors`
     for (size_t lhs_i = 0, lhs_L = length(); lhs_i < lhs_L; ++lhs_i) {
-      Complex_Selector* seq1 = (*this)[lhs_i];
+      Sequence_Selector* seq1 = (*this)[lhs_i];
       for(size_t rhs_i = 0, rhs_L = rhs->length(); rhs_i < rhs_L; ++rhs_i) {
-        Complex_Selector* seq2 = (*rhs)[rhs_i];
+        Sequence_Selector* seq2 = (*rhs)[rhs_i];
 
         CommaSequence_Selector* result = seq1->unify_with(seq2, ctx);
         if( result ) {
@@ -1476,12 +1476,12 @@ namespace Sass {
 
     CommaSequence_Selector* extender = this;
     for (auto complex_sel : extendee->elements()) {
-      Complex_Selector* c = complex_sel;
+      Sequence_Selector* c = complex_sel;
 
 
       // Ignore any parent selectors, until we find the first non Selector_Reference head
       Compound_Selector* compound_sel = c->head();
-      Complex_Selector* pIter = complex_sel;
+      Sequence_Selector* pIter = complex_sel;
       while (pIter) {
         Compound_Selector* pHead = pIter->head();
         if (pHead && dynamic_cast<Parent_Selector*>(pHead->elements()[0]) == NULL) {

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1047,8 +1047,8 @@ namespace Sass {
             tss->name(tss->name() + (*h)[0]->name());
             (*rh)[rh->length()-1] = tss;
             for (i = 1; i < L; ++i) *rh << (*h)[i];
-          } else if (Selector_Placeholder* ps = dynamic_cast<Selector_Placeholder*>(rh->last())) {
-            Selector_Placeholder* pss = new Selector_Placeholder(*ps);
+          } else if (Placeholder_Selector* ps = dynamic_cast<Placeholder_Selector*>(rh->last())) {
+            Placeholder_Selector* pss = new Placeholder_Selector(*ps);
             pss->name(pss->name() + (*h)[0]->name());
             (*rh)[rh->length()-1] = pss;
             for (i = 1; i < L; ++i) *rh << (*h)[i];
@@ -1351,7 +1351,7 @@ namespace Sass {
   }
 
   /* not used anymore - remove?
-  Selector_Placeholder* Selector::find_placeholder()
+  Placeholder_Selector* Selector::find_placeholder()
   {
     return 0;
   }*/

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -132,7 +132,7 @@ namespace Sass {
 
 
 
-  bool Compound_Selector::operator< (const Compound_Selector& rhs) const
+  bool SimpleSequence_Selector::operator< (const SimpleSequence_Selector& rhs) const
   {
     size_t L = std::min(length(), rhs.length());
     for (size_t i = 0; i < L; ++i)
@@ -149,7 +149,7 @@ namespace Sass {
     return length() < rhs.length();
   }
 
-  bool Compound_Selector::has_parent_ref()
+  bool SimpleSequence_Selector::has_parent_ref()
   {
     for (Simple_Selector* s : *this) {
       if (s && s->has_parent_ref()) return true;
@@ -168,8 +168,8 @@ namespace Sass {
     // const iterators for tails
     const Sequence_Selector* l = this;
     const Sequence_Selector* r = &rhs;
-    Compound_Selector* l_h = l ? l->head() : 0;
-    Compound_Selector* r_h = r ? r->head() : 0;
+    SimpleSequence_Selector* l_h = l ? l->head() : 0;
+    SimpleSequence_Selector* r_h = r ? r->head() : 0;
     // process all tails
     while (true)
     {
@@ -230,8 +230,8 @@ namespace Sass {
     // const iterators for tails
     const Sequence_Selector* l = this;
     const Sequence_Selector* r = &rhs;
-    Compound_Selector* l_h = l ? l->head() : 0;
-    Compound_Selector* r_h = r ? r->head() : 0;
+    SimpleSequence_Selector* l_h = l ? l->head() : 0;
+    SimpleSequence_Selector* r_h = r ? r->head() : 0;
     // process all tails
     while (true)
     {
@@ -288,9 +288,9 @@ namespace Sass {
     return false;
   }
 
-  Compound_Selector* Compound_Selector::unify_with(Compound_Selector* rhs, Context& ctx)
+  SimpleSequence_Selector* SimpleSequence_Selector::unify_with(SimpleSequence_Selector* rhs, Context& ctx)
   {
-    Compound_Selector* unified = rhs;
+    SimpleSequence_Selector* unified = rhs;
     for (size_t i = 0, L = length(); i < L; ++i)
     {
       if (!unified) break;
@@ -324,7 +324,7 @@ namespace Sass {
     // solve the double dispatch problem by using RTTI information via dynamic cast
     if (const CommaSequence_Selector* ls = dynamic_cast<const CommaSequence_Selector*>(&rhs)) { return *this == *ls; }
     else if (const Sequence_Selector* ls = dynamic_cast<const Sequence_Selector*>(&rhs)) { return *this == *ls; }
-    else if (const Compound_Selector* ls = dynamic_cast<const Compound_Selector*>(&rhs)) { return *this == *ls; }
+    else if (const SimpleSequence_Selector* ls = dynamic_cast<const SimpleSequence_Selector*>(&rhs)) { return *this == *ls; }
     // no compare method
     return this == &rhs;
   }
@@ -372,7 +372,7 @@ namespace Sass {
     return true;
   }
 
-  Compound_Selector* Simple_Selector::unify_with(Compound_Selector* rhs, Context& ctx)
+  SimpleSequence_Selector* Simple_Selector::unify_with(SimpleSequence_Selector* rhs, Context& ctx)
   {
     for (size_t i = 0, L = rhs->length(); i < L; ++i)
     { if (to_string(ctx.c_options) == (*rhs)[i]->to_string(ctx.c_options)) return rhs; }
@@ -398,11 +398,11 @@ namespace Sass {
     }
     if (!found)
     {
-      Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *rhs);
+      SimpleSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, *rhs);
       (*cpy) << this;
       return cpy;
     }
-    Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, rhs->pstate());
+    SimpleSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, rhs->pstate());
     for (size_t j = 0; j < i; ++j)
     { (*cpy) << (*rhs)[j]; }
     (*cpy) << this;
@@ -446,13 +446,13 @@ namespace Sass {
     return this;
   }
 
-  Compound_Selector* Element_Selector::unify_with(Compound_Selector* rhs, Context& ctx)
+  SimpleSequence_Selector* Element_Selector::unify_with(SimpleSequence_Selector* rhs, Context& ctx)
   {
     // TODO: handle namespaces
 
     // if the rhs is empty, just return a copy of this
     if (rhs->length() == 0) {
-      Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, rhs->pstate());
+      SimpleSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, rhs->pstate());
       (*cpy) << this;
       return cpy;
     }
@@ -464,14 +464,14 @@ namespace Sass {
       if (typeid(*rhs_0) == typeid(Element_Selector))
       {
         // if rhs is universal, just return this tagname + rhs's qualifiers
-        Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *rhs);
+        SimpleSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, *rhs);
         Element_Selector* ts = static_cast<Element_Selector*>(rhs_0);
         (*cpy)[0] = this->unify_with(ts, ctx);
         return cpy;
       }
       else if (dynamic_cast<Selector_Qualifier*>(rhs_0)) {
         // qualifier is `.class`, so we can prefix with `ns|*.class`
-        Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, rhs->pstate());
+        SimpleSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, rhs->pstate());
         if (has_ns() && !rhs_0->has_ns()) {
           if (ns() != "*") (*cpy) << this;
         }
@@ -489,19 +489,19 @@ namespace Sass {
       // if rhs is universal, just return this tagname + rhs's qualifiers
       if (rhs_0->name() != "*" && rhs_0->ns() != "*" && rhs_0->name() != name()) return 0;
       // otherwise create new compound and unify first simple selector
-      Compound_Selector* copy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *rhs);
+      SimpleSequence_Selector* copy = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, *rhs);
       (*copy)[0] = this->unify_with(rhs_0, ctx);
       return copy;
 
     }
     // else it's a tag name and a bunch of qualifiers -- just append them
-    Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, rhs->pstate());
+    SimpleSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, rhs->pstate());
     if (name() != "*") (*cpy) << this;
     (*cpy) += rhs;
     return cpy;
   }
 
-  Compound_Selector* Selector_Qualifier::unify_with(Compound_Selector* rhs, Context& ctx)
+  SimpleSequence_Selector* Selector_Qualifier::unify_with(SimpleSequence_Selector* rhs, Context& ctx)
   {
     if (name()[0] == '#')
     {
@@ -518,7 +518,7 @@ namespace Sass {
     return Simple_Selector::unify_with(rhs, ctx);
   }
 
-  Compound_Selector* Pseudo_Selector::unify_with(Compound_Selector* rhs, Context& ctx)
+  SimpleSequence_Selector* Pseudo_Selector::unify_with(SimpleSequence_Selector* rhs, Context& ctx)
   {
     if (is_pseudo_element())
     {
@@ -671,7 +671,7 @@ namespace Sass {
     return false;
   }
 
-  bool Compound_Selector::is_superselector_of(CommaSequence_Selector* rhs, std::string wrapped)
+  bool SimpleSequence_Selector::is_superselector_of(CommaSequence_Selector* rhs, std::string wrapped)
   {
     for (Sequence_Selector* item : rhs->elements()) {
       if (is_superselector_of(item, wrapped)) return true;
@@ -679,15 +679,15 @@ namespace Sass {
     return false;
   }
 
-  bool Compound_Selector::is_superselector_of(Sequence_Selector* rhs, std::string wrapped)
+  bool SimpleSequence_Selector::is_superselector_of(Sequence_Selector* rhs, std::string wrapped)
   {
     if (rhs->head()) return is_superselector_of(rhs->head(), wrapped);
     return false;
   }
 
-  bool Compound_Selector::is_superselector_of(Compound_Selector* rhs, std::string wrapping)
+  bool SimpleSequence_Selector::is_superselector_of(SimpleSequence_Selector* rhs, std::string wrapping)
   {
-    Compound_Selector* lhs = this;
+    SimpleSequence_Selector* lhs = this;
     Simple_Selector* lbase = lhs->base();
     Simple_Selector* rbase = rhs->base();
 
@@ -743,7 +743,7 @@ namespace Sass {
         if (wrapped->name() == ":matches" || wrapped->name() == ":-moz-any") {
           lhs = wrapped->selector();
           if (CommaSequence_Selector* list = dynamic_cast<CommaSequence_Selector*>(wrapped->selector())) {
-            if (Compound_Selector* comp = dynamic_cast<Compound_Selector*>(rhs)) {
+            if (SimpleSequence_Selector* comp = dynamic_cast<SimpleSequence_Selector*>(rhs)) {
               if (!wrapping.empty() && wrapping != wrapped->name()) return false;
               if (wrapping.empty() || wrapping != wrapped->name()) {;
                 if (list->is_superselector_of(comp, wrapped->name())) return true;
@@ -798,7 +798,7 @@ namespace Sass {
   }
 
   // create complex selector (ancestor of) from compound selector
-  Sequence_Selector* Compound_Selector::to_complex(Memory_Manager& mem)
+  Sequence_Selector* SimpleSequence_Selector::to_complex(Memory_Manager& mem)
   {
     // create an intermediate complex selector
     return SASS_MEMORY_NEW(mem, Sequence_Selector,
@@ -826,15 +826,15 @@ namespace Sass {
     if (r_last->combinator() != Combinator::ANCESTOR_OF ) return 0;
 
     // get the headers for the last tails
-    Compound_Selector* l_last_head = l_last->head();
-    Compound_Selector* r_last_head = r_last->head();
+    SimpleSequence_Selector* l_last_head = l_last->head();
+    SimpleSequence_Selector* r_last_head = r_last->head();
 
     // check valid head pointers (assertion)
     SASS_ASSERT(l_last_head, "lhs head is null");
     SASS_ASSERT(r_last_head, "rhs head is null");
 
     // get the unification of the last compound selectors
-    Compound_Selector* unified = r_last_head->unify_with(l_last_head, ctx);
+    SimpleSequence_Selector* unified = r_last_head->unify_with(l_last_head, ctx);
 
     // abort if we could not unify heads
     if (unified == 0) return 0;
@@ -876,7 +876,7 @@ namespace Sass {
 
   }
 
-  bool Compound_Selector::operator== (const Compound_Selector& rhs) const
+  bool SimpleSequence_Selector::operator== (const SimpleSequence_Selector& rhs) const
   {
     // for array access
     size_t i = 0, n = 0;
@@ -913,7 +913,7 @@ namespace Sass {
     return *pLeft < *pRight;
   }
 
-  bool Sequence_Selector::is_superselector_of(Compound_Selector* rhs, std::string wrapping)
+  bool Sequence_Selector::is_superselector_of(SimpleSequence_Selector* rhs, std::string wrapping)
   {
     return last()->head() && last()->head()->is_superselector_of(rhs, wrapping);
   }
@@ -1024,7 +1024,7 @@ namespace Sass {
     Sequence_Selector* t = ss->tail();
     Combinator c = ss->combinator();
     String* r = ss->reference();
-    Compound_Selector* h = ss->head();
+    SimpleSequence_Selector* h = ss->head();
 
     if (ss->has_line_feed()) has_line_feed(true);
     if (ss->has_line_break()) has_line_break(true);
@@ -1034,7 +1034,7 @@ namespace Sass {
       if (last()->combinator() != ANCESTOR_OF && c != ANCESTOR_OF) {
         error("Invalid parent selector", pstate_);
       } else if (last()->head_ && last()->head_->length()) {
-        Compound_Selector* rh = last()->head();
+        SimpleSequence_Selector* rh = last()->head();
         size_t i = 0, L = h->length();
         if (dynamic_cast<Element_Selector*>(h->first())) {
           if (Selector_Qualifier* sq = dynamic_cast<Selector_Qualifier*>(rh->last())) {
@@ -1101,7 +1101,7 @@ namespace Sass {
   CommaSequence_Selector* Sequence_Selector::resolve_parent_refs(Context& ctx, CommaSequence_Selector* parents, bool implicit_parent)
   {
     Sequence_Selector* tail = this->tail();
-    Compound_Selector* head = this->head();
+    SimpleSequence_Selector* head = this->head();
 
     // first resolve_parent_refs the tail (which may return an expanded list)
     CommaSequence_Selector* tails = tail ? tail->resolve_parent_refs(ctx, parents, implicit_parent) : 0;
@@ -1122,7 +1122,7 @@ namespace Sass {
                 Sequence_Selector* s = parent->cloneFully(ctx);
                 Sequence_Selector* ss = this->clone(ctx);
                 ss->tail(t ? t->clone(ctx) : 0);
-                Compound_Selector* h = head_->clone(ctx);
+                SimpleSequence_Selector* h = head_->clone(ctx);
                 if (h->length()) h->erase(h->begin());
                 ss->head(h->length() ? h : 0);
                 s->append(ctx, ss);
@@ -1143,7 +1143,7 @@ namespace Sass {
                 throw Exception::InvalidParent(parent, ss);
               }
               ss->tail(tail ? tail->clone(ctx) : 0);
-              Compound_Selector* h = head_->clone(ctx);
+              SimpleSequence_Selector* h = head_->clone(ctx);
               if (h->length()) h->erase(h->begin());
               ss->head(h->length() ? h : 0);
               // \/ IMO ruby sass bug \/
@@ -1159,7 +1159,7 @@ namespace Sass {
             for (size_t n = 0, nL = tails->length(); n < nL; ++n) {
               Sequence_Selector* cpy = this->clone(ctx);
               cpy->tail((*tails)[n]->cloneFully(ctx));
-              cpy->head(SASS_MEMORY_NEW(ctx.mem, Compound_Selector, head->pstate()));
+              cpy->head(SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, head->pstate()));
               for (size_t i = 1, L = this->head()->length(); i < L; ++i)
                 *cpy->head() << (*this->head())[i];
               if (!cpy->head()->length()) cpy->head(0);
@@ -1169,7 +1169,7 @@ namespace Sass {
           // have no parent nor tails
           else {
             Sequence_Selector* cpy = this->clone(ctx);
-            cpy->head(SASS_MEMORY_NEW(ctx.mem, Compound_Selector, head->pstate()));
+            cpy->head(SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, head->pstate()));
             for (size_t i = 1, L = this->head()->length(); i < L; ++i)
               *cpy->head() << (*this->head())[i];
             if (!cpy->head()->length()) cpy->head(0);
@@ -1223,7 +1223,7 @@ namespace Sass {
   {
     // declare variables used in loop
     Sequence_Selector* cur = this;
-    const Compound_Selector* head;
+    const SimpleSequence_Selector* head;
     // processing loop
     while (cur)
     {
@@ -1245,7 +1245,7 @@ namespace Sass {
   {
     // declare variables used in loop
     const Sequence_Selector* cur = this->tail_;
-    const Compound_Selector* head = head_;
+    const SimpleSequence_Selector* head = head_;
     // processing loop
     while (cur)
     {
@@ -1322,9 +1322,9 @@ namespace Sass {
     return cpy;
   }
 
-  Compound_Selector* Compound_Selector::clone(Context& ctx) const
+  SimpleSequence_Selector* SimpleSequence_Selector::clone(Context& ctx) const
   {
-    Compound_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, *this);
+    SimpleSequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, *this);
     cpy->is_optional(this->is_optional());
     cpy->media_block(this->media_block());
     cpy->extended(this->extended());
@@ -1426,7 +1426,7 @@ namespace Sass {
 
   // it's a superselector if every selector on the right side
   // is a superselector of any one of the left side selectors
-  bool CommaSequence_Selector::is_superselector_of(Compound_Selector *sub, std::string wrapping)
+  bool CommaSequence_Selector::is_superselector_of(SimpleSequence_Selector *sub, std::string wrapping)
   {
     // Check every lhs selector against right hand
     for(size_t i = 0, L = length(); i < L; ++i) {
@@ -1480,10 +1480,10 @@ namespace Sass {
 
 
       // Ignore any parent selectors, until we find the first non Selector_Reference head
-      Compound_Selector* compound_sel = c->head();
+      SimpleSequence_Selector* compound_sel = c->head();
       Sequence_Selector* pIter = complex_sel;
       while (pIter) {
-        Compound_Selector* pHead = pIter->head();
+        SimpleSequence_Selector* pHead = pIter->head();
         if (pHead && dynamic_cast<Parent_Selector*>(pHead->elements()[0]) == NULL) {
           compound_sel = pHead;
           break;
@@ -1504,7 +1504,7 @@ namespace Sass {
     }
   };
 
-  std::vector<std::string> Compound_Selector::to_str_vec()
+  std::vector<std::string> SimpleSequence_Selector::to_str_vec()
   {
     std::vector<std::string> result;
     result.reserve(length());
@@ -1513,9 +1513,9 @@ namespace Sass {
     return result;
   }
 
-  Compound_Selector* Compound_Selector::minus(Compound_Selector* rhs, Context& ctx)
+  SimpleSequence_Selector* SimpleSequence_Selector::minus(SimpleSequence_Selector* rhs, Context& ctx)
   {
-    Compound_Selector* result = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pstate());
+    SimpleSequence_Selector* result = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, pstate());
     // result->has_parent_reference(has_parent_reference());
 
     // not very efficient because it needs to preserve order
@@ -1537,7 +1537,7 @@ namespace Sass {
     return result;
   }
 
-  void Compound_Selector::mergeSources(SourcesSet& sources, Context& ctx)
+  void SimpleSequence_Selector::mergeSources(SourcesSet& sources, Context& ctx)
   {
     for (SourcesSet::iterator iterator = sources.begin(), endIterator = sources.end(); iterator != endIterator; ++iterator) {
       this->sources_.insert((*iterator)->clone(ctx));

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2033,17 +2033,17 @@ namespace Sass {
   /////////////////////////////////////////////////////////////////////////
   // Placeholder selectors (e.g., "%foo") for use in extend-only selectors.
   /////////////////////////////////////////////////////////////////////////
-  class Selector_Placeholder : public Simple_Selector {
+  class Placeholder_Selector : public Simple_Selector {
   public:
-    Selector_Placeholder(ParserState pstate, std::string n)
+    Placeholder_Selector(ParserState pstate, std::string n)
     : Simple_Selector(pstate, n)
     { has_placeholder(true); }
     virtual unsigned long specificity()
     {
       return Constants::Specificity_Base;
     }
-    // virtual Selector_Placeholder* find_placeholder();
-    virtual ~Selector_Placeholder() {};
+    // virtual Placeholder_Selector* find_placeholder();
+    virtual ~Placeholder_Selector() {};
     ATTACH_OPERATIONS()
   };
 
@@ -2265,7 +2265,7 @@ namespace Sass {
 
     Complex_Selector* to_complex(Memory_Manager& mem);
     Compound_Selector* unify_with(Compound_Selector* rhs, Context& ctx);
-    // virtual Selector_Placeholder* find_placeholder();
+    // virtual Placeholder_Selector* find_placeholder();
     virtual bool has_parent_ref();
     Simple_Selector* base()
     {
@@ -2408,7 +2408,7 @@ namespace Sass {
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Selector_List* sub, std::string wrapping = "");
-    // virtual Selector_Placeholder* find_placeholder();
+    // virtual Placeholder_Selector* find_placeholder();
     Selector_List* unify_with(Complex_Selector* rhs, Context& ctx);
     Combinator clear_innermost();
     void append(Context&, Complex_Selector*);
@@ -2516,7 +2516,7 @@ namespace Sass {
     // basically unwraps parsed selectors
     virtual bool has_parent_ref();
     void remove_parent_selectors();
-    // virtual Selector_Placeholder* find_placeholder();
+    // virtual Placeholder_Selector* find_placeholder();
     Selector_List* resolve_parent_refs(Context& ctx, Selector_List* parents, bool implicit_parent = true);
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapping = "");

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2048,17 +2048,17 @@ namespace Sass {
   };
 
   /////////////////////////////////////////////////////////////////////
-  // Type selectors (and the universal selector) -- e.g., div, span, *.
+  // Element selectors (and the universal selector) -- e.g., div, span, *.
   /////////////////////////////////////////////////////////////////////
-  class Type_Selector : public Simple_Selector {
+  class Element_Selector : public Simple_Selector {
   public:
-    Type_Selector(ParserState pstate, std::string n)
+    Element_Selector(ParserState pstate, std::string n)
     : Simple_Selector(pstate, n)
     { }
     virtual unsigned long specificity()
     {
       if (name() == "*") return 0;
-      else               return Constants::Specificity_Type;
+      else               return Constants::Specificity_Element;
     }
     virtual Simple_Selector* unify_with(Simple_Selector*, Context&);
     virtual Compound_Selector* unify_with(Compound_Selector*, Context&);
@@ -2082,7 +2082,7 @@ namespace Sass {
     {
       if (name()[0] == '#') return Constants::Specificity_ID;
       if (name()[0] == '.') return Constants::Specificity_Class;
-      else                  return Constants::Specificity_Type;
+      else                  return Constants::Specificity_Element;
     }
     virtual Compound_Selector* unify_with(Compound_Selector*, Context&);
     ATTACH_OPERATIONS()
@@ -2173,7 +2173,7 @@ namespace Sass {
     virtual unsigned long specificity()
     {
       if (is_pseudo_element())
-        return Constants::Specificity_Type;
+        return Constants::Specificity_Element;
       return Constants::Specificity_Pseudo;
     }
     bool operator==(const Simple_Selector& rhs) const;
@@ -2275,7 +2275,7 @@ namespace Sass {
     const Simple_Selector* base() const {
       if (length() == 0) return 0;
       // ToDo: why is this needed?
-      if (dynamic_cast<Type_Selector*>((*this)[0]))
+      if (dynamic_cast<Element_Selector*>((*this)[0]))
         return (*this)[0];
       return 0;
     }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1992,12 +1992,12 @@ namespace Sass {
     }
 
     virtual ~Simple_Selector() = 0;
-    virtual Compound_Selector* unify_with(Compound_Selector*, Context&);
+    virtual SimpleSequence_Selector* unify_with(SimpleSequence_Selector*, Context&);
     virtual bool has_parent_ref() { return false; };
     virtual bool is_pseudo_element() { return false; }
     virtual bool is_pseudo_class() { return false; }
 
-    virtual bool is_superselector_of(Compound_Selector* sub) { return false; }
+    virtual bool is_superselector_of(SimpleSequence_Selector* sub) { return false; }
 
     bool operator==(const Simple_Selector& rhs) const;
     inline bool operator!=(const Simple_Selector& rhs) const { return !(*this == rhs); }
@@ -2013,7 +2013,7 @@ namespace Sass {
   // The Parent Selector Expression.
   //////////////////////////////////
   // parent selectors can occur in selectors but also
-  // inside strings in declarations (Compound_Selector).
+  // inside strings in declarations (SimpleSequence_Selector).
   // only one simple parent selector means the first case.
   class Parent_Selector : public Simple_Selector {
   public:
@@ -2061,7 +2061,7 @@ namespace Sass {
       else               return Constants::Specificity_Element;
     }
     virtual Simple_Selector* unify_with(Simple_Selector*, Context&);
-    virtual Compound_Selector* unify_with(Compound_Selector*, Context&);
+    virtual SimpleSequence_Selector* unify_with(SimpleSequence_Selector*, Context&);
     ATTACH_OPERATIONS()
   };
 
@@ -2084,7 +2084,7 @@ namespace Sass {
       if (name()[0] == '.') return Constants::Specificity_Class;
       else                  return Constants::Specificity_Element;
     }
-    virtual Compound_Selector* unify_with(Compound_Selector*, Context&);
+    virtual SimpleSequence_Selector* unify_with(SimpleSequence_Selector*, Context&);
     ATTACH_OPERATIONS()
   };
 
@@ -2180,7 +2180,7 @@ namespace Sass {
     bool operator==(const Pseudo_Selector& rhs) const;
     bool operator<(const Simple_Selector& rhs) const;
     bool operator<(const Pseudo_Selector& rhs) const;
-    virtual Compound_Selector* unify_with(Compound_Selector*, Context&);
+    virtual SimpleSequence_Selector* unify_with(SimpleSequence_Selector*, Context&);
     ATTACH_OPERATIONS()
   };
 
@@ -2233,7 +2233,7 @@ namespace Sass {
   // any parent references or placeholders, to simplify expansion.
   ////////////////////////////////////////////////////////////////////////////
   typedef std::set<Sequence_Selector*, Sequence_Selector_Pointer_Compare> SourcesSet;
-  class Compound_Selector : public Selector, public Vectorized<Simple_Selector*> {
+  class SimpleSequence_Selector : public Selector, public Vectorized<Simple_Selector*> {
   private:
     SourcesSet sources_;
     ADD_PROPERTY(bool, extended);
@@ -2245,7 +2245,7 @@ namespace Sass {
       if (s->has_placeholder()) has_placeholder(true);
     }
   public:
-    Compound_Selector(ParserState pstate, size_t s = 0)
+    SimpleSequence_Selector(ParserState pstate, size_t s = 0)
     : Selector(pstate),
       Vectorized<Simple_Selector*>(s),
       extended_(false),
@@ -2264,13 +2264,13 @@ namespace Sass {
     }
 
     Sequence_Selector* to_complex(Memory_Manager& mem);
-    Compound_Selector* unify_with(Compound_Selector* rhs, Context& ctx);
+    SimpleSequence_Selector* unify_with(SimpleSequence_Selector* rhs, Context& ctx);
     // virtual Placeholder_Selector* find_placeholder();
     virtual bool has_parent_ref();
     Simple_Selector* base()
     {
       // Implement non-const in terms of const. Safe to const_cast since this method is non-const
-      return const_cast<Simple_Selector*>(static_cast<const Compound_Selector*>(this)->base());
+      return const_cast<Simple_Selector*>(static_cast<const SimpleSequence_Selector*>(this)->base());
     }
     const Simple_Selector* base() const {
       if (length() == 0) return 0;
@@ -2279,7 +2279,7 @@ namespace Sass {
         return (*this)[0];
       return 0;
     }
-    virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapped = "");
+    virtual bool is_superselector_of(SimpleSequence_Selector* sub, std::string wrapped = "");
     virtual bool is_superselector_of(Sequence_Selector* sub, std::string wrapped = "");
     virtual bool is_superselector_of(CommaSequence_Selector* sub, std::string wrapped = "");
     virtual size_t hash()
@@ -2314,18 +2314,18 @@ namespace Sass {
     }
     std::vector<std::string> to_str_vec(); // sometimes need to convert to a flat "by-value" data structure
 
-    bool operator<(const Compound_Selector& rhs) const;
+    bool operator<(const SimpleSequence_Selector& rhs) const;
 
-    bool operator==(const Compound_Selector& rhs) const;
-    inline bool operator!=(const Compound_Selector& rhs) const { return !(*this == rhs); }
+    bool operator==(const SimpleSequence_Selector& rhs) const;
+    inline bool operator!=(const SimpleSequence_Selector& rhs) const { return !(*this == rhs); }
 
     SourcesSet& sources() { return sources_; }
     void clearSources() { sources_.clear(); }
     void mergeSources(SourcesSet& sources, Context& ctx);
 
-    Compound_Selector* clone(Context&) const; // does not clone the Simple_Selector*s
+    SimpleSequence_Selector* clone(Context&) const; // does not clone the Simple_Selector*s
 
-    Compound_Selector* minus(Compound_Selector* rhs, Context& ctx);
+    SimpleSequence_Selector* minus(SimpleSequence_Selector* rhs, Context& ctx);
     ATTACH_OPERATIONS()
   };
 
@@ -2339,7 +2339,7 @@ namespace Sass {
     enum Combinator { ANCESTOR_OF, PARENT_OF, PRECEDES, ADJACENT_TO, REFERENCE };
   private:
     ADD_PROPERTY(Combinator, combinator)
-    ADD_PROPERTY(Compound_Selector*, head)
+    ADD_PROPERTY(SimpleSequence_Selector*, head)
     ADD_PROPERTY(Sequence_Selector*, tail)
     ADD_PROPERTY(String*, reference);
   public:
@@ -2350,7 +2350,7 @@ namespace Sass {
     };
     Sequence_Selector(ParserState pstate,
                      Combinator c = ANCESTOR_OF,
-                     Compound_Selector* h = 0,
+                     SimpleSequence_Selector* h = 0,
                      Sequence_Selector* t = 0,
                      String* r = 0)
     : Selector(pstate),
@@ -2405,7 +2405,7 @@ namespace Sass {
 
     size_t length() const;
     CommaSequence_Selector* resolve_parent_refs(Context& ctx, CommaSequence_Selector* parents, bool implicit_parent);
-    virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
+    virtual bool is_superselector_of(SimpleSequence_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Sequence_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(CommaSequence_Selector* sub, std::string wrapping = "");
     // virtual Placeholder_Selector* find_placeholder();
@@ -2451,7 +2451,7 @@ namespace Sass {
 
       SourcesSet srcs;
 
-      Compound_Selector* pHead = head();
+      SimpleSequence_Selector* pHead = head();
       Sequence_Selector*  pTail = tail();
 
       if (pHead) {
@@ -2470,7 +2470,7 @@ namespace Sass {
       // members.map! {|m| m.is_a?(SimpleSequence) ? m.with_more_sources(sources) : m}
       Sequence_Selector* pIter = this;
       while (pIter) {
-        Compound_Selector* pHead = pIter->head();
+        SimpleSequence_Selector* pHead = pIter->head();
 
         if (pHead) {
           pHead->mergeSources(sources, ctx);
@@ -2482,7 +2482,7 @@ namespace Sass {
     void clearSources() {
       Sequence_Selector* pIter = this;
       while (pIter) {
-        Compound_Selector* pHead = pIter->head();
+        SimpleSequence_Selector* pHead = pIter->head();
 
         if (pHead) {
           pHead->clearSources();
@@ -2491,14 +2491,14 @@ namespace Sass {
         pIter = pIter->tail();
       }
     }
-    Sequence_Selector* clone(Context&) const;      // does not clone Compound_Selector*s
-    Sequence_Selector* cloneFully(Context&) const; // clones Compound_Selector*s
-    // std::vector<Compound_Selector*> to_vector();
+    Sequence_Selector* clone(Context&) const;      // does not clone SimpleSequence_Selector*s
+    Sequence_Selector* cloneFully(Context&) const; // clones SimpleSequence_Selector*s
+    // std::vector<SimpleSequence_Selector*> to_vector();
     ATTACH_OPERATIONS()
   };
 
   typedef std::deque<Sequence_Selector*> ComplexSelectorDeque;
-  typedef Subset_Map<std::string, std::pair<Sequence_Selector*, Compound_Selector*> > ExtensionSubsetMap;
+  typedef Subset_Map<std::string, std::pair<Sequence_Selector*, SimpleSequence_Selector*> > ExtensionSubsetMap;
 
   ///////////////////////////////////
   // Comma-separated selector groups.
@@ -2518,7 +2518,7 @@ namespace Sass {
     void remove_parent_selectors();
     // virtual Placeholder_Selector* find_placeholder();
     CommaSequence_Selector* resolve_parent_refs(Context& ctx, CommaSequence_Selector* parents, bool implicit_parent = true);
-    virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
+    virtual bool is_superselector_of(SimpleSequence_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Sequence_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(CommaSequence_Selector* sub, std::string wrapping = "");
     CommaSequence_Selector* unify_with(CommaSequence_Selector*, Context&);
@@ -2554,8 +2554,8 @@ namespace Sass {
       }
       return false;
     }
-    CommaSequence_Selector* clone(Context&) const;      // does not clone Compound_Selector*s
-    CommaSequence_Selector* cloneFully(Context&) const; // clones Compound_Selector*s
+    CommaSequence_Selector* clone(Context&) const;      // does not clone SimpleSequence_Selector*s
+    CommaSequence_Selector* cloneFully(Context&) const; // clones SimpleSequence_Selector*s
     virtual bool operator==(const Selector& rhs) const;
     virtual bool operator==(const CommaSequence_Selector& rhs) const;
     // Selector Lists can be compared to comma lists
@@ -2570,10 +2570,10 @@ namespace Sass {
     // is required for proper stl collection ordering) is implemented using string comparision. This gives stable sorting
     // behavior, and can be used to determine if the selectors would have exactly idential output. operator== matches the
     // ruby sass implementations for eql, which sometimes perform order independent comparisions (like set comparisons of the
-    // members of a SimpleSequence (Compound_Selector)).
+    // members of a SimpleSequence (SimpleSequence_Selector)).
     //
     // Due to the reliance on operator== and operater< behavior, this templated method is currently only intended for
-    // use with Compound_Selector and Sequence_Selector objects.
+    // use with SimpleSequence_Selector and Sequence_Selector objects.
     if (simpleSelectorOrderDependent) {
       return !(one < two) && !(two < one);
     } else {
@@ -2583,7 +2583,7 @@ namespace Sass {
 
   // compare function for sorting and probably other other uses
   struct cmp_complex_selector { inline bool operator() (const Sequence_Selector* l, const Sequence_Selector* r) { return (*l < *r); } };
-  struct cmp_compound_selector { inline bool operator() (const Compound_Selector* l, const Compound_Selector* r) { return (*l < *r); } };
+  struct cmp_compound_selector { inline bool operator() (const SimpleSequence_Selector* l, const SimpleSequence_Selector* r) { return (*l < *r); } };
   struct cmp_simple_selector { inline bool operator() (const Simple_Selector* l, const Simple_Selector* r) { return (*l < *r); } };
 
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2066,23 +2066,40 @@ namespace Sass {
   };
 
   ////////////////////////////////////////////////
-  // Selector qualifiers -- i.e., classes and ids.
+  // Class selectors  -- i.e., .foo.
   ////////////////////////////////////////////////
-  class Selector_Qualifier : public Simple_Selector {
+  class Class_Selector : public Simple_Selector {
   public:
-    Selector_Qualifier(ParserState pstate, std::string n)
+    Class_Selector(ParserState pstate, std::string n)
     : Simple_Selector(pstate, n)
     { }
     virtual bool unique() const
     {
-      if (name()[0] == '#') return true;
-      else return false;
+      return false;
     }
     virtual unsigned long specificity()
     {
-      if (name()[0] == '#') return Constants::Specificity_ID;
-      if (name()[0] == '.') return Constants::Specificity_Class;
-      else                  return Constants::Specificity_Element;
+      return Constants::Specificity_Class;
+    }
+    virtual SimpleSequence_Selector* unify_with(SimpleSequence_Selector*, Context&);
+    ATTACH_OPERATIONS()
+  };
+
+  ////////////////////////////////////////////////
+  // ID selectors -- i.e., #foo.
+  ////////////////////////////////////////////////
+  class Id_Selector : public Simple_Selector {
+  public:
+    Id_Selector(ParserState pstate, std::string n)
+    : Simple_Selector(pstate, n)
+    { }
+    virtual bool unique() const
+    {
+      return true;
+    }
+    virtual unsigned long specificity()
+    {
+      return Constants::Specificity_ID;
     }
     virtual SimpleSequence_Selector* unify_with(SimpleSequence_Selector*, Context&);
     ATTACH_OPERATIONS()

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2281,7 +2281,7 @@ namespace Sass {
     }
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapped = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapped = "");
-    virtual bool is_superselector_of(Selector_List* sub, std::string wrapped = "");
+    virtual bool is_superselector_of(CommaSequence_Selector* sub, std::string wrapped = "");
     virtual size_t hash()
     {
       if (Selector::hash_ == 0) {
@@ -2393,7 +2393,7 @@ namespace Sass {
     // last returns the last real tail
     const Complex_Selector* last() const;
 
-    Selector_List* tails(Context& ctx, Selector_List* tails);
+    CommaSequence_Selector* tails(Context& ctx, CommaSequence_Selector* tails);
 
     // unconstant accessors
     Complex_Selector* first();
@@ -2404,12 +2404,12 @@ namespace Sass {
     Complex_Selector* innermost() { return last(); };
 
     size_t length() const;
-    Selector_List* resolve_parent_refs(Context& ctx, Selector_List* parents, bool implicit_parent);
+    CommaSequence_Selector* resolve_parent_refs(Context& ctx, CommaSequence_Selector* parents, bool implicit_parent);
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapping = "");
-    virtual bool is_superselector_of(Selector_List* sub, std::string wrapping = "");
+    virtual bool is_superselector_of(CommaSequence_Selector* sub, std::string wrapping = "");
     // virtual Placeholder_Selector* find_placeholder();
-    Selector_List* unify_with(Complex_Selector* rhs, Context& ctx);
+    CommaSequence_Selector* unify_with(Complex_Selector* rhs, Context& ctx);
     Combinator clear_innermost();
     void append(Context&, Complex_Selector*);
     void set_innermost(Complex_Selector*, Combinator);
@@ -2503,12 +2503,12 @@ namespace Sass {
   ///////////////////////////////////
   // Comma-separated selector groups.
   ///////////////////////////////////
-  class Selector_List : public Selector, public Vectorized<Complex_Selector*> {
+  class CommaSequence_Selector : public Selector, public Vectorized<Complex_Selector*> {
     ADD_PROPERTY(std::vector<std::string>, wspace)
   protected:
     void adjust_after_pushing(Complex_Selector* c);
   public:
-    Selector_List(ParserState pstate, size_t s = 0)
+    CommaSequence_Selector(ParserState pstate, size_t s = 0)
     : Selector(pstate), Vectorized<Complex_Selector*>(s), wspace_(0)
     { }
     std::string type() { return "list"; }
@@ -2517,12 +2517,12 @@ namespace Sass {
     virtual bool has_parent_ref();
     void remove_parent_selectors();
     // virtual Placeholder_Selector* find_placeholder();
-    Selector_List* resolve_parent_refs(Context& ctx, Selector_List* parents, bool implicit_parent = true);
+    CommaSequence_Selector* resolve_parent_refs(Context& ctx, CommaSequence_Selector* parents, bool implicit_parent = true);
     virtual bool is_superselector_of(Compound_Selector* sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector* sub, std::string wrapping = "");
-    virtual bool is_superselector_of(Selector_List* sub, std::string wrapping = "");
-    Selector_List* unify_with(Selector_List*, Context&);
-    void populate_extends(Selector_List*, Context&, ExtensionSubsetMap&);
+    virtual bool is_superselector_of(CommaSequence_Selector* sub, std::string wrapping = "");
+    CommaSequence_Selector* unify_with(CommaSequence_Selector*, Context&);
+    void populate_extends(CommaSequence_Selector*, Context&, ExtensionSubsetMap&);
     virtual size_t hash()
     {
       if (Selector::hash_ == 0) {
@@ -2554,10 +2554,10 @@ namespace Sass {
       }
       return false;
     }
-    Selector_List* clone(Context&) const;      // does not clone Compound_Selector*s
-    Selector_List* cloneFully(Context&) const; // clones Compound_Selector*s
+    CommaSequence_Selector* clone(Context&) const;      // does not clone Compound_Selector*s
+    CommaSequence_Selector* cloneFully(Context&) const; // clones Compound_Selector*s
     virtual bool operator==(const Selector& rhs) const;
-    virtual bool operator==(const Selector_List& rhs) const;
+    virtual bool operator==(const CommaSequence_Selector& rhs) const;
     // Selector Lists can be compared to comma lists
     virtual bool operator==(const Expression& rhs) const;
     ATTACH_OPERATIONS()

--- a/src/ast_factory.hpp
+++ b/src/ast_factory.hpp
@@ -83,8 +83,8 @@ namespace Sass {
     Placeholder_Selector* new_Placeholder_Selector(std::string p, size_t l, std::string n);
     Pseudo_Selector* new_Pseudo_Selector(std::string p, size_t l, std::string n, Expression* expr = 0);
     Wrapped_Selector* new_Wrapped_Selector(std::string p, size_t l, std::string n, Simple_Base* sel);
-    Compound_Selector* new_Compound_Selector(std::string p, size_t l, size_t s = 0);
-    Sequence_Selector* new_Sequence_Selector(std::string p, size_t l, Sequence_Selector::Combinator c, Sequence_Selector* ctx, Compound_Selector* sel);
+    SimpleSequence_Selector* new_SimpleSequence_Selector(std::string p, size_t l, size_t s = 0);
+    Sequence_Selector* new_Sequence_Selector(std::string p, size_t l, Sequence_Selector::Combinator c, Sequence_Selector* ctx, SimpleSequence_Selector* sel);
     CommaSequence_Selector* new_CommaSequence_Selector(std::string p, size_t l, size_t s = 0);
   };
 }

--- a/src/ast_factory.hpp
+++ b/src/ast_factory.hpp
@@ -85,7 +85,7 @@ namespace Sass {
     Wrapped_Selector* new_Wrapped_Selector(std::string p, size_t l, std::string n, Simple_Base* sel);
     Compound_Selector* new_Compound_Selector(std::string p, size_t l, size_t s = 0);
     Complex_Selector* new_Complex_Selector(std::string p, size_t l, Complex_Selector::Combinator c, Complex_Selector* ctx, Compound_Selector* sel);
-    Selector_List* new_Selector_List(std::string p, size_t l, size_t s = 0);
+    CommaSequence_Selector* new_CommaSequence_Selector(std::string p, size_t l, size_t s = 0);
   };
 }
 

--- a/src/ast_factory.hpp
+++ b/src/ast_factory.hpp
@@ -84,7 +84,7 @@ namespace Sass {
     Pseudo_Selector* new_Pseudo_Selector(std::string p, size_t l, std::string n, Expression* expr = 0);
     Wrapped_Selector* new_Wrapped_Selector(std::string p, size_t l, std::string n, Simple_Base* sel);
     Compound_Selector* new_Compound_Selector(std::string p, size_t l, size_t s = 0);
-    Complex_Selector* new_Complex_Selector(std::string p, size_t l, Complex_Selector::Combinator c, Complex_Selector* ctx, Compound_Selector* sel);
+    Sequence_Selector* new_Sequence_Selector(std::string p, size_t l, Sequence_Selector::Combinator c, Sequence_Selector* ctx, Compound_Selector* sel);
     CommaSequence_Selector* new_CommaSequence_Selector(std::string p, size_t l, size_t s = 0);
   };
 }

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -74,7 +74,7 @@ namespace Sass {
   class Selector;
   class Selector_Schema;
   class Selector_Placeholder;
-  class Type_Selector;
+  class Element_Selector;
   class Selector_Qualifier;
   class Attribute_Selector;
   class Pseudo_Selector;

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -80,7 +80,7 @@ namespace Sass {
   class Pseudo_Selector;
   class Wrapped_Selector;
   class Compound_Selector;
-  class Complex_Selector;
+  class Sequence_Selector;
   class CommaSequence_Selector;
 
   // common classes

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -73,7 +73,7 @@ namespace Sass {
   // selectors
   class Selector;
   class Selector_Schema;
-  class Selector_Placeholder;
+  class Placeholder_Selector;
   class Element_Selector;
   class Selector_Qualifier;
   class Attribute_Selector;

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -81,7 +81,7 @@ namespace Sass {
   class Wrapped_Selector;
   class Compound_Selector;
   class Complex_Selector;
-  class Selector_List;
+  class CommaSequence_Selector;
 
   // common classes
   class Context;

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -79,7 +79,7 @@ namespace Sass {
   class Attribute_Selector;
   class Pseudo_Selector;
   class Wrapped_Selector;
-  class Compound_Selector;
+  class SimpleSequence_Selector;
   class Sequence_Selector;
   class CommaSequence_Selector;
 

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -75,7 +75,8 @@ namespace Sass {
   class Selector_Schema;
   class Placeholder_Selector;
   class Element_Selector;
-  class Selector_Qualifier;
+  class Class_Selector;
+  class Id_Selector;
   class Attribute_Selector;
   class Pseudo_Selector;
   class Wrapped_Selector;

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -11,7 +11,7 @@ namespace Sass {
     // https://github.com/sass/sass/issues/1495#issuecomment-61189114
     extern const unsigned long Specificity_Star = 0;
     extern const unsigned long Specificity_Universal = 0;
-    extern const unsigned long Specificity_Type = 1;
+    extern const unsigned long Specificity_Element = 1;
     extern const unsigned long Specificity_Base = 1000;
     extern const unsigned long Specificity_Class = 1000;
     extern const unsigned long Specificity_Attr = 1000;

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -11,7 +11,7 @@ namespace Sass {
     // The following list of selectors is by increasing specificity:
     extern const unsigned long Specificity_Star;
     extern const unsigned long Specificity_Universal;
-    extern const unsigned long Specificity_Type;
+    extern const unsigned long Specificity_Element;
     extern const unsigned long Specificity_Base;
     extern const unsigned long Specificity_Class;
     extern const unsigned long Specificity_Attr;

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -50,7 +50,7 @@ namespace Sass {
     std::vector<char*> strings;
     std::vector<Resource> resources;
     std::map<const std::string, const StyleSheet> sheets;
-    Subset_Map<std::string, std::pair<Complex_Selector*, Compound_Selector*> > subset_map;
+    Subset_Map<std::string, std::pair<Sequence_Selector*, Compound_Selector*> > subset_map;
     std::vector<Sass_Import_Entry> import_stack;
 
     struct Sass_Compiler* c_compiler;

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -50,7 +50,7 @@ namespace Sass {
     std::vector<char*> strings;
     std::vector<Resource> resources;
     std::map<const std::string, const StyleSheet> sheets;
-    Subset_Map<std::string, std::pair<Sequence_Selector*, Compound_Selector*> > subset_map;
+    Subset_Map<std::string, std::pair<Sequence_Selector*, SimpleSequence_Selector*> > subset_map;
     std::vector<Sass_Import_Entry> import_stack;
 
     struct Sass_Compiler* c_compiler;

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -24,7 +24,7 @@ namespace Sass {
     Cssize(Context&, Backtrace*);
     ~Cssize() { }
 
-    Selector_List* selector();
+    CommaSequence_Selector* selector();
 
     Statement* operator()(Block*);
     Statement* operator()(Ruleset*);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -199,9 +199,9 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
-  } else if (dynamic_cast<Type_Selector*>(node)) {
-    Type_Selector* selector = dynamic_cast<Type_Selector*>(node);
-    std::cerr << ind << "Type_Selector " << selector;
+  } else if (dynamic_cast<Element_Selector*>(node)) {
+    Element_Selector* selector = dynamic_cast<Element_Selector*>(node);
+    std::cerr << ind << "Element_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <<" << selector->ns_name() << ">>";

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -188,9 +188,20 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
     debug_ast(selector->value(), ind + "[" + selector->matcher() + "] ", env);
-  } else if (dynamic_cast<Selector_Qualifier*>(node)) {
-    Selector_Qualifier* selector = dynamic_cast<Selector_Qualifier*>(node);
-    std::cerr << ind << "Selector_Qualifier " << selector;
+  } else if (dynamic_cast<Class_Selector*>(node)) {
+    Class_Selector* selector = dynamic_cast<Class_Selector*>(node);
+    std::cerr << ind << "Class_Selector " << selector;
+    std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " <" << selector->hash() << ">";
+    std::cerr << " <<" << selector->ns_name() << ">>";
+    std::cerr << (selector->is_optional() ? " [is_optional]": " -");
+    std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
+    std::cerr << (selector->has_line_break() ? " [line-break]": " -");
+    std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
+    std::cerr << std::endl;
+  } else if (dynamic_cast<Id_Selector*>(node)) {
+    Id_Selector* selector = dynamic_cast<Id_Selector*>(node);
+    std::cerr << ind << "Id_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <<" << selector->ns_name() << ">>";

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -138,9 +138,9 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     }
     SourcesSet set = selector->sources();
     // debug_sources_set(set, ind + "  @--> ");
-  } else if (dynamic_cast<Compound_Selector*>(node)) {
-    Compound_Selector* selector = dynamic_cast<Compound_Selector*>(node);
-    std::cerr << ind << "Compound_Selector " << selector;
+  } else if (dynamic_cast<SimpleSequence_Selector*>(node)) {
+    SimpleSequence_Selector* selector = dynamic_cast<SimpleSequence_Selector*>(node);
+    std::cerr << ind << "SimpleSequence_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
     std::cerr << " [weight:" << longToHex(selector->specificity()) << "]";
@@ -742,7 +742,7 @@ inline void debug_subset_map(Sass::ExtensionSubsetMap& map, std::string ind = ""
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
 }
 
-typedef std::pair<Sequence_Selector*, Compound_Selector*> ExtensionPair;
+typedef std::pair<Sequence_Selector*, SimpleSequence_Selector*> ExtensionPair;
 typedef std::vector<ExtensionPair> SubsetMapEntries;
 
 inline void debug_subset_entries(SubsetMapEntries* entries, std::string ind = "")

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -108,9 +108,9 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
 //    debug_ast(selector->selector(), ind + "->", env);
 
-  } else if (dynamic_cast<Complex_Selector*>(node)) {
-    Complex_Selector* selector = dynamic_cast<Complex_Selector*>(node);
-    std::cerr << ind << "Complex_Selector " << selector
+  } else if (dynamic_cast<Sequence_Selector*>(node)) {
+    Sequence_Selector* selector = dynamic_cast<Sequence_Selector*>(node);
+    std::cerr << ind << "Sequence_Selector " << selector
       << " (" << pstate_source_position(node) << ")"
       << " <" << selector->hash() << ">"
       << " [weight:" << longToHex(selector->specificity()) << "]"
@@ -122,11 +122,11 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
       << " -- ";
       std::string del;
       switch (selector->combinator()) {
-        case Complex_Selector::PARENT_OF:   del = ">"; break;
-        case Complex_Selector::PRECEDES:    del = "~"; break;
-        case Complex_Selector::ADJACENT_TO: del = "+"; break;
-        case Complex_Selector::ANCESTOR_OF: del = " "; break;
-        case Complex_Selector::REFERENCE:   del = "//"; break;
+        case Sequence_Selector::PARENT_OF:   del = ">"; break;
+        case Sequence_Selector::PRECEDES:    del = "~"; break;
+        case Sequence_Selector::ADJACENT_TO: del = "+"; break;
+        case Sequence_Selector::ANCESTOR_OF: del = " "; break;
+        case Sequence_Selector::REFERENCE:   del = "//"; break;
       }
       // if (del = "/") del += selector->reference()->perform(&to_string) + "/";
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
@@ -682,11 +682,11 @@ inline void debug_node(Node* node, std::string ind = "")
     std::cerr << node << " ";
     if (node->got_line_feed) std::cerr << "[LF] ";
     switch (node->combinator()) {
-      case Complex_Selector::ADJACENT_TO: std::cerr << "{+} "; break;
-      case Complex_Selector::PARENT_OF:   std::cerr << "{>} "; break;
-      case Complex_Selector::PRECEDES:    std::cerr << "{~} "; break;
-      case Complex_Selector::REFERENCE:   std::cerr << "{@} "; break;
-      case Complex_Selector::ANCESTOR_OF: std::cerr << "{ } "; break;
+      case Sequence_Selector::ADJACENT_TO: std::cerr << "{+} "; break;
+      case Sequence_Selector::PARENT_OF:   std::cerr << "{>} "; break;
+      case Sequence_Selector::PRECEDES:    std::cerr << "{~} "; break;
+      case Sequence_Selector::REFERENCE:   std::cerr << "{@} "; break;
+      case Sequence_Selector::ANCESTOR_OF: std::cerr << "{ } "; break;
     }
     std::cerr << std::endl;
     // debug_ast(node->combinator(), ind + "  ");
@@ -742,7 +742,7 @@ inline void debug_subset_map(Sass::ExtensionSubsetMap& map, std::string ind = ""
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
 }
 
-typedef std::pair<Complex_Selector*, Compound_Selector*> ExtensionPair;
+typedef std::pair<Sequence_Selector*, Compound_Selector*> ExtensionPair;
 typedef std::vector<ExtensionPair> SubsetMapEntries;
 
 inline void debug_subset_entries(SubsetMapEntries* entries, std::string ind = "")

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -211,10 +211,10 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">";
     std::cerr << std::endl;
-  } else if (dynamic_cast<Selector_Placeholder*>(node)) {
+  } else if (dynamic_cast<Placeholder_Selector*>(node)) {
 
-    Selector_Placeholder* selector = dynamic_cast<Selector_Placeholder*>(node);
-    std::cerr << ind << "Selector_Placeholder [" << selector->ns_name() << "] " << selector
+    Placeholder_Selector* selector = dynamic_cast<Placeholder_Selector*>(node);
+    std::cerr << ind << "Placeholder_Selector [" << selector->ns_name() << "] " << selector
       << " <" << selector->hash() << ">"
       << " [@media:" << selector->media_block() << "]"
       << (selector->is_optional() ? " [is_optional]": " -")

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -81,9 +81,9 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << std::endl;
     debug_ast(root_block->expression(), ind + ":", env);
     debug_ast(root_block->block(), ind + " ", env);
-  } else if (dynamic_cast<Selector_List*>(node)) {
-    Selector_List* selector = dynamic_cast<Selector_List*>(node);
-    std::cerr << ind << "Selector_List " << selector;
+  } else if (dynamic_cast<CommaSequence_Selector*>(node)) {
+    CommaSequence_Selector* selector = dynamic_cast<CommaSequence_Selector*>(node);
+    std::cerr << ind << "CommaSequence_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
     std::cerr << " [@media:" << selector->media_block() << "]";

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -57,7 +57,7 @@ namespace Sass {
     return exp.environment();
   }
 
-  Selector_List* Eval::selector()
+  CommaSequence_Selector* Eval::selector()
   {
     return exp.selector();
   }
@@ -223,7 +223,7 @@ namespace Sass {
     if (expr->concrete_type() == Expression::MAP) {
       map = static_cast<Map*>(expr);
     }
-    else if (Selector_List* ls = dynamic_cast<Selector_List*>(expr)) {
+    else if (CommaSequence_Selector* ls = dynamic_cast<CommaSequence_Selector*>(expr)) {
       Listize listize(ctx.mem);
       list = dynamic_cast<List*>(ls->perform(&listize));
     }
@@ -257,7 +257,7 @@ namespace Sass {
       }
     }
     else {
-      if (list->length() == 1 && dynamic_cast<Selector_List*>(list)) {
+      if (list->length() == 1 && dynamic_cast<CommaSequence_Selector*>(list)) {
         list = dynamic_cast<Vectorized<Expression*>*>(list);
       }
       for (size_t i = 0, L = list->length(); i < L; ++i) {
@@ -1094,7 +1094,7 @@ namespace Sass {
     // Value
     // Textual
     // Function_Call
-    // Selector_List
+    // CommaSequence_Selector
     // String_Quoted
     // String_Constant
     // Parent_Selector
@@ -1611,10 +1611,10 @@ namespace Sass {
     return e;
   }
 
-  Selector_List* Eval::operator()(Selector_List* s)
+  CommaSequence_Selector* Eval::operator()(CommaSequence_Selector* s)
   {
-    std::vector<Selector_List*> rv;
-    Selector_List* sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, s->pstate());
+    std::vector<CommaSequence_Selector*> rv;
+    CommaSequence_Selector* sl = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, s->pstate());
     sl->is_optional(s->is_optional());
     sl->media_block(s->media_block());
     sl->is_optional(s->is_optional());
@@ -1644,7 +1644,7 @@ namespace Sass {
   }
 
 
-  Selector_List* Eval::operator()(Complex_Selector* s)
+  CommaSequence_Selector* Eval::operator()(Complex_Selector* s)
   {
     bool implicit_parent = !exp.old_at_root_without_rule;
     return s->resolve_parent_refs(ctx, selector(), implicit_parent);
@@ -1661,21 +1661,21 @@ namespace Sass {
     return ss;
   }
 
-  Selector_List* Eval::operator()(Selector_Schema* s)
+  CommaSequence_Selector* Eval::operator()(Selector_Schema* s)
   {
     // the parser will look for a brace to end the selector
     std::string result_str(s->contents()->perform(this)->to_string(ctx.c_options));
     result_str = unquote(Util::rtrim(result_str)) + "\n{";
     Parser p = Parser::from_c_str(result_str.c_str(), ctx, s->pstate());
     p.last_media_block = s->media_block();
-    Selector_List* sl = p.parse_selector_list(exp.block_stack.back()->is_root());
+    CommaSequence_Selector* sl = p.parse_selector_list(exp.block_stack.back()->is_root());
     if (s->has_parent_ref()) sl->remove_parent_selectors();
     return operator()(sl);
   }
 
   Expression* Eval::operator()(Parent_Selector* p)
   {
-    Selector_List* pr = selector();
+    CommaSequence_Selector* pr = selector();
     if (pr) {
       exp.selector_stack.pop_back();
       pr = operator()(pr);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1644,7 +1644,7 @@ namespace Sass {
   }
 
 
-  CommaSequence_Selector* Eval::operator()(Complex_Selector* s)
+  CommaSequence_Selector* Eval::operator()(Sequence_Selector* s)
   {
     bool implicit_parent = !exp.old_at_root_without_rule;
     return s->resolve_parent_refs(ctx, selector(), implicit_parent);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -74,7 +74,7 @@ namespace Sass {
     Selector_List* operator()(Complex_Selector*);
     Attribute_Selector* operator()(Attribute_Selector*);
     // they don't have any specific implementatio (yet)
-    Type_Selector* operator()(Type_Selector* s) { return s; };
+    Element_Selector* operator()(Element_Selector* s) { return s; };
     Pseudo_Selector* operator()(Pseudo_Selector* s) { return s; };
     Wrapped_Selector* operator()(Wrapped_Selector* s) { return s; };
     Selector_Qualifier* operator()(Selector_Qualifier* s) { return s; };

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -27,7 +27,7 @@ namespace Sass {
 
     Env* environment();
     Context& context();
-    Selector_List* selector();
+    CommaSequence_Selector* selector();
     Backtrace* backtrace();
 
     // for evaluating function bodies
@@ -56,7 +56,7 @@ namespace Sass {
     Expression* operator()(String_Schema*);
     Expression* operator()(String_Quoted*);
     Expression* operator()(String_Constant*);
-    // Expression* operator()(Selector_List*);
+    // Expression* operator()(CommaSequence_Selector*);
     Expression* operator()(Media_Query*);
     Expression* operator()(Media_Query_Expression*);
     Expression* operator()(At_Root_Query*);
@@ -70,8 +70,8 @@ namespace Sass {
     Expression* operator()(Comment*);
 
     // these will return selectors
-    Selector_List* operator()(Selector_List*);
-    Selector_List* operator()(Complex_Selector*);
+    CommaSequence_Selector* operator()(CommaSequence_Selector*);
+    CommaSequence_Selector* operator()(Complex_Selector*);
     Attribute_Selector* operator()(Attribute_Selector*);
     // they don't have any specific implementatio (yet)
     Element_Selector* operator()(Element_Selector* s) { return s; };
@@ -80,7 +80,7 @@ namespace Sass {
     Selector_Qualifier* operator()(Selector_Qualifier* s) { return s; };
     Placeholder_Selector* operator()(Placeholder_Selector* s) { return s; };
     // actual evaluated selectors
-    Selector_List* operator()(Selector_Schema*);
+    CommaSequence_Selector* operator()(Selector_Schema*);
     Expression* operator()(Parent_Selector*);
 
     template <typename U>

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -78,7 +78,7 @@ namespace Sass {
     Pseudo_Selector* operator()(Pseudo_Selector* s) { return s; };
     Wrapped_Selector* operator()(Wrapped_Selector* s) { return s; };
     Selector_Qualifier* operator()(Selector_Qualifier* s) { return s; };
-    Selector_Placeholder* operator()(Selector_Placeholder* s) { return s; };
+    Placeholder_Selector* operator()(Placeholder_Selector* s) { return s; };
     // actual evaluated selectors
     Selector_List* operator()(Selector_Schema*);
     Expression* operator()(Parent_Selector*);

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -71,7 +71,7 @@ namespace Sass {
 
     // these will return selectors
     CommaSequence_Selector* operator()(CommaSequence_Selector*);
-    CommaSequence_Selector* operator()(Complex_Selector*);
+    CommaSequence_Selector* operator()(Sequence_Selector*);
     Attribute_Selector* operator()(Attribute_Selector*);
     // they don't have any specific implementatio (yet)
     Element_Selector* operator()(Element_Selector* s) { return s; };

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -77,7 +77,8 @@ namespace Sass {
     Element_Selector* operator()(Element_Selector* s) { return s; };
     Pseudo_Selector* operator()(Pseudo_Selector* s) { return s; };
     Wrapped_Selector* operator()(Wrapped_Selector* s) { return s; };
-    Selector_Qualifier* operator()(Selector_Qualifier* s) { return s; };
+    Class_Selector* operator()(Class_Selector* s) { return s; };
+    Id_Selector* operator()(Id_Selector* s) { return s; };
     Placeholder_Selector* operator()(Placeholder_Selector* s) { return s; };
     // actual evaluated selectors
     CommaSequence_Selector* operator()(Selector_Schema*);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -106,8 +106,8 @@ namespace Sass {
     // do some special checks for the base level rules
     if (r->is_root()) {
       if (CommaSequence_Selector* selector_list = dynamic_cast<CommaSequence_Selector*>(r->selector())) {
-        for (Complex_Selector* complex_selector : selector_list->elements()) {
-          Complex_Selector* tail = complex_selector;
+        for (Sequence_Selector* complex_selector : selector_list->elements()) {
+          Sequence_Selector* tail = complex_selector;
           while (tail) {
             if (tail->head()) for (Simple_Selector* header : tail->head()->elements()) {
               if (dynamic_cast<Parent_Selector*>(header) == NULL) continue; // skip all others
@@ -555,8 +555,8 @@ namespace Sass {
   void Expand::expand_selector_list(Selector* s, CommaSequence_Selector* extender) {
 
     if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(s)) {
-      for (Complex_Selector* complex_selector : sl->elements()) {
-        Complex_Selector* tail = complex_selector;
+      for (Sequence_Selector* complex_selector : sl->elements()) {
+        Sequence_Selector* tail = complex_selector;
         while (tail) {
           if (tail->head()) for (Simple_Selector* header : tail->head()->elements()) {
             if (dynamic_cast<Parent_Selector*>(header) == NULL) continue; // skip all others
@@ -572,7 +572,7 @@ namespace Sass {
     CommaSequence_Selector* contextualized = dynamic_cast<CommaSequence_Selector*>(s->perform(&eval));
     if (contextualized == NULL) return;
     for (auto complex_sel : contextualized->elements()) {
-      Complex_Selector* c = complex_sel;
+      Sequence_Selector* c = complex_sel;
       if (!c->head() || c->tail()) {
         std::string sel_str(contextualized->to_string(ctx.c_options));
         error("Can't extend " + sel_str + ": can't extend nested selectors", c->pstate(), backtrace());
@@ -580,13 +580,13 @@ namespace Sass {
       Compound_Selector* placeholder = c->head();
       if (contextualized->is_optional()) placeholder->is_optional(true);
       for (size_t i = 0, L = extender->length(); i < L; ++i) {
-        Complex_Selector* sel = (*extender)[i];
+        Sequence_Selector* sel = (*extender)[i];
         if (!(sel->head() && sel->head()->length() > 0 &&
             dynamic_cast<Parent_Selector*>((*sel->head())[0])))
         {
           Compound_Selector* hh = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, (*extender)[i]->pstate());
           hh->media_block((*extender)[i]->media_block());
-          Complex_Selector* ssel = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, (*extender)[i]->pstate());
+          Sequence_Selector* ssel = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, (*extender)[i]->pstate());
           ssel->media_block((*extender)[i]->media_block());
           if (sel->has_line_feed()) ssel->has_line_feed(true);
           Parent_Selector* ps = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, (*extender)[i]->pstate());
@@ -611,7 +611,7 @@ namespace Sass {
         if (schema->has_parent_ref()) s = eval(schema);
       }
       if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(s)) {
-        for (Complex_Selector* cs : *sl) {
+        for (Sequence_Selector* cs : *sl) {
           if (cs != NULL && cs->head() != NULL) {
             cs->head()->media_block(media_block_stack.back());
           }

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -18,7 +18,7 @@ namespace Sass {
     block_stack(std::vector<Block*>()),
     call_stack(std::vector<AST_Node*>()),
     property_stack(std::vector<String*>()),
-    selector_stack(std::vector<Selector_List*>()),
+    selector_stack(std::vector<CommaSequence_Selector*>()),
     media_block_stack(std::vector<Media_Block*>()),
     backtrace_stack(std::vector<Backtrace*>()),
     in_keyframes(false),
@@ -49,7 +49,7 @@ namespace Sass {
     return 0;
   }
 
-  Selector_List* Expand::selector()
+  CommaSequence_Selector* Expand::selector()
   {
     if (selector_stack.size() > 0)
       return selector_stack.back();
@@ -94,7 +94,7 @@ namespace Sass {
       Keyframe_Rule* k = SASS_MEMORY_NEW(ctx.mem, Keyframe_Rule, r->pstate(), r->block()->perform(this)->block());
       if (r->selector()) {
         selector_stack.push_back(0);
-        k->selector(static_cast<Selector_List*>(r->selector()->perform(&eval)));
+        k->selector(static_cast<CommaSequence_Selector*>(r->selector()->perform(&eval)));
         selector_stack.pop_back();
       }
       return k;
@@ -105,7 +105,7 @@ namespace Sass {
 
     // do some special checks for the base level rules
     if (r->is_root()) {
-      if (Selector_List* selector_list = dynamic_cast<Selector_List*>(r->selector())) {
+      if (CommaSequence_Selector* selector_list = dynamic_cast<CommaSequence_Selector*>(r->selector())) {
         for (Complex_Selector* complex_selector : selector_list->elements()) {
           Complex_Selector* tail = complex_selector;
           while (tail) {
@@ -121,13 +121,13 @@ namespace Sass {
     }
 
     Expression* ex = r->selector()->perform(&eval);
-    Selector_List* sel = dynamic_cast<Selector_List*>(ex);
+    CommaSequence_Selector* sel = dynamic_cast<CommaSequence_Selector*>(ex);
     if (sel == 0) throw std::runtime_error("Expanded null selector");
 
     if (sel->length() == 0 || sel->has_parent_ref()) {
       bool has_parent_selector = false;
       for (size_t i = 0, L = selector_stack.size(); i < L && !has_parent_selector; i++) {
-        Selector_List* ll = selector_stack.at(i);
+        CommaSequence_Selector* ll = selector_stack.at(i);
         has_parent_selector = ll != 0 && ll->length() > 0;
       }
       if (!has_parent_selector) {
@@ -456,7 +456,7 @@ namespace Sass {
     if (expr->concrete_type() == Expression::MAP) {
       map = static_cast<Map*>(expr);
     }
-    else if (Selector_List* ls = dynamic_cast<Selector_List*>(expr)) {
+    else if (CommaSequence_Selector* ls = dynamic_cast<CommaSequence_Selector*>(expr)) {
       Listize listize(ctx.mem);
       list = dynamic_cast<List*>(ls->perform(&listize));
     }
@@ -492,7 +492,7 @@ namespace Sass {
     }
     else {
       // bool arglist = list->is_arglist();
-      if (list->length() == 1 && dynamic_cast<Selector_List*>(list)) {
+      if (list->length() == 1 && dynamic_cast<CommaSequence_Selector*>(list)) {
         list = dynamic_cast<Vectorized<Expression*>*>(list);
       }
       for (size_t i = 0, L = list->length(); i < L; ++i) {
@@ -552,9 +552,9 @@ namespace Sass {
   }
 
 
-  void Expand::expand_selector_list(Selector* s, Selector_List* extender) {
+  void Expand::expand_selector_list(Selector* s, CommaSequence_Selector* extender) {
 
-    if (Selector_List* sl = dynamic_cast<Selector_List*>(s)) {
+    if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(s)) {
       for (Complex_Selector* complex_selector : sl->elements()) {
         Complex_Selector* tail = complex_selector;
         while (tail) {
@@ -569,7 +569,7 @@ namespace Sass {
     }
 
 
-    Selector_List* contextualized = dynamic_cast<Selector_List*>(s->perform(&eval));
+    CommaSequence_Selector* contextualized = dynamic_cast<CommaSequence_Selector*>(s->perform(&eval));
     if (contextualized == NULL) return;
     for (auto complex_sel : contextualized->elements()) {
       Complex_Selector* c = complex_sel;
@@ -605,12 +605,12 @@ namespace Sass {
 
   Statement* Expand::operator()(Extension* e)
   {
-    if (Selector_List* extender = dynamic_cast<Selector_List*>(selector())) {
+    if (CommaSequence_Selector* extender = dynamic_cast<CommaSequence_Selector*>(selector())) {
       Selector* s = e->selector();
       if (Selector_Schema* schema = dynamic_cast<Selector_Schema*>(s)) {
         if (schema->has_parent_ref()) s = eval(schema);
       }
-      if (Selector_List* sl = dynamic_cast<Selector_List*>(s)) {
+      if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(s)) {
         for (Complex_Selector* cs : *sl) {
           if (cs != NULL && cs->head() != NULL) {
             cs->head()->media_block(media_block_stack.back());

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -577,14 +577,14 @@ namespace Sass {
         std::string sel_str(contextualized->to_string(ctx.c_options));
         error("Can't extend " + sel_str + ": can't extend nested selectors", c->pstate(), backtrace());
       }
-      Compound_Selector* placeholder = c->head();
+      SimpleSequence_Selector* placeholder = c->head();
       if (contextualized->is_optional()) placeholder->is_optional(true);
       for (size_t i = 0, L = extender->length(); i < L; ++i) {
         Sequence_Selector* sel = (*extender)[i];
         if (!(sel->head() && sel->head()->length() > 0 &&
             dynamic_cast<Parent_Selector*>((*sel->head())[0])))
         {
-          Compound_Selector* hh = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, (*extender)[i]->pstate());
+          SimpleSequence_Selector* hh = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, (*extender)[i]->pstate());
           hh->media_block((*extender)[i]->media_block());
           Sequence_Selector* ssel = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, (*extender)[i]->pstate());
           ssel->media_block((*extender)[i]->media_block());

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -21,7 +21,7 @@ namespace Sass {
 
     Env* environment();
     Context& context();
-    Selector_List* selector();
+    CommaSequence_Selector* selector();
     Backtrace* backtrace();
 
     Context&          ctx;
@@ -32,7 +32,7 @@ namespace Sass {
     std::vector<Block*>         block_stack;
     std::vector<AST_Node*>      call_stack;
     std::vector<String*>        property_stack;
-    std::vector<Selector_List*> selector_stack;
+    std::vector<CommaSequence_Selector*> selector_stack;
     std::vector<Media_Block*>   media_block_stack;
     std::vector<Backtrace*>     backtrace_stack;
     bool                        in_keyframes;
@@ -42,7 +42,7 @@ namespace Sass {
     Statement* fallback_impl(AST_Node* n);
 
   private:
-    void expand_selector_list(Selector*, Selector_List* extender);
+    void expand_selector_list(Selector*, CommaSequence_Selector* extender);
 
   public:
     Expand(Context&, Env*, Backtrace*);

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -291,7 +291,7 @@ namespace Sass {
     // TODO: figure out a better way to create a Complex_Selector from scratch
     // TODO: There's got to be a better way. This got ugly quick...
     Position noPosition(-1, -1, -1);
-    Type_Selector fakeParent(ParserState("[FAKE]"), "temp");
+    Element_Selector fakeParent(ParserState("[FAKE]"), "temp");
     Compound_Selector fakeHead(ParserState("[FAKE]"), 1 /*size*/);
     fakeHead.elements().push_back(&fakeParent);
     Complex_Selector fakeParentContainer(ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
@@ -654,7 +654,7 @@ namespace Sass {
     // TODO: figure out a better way to create a Complex_Selector from scratch
     // TODO: There's got to be a better way. This got ugly quick...
     Position noPosition(-1, -1, -1);
-    Type_Selector fakeParent(ParserState("[FAKE]"), "temp");
+    Element_Selector fakeParent(ParserState("[FAKE]"), "temp");
     Compound_Selector fakeHead(ParserState("[FAKE]"), 1 /*size*/);
     fakeHead.elements().push_back(&fakeParent);
     Complex_Selector fakeParentContainer(ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
@@ -1976,7 +1976,7 @@ namespace Sass {
                 // special case for ruby ass
                 if (sl->empty()) {
                   // this seems inconsistent but it is how ruby sass seems to remove parentheses
-                  *cpy_head << SASS_MEMORY_NEW(ctx.mem, Type_Selector, hs->pstate(), ws->name());
+                  *cpy_head << SASS_MEMORY_NEW(ctx.mem, Element_Selector, hs->pstate(), ws->name());
                 }
                 // has wrapped selectors
                 else {

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1725,7 +1725,7 @@ namespace Sass {
         if (seen.find(*pHead) == seen.end()) {
           for (Simple_Selector* pSimple : *pHead) {
             if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(pSimple)) {
-              if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
+              if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(ws->selector())) {
                 for (Complex_Selector* cs : sl->elements()) {
                   while (cs) {
                     if (complexSelectorHasExtension(cs, ctx, subset_map, seen)) {
@@ -1909,7 +1909,7 @@ namespace Sass {
   /*
    This is the equivalent of ruby's CommaSequence.do_extend.
   */
-  Selector_List* Extend::extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething) {
+  CommaSequence_Selector* Extend::extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething) {
     std::set<Compound_Selector> seen;
     return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething, seen);
   }
@@ -1917,9 +1917,9 @@ namespace Sass {
   /*
    This is the equivalent of ruby's CommaSequence.do_extend.
   */
-  Selector_List* Extend::extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen) {
+  CommaSequence_Selector* Extend::extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen) {
 
-    Selector_List* pNewSelectors = SASS_MEMORY_NEW(ctx.mem, Selector_List, pSelectorList->pstate(), pSelectorList->length());
+    CommaSequence_Selector* pNewSelectors = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pSelectorList->pstate(), pSelectorList->length());
 
     extendedSomething = false;
 
@@ -1972,7 +1972,7 @@ namespace Sass {
           Compound_Selector* cpy_head = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, cur->pstate());
           for (Simple_Selector* hs : *cur->head()) {
             if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(hs)) {
-              if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
+              if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(ws->selector())) {
                 // special case for ruby ass
                 if (sl->empty()) {
                   // this seems inconsistent but it is how ruby sass seems to remove parentheses
@@ -1981,12 +1981,12 @@ namespace Sass {
                 // has wrapped selectors
                 else {
                   // extend the inner list of wrapped selector
-                  Selector_List* ext_sl = extendSelectorList(sl, ctx, subset_map, recseen);
+                  CommaSequence_Selector* ext_sl = extendSelectorList(sl, ctx, subset_map, recseen);
                   for (size_t i = 0; i < ext_sl->length(); i += 1) {
                     if (Complex_Selector* ext_cs = ext_sl->at(i)) {
                       // create clones for wrapped selector and the inner list
                       Wrapped_Selector* cpy_ws = SASS_MEMORY_NEW(ctx.mem, Wrapped_Selector, *ws);
-                      Selector_List* cpy_ws_sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, sl->pstate());
+                      CommaSequence_Selector* cpy_ws_sl = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, sl->pstate());
                       // remove parent selectors from inner selector
                       if (ext_cs->first()) {
                         if (ext_cs->first()->has_wrapped_selector()) {
@@ -2055,7 +2055,7 @@ namespace Sass {
   template <typename ObjectType>
   static void extendObjectWithSelectorAndBlock(ObjectType* pObject, Context& ctx, ExtensionSubsetMap& subset_map) {
 
-    DEBUG_PRINTLN(EXTEND_OBJECT, "FOUND SELECTOR: " << static_cast<Selector_List*>(pObject->selector())->to_string(ctx.c_options))
+    DEBUG_PRINTLN(EXTEND_OBJECT, "FOUND SELECTOR: " << static_cast<CommaSequence_Selector*>(pObject->selector())->to_string(ctx.c_options))
 
     // Ruby sass seems to filter nodes that don't have any content well before we get here. I'm not sure the repercussions
     // of doing so, so for now, let's just not extend things that won't be output later.
@@ -2065,10 +2065,10 @@ namespace Sass {
     }
 
     bool extendedSomething = false;
-    Selector_List* pNewSelectorList = Extend::extendSelectorList(static_cast<Selector_List*>(pObject->selector()), ctx, subset_map, false, extendedSomething);
+    CommaSequence_Selector* pNewSelectorList = Extend::extendSelectorList(static_cast<CommaSequence_Selector*>(pObject->selector()), ctx, subset_map, false, extendedSomething);
 
     if (extendedSomething && pNewSelectorList) {
-      DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << static_cast<Selector_List*>(pObject->selector())->to_string(ctx.c_options))
+      DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << static_cast<CommaSequence_Selector*>(pObject->selector())->to_string(ctx.c_options))
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND SETTING NEW SELECTORS: " << pNewSelectorList->to_string(ctx.c_options))
       pNewSelectorList->remove_parent_selectors();
       pObject->selector(pNewSelectorList);
@@ -2127,7 +2127,7 @@ namespace Sass {
 
   void Extend::operator()(Directive* a)
   {
-    // Selector_List* ls = dynamic_cast<Selector_List*>(a->selector());
+    // CommaSequence_Selector* ls = dynamic_cast<CommaSequence_Selector*>(a->selector());
     // selector_stack.push_back(ls);
     if (a->block()) a->block()->perform(this);
     // exp.selector_stack.pop_back();

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -62,7 +62,7 @@
 namespace Sass {
 
 
-  typedef std::pair<Sequence_Selector*, Compound_Selector*> ExtensionPair;
+  typedef std::pair<Sequence_Selector*, SimpleSequence_Selector*> ExtensionPair;
   typedef std::vector<ExtensionPair> SubsetMapEntries;
 
 #ifdef DEBUG
@@ -81,7 +81,7 @@ namespace Sass {
   }
 
 
-  std::ostream& operator<<(std::ostream& os, Compound_Selector& compoundSelector) {
+  std::ostream& operator<<(std::ostream& os, SimpleSequence_Selector& compoundSelector) {
     for (size_t i = 0, L = compoundSelector.length(); i < L; ++i) {
       if (i > 0) os << ", ";
       os << compoundSelector[i]->to_string();
@@ -94,7 +94,7 @@ namespace Sass {
     return os;
   }
 
-  // Print a string representation of a Compound_Selector
+  // Print a string representation of a SimpleSequence_Selector
   static void printSimpleSelector(Simple_Selector* pSimpleSelector, const char* message=NULL, bool newline=true) {
 
     if (message) {
@@ -112,13 +112,13 @@ namespace Sass {
     }
   }
 
-  // Print a string representation of a Compound_Selector
-    typedef std::pair<Compound_Selector*, Sequence_Selector*> SelsNewSeqPair;
+  // Print a string representation of a SimpleSequence_Selector
+    typedef std::pair<SimpleSequence_Selector*, Sequence_Selector*> SelsNewSeqPair;
     typedef std::vector<SelsNewSeqPair> SelsNewSeqPairCollection;
 
 
-  // Print a string representation of a Compound_Selector
-  static void printCompoundSelector(Compound_Selector* pCompoundSelector, const char* message=NULL, bool newline=true) {
+  // Print a string representation of a SimpleSequence_Selector
+  static void printCompoundSelector(SimpleSequence_Selector* pCompoundSelector, const char* message=NULL, bool newline=true) {
 
     if (message) {
       std::cerr << message;
@@ -201,7 +201,7 @@ namespace Sass {
         std::cerr << ", ";
       }
       std::cerr << "[";
-      Compound_Selector* pSels = pair.first;
+      SimpleSequence_Selector* pSels = pair.first;
       Sequence_Selector* pNewSelector = pair.second;
       std::cerr << "[" << *pSels << "], ";
       printComplexSelector(pNewSelector, NULL, false);
@@ -255,7 +255,7 @@ namespace Sass {
 
     for (SubsetMapEntries::iterator iterator = entries.begin(), endIterator = entries.end(); iterator != endIterator; ++iterator) {
       Sequence_Selector* pExtComplexSelector = iterator->first;    // The selector up to where the @extend is (ie, the thing to merge)
-      Compound_Selector* pExtCompoundSelector = iterator->second; // The stuff after the @extend
+      SimpleSequence_Selector* pExtCompoundSelector = iterator->second; // The stuff after the @extend
 
       if (iterator != entries.begin()) {
         os << ", ";
@@ -292,7 +292,7 @@ namespace Sass {
     // TODO: There's got to be a better way. This got ugly quick...
     Position noPosition(-1, -1, -1);
     Element_Selector fakeParent(ParserState("[FAKE]"), "temp");
-    Compound_Selector fakeHead(ParserState("[FAKE]"), 1 /*size*/);
+    SimpleSequence_Selector fakeHead(ParserState("[FAKE]"), 1 /*size*/);
     fakeHead.elements().push_back(&fakeParent);
     Sequence_Selector fakeParentContainer(ParserState("[FAKE]"), Sequence_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
 
@@ -655,7 +655,7 @@ namespace Sass {
     // TODO: There's got to be a better way. This got ugly quick...
     Position noPosition(-1, -1, -1);
     Element_Selector fakeParent(ParserState("[FAKE]"), "temp");
-    Compound_Selector fakeHead(ParserState("[FAKE]"), 1 /*size*/);
+    SimpleSequence_Selector fakeHead(ParserState("[FAKE]"), 1 /*size*/);
     fakeHead.elements().push_back(&fakeParent);
     Sequence_Selector fakeParentContainer(ParserState("[FAKE]"), Sequence_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
 
@@ -989,7 +989,7 @@ namespace Sass {
 
           Sequence_Selector* pMergedWrapper = sel1.selector()->clone(ctx); // Clone the Sequence_Selector to get back to something we can transform to a node once we replace the head with the unification result
           // TODO: does subject matter? Ruby: return unless merged = sel1.unify(sel2.members, sel2.subject?)
-          Compound_Selector* pMerged = sel1.selector()->head()->unify_with(sel2.selector()->head(), ctx);
+          SimpleSequence_Selector* pMerged = sel1.selector()->head()->unify_with(sel2.selector()->head(), ctx);
           pMergedWrapper->head(pMerged);
 
           DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
@@ -1048,7 +1048,7 @@ namespace Sass {
 
             Sequence_Selector* pMergedWrapper = plusSel.selector()->clone(ctx); // Clone the Sequence_Selector to get back to something we can transform to a node once we replace the head with the unification result
             // TODO: does subject matter? Ruby: merged = plus_sel.unify(tilde_sel.members, tilde_sel.subject?)
-            Compound_Selector* pMerged = plusSel.selector()->head()->unify_with(tildeSel.selector()->head(), ctx);
+            SimpleSequence_Selector* pMerged = plusSel.selector()->head()->unify_with(tildeSel.selector()->head(), ctx);
             pMergedWrapper->head(pMerged);
 
             DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
@@ -1097,7 +1097,7 @@ namespace Sass {
 
         Sequence_Selector* pMergedWrapper = sel1.selector()->clone(ctx); // Clone the Sequence_Selector to get back to something we can transform to a node once we replace the head with the unification result
         // TODO: does subject matter? Ruby: return unless merged = sel1.unify(sel2.members, sel2.subject?)
-        Compound_Selector* pMerged = sel1.selector()->head()->unify_with(sel2.selector()->head(), ctx);
+        SimpleSequence_Selector* pMerged = sel1.selector()->head()->unify_with(sel2.selector()->head(), ctx);
         pMergedWrapper->head(pMerged);
 
         DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
@@ -1512,7 +1512,7 @@ namespace Sass {
     Sequence_Selector* pComplexSelector,
     Context& ctx,
     ExtensionSubsetMap& subset_map,
-    std::set<Compound_Selector> seen, bool isReplace, bool isOriginal);
+    std::set<SimpleSequence_Selector> seen, bool isReplace, bool isOriginal);
 
 
 
@@ -1537,10 +1537,10 @@ namespace Sass {
     }
   };
   static Node extendCompoundSelector(
-    Compound_Selector* pSelector,
+    SimpleSequence_Selector* pSelector,
     Context& ctx,
     ExtensionSubsetMap& subset_map,
-    std::set<Compound_Selector> seen, bool isReplace) {
+    std::set<SimpleSequence_Selector> seen, bool isReplace) {
 
     DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelector, "EXTEND COMPOUND: "))
     // TODO: Ruby has another loop here to skip certain members?
@@ -1556,7 +1556,7 @@ namespace Sass {
     GroupedByToAResult arr;
     group_by_to_a(entries, extPairKeyFunctor, arr);
 
-    typedef std::pair<Compound_Selector*, Sequence_Selector*> SelsNewSeqPair;
+    typedef std::pair<SimpleSequence_Selector*, Sequence_Selector*> SelsNewSeqPair;
     typedef std::vector<SelsNewSeqPair> SelsNewSeqPairCollection;
 
 
@@ -1572,10 +1572,10 @@ namespace Sass {
       DEBUG_EXEC(EXTEND_COMPOUND, printComplexSelector(&seq, "SEQ: "))
 
 
-      Compound_Selector* pSels = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pSelector->pstate());
+      SimpleSequence_Selector* pSels = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, pSelector->pstate());
       for (std::vector<ExtensionPair>::iterator groupIter = group.begin(), groupIterEnd = group.end(); groupIter != groupIterEnd; groupIter++) {
         ExtensionPair& pair = *groupIter;
-        Compound_Selector* pCompound = pair.second;
+        SimpleSequence_Selector* pCompound = pair.second;
         for (size_t index = 0; index < pCompound->length(); index++) {
           Simple_Selector* pSimpleSelector = (*pCompound)[index];
           (*pSels) << pSimpleSelector;
@@ -1586,20 +1586,20 @@ namespace Sass {
       DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSels, "SELS: "))
 
       Sequence_Selector* pExtComplexSelector = &seq;    // The selector up to where the @extend is (ie, the thing to merge)
-      Compound_Selector* pExtCompoundSelector = pSels; // All the simple selectors to be replaced from the current compound selector from all extensions
+      SimpleSequence_Selector* pExtCompoundSelector = pSels; // All the simple selectors to be replaced from the current compound selector from all extensions
 
-      // TODO: This can return a Compound_Selector with no elements. Should that just be returning NULL?
+      // TODO: This can return a SimpleSequence_Selector with no elements. Should that just be returning NULL?
       // RUBY: self_without_sel = Sass::Util.array_minus(members, sels)
-      Compound_Selector* pSelectorWithoutExtendSelectors = pSelector->minus(pExtCompoundSelector, ctx);
+      SimpleSequence_Selector* pSelectorWithoutExtendSelectors = pSelector->minus(pExtCompoundSelector, ctx);
 
       DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelector, "MEMBERS: "))
       DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelectorWithoutExtendSelectors, "SELF_WO_SEL: "))
 
-      Compound_Selector* pInnermostCompoundSelector = pExtComplexSelector->last()->head();
-      Compound_Selector* pUnifiedSelector = NULL;
+      SimpleSequence_Selector* pInnermostCompoundSelector = pExtComplexSelector->last()->head();
+      SimpleSequence_Selector* pUnifiedSelector = NULL;
 
       if (!pInnermostCompoundSelector) {
-        pInnermostCompoundSelector = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pSelector->pstate());
+        pInnermostCompoundSelector = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, pSelector->pstate());
       }
 
       pUnifiedSelector = pInnermostCompoundSelector->unify_with(pSelectorWithoutExtendSelectors, ctx);
@@ -1618,7 +1618,7 @@ namespace Sass {
       // next if group.map {|e, _| check_directives_match!(e, parent_directives)}.none?
 
       // TODO: This seems a little fishy to me. See if it causes any problems. From the ruby, we should be able to just
-      // get rid of the last Compound_Selector and replace it with this one. I think the reason this code is more
+      // get rid of the last SimpleSequence_Selector and replace it with this one. I think the reason this code is more
       // complex is that Sequence_Selector contains a combinator, but in ruby combinators have already been filtered
       // out and aren't operated on.
       Sequence_Selector* pNewSelector = pExtComplexSelector->cloneFully(ctx); // ->first();
@@ -1669,7 +1669,7 @@ namespace Sass {
     for (SelsNewSeqPairCollection::iterator holderIter = holder.begin(), holderIterEnd = holder.end(); holderIter != holderIterEnd; holderIter++) {
       SelsNewSeqPair& pair = *holderIter;
 
-      Compound_Selector* pSels = pair.first;
+      SimpleSequence_Selector* pSels = pair.first;
       Sequence_Selector* pNewSelector = pair.second;
 
 
@@ -1679,7 +1679,7 @@ namespace Sass {
       }
 
 
-      std::set<Compound_Selector> recurseSeen(seen);
+      std::set<SimpleSequence_Selector> recurseSeen(seen);
       recurseSeen.insert(*pSels);
 
 
@@ -1712,14 +1712,14 @@ namespace Sass {
     Sequence_Selector* pComplexSelector,
     Context& ctx,
     ExtensionSubsetMap& subset_map,
-    std::set<Compound_Selector>& seen) {
+    std::set<SimpleSequence_Selector>& seen) {
 
     bool hasExtension = false;
 
     Sequence_Selector* pIter = pComplexSelector;
 
     while (!hasExtension && pIter) {
-      Compound_Selector* pHead = pIter->head();
+      SimpleSequence_Selector* pHead = pIter->head();
 
       if (pHead) {
         if (seen.find(*pHead) == seen.end()) {
@@ -1789,7 +1789,7 @@ namespace Sass {
     Sequence_Selector* pComplexSelector,
     Context& ctx,
     ExtensionSubsetMap& subset_map,
-    std::set<Compound_Selector> seen, bool isReplace, bool isOriginal) {
+    std::set<SimpleSequence_Selector> seen, bool isReplace, bool isOriginal) {
 
     Node complexSelector = complexSelectorToNode(pComplexSelector, ctx);
     DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTEND COMPLEX: " << complexSelector)
@@ -1818,7 +1818,7 @@ namespace Sass {
         continue;
       }
 
-      Compound_Selector* pCompoundSelector = sseqOrOp.selector()->head();
+      SimpleSequence_Selector* pCompoundSelector = sseqOrOp.selector()->head();
 
       // RUBY: extended = sseq_or_op.do_extend(extends, parent_directives, replace, seen)
       Node extended = extendCompoundSelector(pCompoundSelector, ctx, subset_map, seen, isReplace);
@@ -1826,7 +1826,7 @@ namespace Sass {
       DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTENDED: " << extended)
 
 
-      // Prepend the Compound_Selector based on the choices logic; choices seems to be extend but with an ruby Array instead of a Sequence
+      // Prepend the SimpleSequence_Selector based on the choices logic; choices seems to be extend but with an ruby Array instead of a Sequence
       // due to the member mapping: choices = extended.map {|seq| seq.members}
       Sequence_Selector* pJustCurrentCompoundSelector = sseqOrOp.selector();
 
@@ -1910,14 +1910,14 @@ namespace Sass {
    This is the equivalent of ruby's CommaSequence.do_extend.
   */
   CommaSequence_Selector* Extend::extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething) {
-    std::set<Compound_Selector> seen;
+    std::set<SimpleSequence_Selector> seen;
     return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething, seen);
   }
 
   /*
    This is the equivalent of ruby's CommaSequence.do_extend.
   */
-  CommaSequence_Selector* Extend::extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen) {
+  CommaSequence_Selector* Extend::extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<SimpleSequence_Selector>& seen) {
 
     CommaSequence_Selector* pNewSelectors = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pSelectorList->pstate(), pSelectorList->length());
 
@@ -1966,10 +1966,10 @@ namespace Sass {
       while (cur) {
         // process header
         if (cur->head() && seen.find(*cur->head()) == seen.end()) {
-          std::set<Compound_Selector> recseen(seen);
+          std::set<SimpleSequence_Selector> recseen(seen);
           recseen.insert(*cur->head());
           // create a copy since we add multiple items if stuff get unwrapped
-          Compound_Selector* cpy_head = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, cur->pstate());
+          SimpleSequence_Selector* cpy_head = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, cur->pstate());
           for (Simple_Selector* hs : *cur->head()) {
             if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(hs)) {
               if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(ws->selector())) {
@@ -2094,7 +2094,7 @@ namespace Sass {
       // debug_subset_map(subset_map);
       for(auto const &it : subset_map.values()) {
         Sequence_Selector* sel = it.first ? it.first->first() : NULL;
-        Compound_Selector* ext = it.second ? it.second : NULL;
+        SimpleSequence_Selector* ext = it.second ? it.second : NULL;
         if (ext && (ext->extended() || ext->is_optional())) continue;
         std::string str_sel(sel->to_string({ NESTED, 5 }));
         std::string str_ext(ext->to_string({ NESTED, 5 }));

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -24,13 +24,13 @@ namespace Sass {
 
   public:
     static Node subweave(Node& one, Node& two, Context& ctx);
-    static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
-    static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething);
-    static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace = false) {
+    static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
+    static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething);
+    static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace = false) {
       bool extendedSomething = false;
       return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething);
     }
-    static Selector_List* extendSelectorList(Selector_List* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, std::set<Compound_Selector>& seen) {
+    static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, std::set<Compound_Selector>& seen) {
       bool isReplace = false;
       bool extendedSomething = false;
       return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething, seen);

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -13,7 +13,7 @@ namespace Sass {
   class Context;
   class Node;
 
-  typedef Subset_Map<std::string, std::pair<Sequence_Selector*, Compound_Selector*> > ExtensionSubsetMap;
+  typedef Subset_Map<std::string, std::pair<Sequence_Selector*, SimpleSequence_Selector*> > ExtensionSubsetMap;
 
   class Extend : public Operation_CRTP<void, Extend> {
 
@@ -24,13 +24,13 @@ namespace Sass {
 
   public:
     static Node subweave(Node& one, Node& two, Context& ctx);
-    static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
+    static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<SimpleSequence_Selector>& seen);
     static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething);
     static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace = false) {
       bool extendedSomething = false;
       return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething);
     }
-    static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, std::set<Compound_Selector>& seen) {
+    static CommaSequence_Selector* extendSelectorList(CommaSequence_Selector* pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, std::set<SimpleSequence_Selector>& seen) {
       bool isReplace = false;
       bool extendedSomething = false;
       return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething, seen);

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -13,7 +13,7 @@ namespace Sass {
   class Context;
   class Node;
 
-  typedef Subset_Map<std::string, std::pair<Complex_Selector*, Compound_Selector*> > ExtensionSubsetMap;
+  typedef Subset_Map<std::string, std::pair<Sequence_Selector*, Compound_Selector*> > ExtensionSubsetMap;
 
   class Extend : public Operation_CRTP<void, Extend> {
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1821,7 +1821,7 @@ namespace Sass {
             }
 
             // Cannot be a Universal selector
-            Type_Selector* pType = dynamic_cast<Type_Selector*>(childSeq->head()->first());
+            Element_Selector* pType = dynamic_cast<Element_Selector*>(childSeq->head()->first());
             if(pType && pType->name() == "*") {
               std::string msg("Can't append  `");
               msg += childSeq->to_string();

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -155,7 +155,7 @@ namespace Sass {
     T* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx);
 
     template <>
-    Selector_List* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
+    CommaSequence_Selector* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
       Expression* exp = ARG(argname, Expression);
       if (exp->concrete_type() == Expression::NULL_VAL) {
         std::stringstream msg;
@@ -183,7 +183,7 @@ namespace Sass {
         str->quote_mark(0);
       }
       std::string exp_src = exp->to_string(ctx.c_options) + "{";
-      Selector_List* sel_list = Parser::parse_selector(exp_src.c_str(), ctx);
+      CommaSequence_Selector* sel_list = Parser::parse_selector(exp_src.c_str(), ctx);
       return (sel_list->length() > 0) ? sel_list->first() : 0;
     }
 
@@ -199,7 +199,7 @@ namespace Sass {
         str->quote_mark(0);
       }
       std::string exp_src = exp->to_string(ctx.c_options) + "{";
-      Selector_List* sel_list = Parser::parse_selector(exp_src.c_str(), ctx);
+      CommaSequence_Selector* sel_list = Parser::parse_selector(exp_src.c_str(), ctx);
       return (sel_list->length() > 0) ? sel_list->first()->tail()->head() : 0;
     }
 
@@ -1211,7 +1211,7 @@ namespace Sass {
     Signature length_sig = "length($list)";
     BUILT_IN(length)
     {
-      if (Selector_List* sl = dynamic_cast<Selector_List*>(env["$list"])) {
+      if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(env["$list"])) {
         return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)sl->length());
       }
       Expression* v = ARG("$list", Expression);
@@ -1222,7 +1222,7 @@ namespace Sass {
       if (v->concrete_type() == Expression::SELECTOR) {
         if (Compound_Selector* h = dynamic_cast<Compound_Selector*>(v)) {
           return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)h->length());
-        } else if (Selector_List* ls = dynamic_cast<Selector_List*>(v)) {
+        } else if (CommaSequence_Selector* ls = dynamic_cast<CommaSequence_Selector*>(v)) {
           return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)ls->length());
         } else {
           return SASS_MEMORY_NEW(ctx.mem, Number, pstate, 1);
@@ -1240,7 +1240,7 @@ namespace Sass {
     {
       Number* n = ARG("$n", Number);
       Map* m = dynamic_cast<Map*>(env["$list"]);
-      if (Selector_List* sl = dynamic_cast<Selector_List*>(env["$list"])) {
+      if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(env["$list"])) {
         size_t len = m ? m->length() : sl->length();
         bool empty = m ? m->empty() : sl->empty();
         if (empty) error("argument `$list` of `" + std::string(sig) + "` must not be empty", pstate);
@@ -1343,7 +1343,7 @@ namespace Sass {
     {
       List* l = dynamic_cast<List*>(env["$list"]);
       Expression* v = ARG("$val", Expression);
-      if (Selector_List* sl = dynamic_cast<Selector_List*>(env["$list"])) {
+      if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(env["$list"])) {
         Listize listize(ctx.mem);
         l = dynamic_cast<List*>(sl->perform(&listize));
       }
@@ -1715,7 +1715,7 @@ namespace Sass {
         error("$selectors: At least one selector must be passed", pstate);
 
       // Parse args into vector of selectors
-      std::vector<Selector_List*> parsedSelectors;
+      std::vector<CommaSequence_Selector*> parsedSelectors;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression* exp = dynamic_cast<Expression*>(arglist->value_at_index(i));
         if (exp->concrete_type() == Expression::NULL_VAL) {
@@ -1728,7 +1728,7 @@ namespace Sass {
           str->quote_mark(0);
         }
         std::string exp_src = exp->to_string(ctx.c_options) + "{";
-        Selector_List* sel = Parser::parse_selector(exp_src.c_str(), ctx);
+        CommaSequence_Selector* sel = Parser::parse_selector(exp_src.c_str(), ctx);
         parsedSelectors.push_back(sel);
       }
 
@@ -1738,14 +1738,14 @@ namespace Sass {
       }
 
       // Set the first element as the `result`, keep appending to as we go down the parsedSelector vector.
-      std::vector<Selector_List*>::iterator itr = parsedSelectors.begin();
-      Selector_List* result = *itr;
+      std::vector<CommaSequence_Selector*>::iterator itr = parsedSelectors.begin();
+      CommaSequence_Selector* result = *itr;
       ++itr;
 
       for(;itr != parsedSelectors.end(); ++itr) {
-        Selector_List* child = *itr;
+        CommaSequence_Selector* child = *itr;
         std::vector<Complex_Selector*> exploded;
-        Selector_List* rv = child->resolve_parent_refs(ctx, result);
+        CommaSequence_Selector* rv = child->resolve_parent_refs(ctx, result);
         for (size_t m = 0, mLen = rv->length(); m < mLen; ++m) {
           exploded.push_back((*rv)[m]);
         }
@@ -1766,7 +1766,7 @@ namespace Sass {
         error("$selectors: At least one selector must be passed", pstate);
 
       // Parse args into vector of selectors
-      std::vector<Selector_List*> parsedSelectors;
+      std::vector<CommaSequence_Selector*> parsedSelectors;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression* exp = dynamic_cast<Expression*>(arglist->value_at_index(i));
         if (exp->concrete_type() == Expression::NULL_VAL) {
@@ -1779,7 +1779,7 @@ namespace Sass {
           str->quote_mark(0);
         }
         std::string exp_src = exp->to_string() + "{";
-        Selector_List* sel = Parser::parse_selector(exp_src.c_str(), ctx);
+        CommaSequence_Selector* sel = Parser::parse_selector(exp_src.c_str(), ctx);
         parsedSelectors.push_back(sel);
       }
 
@@ -1789,12 +1789,12 @@ namespace Sass {
       }
 
       // Set the first element as the `result`, keep appending to as we go down the parsedSelector vector.
-      std::vector<Selector_List*>::iterator itr = parsedSelectors.begin();
-      Selector_List* result = *itr;
+      std::vector<CommaSequence_Selector*>::iterator itr = parsedSelectors.begin();
+      CommaSequence_Selector* result = *itr;
       ++itr;
 
       for(;itr != parsedSelectors.end(); ++itr) {
-        Selector_List* child = *itr;
+        CommaSequence_Selector* child = *itr;
         std::vector<Complex_Selector*> newElements;
 
         // For every COMPLEX_SELECTOR in `result`
@@ -1853,10 +1853,10 @@ namespace Sass {
     Signature selector_unify_sig = "selector-unify($selector1, $selector2)";
     BUILT_IN(selector_unify)
     {
-      Selector_List* selector1 = ARGSEL("$selector1", Selector_List, p_contextualize);
-      Selector_List* selector2 = ARGSEL("$selector2", Selector_List, p_contextualize);
+      CommaSequence_Selector* selector1 = ARGSEL("$selector1", CommaSequence_Selector, p_contextualize);
+      CommaSequence_Selector* selector2 = ARGSEL("$selector2", CommaSequence_Selector, p_contextualize);
 
-      Selector_List* result = selector1->unify_with(selector2, ctx);
+      CommaSequence_Selector* result = selector1->unify_with(selector2, ctx);
       Listize listize(ctx.mem);
       return result->perform(&listize);
     }
@@ -1881,14 +1881,14 @@ namespace Sass {
     Signature selector_extend_sig = "selector-extend($selector, $extendee, $extender)";
     BUILT_IN(selector_extend)
     {
-      Selector_List*  selector = ARGSEL("$selector", Selector_List, p_contextualize);
-      Selector_List*  extendee = ARGSEL("$extendee", Selector_List, p_contextualize);
-      Selector_List*  extender = ARGSEL("$extender", Selector_List, p_contextualize);
+      CommaSequence_Selector*  selector = ARGSEL("$selector", CommaSequence_Selector, p_contextualize);
+      CommaSequence_Selector*  extendee = ARGSEL("$extendee", CommaSequence_Selector, p_contextualize);
+      CommaSequence_Selector*  extender = ARGSEL("$extender", CommaSequence_Selector, p_contextualize);
 
       ExtensionSubsetMap subset_map;
       extender->populate_extends(extendee, ctx, subset_map);
 
-      Selector_List* result = Extend::extendSelectorList(selector, ctx, subset_map, false);
+      CommaSequence_Selector* result = Extend::extendSelectorList(selector, ctx, subset_map, false);
 
       Listize listize(ctx.mem);
       return result->perform(&listize);
@@ -1897,14 +1897,14 @@ namespace Sass {
     Signature selector_replace_sig = "selector-replace($selector, $original, $replacement)";
     BUILT_IN(selector_replace)
     {
-      Selector_List*  selector = ARGSEL("$selector", Selector_List, p_contextualize);
-      Selector_List*  original = ARGSEL("$original", Selector_List, p_contextualize);
-      Selector_List*  replacement = ARGSEL("$replacement", Selector_List, p_contextualize);
+      CommaSequence_Selector*  selector = ARGSEL("$selector", CommaSequence_Selector, p_contextualize);
+      CommaSequence_Selector*  original = ARGSEL("$original", CommaSequence_Selector, p_contextualize);
+      CommaSequence_Selector*  replacement = ARGSEL("$replacement", CommaSequence_Selector, p_contextualize);
 
       ExtensionSubsetMap subset_map;
       replacement->populate_extends(original, ctx, subset_map);
 
-      Selector_List* result = Extend::extendSelectorList(selector, ctx, subset_map, true);
+      CommaSequence_Selector* result = Extend::extendSelectorList(selector, ctx, subset_map, true);
 
       Listize listize(ctx.mem);
       return result->perform(&listize);
@@ -1913,7 +1913,7 @@ namespace Sass {
     Signature selector_parse_sig = "selector-parse($selector)";
     BUILT_IN(selector_parse)
     {
-      Selector_List* sel = ARGSEL("$selector", Selector_List, p_contextualize);
+      CommaSequence_Selector* sel = ARGSEL("$selector", CommaSequence_Selector, p_contextualize);
 
       Listize listize(ctx.mem);
       return sel->perform(&listize);
@@ -1922,8 +1922,8 @@ namespace Sass {
     Signature is_superselector_sig = "is-superselector($super, $sub)";
     BUILT_IN(is_superselector)
     {
-      Selector_List*  sel_sup = ARGSEL("$super", Selector_List, p_contextualize);
-      Selector_List*  sel_sub = ARGSEL("$sub", Selector_List, p_contextualize);
+      CommaSequence_Selector*  sel_sup = ARGSEL("$super", CommaSequence_Selector, p_contextualize);
+      CommaSequence_Selector*  sel_sub = ARGSEL("$sub", CommaSequence_Selector, p_contextualize);
       bool result = sel_sup->is_superselector_of(sel_sub);
       return SASS_MEMORY_NEW(ctx.mem, Boolean, pstate, result);
     }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -171,7 +171,7 @@ namespace Sass {
     }
 
     template <>
-    Complex_Selector* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
+    Sequence_Selector* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
       Expression* exp = ARG(argname, Expression);
       if (exp->concrete_type() == Expression::NULL_VAL) {
         std::stringstream msg;
@@ -1744,7 +1744,7 @@ namespace Sass {
 
       for(;itr != parsedSelectors.end(); ++itr) {
         CommaSequence_Selector* child = *itr;
-        std::vector<Complex_Selector*> exploded;
+        std::vector<Sequence_Selector*> exploded;
         CommaSequence_Selector* rv = child->resolve_parent_refs(ctx, result);
         for (size_t m = 0, mLen = rv->length(); m < mLen; ++m) {
           exploded.push_back((*rv)[m]);
@@ -1795,7 +1795,7 @@ namespace Sass {
 
       for(;itr != parsedSelectors.end(); ++itr) {
         CommaSequence_Selector* child = *itr;
-        std::vector<Complex_Selector*> newElements;
+        std::vector<Sequence_Selector*> newElements;
 
         // For every COMPLEX_SELECTOR in `result`
         // For every COMPLEX_SELECTOR in `child`
@@ -1806,12 +1806,12 @@ namespace Sass {
         // Replace result->elements with newElements
         for (size_t i = 0, resultLen = result->length(); i < resultLen; ++i) {
           for (size_t j = 0, childLen = child->length(); j < childLen; ++j) {
-            Complex_Selector* parentSeqClone = (*result)[i]->cloneFully(ctx);
-            Complex_Selector* childSeq = (*child)[j];
-            Complex_Selector* base = childSeq->tail();
+            Sequence_Selector* parentSeqClone = (*result)[i]->cloneFully(ctx);
+            Sequence_Selector* childSeq = (*child)[j];
+            Sequence_Selector* base = childSeq->tail();
 
             // Must be a simple sequence
-            if( childSeq->combinator() != Complex_Selector::Combinator::ANCESTOR_OF ) {
+            if( childSeq->combinator() != Sequence_Selector::Combinator::ANCESTOR_OF ) {
               std::string msg("Can't append  `");
               msg += childSeq->to_string();
               msg += "` to `";

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -188,7 +188,7 @@ namespace Sass {
     }
 
     template <>
-    Compound_Selector* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
+    SimpleSequence_Selector* get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx) {
       Expression* exp = ARG(argname, Expression);
       if (exp->concrete_type() == Expression::NULL_VAL) {
         std::stringstream msg;
@@ -1220,7 +1220,7 @@ namespace Sass {
         return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)(map ? map->length() : 1));
       }
       if (v->concrete_type() == Expression::SELECTOR) {
-        if (Compound_Selector* h = dynamic_cast<Compound_Selector*>(v)) {
+        if (SimpleSequence_Selector* h = dynamic_cast<SimpleSequence_Selector*>(v)) {
           return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)h->length());
         } else if (CommaSequence_Selector* ls = dynamic_cast<CommaSequence_Selector*>(v)) {
           return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)ls->length());
@@ -1864,7 +1864,7 @@ namespace Sass {
     Signature simple_selectors_sig = "simple-selectors($selector)";
     BUILT_IN(simple_selectors)
     {
-      Compound_Selector* sel = ARGSEL("$selector", Compound_Selector, p_contextualize);
+      SimpleSequence_Selector* sel = ARGSEL("$selector", SimpleSequence_Selector, p_contextualize);
 
       List* l = SASS_MEMORY_NEW(ctx.mem, List, sel->pstate(), sel->length(), SASS_COMMA);
 

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -887,7 +887,7 @@ namespace Sass {
 
   }
 
-  void Inspect::operator()(Type_Selector* s)
+  void Inspect::operator()(Element_Selector* s)
   {
     append_token(s->ns_name(), s);
   }

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -892,7 +892,14 @@ namespace Sass {
     append_token(s->ns_name(), s);
   }
 
-  void Inspect::operator()(Selector_Qualifier* s)
+  void Inspect::operator()(Class_Selector* s)
+  {
+    append_token(s->ns_name(), s);
+    if (s->has_line_break()) append_optional_linefeed();
+    if (s->has_line_break()) append_indentation();
+  }
+
+  void Inspect::operator()(Id_Selector* s)
   {
     append_token(s->ns_name(), s);
     if (s->has_line_break()) append_optional_linefeed();

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -879,7 +879,7 @@ namespace Sass {
     append_string("&");
   }
 
-  void Inspect::operator()(Selector_Placeholder* s)
+  void Inspect::operator()(Placeholder_Selector* s)
   {
     append_token(s->name(), s);
     if (s->has_line_break()) append_optional_linefeed();

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -938,7 +938,7 @@ namespace Sass {
     in_wrapped = was;
   }
 
-  void Inspect::operator()(Compound_Selector* s)
+  void Inspect::operator()(SimpleSequence_Selector* s)
   {
     for (size_t i = 0, L = s->length(); i < L; ++i) {
       (*s)[i]->perform(this);
@@ -952,7 +952,7 @@ namespace Sass {
 
   void Inspect::operator()(Sequence_Selector* c)
   {
-    Compound_Selector*            head = c->head();
+    SimpleSequence_Selector*      head = c->head();
     Sequence_Selector*            tail = c->tail();
     Sequence_Selector::Combinator comb = c->combinator();
 

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -375,7 +375,7 @@ namespace Sass {
         !list->from_selector() &&
         !dynamic_cast<List*>((*list)[0]) &&
         !dynamic_cast<List*>((*list)[0]) &&
-        !dynamic_cast<Selector_List*>((*list)[0])) {
+        !dynamic_cast<CommaSequence_Selector*>((*list)[0])) {
       append_string("(");
     }
     else if (!in_declaration && (list->separator() == SASS_HASH ||
@@ -417,7 +417,7 @@ namespace Sass {
         !list->from_selector() &&
         !dynamic_cast<List*>((*list)[0]) &&
         !dynamic_cast<List*>((*list)[0]) &&
-        !dynamic_cast<Selector_List*>((*list)[0])) {
+        !dynamic_cast<CommaSequence_Selector*>((*list)[0])) {
       append_string(",)");
     }
     else if (!in_declaration && (list->separator() == SASS_HASH ||
@@ -1013,7 +1013,7 @@ namespace Sass {
     }
   }
 
-  void Inspect::operator()(Selector_List* g)
+  void Inspect::operator()(CommaSequence_Selector* g)
   {
 
     if (g->empty()) {
@@ -1028,7 +1028,7 @@ namespace Sass {
     // probably ruby sass eqivalent of element_needs_parens
     if (output_style() == TO_SASS && g->length() == 1 &&
       (!dynamic_cast<List*>((*g)[0]) &&
-       !dynamic_cast<Selector_List*>((*g)[0]))) {
+       !dynamic_cast<CommaSequence_Selector*>((*g)[0]))) {
       append_string("(");
     }
     else if (!in_declaration && in_comma_array) {
@@ -1054,7 +1054,7 @@ namespace Sass {
     // probably ruby sass eqivalent of element_needs_parens
     if (output_style() == TO_SASS && g->length() == 1 &&
       (!dynamic_cast<List*>((*g)[0]) &&
-       !dynamic_cast<Selector_List*>((*g)[0]))) {
+       !dynamic_cast<CommaSequence_Selector*>((*g)[0]))) {
       append_string(",)");
     }
     else if (!in_declaration && in_comma_array) {

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -950,13 +950,13 @@ namespace Sass {
     }
   }
 
-  void Inspect::operator()(Complex_Selector* c)
+  void Inspect::operator()(Sequence_Selector* c)
   {
-    Compound_Selector*           head = c->head();
-    Complex_Selector*            tail = c->tail();
-    Complex_Selector::Combinator comb = c->combinator();
+    Compound_Selector*            head = c->head();
+    Sequence_Selector*            tail = c->tail();
+    Sequence_Selector::Combinator comb = c->combinator();
 
-    if (comb == Complex_Selector::ANCESTOR_OF && (!head || head->empty())) {
+    if (comb == Sequence_Selector::ANCESTOR_OF && (!head || head->empty())) {
       if (tail) tail->perform(this);
       return;
     }
@@ -971,30 +971,30 @@ namespace Sass {
     if (head && head->length() != 0) head->perform(this);
     bool is_empty = !head || head->length() == 0 || head->is_empty_reference();
     bool is_tail = head && !head->is_empty_reference() && tail;
-    if (output_style() == COMPRESSED && comb != Complex_Selector::ANCESTOR_OF) scheduled_space = 0;
+    if (output_style() == COMPRESSED && comb != Sequence_Selector::ANCESTOR_OF) scheduled_space = 0;
 
     switch (comb) {
-      case Complex_Selector::ANCESTOR_OF:
+      case Sequence_Selector::ANCESTOR_OF:
         if (is_tail) append_mandatory_space();
       break;
-      case Complex_Selector::PARENT_OF:
+      case Sequence_Selector::PARENT_OF:
         append_optional_space();
         append_string(">");
         append_optional_space();
       break;
-      case Complex_Selector::ADJACENT_TO:
+      case Sequence_Selector::ADJACENT_TO:
         append_optional_space();
         append_string("+");
         append_optional_space();
       break;
-      case Complex_Selector::REFERENCE:
+      case Sequence_Selector::REFERENCE:
         append_mandatory_space();
         append_string("/");
         c->reference()->perform(this);
         append_string("/");
         append_mandatory_space();
       break;
-      case Complex_Selector::PRECEDES:
+      case Sequence_Selector::PRECEDES:
         if (is_empty) append_optional_space();
         else append_mandatory_space();
         append_string("~");
@@ -1002,7 +1002,7 @@ namespace Sass {
         else append_optional_space();
       break;
     }
-    if (tail && comb != Complex_Selector::ANCESTOR_OF) {
+    if (tail && comb != Sequence_Selector::ANCESTOR_OF) {
       if (c->has_line_break()) append_optional_linefeed();
     }
     if (tail) tail->perform(this);

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -82,7 +82,7 @@ namespace Sass {
     // selectors
     virtual void operator()(Selector_Schema*);
     virtual void operator()(Selector_Placeholder*);
-    virtual void operator()(Type_Selector*);
+    virtual void operator()(Element_Selector*);
     virtual void operator()(Selector_Qualifier*);
     virtual void operator()(Attribute_Selector*);
     virtual void operator()(Pseudo_Selector*);

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -88,7 +88,7 @@ namespace Sass {
     virtual void operator()(Pseudo_Selector*);
     virtual void operator()(Wrapped_Selector*);
     virtual void operator()(Compound_Selector*);
-    virtual void operator()(Complex_Selector*);
+    virtual void operator()(Sequence_Selector*);
     virtual void operator()(CommaSequence_Selector*);
 
     // template <typename U>

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -87,7 +87,7 @@ namespace Sass {
     virtual void operator()(Attribute_Selector*);
     virtual void operator()(Pseudo_Selector*);
     virtual void operator()(Wrapped_Selector*);
-    virtual void operator()(Compound_Selector*);
+    virtual void operator()(SimpleSequence_Selector*);
     virtual void operator()(Sequence_Selector*);
     virtual void operator()(CommaSequence_Selector*);
 

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -83,7 +83,8 @@ namespace Sass {
     virtual void operator()(Selector_Schema*);
     virtual void operator()(Placeholder_Selector*);
     virtual void operator()(Element_Selector*);
-    virtual void operator()(Selector_Qualifier*);
+    virtual void operator()(Class_Selector*);
+    virtual void operator()(Id_Selector*);
     virtual void operator()(Attribute_Selector*);
     virtual void operator()(Pseudo_Selector*);
     virtual void operator()(Wrapped_Selector*);

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -89,7 +89,7 @@ namespace Sass {
     virtual void operator()(Wrapped_Selector*);
     virtual void operator()(Compound_Selector*);
     virtual void operator()(Complex_Selector*);
-    virtual void operator()(Selector_List*);
+    virtual void operator()(CommaSequence_Selector*);
 
     // template <typename U>
     // void fallback(U x) { fallback_impl(reinterpret_cast<AST_Node*>(x)); }

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -81,7 +81,7 @@ namespace Sass {
     virtual void operator()(Arguments*);
     // selectors
     virtual void operator()(Selector_Schema*);
-    virtual void operator()(Selector_Placeholder*);
+    virtual void operator()(Placeholder_Selector*);
     virtual void operator()(Element_Selector*);
     virtual void operator()(Selector_Qualifier*);
     virtual void operator()(Attribute_Selector*);

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -36,7 +36,7 @@ namespace Sass {
     return SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), str);
   }
 
-  Expression* Listize::operator()(Complex_Selector* sel)
+  Expression* Listize::operator()(Sequence_Selector* sel)
   {
     List* l = SASS_MEMORY_NEW(mem, List, sel->pstate(), 2);
     l->from_selector(true);
@@ -51,23 +51,23 @@ namespace Sass {
       : sel->reference()->to_string();
     switch(sel->combinator())
     {
-      case Complex_Selector::PARENT_OF:
+      case Sequence_Selector::PARENT_OF:
         *l << SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), ">");
       break;
-      case Complex_Selector::ADJACENT_TO:
+      case Sequence_Selector::ADJACENT_TO:
         *l << SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), "+");
       break;
-      case Complex_Selector::REFERENCE:
+      case Sequence_Selector::REFERENCE:
         *l << SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), "/" + reference + "/");
       break;
-      case Complex_Selector::PRECEDES:
+      case Sequence_Selector::PRECEDES:
         *l << SASS_MEMORY_NEW(mem, String_Quoted, sel->pstate(), "~");
       break;
-      case Complex_Selector::ANCESTOR_OF:
+      case Sequence_Selector::ANCESTOR_OF:
       break;
     }
 
-    Complex_Selector* tail = sel->tail();
+    Sequence_Selector* tail = sel->tail();
     if (tail)
     {
       Expression* tt = tail->perform(this);

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -14,7 +14,7 @@ namespace Sass {
   : mem(mem)
   {  }
 
-  Expression* Listize::operator()(Selector_List* sel)
+  Expression* Listize::operator()(CommaSequence_Selector* sel)
   {
     List* l = SASS_MEMORY_NEW(mem, List, sel->pstate(), sel->length(), SASS_COMMA);
     l->from_selector(true);

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -26,7 +26,7 @@ namespace Sass {
     return SASS_MEMORY_NEW(mem, Null, l->pstate());
   }
 
-  Expression* Listize::operator()(Compound_Selector* sel)
+  Expression* Listize::operator()(SimpleSequence_Selector* sel)
   {
     std::string str;
     for (size_t i = 0, L = sel->length(); i < L; ++i) {
@@ -40,7 +40,7 @@ namespace Sass {
   {
     List* l = SASS_MEMORY_NEW(mem, List, sel->pstate(), 2);
     l->from_selector(true);
-    Compound_Selector* head = sel->head();
+    SimpleSequence_Selector* head = sel->head();
     if (head && !head->is_empty_reference())
     {
       Expression* hh = head->perform(this);

--- a/src/listize.hpp
+++ b/src/listize.hpp
@@ -26,7 +26,7 @@ namespace Sass {
 
     Expression* operator()(CommaSequence_Selector*);
     Expression* operator()(Sequence_Selector*);
-    Expression* operator()(Compound_Selector*);
+    Expression* operator()(SimpleSequence_Selector*);
 
     template <typename U>
     Expression* fallback(U x) { return fallback_impl(x); }

--- a/src/listize.hpp
+++ b/src/listize.hpp
@@ -25,7 +25,7 @@ namespace Sass {
     ~Listize() { }
 
     Expression* operator()(CommaSequence_Selector*);
-    Expression* operator()(Complex_Selector*);
+    Expression* operator()(Sequence_Selector*);
     Expression* operator()(Compound_Selector*);
 
     template <typename U>

--- a/src/listize.hpp
+++ b/src/listize.hpp
@@ -24,7 +24,7 @@ namespace Sass {
     Listize(Memory_Manager&);
     ~Listize() { }
 
-    Expression* operator()(Selector_List*);
+    Expression* operator()(CommaSequence_Selector*);
     Expression* operator()(Complex_Selector*);
     Expression* operator()(Compound_Selector*);
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -8,20 +8,20 @@
 namespace Sass {
 
 
-  Node Node::createCombinator(const Complex_Selector::Combinator& combinator) {
+  Node Node::createCombinator(const Sequence_Selector::Combinator& combinator) {
     NodeDequePtr null;
     return Node(COMBINATOR, combinator, NULL /*pSelector*/, null /*pCollection*/);
   }
 
 
-  Node Node::createSelector(Complex_Selector* pSelector, Context& ctx) {
+  Node Node::createSelector(Sequence_Selector* pSelector, Context& ctx) {
     NodeDequePtr null;
 
-    Complex_Selector* pStripped = pSelector->clone(ctx);
+    Sequence_Selector* pStripped = pSelector->clone(ctx);
     pStripped->tail(NULL);
-    pStripped->combinator(Complex_Selector::ANCESTOR_OF);
+    pStripped->combinator(Sequence_Selector::ANCESTOR_OF);
 
-    Node n(SELECTOR, Complex_Selector::ANCESTOR_OF, pStripped, null /*pCollection*/);
+    Node n(SELECTOR, Sequence_Selector::ANCESTOR_OF, pStripped, null /*pCollection*/);
     if (pSelector) n.got_line_feed = pSelector->has_line_feed();
     return n;
   }
@@ -29,23 +29,23 @@ namespace Sass {
 
   Node Node::createCollection() {
     NodeDequePtr pEmptyCollection = std::make_shared<NodeDeque>();
-    return Node(COLLECTION, Complex_Selector::ANCESTOR_OF, NULL /*pSelector*/, pEmptyCollection);
+    return Node(COLLECTION, Sequence_Selector::ANCESTOR_OF, NULL /*pSelector*/, pEmptyCollection);
   }
 
 
   Node Node::createCollection(const NodeDeque& values) {
     NodeDequePtr pShallowCopiedCollection = std::make_shared<NodeDeque>(values);
-    return Node(COLLECTION, Complex_Selector::ANCESTOR_OF, NULL /*pSelector*/, pShallowCopiedCollection);
+    return Node(COLLECTION, Sequence_Selector::ANCESTOR_OF, NULL /*pSelector*/, pShallowCopiedCollection);
   }
 
 
   Node Node::createNil() {
     NodeDequePtr null;
-    return Node(NIL, Complex_Selector::ANCESTOR_OF, NULL /*pSelector*/, null /*pCollection*/);
+    return Node(NIL, Sequence_Selector::ANCESTOR_OF, NULL /*pSelector*/, null /*pCollection*/);
   }
 
 
-  Node::Node(const TYPE& type, Complex_Selector::Combinator combinator, Complex_Selector* pSelector, NodeDequePtr& pCollection)
+  Node::Node(const TYPE& type, Sequence_Selector::Combinator combinator, Sequence_Selector* pSelector, NodeDequePtr& pCollection)
   : got_line_feed(false), mType(type), mCombinator(combinator), mpSelector(pSelector), mpCollection(pCollection)
   { if (pSelector) got_line_feed = pSelector->has_line_feed(); }
 
@@ -140,11 +140,11 @@ namespace Sass {
     if (node.isCombinator()) {
 
       switch (node.combinator()) {
-        case Complex_Selector::ANCESTOR_OF: os << "\" \""; break;
-        case Complex_Selector::PARENT_OF:   os << "\">\""; break;
-        case Complex_Selector::PRECEDES:    os << "\"~\""; break;
-        case Complex_Selector::ADJACENT_TO: os << "\"+\""; break;
-        case Complex_Selector::REFERENCE: os    << "\"/\""; break;
+        case Sequence_Selector::ANCESTOR_OF: os << "\" \""; break;
+        case Sequence_Selector::PARENT_OF:   os << "\">\""; break;
+        case Sequence_Selector::PRECEDES:    os << "\"~\""; break;
+        case Sequence_Selector::ADJACENT_TO: os << "\"+\""; break;
+        case Sequence_Selector::REFERENCE: os    << "\"/\""; break;
       }
 
     } else if (node.isNil()) {
@@ -177,7 +177,7 @@ namespace Sass {
 #endif
 
 
-  Node complexSelectorToNode(Complex_Selector* pToConvert, Context& ctx) {
+  Node complexSelectorToNode(Sequence_Selector* pToConvert, Context& ctx) {
     if (pToConvert == NULL) {
       return Node::createNil();
     }
@@ -187,7 +187,7 @@ namespace Sass {
 
     // unwrap the selector from parent ref
     if (pToConvert->head() && pToConvert->head()->has_parent_ref()) {
-      Complex_Selector* tail = pToConvert->tail();
+      Sequence_Selector* tail = pToConvert->tail();
       if (tail) tail->has_line_feed(pToConvert->has_line_feed());
       pToConvert = tail;
     }
@@ -199,14 +199,14 @@ namespace Sass {
       if (pToConvert->head() == NULL || empty_parent_ref) {
       }
 
-      // the first Complex_Selector may contain a dummy head pointer, skip it.
+      // the first Sequence_Selector may contain a dummy head pointer, skip it.
       if (pToConvert->head() != NULL && !empty_parent_ref) {
         node.collection()->push_back(Node::createSelector(pToConvert, ctx));
         if (has_lf) node.collection()->back().got_line_feed = has_lf;
         has_lf = false;
       }
 
-      if (pToConvert->combinator() != Complex_Selector::ANCESTOR_OF) {
+      if (pToConvert->combinator() != Sequence_Selector::ANCESTOR_OF) {
         node.collection()->push_back(Node::createCombinator(pToConvert->combinator()));
         if (has_lf) node.collection()->back().got_line_feed = has_lf;
         has_lf = false;
@@ -223,14 +223,14 @@ namespace Sass {
   }
 
 
-  Complex_Selector* nodeToComplexSelector(const Node& toConvert, Context& ctx) {
+  Sequence_Selector* nodeToComplexSelector(const Node& toConvert, Context& ctx) {
     if (toConvert.isNil()) {
       return NULL;
     }
 
 
     if (!toConvert.isCollection()) {
-      throw "The node to convert to a Complex_Selector* must be a collection type or nil.";
+      throw "The node to convert to a Sequence_Selector* must be a collection type or nil.";
     }
 
 
@@ -238,9 +238,9 @@ namespace Sass {
 
     std::string noPath("");
     Position noPosition(-1, -1, -1);
-    Complex_Selector* pFirst = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL);
+    Sequence_Selector* pFirst = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, ParserState("[NODE]"), Sequence_Selector::ANCESTOR_OF, NULL, NULL);
 
-    Complex_Selector* pCurrent = pFirst;
+    Sequence_Selector* pCurrent = pFirst;
 
     if (toConvert.isSelector()) pFirst->has_line_feed(toConvert.got_line_feed);
     if (toConvert.isCombinator()) pFirst->has_line_feed(toConvert.got_line_feed);
@@ -257,11 +257,11 @@ namespace Sass {
         pCurrent->combinator(child.combinator());
         if (child.got_line_feed) pCurrent->has_line_feed(child.got_line_feed);
 
-        // if the next node is also a combinator, create another Complex_Selector to hold it so it doesn't replace the current combinator
+        // if the next node is also a combinator, create another Sequence_Selector to hold it so it doesn't replace the current combinator
         if (childIter+1 != childIterEnd) {
           Node& nextNode = *(childIter+1);
           if (nextNode.isCombinator()) {
-            pCurrent->tail(SASS_MEMORY_NEW(ctx.mem, Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL));
+            pCurrent->tail(SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, ParserState("[NODE]"), Sequence_Selector::ANCESTOR_OF, NULL, NULL));
             if (nextNode.got_line_feed) pCurrent->tail()->has_line_feed(nextNode.got_line_feed);
             pCurrent = pCurrent->tail();
           }
@@ -282,11 +282,11 @@ namespace Sass {
   }
 
   // A very naive trim function, which removes duplicates in a node
-  // This is only used in Complex_Selector::unify_with for now, may need modifications to fit other needs
+  // This is only used in Sequence_Selector::unify_with for now, may need modifications to fit other needs
   Node Node::naiveTrim(Node& seqses, Context& ctx) {
 
     std::vector<Node*> res;
-    std::vector<Complex_Selector*> known;
+    std::vector<Sequence_Selector*> known;
 
     NodeDeque::reverse_iterator seqsesIter = seqses.collection()->rbegin(),
                                 seqsesIterEnd = seqses.collection()->rend();
@@ -295,8 +295,8 @@ namespace Sass {
     {
       Node& seqs1 = *seqsesIter;
       if( seqs1.isSelector() ) {
-        Complex_Selector* sel = seqs1.selector();
-        std::vector<Complex_Selector*>::iterator it;
+        Sequence_Selector* sel = seqs1.selector();
+        std::vector<Sequence_Selector*>::iterator it;
         bool found = false;
         for (it = known.begin(); it != known.end(); ++it) {
           if (**it == *sel) { found = true; break; }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -271,8 +271,8 @@ namespace Sass {
       }
     }
 
-    // Put the dummy Compound_Selector in the first position, for consistency with the rest of libsass
-    Compound_Selector* fakeHead = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, ParserState("[NODE]"), 1);
+    // Put the dummy SimpleSequence_Selector in the first position, for consistency with the rest of libsass
+    SimpleSequence_Selector* fakeHead = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, ParserState("[NODE]"), 1);
     Parent_Selector* selectorRef = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, ParserState("[NODE]"));
     fakeHead->elements().push_back(selectorRef);
     if (toConvert.got_line_feed) pFirst->has_line_feed(toConvert.got_line_feed);

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -17,7 +17,7 @@ namespace Sass {
   /*
    There are a lot of stumbling blocks when trying to port the ruby extend code to C++. The biggest is the choice of
    data type. The ruby code will pretty seamlessly switch types between an Array<SimpleSequence or Op> (libsass'
-   equivalent is the Complex_Selector) to a Sequence, which contains more metadata about the sequence than just the
+   equivalent is the Sequence_Selector) to a Sequence, which contains more metadata about the sequence than just the
    selector info. They also have the ability to have arbitrary nestings of arrays like [1, [2]], which is hard to
    implement using Array equivalents in C++ (like the deque or vector). They also have the ability to include nil
    in the arrays, like [1, nil, 3], which has potential semantic differences than an empty array [1, [], 3]. To be
@@ -26,7 +26,7 @@ namespace Sass {
    more closely match the ruby code, which is a huge benefit when attempting to implement an complex algorithm like
    the Extend operator.
 
-   Note that the current libsass data model also pairs the combinator with the Complex_Selector that follows it, but
+   Note that the current libsass data model also pairs the combinator with the Sequence_Selector that follows it, but
    ruby sass has no such restriction, so we attempt to create a data structure that can handle them split apart.
    */
 
@@ -50,18 +50,18 @@ namespace Sass {
     bool isNil() const { return mType == NIL; }
     bool got_line_feed;
 
-    Complex_Selector::Combinator combinator() const { return mCombinator; }
+    Sequence_Selector::Combinator combinator() const { return mCombinator; }
 
-    Complex_Selector* selector() { return mpSelector; }
-    const Complex_Selector* selector() const { return mpSelector; }
+    Sequence_Selector* selector() { return mpSelector; }
+    const Sequence_Selector* selector() const { return mpSelector; }
 
     NodeDequePtr collection() { return mpCollection; }
     const NodeDequePtr collection() const { return mpCollection; }
 
-    static Node createCombinator(const Complex_Selector::Combinator& combinator);
+    static Node createCombinator(const Sequence_Selector::Combinator& combinator);
 
     // This method will clone the selector, stripping off the tail and combinator
-    static Node createSelector(Complex_Selector* pSelector, Context& ctx);
+    static Node createSelector(Sequence_Selector* pSelector, Context& ctx);
 
     static Node createCollection();
     static Node createCollection(const NodeDeque& values);
@@ -79,7 +79,7 @@ namespace Sass {
     COLLECTION FUNCTIONS
 
     Most types don't need any helper methods (nil and combinator due to their simplicity and
-    selector due to the fact that we leverage the non-node selector code on the Complex_Selector
+    selector due to the fact that we leverage the non-node selector code on the Sequence_Selector
     whereever possible). The following methods are intended to be called on Node objects whose
     type is COLLECTION only.
     */
@@ -97,21 +97,21 @@ namespace Sass {
     // Private constructor; Use the static methods (like createCombinator and createSelector)
     // to instantiate this object. This is more expressive, and it allows us to break apart each
     // case into separate functions.
-    Node(const TYPE& type, Complex_Selector::Combinator combinator, Complex_Selector* pSelector, NodeDequePtr& pCollection);
+    Node(const TYPE& type, Sequence_Selector::Combinator combinator, Sequence_Selector* pSelector, NodeDequePtr& pCollection);
 
     TYPE mType;
 
     // TODO: can we union these to save on memory?
-    Complex_Selector::Combinator mCombinator;
-    Complex_Selector* mpSelector; // this is an AST_Node, so it will be handled by the Memory_Manager
+    Sequence_Selector::Combinator mCombinator;
+    Sequence_Selector* mpSelector; // this is an AST_Node, so it will be handled by the Memory_Manager
     NodeDequePtr mpCollection;
   };
 
 #ifdef DEBUG
   std::ostream& operator<<(std::ostream& os, const Node& node);
 #endif
-  Node complexSelectorToNode(Complex_Selector* pToConvert, Context& ctx);
-  Complex_Selector* nodeToComplexSelector(const Node& toConvert, Context& ctx);
+  Node complexSelectorToNode(Sequence_Selector* pToConvert, Context& ctx);
+  Sequence_Selector* nodeToComplexSelector(const Node& toConvert, Context& ctx);
 
   bool nodesEqual(const Node& one, const Node& two, bool simpleSelectorOrderDependent);
 

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -72,7 +72,7 @@ namespace Sass {
     // selectors
     virtual T operator()(Selector_Schema* x)        = 0;
     virtual T operator()(Selector_Placeholder* x)   = 0;
-    virtual T operator()(Type_Selector* x)          = 0;
+    virtual T operator()(Element_Selector* x)       = 0;
     virtual T operator()(Selector_Qualifier* x)     = 0;
     virtual T operator()(Attribute_Selector* x)     = 0;
     virtual T operator()(Pseudo_Selector* x)        = 0;
@@ -153,7 +153,7 @@ namespace Sass {
     // selectors
     T operator()(Selector_Schema* x)        { return static_cast<D*>(this)->fallback(x); }
     T operator()(Selector_Placeholder* x)   { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Type_Selector* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Element_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
     T operator()(Selector_Qualifier* x)     { return static_cast<D*>(this)->fallback(x); }
     T operator()(Attribute_Selector* x)     { return static_cast<D*>(this)->fallback(x); }
     T operator()(Pseudo_Selector* x)        { return static_cast<D*>(this)->fallback(x); }

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -78,7 +78,7 @@ namespace Sass {
     virtual T operator()(Pseudo_Selector* x)        = 0;
     virtual T operator()(Wrapped_Selector* x)       = 0;
     virtual T operator()(Compound_Selector* x)      = 0;
-    virtual T operator()(Complex_Selector* x)       = 0;
+    virtual T operator()(Sequence_Selector* x)      = 0;
     virtual T operator()(CommaSequence_Selector* x) = 0;
 
     template <typename U>
@@ -159,7 +159,7 @@ namespace Sass {
     T operator()(Pseudo_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
     T operator()(Wrapped_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
     T operator()(Compound_Selector* x)      { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Complex_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Sequence_Selector* x)      { return static_cast<D*>(this)->fallback(x); }
     T operator()(CommaSequence_Selector* x) { return static_cast<D*>(this)->fallback(x); }
 
     template <typename U>

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -79,7 +79,7 @@ namespace Sass {
     virtual T operator()(Wrapped_Selector* x)       = 0;
     virtual T operator()(Compound_Selector* x)      = 0;
     virtual T operator()(Complex_Selector* x)       = 0;
-    virtual T operator()(Selector_List* x)          = 0;
+    virtual T operator()(CommaSequence_Selector* x) = 0;
 
     template <typename U>
     T fallback(U x) { return T(); }
@@ -160,7 +160,7 @@ namespace Sass {
     T operator()(Wrapped_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
     T operator()(Compound_Selector* x)      { return static_cast<D*>(this)->fallback(x); }
     T operator()(Complex_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Selector_List* x)          { return static_cast<D*>(this)->fallback(x); }
+    T operator()(CommaSequence_Selector* x) { return static_cast<D*>(this)->fallback(x); }
 
     template <typename U>
     T fallback(U x)                         { return T(); }

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -73,7 +73,8 @@ namespace Sass {
     virtual T operator()(Selector_Schema* x)        = 0;
     virtual T operator()(Placeholder_Selector* x)   = 0;
     virtual T operator()(Element_Selector* x)       = 0;
-    virtual T operator()(Selector_Qualifier* x)     = 0;
+    virtual T operator()(Class_Selector* x)         = 0;
+    virtual T operator()(Id_Selector* x)            = 0;
     virtual T operator()(Attribute_Selector* x)     = 0;
     virtual T operator()(Pseudo_Selector* x)        = 0;
     virtual T operator()(Wrapped_Selector* x)       = 0;
@@ -154,7 +155,8 @@ namespace Sass {
     T operator()(Selector_Schema* x)        { return static_cast<D*>(this)->fallback(x); }
     T operator()(Placeholder_Selector* x)   { return static_cast<D*>(this)->fallback(x); }
     T operator()(Element_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Selector_Qualifier* x)     { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Class_Selector* x)         { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Id_Selector* x)            { return static_cast<D*>(this)->fallback(x); }
     T operator()(Attribute_Selector* x)     { return static_cast<D*>(this)->fallback(x); }
     T operator()(Pseudo_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
     T operator()(Wrapped_Selector* x)       { return static_cast<D*>(this)->fallback(x); }

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -77,7 +77,7 @@ namespace Sass {
     virtual T operator()(Attribute_Selector* x)     = 0;
     virtual T operator()(Pseudo_Selector* x)        = 0;
     virtual T operator()(Wrapped_Selector* x)       = 0;
-    virtual T operator()(Compound_Selector* x)      = 0;
+    virtual T operator()(SimpleSequence_Selector* x)= 0;
     virtual T operator()(Sequence_Selector* x)      = 0;
     virtual T operator()(CommaSequence_Selector* x) = 0;
 
@@ -158,7 +158,7 @@ namespace Sass {
     T operator()(Attribute_Selector* x)     { return static_cast<D*>(this)->fallback(x); }
     T operator()(Pseudo_Selector* x)        { return static_cast<D*>(this)->fallback(x); }
     T operator()(Wrapped_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Compound_Selector* x)      { return static_cast<D*>(this)->fallback(x); }
+    T operator()(SimpleSequence_Selector* x){ return static_cast<D*>(this)->fallback(x); }
     T operator()(Sequence_Selector* x)      { return static_cast<D*>(this)->fallback(x); }
     T operator()(CommaSequence_Selector* x) { return static_cast<D*>(this)->fallback(x); }
 

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -71,7 +71,7 @@ namespace Sass {
     virtual T operator()(Arguments* x)              = 0;
     // selectors
     virtual T operator()(Selector_Schema* x)        = 0;
-    virtual T operator()(Selector_Placeholder* x)   = 0;
+    virtual T operator()(Placeholder_Selector* x)   = 0;
     virtual T operator()(Element_Selector* x)       = 0;
     virtual T operator()(Selector_Qualifier* x)     = 0;
     virtual T operator()(Attribute_Selector* x)     = 0;
@@ -152,7 +152,7 @@ namespace Sass {
     T operator()(Arguments* x)              { return static_cast<D*>(this)->fallback(x); }
     // selectors
     T operator()(Selector_Schema* x)        { return static_cast<D*>(this)->fallback(x); }
-    T operator()(Selector_Placeholder* x)   { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Placeholder_Selector* x)   { return static_cast<D*>(this)->fallback(x); }
     T operator()(Element_Selector* x)       { return static_cast<D*>(this)->fallback(x); }
     T operator()(Selector_Qualifier* x)     { return static_cast<D*>(this)->fallback(x); }
     T operator()(Attribute_Selector* x)     { return static_cast<D*>(this)->fallback(x); }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -771,7 +771,7 @@ namespace Sass {
       // parse type selector
       else if (lex< re_type_selector >(false))
       {
-        (*seq) << SASS_MEMORY_NEW(ctx.mem, Type_Selector, pstate, lexed);
+        (*seq) << SASS_MEMORY_NEW(ctx.mem, Element_Selector, pstate, lexed);
       }
       // peek for abort conditions
       else if (peek< spaces >()) break;
@@ -803,10 +803,10 @@ namespace Sass {
       return SASS_MEMORY_NEW(ctx.mem, Selector_Qualifier, pstate, lexed);
     }
     else if (lex< quoted_string >()) {
-      return SASS_MEMORY_NEW(ctx.mem, Type_Selector, pstate, unquote(lexed));
+      return SASS_MEMORY_NEW(ctx.mem, Element_Selector, pstate, unquote(lexed));
     }
     else if (lex< alternatives < variable, number, static_reference_combinator > >()) {
-      return SASS_MEMORY_NEW(ctx.mem, Type_Selector, pstate, lexed);
+      return SASS_MEMORY_NEW(ctx.mem, Element_Selector, pstate, lexed);
     }
     else if (peek< pseudo_not >()) {
       return parse_negated_selector();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -599,7 +599,7 @@ namespace Sass {
   {
     bool reloop = true;
     bool had_linefeed = false;
-    Complex_Selector* sel = 0;
+    Sequence_Selector* sel = 0;
     CommaSequence_Selector* group = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate);
     group->media_block(last_media_block);
 
@@ -647,7 +647,7 @@ namespace Sass {
   // complex selector, with one of four combinator operations.
   // the compound selector (head) is optional, since the combinator
   // can come first in the whole selector sequence (like `> DIV').
-  Complex_Selector* Parser::parse_complex_selector(bool in_root)
+  Sequence_Selector* Parser::parse_complex_selector(bool in_root)
   {
 
     String* reference = 0;
@@ -664,28 +664,28 @@ namespace Sass {
     if (peek < end_of_file >()) return 0;
 
     // parse combinator between lhs and rhs
-    Complex_Selector::Combinator combinator;
-    if      (lex< exactly<'+'> >()) combinator = Complex_Selector::ADJACENT_TO;
-    else if (lex< exactly<'~'> >()) combinator = Complex_Selector::PRECEDES;
-    else if (lex< exactly<'>'> >()) combinator = Complex_Selector::PARENT_OF;
+    Sequence_Selector::Combinator combinator;
+    if      (lex< exactly<'+'> >()) combinator = Sequence_Selector::ADJACENT_TO;
+    else if (lex< exactly<'~'> >()) combinator = Sequence_Selector::PRECEDES;
+    else if (lex< exactly<'>'> >()) combinator = Sequence_Selector::PARENT_OF;
     else if (lex< sequence < exactly<'/'>, negate < exactly < '*' > > > >()) {
       // comments are allowed, but not spaces?
-      combinator = Complex_Selector::REFERENCE;
+      combinator = Sequence_Selector::REFERENCE;
       if (!lex < re_reference_combinator >()) return 0;
       reference = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
       if (!lex < exactly < '/' > >()) return 0; // ToDo: error msg?
     }
-    else /* if (lex< zero >()) */   combinator = Complex_Selector::ANCESTOR_OF;
+    else /* if (lex< zero >()) */   combinator = Sequence_Selector::ANCESTOR_OF;
 
-    if (!lhs && combinator == Complex_Selector::ANCESTOR_OF) return 0;
+    if (!lhs && combinator == Sequence_Selector::ANCESTOR_OF) return 0;
 
     // lex < block_comment >();
     // source position of a complex selector points to the combinator
     // ToDo: make sure we update pstate for ancestor of (lex < zero >());
-    Complex_Selector* sel = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pstate, combinator, lhs);
+    Sequence_Selector* sel = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, pstate, combinator, lhs);
     sel->media_block(last_media_block);
 
-    if (combinator == Complex_Selector::REFERENCE) sel->reference(reference);
+    if (combinator == Sequence_Selector::REFERENCE) sel->reference(reference);
     // has linfeed after combinator?
     sel->has_line_break(peek_newline());
     // sel->has_line_feed(has_line_feed);
@@ -715,7 +715,7 @@ namespace Sass {
       if (!sel->head()) { sel->head(head); }
       // otherwise we need to create a new complex selector and set the old one as its tail
       else {
-        sel = SASS_MEMORY_NEW(ctx.mem, Complex_Selector, pstate, Complex_Selector::ANCESTOR_OF, head, sel);
+        sel = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, pstate, Sequence_Selector::ANCESTOR_OF, head, sel);
         sel->media_block(last_media_block);
       }
       // peek for linefeed and remember result on head

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -653,7 +653,7 @@ namespace Sass {
     String* reference = 0;
     lex < block_comment >();
     // parse the left hand side
-    Compound_Selector* lhs = 0;
+    SimpleSequence_Selector* lhs = 0;
     // special case if it starts with combinator ([+~>])
     if (!peek_css< class_char < selector_combinator_ops > >()) {
       // parse the left hand side
@@ -707,7 +707,7 @@ namespace Sass {
       // create the objects to wrap parent selector reference
       Parent_Selector* parent = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate);
       parent->media_block(last_media_block);
-      Compound_Selector* head = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pstate);
+      SimpleSequence_Selector* head = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, pstate);
       head->media_block(last_media_block);
       // add simple selector
       (*head) << parent;
@@ -730,10 +730,10 @@ namespace Sass {
   // parse one compound selector, which is basically
   // a list of simple selectors (directly adjacent)
   // lex them exactly (without skipping white-space)
-  Compound_Selector* Parser::parse_compound_selector()
+  SimpleSequence_Selector* Parser::parse_compound_selector()
   {
     // init an empty compound selector wrapper
-    Compound_Selector* seq = SASS_MEMORY_NEW(ctx.mem, Compound_Selector, pstate);
+    SimpleSequence_Selector* seq = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, pstate);
     seq->media_block(last_media_block);
 
     // skip initial white-space

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -799,8 +799,11 @@ namespace Sass {
   Simple_Selector* Parser::parse_simple_selector()
   {
     lex < css_comments >(false);
-    if (lex< alternatives < id_name, class_name > >()) {
-      return SASS_MEMORY_NEW(ctx.mem, Selector_Qualifier, pstate, lexed);
+    if (lex< class_name >()) {
+      return SASS_MEMORY_NEW(ctx.mem, Class_Selector, pstate, lexed);
+    }
+    else if (lex< id_name >()) {
+      return SASS_MEMORY_NEW(ctx.mem, Id_Selector, pstate, lexed);
     }
     else if (lex< quoted_string >()) {
       return SASS_MEMORY_NEW(ctx.mem, Element_Selector, pstate, unquote(lexed));

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -821,7 +821,7 @@ namespace Sass {
       return parse_attribute_selector();
     }
     else if (lex< placeholder >()) {
-      Selector_Placeholder* sel = SASS_MEMORY_NEW(ctx.mem, Selector_Placeholder, pstate, lexed);
+      Placeholder_Selector* sel = SASS_MEMORY_NEW(ctx.mem, Placeholder_Selector, pstate, lexed);
       sel->media_block(last_media_block);
       return sel;
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -55,7 +55,7 @@ namespace Sass {
     return p;
   }
 
-  Selector_List* Parser::parse_selector(const char* beg, Context& ctx, ParserState pstate, const char* source)
+  CommaSequence_Selector* Parser::parse_selector(const char* beg, Context& ctx, ParserState pstate, const char* source)
   {
     Parser p = Parser::from_c_str(beg, ctx, pstate, source);
     // ToDo: ruby sass errors on parent references
@@ -595,12 +595,12 @@ namespace Sass {
 
   // parse a list of complex selectors
   // this is the main entry point for most
-  Selector_List* Parser::parse_selector_list(bool in_root)
+  CommaSequence_Selector* Parser::parse_selector_list(bool in_root)
   {
     bool reloop = true;
     bool had_linefeed = false;
     Complex_Selector* sel = 0;
-    Selector_List* group = SASS_MEMORY_NEW(ctx.mem, Selector_List, pstate);
+    CommaSequence_Selector* group = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, pstate);
     group->media_block(last_media_block);
 
     do {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -240,7 +240,7 @@ namespace Sass {
     Selector_Schema* parse_selector_schema(const char* end_of_selector);
     CommaSequence_Selector* parse_selector_list(bool at_root = false);
     Sequence_Selector* parse_complex_selector(bool in_root = true);
-    Compound_Selector* parse_compound_selector();
+    SimpleSequence_Selector* parse_compound_selector();
     Simple_Selector* parse_simple_selector();
     Wrapped_Selector* parse_negated_selector();
     Simple_Selector* parse_pseudo_selector();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -239,7 +239,7 @@ namespace Sass {
     Ruleset* parse_ruleset(Lookahead lookahead, bool is_root = false);
     Selector_Schema* parse_selector_schema(const char* end_of_selector);
     CommaSequence_Selector* parse_selector_list(bool at_root = false);
-    Complex_Selector* parse_complex_selector(bool in_root = true);
+    Sequence_Selector* parse_complex_selector(bool in_root = true);
     Compound_Selector* parse_compound_selector();
     Simple_Selector* parse_simple_selector();
     Wrapped_Selector* parse_negated_selector();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -51,7 +51,7 @@ namespace Sass {
     static Parser from_c_str(const char* beg, const char* end, Context& ctx, ParserState pstate = ParserState("[CSTRING]"), const char* source = 0);
     static Parser from_token(Token t, Context& ctx, ParserState pstate = ParserState("[TOKEN]"), const char* source = 0);
     // special static parsers to convert strings into certain selectors
-    static Selector_List* parse_selector(const char* src, Context& ctx, ParserState pstate = ParserState("[SELECTOR]"), const char* source = 0);
+    static CommaSequence_Selector* parse_selector(const char* src, Context& ctx, ParserState pstate = ParserState("[SELECTOR]"), const char* source = 0);
 
 #ifdef __clang__
 
@@ -238,7 +238,7 @@ namespace Sass {
     Assignment* parse_assignment();
     Ruleset* parse_ruleset(Lookahead lookahead, bool is_root = false);
     Selector_Schema* parse_selector_schema(const char* end_of_selector);
-    Selector_List* parse_selector_list(bool at_root = false);
+    CommaSequence_Selector* parse_selector_list(bool at_root = false);
     Complex_Selector* parse_complex_selector(bool in_root = true);
     Compound_Selector* parse_compound_selector();
     Simple_Selector* parse_simple_selector();

--- a/src/remove_placeholders.cpp
+++ b/src/remove_placeholders.cpp
@@ -16,9 +16,9 @@ namespace Sass {
         }
     }
 
-    Selector_List* Remove_Placeholders::remove_placeholders(Selector_List* sl)
+    CommaSequence_Selector* Remove_Placeholders::remove_placeholders(CommaSequence_Selector* sl)
     {
-      Selector_List* new_sl = SASS_MEMORY_NEW(ctx.mem, Selector_List, sl->pstate());
+      CommaSequence_Selector* new_sl = SASS_MEMORY_NEW(ctx.mem, CommaSequence_Selector, sl->pstate());
 
       for (size_t i = 0, L = sl->length(); i < L; ++i) {
           if (!(*sl)[i]->contains_placeholder()) {
@@ -33,7 +33,7 @@ namespace Sass {
 
     void Remove_Placeholders::operator()(Ruleset* r) {
         // Create a new selector group without placeholders
-        Selector_List* sl = static_cast<Selector_List*>(r->selector());
+        CommaSequence_Selector* sl = static_cast<CommaSequence_Selector*>(r->selector());
 
         if (sl) {
           // Set the new placeholder selector list
@@ -44,8 +44,8 @@ namespace Sass {
               if (cs->head()) {
                 for (Simple_Selector* ss : *cs->head()) {
                   if (Wrapped_Selector* ws = dynamic_cast<Wrapped_Selector*>(ss)) {
-                    if (Selector_List* sl = dynamic_cast<Selector_List*>(ws->selector())) {
-                      Selector_List* clean = remove_placeholders(sl);
+                    if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(ws->selector())) {
+                      CommaSequence_Selector* clean = remove_placeholders(sl);
                       // also clean superflous parent selectors
                       // probably not really the correct place
                       clean->remove_parent_selectors();

--- a/src/remove_placeholders.cpp
+++ b/src/remove_placeholders.cpp
@@ -39,7 +39,7 @@ namespace Sass {
           // Set the new placeholder selector list
           r->selector(remove_placeholders(sl));
           // Remove placeholders in wrapped selectors
-          for (Complex_Selector* cs : *sl) {
+          for (Sequence_Selector* cs : *sl) {
             while (cs) {
               if (cs->head()) {
                 for (Simple_Selector* ss : *cs->head()) {

--- a/src/remove_placeholders.hpp
+++ b/src/remove_placeholders.hpp
@@ -18,7 +18,7 @@ namespace Sass {
         void fallback_impl(AST_Node* n) {}
 
     public:
-      Selector_List* remove_placeholders(Selector_List*);
+      CommaSequence_Selector* remove_placeholders(CommaSequence_Selector*);
 
     public:
         Remove_Placeholders(Context&);

--- a/src/to_value.cpp
+++ b/src/to_value.cpp
@@ -88,8 +88,8 @@ namespace Sass {
     return arg->value()->perform(this);
   }
 
-  // Selector_List is converted to a string
-  Value* To_Value::operator()(Selector_List* s)
+  // CommaSequence_Selector is converted to a string
+  Value* To_Value::operator()(CommaSequence_Selector* s)
   {
     return SASS_MEMORY_NEW(mem, String_Quoted,
                            s->pstate(),

--- a/src/to_value.hpp
+++ b/src/to_value.hpp
@@ -37,7 +37,7 @@ namespace Sass {
     Value* operator()(Null*);
 
     // convert to string via `To_String`
-    Value* operator()(Selector_List*);
+    Value* operator()(CommaSequence_Selector*);
     Value* operator()(Binary_Expression*);
 
     // fallback throws error

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -458,7 +458,7 @@ namespace Sass {
 
       Block* b = r->block();
 
-      bool hasSelectors = static_cast<Selector_List*>(r->selector())->length() > 0;
+      bool hasSelectors = static_cast<CommaSequence_Selector*>(r->selector())->length() > 0;
 
       if (!hasSelectors) {
         return false;
@@ -523,7 +523,7 @@ namespace Sass {
 
       Block* b = f->block();
 
-//      bool hasSelectors = f->selector() && static_cast<Selector_List*>(f->selector())->length() > 0;
+//      bool hasSelectors = f->selector() && static_cast<CommaSequence_Selector*>(f->selector())->length() > 0;
 
       bool hasDeclarations = false;
       bool hasPrintableChildBlocks = false;


### PR DESCRIPTION
This PR renames most selector AST nodes to better match
their Ruby Sass equivalents. Although we mostly have 1-to-1
mapping between the AST nodes their implementations still
differ significantly. Aligning our selector implementation with
Ruby Sass will the focus upcoming work.

I wasn't able to split the `Element_Selector` into the respective
`Element` and `Universal` selector in Ruby Sass because the
LibSass implementation differed too much.