### PR TITLE
[WIP] Refactor selector resolve parent ref

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2380,6 +2380,8 @@ namespace Sass {
     }
     virtual bool has_parent_ref();
 
+
+
     Sequence_Selector* skip_empty_reference()
     {
       if ((!head_ || !head_->length() || head_->is_empty_reference()) &&

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -29,6 +29,7 @@
 #include "sass2scss.h"
 #include "prelexer.hpp"
 #include "emitter.hpp"
+#include "debugger.hpp"
 
 namespace Sass {
   using namespace Constants;
@@ -650,6 +651,7 @@ namespace Sass {
     Expand expand(*this, &global, &backtrace);
     Cssize cssize(*this, &backtrace);
     CheckNesting check_nesting;
+    debug_ast(root);
     // check nesting
     root->perform(&check_nesting)->block();
     // expand and eval the tree

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1618,6 +1618,10 @@ namespace Sass {
     sl->is_optional(s->is_optional());
     sl->media_block(s->media_block());
     sl->is_optional(s->is_optional());
+
+    bool implicit_parent = !exp.old_at_root_without_rule;
+    return s->resolve_parent_refs(ctx, selector(), implicit_parent);
+
     for (size_t i = 0, iL = s->length(); i < iL; ++i) {
       rv.push_back(operator()((*s)[i]));
     }

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -104,21 +104,21 @@ namespace Sass {
     LOCAL_FLAG(at_root_without_rule, false);
 
     // do some special checks for the base level rules
-    if (r->is_root()) {
-      if (CommaSequence_Selector* selector_list = dynamic_cast<CommaSequence_Selector*>(r->selector())) {
-        for (Sequence_Selector* complex_selector : selector_list->elements()) {
-          Sequence_Selector* tail = complex_selector;
-          while (tail) {
-            if (tail->head()) for (Simple_Selector* header : tail->head()->elements()) {
-              if (dynamic_cast<Parent_Selector*>(header) == NULL) continue; // skip all others
-              std::string sel_str(complex_selector->to_string(ctx.c_options));
-              error("Base-level rules cannot contain the parent-selector-referencing character '&'.", header->pstate(), backtrace());
-            }
-            tail = tail->tail();
-          }
-        }
-      }
-    }
+    // if (r->is_root()) {
+    //   if (CommaSequence_Selector* selector_list = dynamic_cast<CommaSequence_Selector*>(r->selector())) {
+    //     for (Sequence_Selector* complex_selector : selector_list->elements()) {
+    //       Sequence_Selector* tail = complex_selector;
+    //       while (tail) {
+    //         if (tail->head()) for (Simple_Selector* header : tail->head()->elements()) {
+    //           if (dynamic_cast<Parent_Selector*>(header) == NULL) continue; // skip all others
+    //           std::string sel_str(complex_selector->to_string(ctx.c_options));
+    //           error("Base-level rules cannot contain the parent-selector-referencing character '&'.", header->pstate(), backtrace());
+    //         }
+    //         tail = tail->tail();
+    //       }
+    //     }
+    //   }
+    // }
 
     Expression* ex = r->selector()->perform(&eval);
     CommaSequence_Selector* sel = dynamic_cast<CommaSequence_Selector*>(ex);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -701,26 +701,26 @@ namespace Sass {
       }
     }
 
-    // add a parent selector if we are not in a root
-    // also skip adding parent ref if we only have refs
-    if (!sel->has_parent_ref() && !in_at_root && !in_root) {
-      // create the objects to wrap parent selector reference
-      Parent_Selector* parent = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate);
-      parent->media_block(last_media_block);
-      SimpleSequence_Selector* head = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, pstate);
-      head->media_block(last_media_block);
-      // add simple selector
-      (*head) << parent;
-      // selector may not have any head yet
-      if (!sel->head()) { sel->head(head); }
-      // otherwise we need to create a new complex selector and set the old one as its tail
-      else {
-        sel = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, pstate, Sequence_Selector::ANCESTOR_OF, head, sel);
-        sel->media_block(last_media_block);
-      }
-      // peek for linefeed and remember result on head
-      // if (peek_newline()) head->has_line_break(true);
-    }
+    // // add a parent selector if we are not in a root
+    // // also skip adding parent ref if we only have refs
+    // if (!sel->has_parent_ref() && !in_at_root && !in_root) {
+    //   // create the objects to wrap parent selector reference
+    //   Parent_Selector* parent = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate);
+    //   parent->media_block(last_media_block);
+    //   SimpleSequence_Selector* head = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, pstate);
+    //   head->media_block(last_media_block);
+    //   // add simple selector
+    //   (*head) << parent;
+    //   // selector may not have any head yet
+    //   if (!sel->head()) { sel->head(head); }
+    //   // otherwise we need to create a new complex selector and set the old one as its tail
+    //   else {
+    //     sel = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, pstate, Sequence_Selector::ANCESTOR_OF, head, sel);
+    //     sel->media_block(last_media_block);
+    //   }
+    //   // peek for linefeed and remember result on head
+    //   // if (peek_newline()) head->has_line_break(true);
+    // }
 
     // complex selector
     return sel;


### PR DESCRIPTION
This is super early WIP of a light refactor to selector resolve parent ref. I spent a bunch of time trying to overhaul selector handling to match Ruby Sass but it was an unreasonable amount of change.

The intent here is to match the Ruby Sass implementation of `resolve_parent_ref`.

Fixes #1890
Fixes #2006
