### PR TITLE
Fix issue with invalid duplicate keys

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2004,6 +2004,21 @@ namespace Sass {
     return false;
   }
 
+  bool Number::eq (const Expression& rhs) const
+  {
+    if (const Number* r = dynamic_cast<const Number*>(&rhs)) {
+      size_t lhs_units = numerator_units_.size() + denominator_units_.size();
+      size_t rhs_units = r->numerator_units_.size() + r->denominator_units_.size();
+      if (!lhs_units && !rhs_units) {
+        return std::fabs(value() - r->value()) < NUMBER_EPSILON;
+      }
+      return (numerator_units_ == r->numerator_units_) &&
+             (denominator_units_ == r->denominator_units_) &&
+             std::fabs(value() - r->value()) < NUMBER_EPSILON;
+    }
+    return false;
+  }
+
   bool Number::operator== (const Expression& rhs) const
   {
     if (const Number* r = dynamic_cast<const Number*>(&rhs)) {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -152,6 +152,7 @@ namespace Sass {
     static std::string type_name() { return ""; }
     virtual bool is_false() { return false; }
     virtual bool operator== (const Expression& rhs) const { return false; }
+    virtual bool eq(const Expression& rhs) const { return *this == rhs; };
     virtual void set_delayed(bool delayed) { is_delayed(delayed); }
     virtual bool has_interpolant() const { return is_interpolant(); }
     virtual bool is_left_interpolant() const { return is_interpolant(); }
@@ -289,7 +290,7 @@ namespace Sass {
   };
   struct CompareExpression {
     bool operator()(const Expression* lhs, const Expression* rhs) const {
-      return lhs && rhs && *lhs == *rhs;
+      return lhs && rhs && lhs->eq(*rhs);
     }
   };
   typedef std::unordered_map<
@@ -1369,6 +1370,7 @@ namespace Sass {
 
     virtual bool operator< (const Number& rhs) const;
     virtual bool operator== (const Expression& rhs) const;
+    virtual bool eq(const Expression& rhs) const;
 
     ATTACH_OPERATIONS()
   };


### PR DESCRIPTION
Keys `1` and `1px` were considered duplicates if they end
up in the same bucket. In sass these are indeed equal but
that does not seem to apply when used as hash keys.

@xzyfer feel free to refactor as you see fit.