### PR TITLE
Fix parser when reaching EOF in selector lookahead

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2437,7 +2437,7 @@ namespace Sass {
       else if (peek < exactly<'('> >(q)) rv.found = q;
       // else if (peek < exactly<';'> >(q)) rv.found = q;
       // else if (peek < exactly<'}'> >(q)) rv.found = q;
-      if (rv.found || *p == 0) rv.error = 0;
+      if (rv.found) rv.error = 0;
     }
 
     rv.parsable = ! rv.has_interpolants;


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/2123

This breaks two error specs by differing in the given error message (they still error). Therefore it may be worth merging anyway, as it fixes a real issue for trading different error messages.
