### PR TITLE
Improve memory footprint when evaluating in loops

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -141,7 +141,7 @@ namespace Sass {
                bool d = false, bool e = false, bool i = false, Concrete_Type ct = NONE)
     : AST_Node(pstate),
       is_delayed_(d),
-      is_expanded_(d),
+      is_expanded_(e),
       is_interpolant_(i),
       concrete_type_(ct)
     { }
@@ -225,7 +225,7 @@ namespace Sass {
     void reset_hash() { hash_ = 0; }
     virtual void adjust_after_pushing(T element) { }
   public:
-    Vectorized(size_t s = 0) : elements_(std::vector<T>())
+    Vectorized(size_t s = 0) : elements_(std::vector<T>()), hash_(0)
     { elements_.reserve(s); }
     virtual ~Vectorized() = 0;
     size_t length() const   { return elements_.size(); }


### PR DESCRIPTION
We are cloning/copying too many objects when evaluating loops. i.e. a simple `map-get` call will always clone the full map that is passed, which can lead to an absurd amount of allocated memory. But we cannot really cache the results as 1) variables can be re-assigned and 2) some code paths (i.e. equality checks) evaluate binary expressions different than normaly. This fix will only cache "delayed" results, which should cover 90% of the cases. This should also improve performance in certain cases by a lot.