### PR TITLE
Support list functions on maps

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2226,4 +2226,20 @@ namespace Sass {
     }
   }
 
+  //////////////////////////////////////////////////////////////////////////////////////////
+  // Convert map to (key, value) list.
+  //////////////////////////////////////////////////////////////////////////////////////////
+  List* Map::to_list(Context& ctx, ParserState& pstate) {
+    List* ret = SASS_MEMORY_NEW(ctx.mem, List, pstate, length(), SASS_COMMA);
+
+    for (auto key : keys()) {
+      List* l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 2);
+      *l << key;
+      *l << at(key);
+      *ret << l;
+    }
+
+    return ret;
+  }
+
 }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -924,6 +924,7 @@ namespace Sass {
     std::string type() { return "map"; }
     static std::string type_name() { return "map"; }
     bool is_invisible() const { return empty(); }
+    List* to_list(Context& ctx, ParserState& pstate);
 
     virtual size_t hash()
     {

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1357,6 +1357,7 @@ namespace Sass {
     Signature append_sig = "append($list, $val, $separator: auto)";
     BUILT_IN(append)
     {
+      Map* m = dynamic_cast<Map*>(env["$list"]);
       List* l = dynamic_cast<List*>(env["$list"]);
       Expression* v = ARG("$val", Expression);
       if (CommaSequence_Selector* sl = dynamic_cast<CommaSequence_Selector*>(env["$list"])) {
@@ -1367,6 +1368,9 @@ namespace Sass {
       if (!l) {
         l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << ARG("$list", Expression);
+      }
+      if (m) {
+        l = m->to_list(ctx, pstate);
       }
       List* result = SASS_MEMORY_NEW(ctx.mem, List, pstate, l->length() + 1, l->separator());
       std::string sep_str(unquote(sep->value()));

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1311,11 +1311,15 @@ namespace Sass {
     Signature index_sig = "index($list, $value)";
     BUILT_IN(index)
     {
+      Map* m = dynamic_cast<Map*>(env["$list"]);
       List* l = dynamic_cast<List*>(env["$list"]);
       Expression* v = ARG("$value", Expression);
       if (!l) {
         l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << ARG("$list", Expression);
+      }
+      if (m) {
+        l = m->to_list(ctx, pstate);
       }
       for (size_t i = 0, L = l->length(); i < L; ++i) {
         if (Eval::eq(l->value_at_index(i), v)) return SASS_MEMORY_NEW(ctx.mem, Number, pstate, (double)(i+1));

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1291,12 +1291,16 @@ namespace Sass {
     Signature set_nth_sig = "set-nth($list, $n, $value)";
     BUILT_IN(set_nth)
     {
+      Map* m = dynamic_cast<Map*>(env["$list"]);
       List* l = dynamic_cast<List*>(env["$list"]);
       Number* n = ARG("$n", Number);
       Expression* v = ARG("$value", Expression);
       if (!l) {
         l = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l << ARG("$list", Expression);
+      }
+      if (m) {
+        l = m->to_list(ctx, pstate);
       }
       if (l->empty()) error("argument `$list` of `" + std::string(sig) + "` must not be empty", pstate);
       double index = std::floor(n->value() < 0 ? l->length() + n->value() : n->value() - 1);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1330,6 +1330,8 @@ namespace Sass {
     Signature join_sig = "join($list1, $list2, $separator: auto)";
     BUILT_IN(join)
     {
+      Map* m1 = dynamic_cast<Map*>(env["$list1"]);
+      Map* m2 = dynamic_cast<Map*>(env["$list2"]);
       List* l1 = dynamic_cast<List*>(env["$list1"]);
       List* l2 = dynamic_cast<List*>(env["$list2"]);
       String_Constant* sep = ARG("$separator", String_Constant);
@@ -1342,6 +1344,13 @@ namespace Sass {
       if (!l2) {
         l2 = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
         *l2 << ARG("$list2", Expression);
+      }
+      if (m1) {
+        l1 = m1->to_list(ctx, pstate);
+        sep_val = SASS_COMMA;
+      }
+      if (m2) {
+        l2 = m2->to_list(ctx, pstate);
       }
       size_t len = l1->length() + l2->length();
       std::string sep_str = unquote(sep->value());

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1414,9 +1414,14 @@ namespace Sass {
       size_t shortest = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         List* ith = dynamic_cast<List*>(arglist->value_at_index(i));
+        Map* mith = dynamic_cast<Map*>(arglist->value_at_index(i));
         if (!ith) {
-          ith = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
-          *ith << arglist->value_at_index(i);
+          if (mith) {
+            ith = mith->to_list(ctx, pstate);
+          } else {
+            ith = SASS_MEMORY_NEW(ctx.mem, List, pstate, 1);
+            *ith << arglist->value_at_index(i);
+          }
           if (arglist->is_arglist()) {
             ((Argument*)(*arglist)[i])->value(ith);
           } else {


### PR DESCRIPTION
When Sass added maps the updated the list functions to operate on lists. With a list function gets a map it's treated as a list of key value lists. i.e. `(a: 1, b: 2)` becomes `(a 1), (b 2)`. When I originally implemented maps I only added map support for a subset of list functions.

- [x] append
- [x] index
- [x] join
- [x] length
- [x] nth
- [x] set-nth
- [x] zip

Fixes #1930
Specs sass/sass-spec#919