### PR TITLE
Fix OSX CI failures

### DIFF
--- a/script/ci-install-deps
+++ b/script/ci-install-deps
@@ -7,8 +7,17 @@ else
 fi
 
 if [ "x$AUTOTOOLS" == "xyes" ]; then
-  sudo add-apt-repository -y ppa:rbose-debianizer/automake &> /dev/null
-  sudo apt-get -qq update
-  sudo apt-get -qq install automake
   AUTOTOOLS=yes
+
+  if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    sudo add-apt-repository -y ppa:rbose-debianizer/automake &> /dev/null
+    sudo apt-get -qq update
+    sudo apt-get -qq install automake
+  fi
+
+  # https://github.com/sass/libsass/pull/2183
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    brew uninstall libtool
+    brew install libtool
+  fi
 fi


### PR DESCRIPTION
[Brew released 1.0.0][1] today and in true major release
fashion it has broken OSX CI builds.

[1]: http://brew.sh/2016/09/02/homebrew-1.0.0/