### PR TITLE
Fix parsing for urls with unicode characters

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -81,9 +81,9 @@ namespace Sass {
     bool is_nonascii(const char& chr)
     {
       return (
-        (unsigned(chr) > 127 && unsigned(chr) < 55296) ||
-        (unsigned(chr) > 57343 && unsigned(chr) < 65534) ||
-        (unsigned(chr) > 65535 && unsigned(chr) < 1114111)
+        (unsigned(chr) >= 128 && unsigned(chr) <= 15572911) ||
+        (unsigned(chr) >= 15630464 && unsigned(chr) <= 15712189) ||
+        (unsigned(chr) >= 4036001920)
       );
     }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -88,12 +88,11 @@ namespace Sass {
     }
 
     // check if char is within a reduced ascii range
-    // valid in a uri (and also unicode octets)
+    // valid in a uri (copied from Ruby Sass)
     bool is_uri_character(const char& chr)
     {
-      return unsigned(chr) > 41 ||
-             unsigned(chr) == ':' ||
-             unsigned(chr) == '/';
+      return (unsigned(chr) > 41 && unsigned(chr) < 127) ||
+             unsigned(chr) == ':' || unsigned(chr) == '/';
     }
 
     // check if char is within a reduced ascii range

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -316,6 +316,10 @@ namespace Sass {
         else if (String* the_url = parse_url_function_argument()) {
           *args << SASS_MEMORY_NEW(ctx.mem, Argument, the_url->pstate(), the_url);
         }
+        else if (peek < skip_over_scopes < exactly < '(' >, exactly < ')' > > >(position)) {
+          Expression* the_url = parse_list(); // parse_interpolated_chunk(lexed);
+          *args << SASS_MEMORY_NEW(ctx.mem, Argument, the_url->pstate(), the_url);
+        }
         else {
           error("malformed URL", pstate);
         }


### PR DESCRIPTION
This was addressed in #2125 but was done in a way that significantly diverged url parsing from Ruby Sass. 

This reverts thats patch and fixes the broken regex to closer [match Ruby Sass][1]. This bug was a victim of me not understanding how Ruby handles `\u` sequences.

[1]: https://github.com/sass/sass/blob/stable/lib/sass/scss/rx.rb#L56