### PR TITLE
Do not cache `has_placeholder` flag

### DIFF
--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -87,6 +87,8 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
     std::cerr << " [@media:" << selector->media_block() << "]";
+    std::cerr << (selector->is_invisible() ? " [INVISIBLE]": " -");
+    std::cerr << (selector->has_placeholder() ? " [PLACEHOLDER]": " -");
     std::cerr << (selector->is_optional() ? " [is_optional]": " -");
     std::cerr << (selector->has_parent_ref() ? " [has-parent]": " -");
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
@@ -115,6 +117,8 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
       << " <" << selector->hash() << ">"
       << " [weight:" << longToHex(selector->specificity()) << "]"
       << " [@media:" << selector->media_block() << "]"
+      << (selector->is_invisible() ? " [INVISIBLE]": " -")
+      << (selector->has_placeholder() ? " [PLACEHOLDER]": " -")
       << (selector->is_optional() ? " [is_optional]": " -")
       << (selector->has_parent_ref() ? " [has parent]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
@@ -460,6 +464,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "Ruleset " << ruleset;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [indent: " << ruleset->tabs() << "]";
+    std::cerr << (ruleset->is_invisible() ? " [INVISIBLE]" : "");
     std::cerr << (ruleset->at_root() ? " [@ROOT]" : "");
     std::cerr << (ruleset->is_root() ? " [root]" : "");
     std::cerr << std::endl;
@@ -469,6 +474,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     Block* block = dynamic_cast<Block*>(node);
     std::cerr << ind << "Block " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << (block->is_invisible() ? " [INVISIBLE]" : "");
     std::cerr << " [indent: " << block->tabs() << "]" << std::endl;
     for(auto i : block->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Textual*>(node)) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -697,11 +697,6 @@ namespace Sass {
     if (!peek_css< class_char < complex_selector_delims > >()) {
       // parse next selector in sequence
       sel->tail(parse_complex_selector(true));
-      if (sel->tail()) {
-        // ToDo: move this logic below into tail setter
-        // if (sel->tail()->has_reference()) sel->has_reference(true);
-        if (sel->tail()->has_placeholder()) sel->has_placeholder(true);
-      }
     }
 
     // add a parent selector if we are not in a root


### PR DESCRIPTION
Change implementation to always query the AST tree.
Fixes https://github.com/sass/libsass/issues/2150