### PR TITLE
Re-order the sourcemap writing to match spec

### DIFF
--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -25,15 +25,15 @@ namespace Sass {
 
     json_append_member(json_srcmap, "version", json_mknumber(3));
 
+    const char *include = file.c_str();
+    JsonNode *json_include = json_mkstring(include);
+    json_append_member(json_srcmap, "file", json_include);
+
     // pass-through sourceRoot option
     if (!ctx.source_map_root.empty()) {
       JsonNode* root = json_mkstring(ctx.source_map_root.c_str());
       json_append_member(json_srcmap, "sourceRoot", root);
     }
-
-    const char *include = file.c_str();
-    JsonNode *json_include = json_mkstring(include);
-    json_append_member(json_srcmap, "file", json_include);
 
     JsonNode *json_includes = json_mkarray();
     for (size_t i = 0; i < source_index.size(); ++i) {
@@ -54,14 +54,14 @@ namespace Sass {
         json_append_member(json_srcmap, "sourcesContent", json_contents);
     }
 
-    std::string mappings = serialize_mappings();
-    JsonNode *json_mappings = json_mkstring(mappings.c_str());
-    json_append_member(json_srcmap, "mappings", json_mappings);
-
     JsonNode *json_names = json_mkarray();
     // so far we have no implementation for names
     // no problem as we do not alter any identifiers
     json_append_member(json_srcmap, "names", json_names);
+
+    std::string mappings = serialize_mappings();
+    JsonNode *json_mappings = json_mkstring(mappings.c_str());
+    json_append_member(json_srcmap, "mappings", json_mappings);
 
     char *str = json_stringify(json_srcmap, "\t");
     std::string result = std::string(str);


### PR DESCRIPTION
The spec
https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6f
AH0KY0k/edit?pli=1# outlines the order of the elements as:
Line 1: The entire file is a single JSON object
Line 2: File version (always the first entry in the object) and must be
a positive integer.
Line 3: An optional name of the generated code that this source map is
associated with.
Line 4: An optional source root, useful for relocating source files on
a server or removing repeated values in the “sources” entry.  This
value is prepended to the individual entries in the “source” field.
Line 5: A list of original sources used by the “mappings” entry.
Line 6: An optional list of source content, useful when the “source”
can’t be hosted. The contents are listed in the same order as the
sources in line 5. “null” may be used if some original sources should
be retrieved by name.
Line 7: A list of symbol names used by the “mappings” entry.
Line 8: A string with the encoded mapping data.