### PR TITLE
Don't probe tests in CI

### DIFF
--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -120,10 +120,10 @@ then
     echo "Fetching Sass Spec PR $SPEC_PR"
     git -C sass-spec fetch -u origin pull/$SPEC_PR/head:ci-spec-pr-$SPEC_PR
     git -C sass-spec checkout --force ci-spec-pr-$SPEC_PR
-    LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_probe
+    LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_build
   else
-    LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_probe
+    LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_build
   fi
 else
-  LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_probe
+  LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_build
 fi


### PR DESCRIPTION
Sass spec has a bug with probe todo that causes some failures to be
hidden. As a result #2189 caused a regression.

/cc @mgreter