### PR TITLE
Workaround parent selector issues with at-root

### DIFF
--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -107,6 +107,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
 //    if (selector->not_selector()) cerr << " [in_declaration]";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
+    std::cerr << " [" << (selector->is_real_parent_ref() ? "REAL" : "FAKE") << "]";
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
 //    debug_ast(selector->selector(), ind + "->", env);
 

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -876,7 +876,7 @@ namespace Sass {
 
   void Inspect::operator()(Parent_Selector* p)
   {
-    append_string("&");
+    if (p->is_real_parent_ref()) append_string("&");
   }
 
   void Inspect::operator()(Placeholder_Selector* s)

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -703,7 +703,7 @@ namespace Sass {
     // also skip adding parent ref if we only have refs
     if (!sel->has_parent_ref() && !in_at_root && !in_root) {
       // create the objects to wrap parent selector reference
-      Parent_Selector* parent = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate);
+      Parent_Selector* parent = SASS_MEMORY_NEW(ctx.mem, Parent_Selector, pstate, false);
       parent->media_block(last_media_block);
       SimpleSequence_Selector* head = SASS_MEMORY_NEW(ctx.mem, SimpleSequence_Selector, pstate);
       head->media_block(last_media_block);


### PR DESCRIPTION
LibSass fully parses selectors during the parsing stage. This is
different from Ruby Sass which parse selectors and string during
the parsing stage, and lazily eval'ing when required. This 
difference causes some pathological selector issues. Our eager
parsing of selectors has resulted in us hacking in fake 
`Parent_Selector` into `Sequence_Selector` during parsing.

These fake `Parent_Selector` play havoc with `resolve_parent_refs`
when within `@at-root` blocks. I spent a couple weeks going down 
the rabbit whole of refactoring our selector parsing to be lazy before 
bailing.

Explicitly marking which `Parent_Selector` are fake during parsing
allows us faithfully implement the `implicit_parent` flag in 
`resolve_parent_refs`.

Fixes #2006
Fixes #2198
Spec sass/sass-spec#936