### PR TITLE
Don't drop pseudo elements in wrapped selectors

### DIFF
--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -116,6 +116,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     std::cerr << ind << "Sequence_Selector " << selector
       << " (" << pstate_source_position(node) << ")"
       << " <" << selector->hash() << ">"
+      << " [length:" << longToHex(selector->length()) << "]"
       << " [weight:" << longToHex(selector->specificity()) << "]"
       << " [@media:" << selector->media_block() << "]"
       << (selector->is_invisible() ? " [INVISIBLE]": " -")


### PR DESCRIPTION
The extend visitor currently mutates some selectors, even ones that
get extended. This patch works around a specific use case that breaks
foundation.

Spec sass/sass-spec#949
Fixes #2200