### PR TITLE
Fix for sourcemap offsets

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -13,6 +13,8 @@
 #include <cctype>
 #include <locale>
 
+#include "debugger.hpp"
+
 namespace Sass {
 
   static Null sass_null(Sass::Null(ParserState("null")));
@@ -1053,24 +1055,24 @@ namespace Sass {
         SimpleSequence_Selector* rh = last()->head();
         size_t i = 0, L = h->length();
         if (dynamic_cast<Element_Selector*>(h->first())) {
-          if (Class_Selector* sq = dynamic_cast<Class_Selector*>(rh->last())) {
-            Class_Selector* sqs = new Class_Selector(*sq);
-            sqs->name(sqs->name() + (*h)[0]->name());
+          if (dynamic_cast<Class_Selector*>(rh->last())) {
+            Class_Selector* sqs = new Class_Selector(
+              h->first()->pstate(), rh->last()->name() + (*h)[0]->name());
             (*rh)[rh->length()-1] = sqs;
             for (i = 1; i < L; ++i) *rh << (*h)[i];
-          } else if (Id_Selector* sq = dynamic_cast<Id_Selector*>(rh->last())) {
-            Id_Selector* sqs = new Id_Selector(*sq);
-            sqs->name(sqs->name() + (*h)[0]->name());
+          } else if (dynamic_cast<Id_Selector*>(rh->last())) {
+            Id_Selector* sqs = new Id_Selector(
+              h->first()->pstate(), rh->last()->name() + (*h)[0]->name());
             (*rh)[rh->length()-1] = sqs;
             for (i = 1; i < L; ++i) *rh << (*h)[i];
-          } else if (Element_Selector* ts = dynamic_cast<Element_Selector*>(rh->last())) {
-            Element_Selector* tss = new Element_Selector(*ts);
-            tss->name(tss->name() + (*h)[0]->name());
+          } else if (dynamic_cast<Element_Selector*>(rh->last())) {
+            Element_Selector* tss = new Element_Selector(
+              h->first()->pstate(), rh->last()->name() + (*h)[0]->name());
             (*rh)[rh->length()-1] = tss;
             for (i = 1; i < L; ++i) *rh << (*h)[i];
-          } else if (Placeholder_Selector* ps = dynamic_cast<Placeholder_Selector*>(rh->last())) {
-            Placeholder_Selector* pss = new Placeholder_Selector(*ps);
-            pss->name(pss->name() + (*h)[0]->name());
+          } else if (dynamic_cast<Placeholder_Selector*>(rh->last())) {
+            Placeholder_Selector* pss = new Placeholder_Selector(
+              h->first()->pstate(), rh->last()->name() + (*h)[0]->name());
             (*rh)[rh->length()-1] = pss;
             for (i = 1; i < L; ++i) *rh << (*h)[i];
           } else {
@@ -1146,7 +1148,7 @@ namespace Sass {
               for (size_t i = 0, iL = parents->length(); i < iL; ++i) {
                 Sequence_Selector* t = (*tails)[n];
                 Sequence_Selector* parent = (*parents)[i];
-                Sequence_Selector* s = parent->cloneFullyScoped(ctx, this);
+                Sequence_Selector* s = parent->cloneFully(ctx);
                 Sequence_Selector* ss = this->clone(ctx);
                 ss->tail(t ? t->clone(ctx) : 0);
                 SimpleSequence_Selector* h = head_->clone(ctx);
@@ -1162,7 +1164,7 @@ namespace Sass {
           else {
             for (size_t i = 0, iL = parents->length(); i < iL; ++i) {
               Sequence_Selector* parent = (*parents)[i];
-              Sequence_Selector* s = parent->cloneFullyScoped(ctx, this);
+              Sequence_Selector* s = parent->cloneFully(ctx);
               Sequence_Selector* ss = this->clone(ctx);
               // this is only if valid if the parent has no trailing op
               // otherwise we cannot append more simple selectors to head
@@ -1348,33 +1350,6 @@ namespace Sass {
 
     return cpy;
   }
-
-  Sequence_Selector* Sequence_Selector::cloneFullyScoped(Context& ctx, const Sequence_Selector *s) const
-  {
-    // when cloning a parent selector, the scope of the sequence selector must
-    // be preserved in order for sourcemaps to work, so the sequence selector
-    // of the current scope is used as an injection vector
-    Sequence_Selector* cpy = SASS_MEMORY_NEW(ctx.mem, Sequence_Selector, tail() ? *this : *s);
-    // set properties t the current node and reset tail by default
-    cpy->combinator(this->combinator());
-    cpy->reference(this->reference());
-    cpy->tail(0);
-    cpy->has_line_feed(this->has_line_feed());
-    cpy->has_line_break(this->has_line_break());
-
-    cpy->is_optional(this->is_optional());
-    cpy->media_block(this->media_block());
-    if (head()) {
-      cpy->head(head()->clone(ctx));
-    }
-
-    if (tail()) {
-      cpy->tail(tail()->cloneFullyScoped(ctx, s));
-    }
-
-    return cpy;
-  }
-
 
   SimpleSequence_Selector* SimpleSequence_Selector::clone(Context& ctx) const
   {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2538,7 +2538,7 @@ namespace Sass {
     }
     Sequence_Selector* clone(Context&) const;      // does not clone SimpleSequence_Selector*s
     Sequence_Selector* cloneFully(Context&) const; // clones SimpleSequence_Selector*s
-    Sequence_Selector* cloneFullyScoped(Context&, const Sequence_Selector*) const; // clones SimpleSequence_Selector*s
+    Sequence_Selector* cloneFullyInto(Context&, const Sequence_Selector*) const; // clones SimpleSequence_Selector*s
     // std::vector<SimpleSequence_Selector*> to_vector();
     ATTACH_OPERATIONS()
   };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2538,6 +2538,7 @@ namespace Sass {
     }
     Sequence_Selector* clone(Context&) const;      // does not clone SimpleSequence_Selector*s
     Sequence_Selector* cloneFully(Context&) const; // clones SimpleSequence_Selector*s
+    Sequence_Selector* cloneFullyScoped(Context&, const Sequence_Selector*) const; // clones SimpleSequence_Selector*s
     // std::vector<SimpleSequence_Selector*> to_vector();
     ATTACH_OPERATIONS()
   };

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -14,6 +14,7 @@ namespace Sass {
     scheduled_space(0),
     scheduled_linefeed(0),
     scheduled_delimiter(false),
+    scheduled_mapping(0),
     in_comment(false),
     in_wrapped(false),
     in_media_block(false),

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -5,6 +5,9 @@
 #include "emitter.hpp"
 #include "utf8_string.hpp"
 
+#include <iostream>
+#include "debugger.hpp"
+
 namespace Sass {
 
   Emitter::Emitter(struct Sass_Output_Options& opt)
@@ -141,15 +144,24 @@ namespace Sass {
   // this adds source-mappings for node start and end
   void Emitter::append_token(const std::string& text, const AST_Node* node)
   {
+    // printf("node.open\n");
+    // debug_ast(node);
+
     flush_schedules();
     add_open_mapping(node);
     // hotfix for browser issues
     // this is pretty ugly indeed
     if (scheduled_mapping) {
-      add_open_mapping(scheduled_mapping);
+    //   add_open_mapping(scheduled_mapping);
       scheduled_mapping = 0;
     }
     append_string(text);
+
+    // printf("string\n");
+    // std::cout << text << std::endl;
+    //
+    // printf("node.close\n");
+    // debug_ast(node);
     add_close_mapping(node);
   }
 
@@ -241,10 +253,12 @@ namespace Sass {
 
   void Emitter::append_scope_opener(AST_Node* node)
   {
+    // printf("scope.open\n");
+    // debug_ast(node);
     scheduled_linefeed = 0;
     append_optional_space();
     flush_schedules();
-    if (node) add_open_mapping(node);
+    // if (node) add_open_mapping(node);
     append_string("{");
     append_optional_linefeed();
     // append_optional_space();
@@ -263,7 +277,9 @@ namespace Sass {
       append_optional_space();
     }
     append_string("}");
-    if (node) add_close_mapping(node);
+    // printf("scope.close\n");
+    // debug_ast(node);
+    // if (node) add_close_mapping(node);
     append_optional_linefeed();
     if (indentation != 0) return;
     if (output_style() != COMPRESSED)

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -5,9 +5,6 @@
 #include "emitter.hpp"
 #include "utf8_string.hpp"
 
-#include <iostream>
-#include "debugger.hpp"
-
 namespace Sass {
 
   Emitter::Emitter(struct Sass_Output_Options& opt)
@@ -17,7 +14,6 @@ namespace Sass {
     scheduled_space(0),
     scheduled_linefeed(0),
     scheduled_delimiter(false),
-    scheduled_mapping(0),
     in_comment(false),
     in_wrapped(false),
     in_media_block(false),
@@ -48,8 +44,6 @@ namespace Sass {
   void Emitter::set_filename(const std::string& str)
   { wbuf.smap.file = str; }
 
-  void Emitter::schedule_mapping(const AST_Node* node)
-  { scheduled_mapping = node; }
   void Emitter::add_open_mapping(const AST_Node* node)
   { wbuf.smap.add_open_mapping(node); }
   void Emitter::add_close_mapping(const AST_Node* node)
@@ -111,7 +105,6 @@ namespace Sass {
   // append some text or token to the buffer
   void Emitter::append_string(const std::string& text)
   {
-
     // write space/lf
     flush_schedules();
 
@@ -144,24 +137,9 @@ namespace Sass {
   // this adds source-mappings for node start and end
   void Emitter::append_token(const std::string& text, const AST_Node* node)
   {
-    // printf("node.open\n");
-    // debug_ast(node);
-
     flush_schedules();
     add_open_mapping(node);
-    // hotfix for browser issues
-    // this is pretty ugly indeed
-    if (scheduled_mapping) {
-    //   add_open_mapping(scheduled_mapping);
-      scheduled_mapping = 0;
-    }
     append_string(text);
-
-    // printf("string\n");
-    // std::cout << text << std::endl;
-    //
-    // printf("node.close\n");
-    // debug_ast(node);
     add_close_mapping(node);
   }
 
@@ -253,12 +231,9 @@ namespace Sass {
 
   void Emitter::append_scope_opener(AST_Node* node)
   {
-    // printf("scope.open\n");
-    // debug_ast(node);
     scheduled_linefeed = 0;
     append_optional_space();
     flush_schedules();
-    // if (node) add_open_mapping(node);
     append_string("{");
     append_optional_linefeed();
     // append_optional_space();
@@ -277,9 +252,6 @@ namespace Sass {
       append_optional_space();
     }
     append_string("}");
-    // printf("scope.close\n");
-    // debug_ast(node);
-    // if (node) add_close_mapping(node);
     append_optional_linefeed();
     if (indentation != 0) return;
     if (output_style() != COMPRESSED)

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -27,7 +27,6 @@ namespace Sass {
       void set_filename(const std::string& str);
       void add_open_mapping(const AST_Node* node);
       void add_close_mapping(const AST_Node* node);
-      void schedule_mapping(const AST_Node* node);
       std::string render_srcmap(Context &ctx);
       ParserState remap(const ParserState& pstate);
 

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -63,7 +63,7 @@ namespace Sass {
   void Inspect::operator()(Media_Block* media_block)
   {
     append_indentation();
-    append_token("@media", media_block);
+    append_string("@media");
     append_mandatory_space();
     in_media_block = true;
     media_block->media_queries()->perform(this);
@@ -74,7 +74,7 @@ namespace Sass {
   void Inspect::operator()(Supports_Block* feature_block)
   {
     append_indentation();
-    append_token("@supports", feature_block);
+    append_string("@supports");
     append_mandatory_space();
     feature_block->condition()->perform(this);
     feature_block->block()->perform(this);
@@ -83,7 +83,7 @@ namespace Sass {
   void Inspect::operator()(At_Root_Block* at_root_block)
   {
     append_indentation();
-    append_token("@at-root ", at_root_block);
+    append_string("@at-root ");
     append_mandatory_space();
     if(at_root_block->expression()) at_root_block->expression()->perform(this);
     at_root_block->block()->perform(this);
@@ -92,7 +92,7 @@ namespace Sass {
   void Inspect::operator()(Directive* at_rule)
   {
     append_indentation();
-    append_token(at_rule->keyword(), at_rule);
+    append_string(at_rule->keyword());
     if (at_rule->selector()) {
       append_mandatory_space();
       bool was_wrapped = in_wrapped;
@@ -120,6 +120,7 @@ namespace Sass {
     if (output_style() == NESTED)
       indentation += dec->tabs();
     append_indentation();
+    add_open_mapping(dec);
     dec->property()->perform(this);
     append_colon_separator();
 
@@ -139,13 +140,12 @@ namespace Sass {
     if (output_style() == NESTED)
       indentation -= dec->tabs();
     in_declaration = was_decl;
-    // hotfix to fix wrong line offsets for declarations that use variables
     add_close_mapping(dec);
   }
 
   void Inspect::operator()(Assignment* assn)
   {
-    append_token(assn->variable(), assn);
+    append_string(assn->variable());
     append_colon_separator();
     assn->value()->perform(this);
     if (assn->is_default()) {
@@ -293,7 +293,7 @@ namespace Sass {
   void Inspect::operator()(Extension* extend)
   {
     append_indentation();
-    append_token("@extend", extend);
+    append_string("@extend");
     append_mandatory_space();
     extend->selector()->perform(this);
     append_delimiter();
@@ -303,10 +303,10 @@ namespace Sass {
   {
     append_indentation();
     if (def->type() == Definition::MIXIN) {
-      append_token("@mixin", def);
+      append_string("@mixin");
       append_mandatory_space();
     } else {
-      append_token("@function", def);
+      append_string("@function");
       append_mandatory_space();
     }
     append_string(def->name());
@@ -317,7 +317,7 @@ namespace Sass {
   void Inspect::operator()(Mixin_Call* call)
   {
     append_indentation();
-    append_token("@include", call);
+    append_string("@include");
     append_mandatory_space();
     append_string(call->name());
     if (call->arguments()) {
@@ -333,7 +333,7 @@ namespace Sass {
   void Inspect::operator()(Content* content)
   {
     append_indentation();
-    append_token("@content", content);
+    append_string("@content");
     append_delimiter();
   }
 
@@ -477,7 +477,7 @@ namespace Sass {
 
   void Inspect::operator()(Function_Call* call)
   {
-    append_token(call->name(), call);
+    append_string(call->name());
     call->arguments()->perform(this);
   }
 
@@ -489,12 +489,12 @@ namespace Sass {
 
   void Inspect::operator()(Variable* var)
   {
-    append_token(var->name(), var);
+    append_string(var->name());
   }
 
   void Inspect::operator()(Textual* txt)
   {
-    append_token(txt->value(), txt);
+    append_string(txt->value());
   }
 
   void Inspect::operator()(Number* n)
@@ -579,7 +579,7 @@ namespace Sass {
     res += n->unit();
 
     // output the final token
-    append_token(res, n);
+    append_string(res);
   }
 
   // helper function for serializing colors
@@ -638,7 +638,7 @@ namespace Sass {
 
     if (compressed && !c->is_delayed()) name = "";
     if (opt.output_style == INSPECT && a >= 1) {
-      append_token(hexlet.str(), c);
+      append_string(hexlet.str());
       return;
     }
 
@@ -672,14 +672,14 @@ namespace Sass {
       ss << a << ')';
     }
 
-    append_token(ss.str(), c);
+    append_string(ss.str());
 
   }
 
   void Inspect::operator()(Boolean* b)
   {
     // output the final token
-    append_token(b->value() ? "true" : "false", b);
+    append_string(b->value() ? "true" : "false");
   }
 
   void Inspect::operator()(String_Schema* ss)
@@ -695,28 +695,26 @@ namespace Sass {
 
   void Inspect::operator()(String_Constant* s)
   {
-    add_open_mapping(s);
-    append_token(s->value(), s);
-    add_close_mapping(s);
+    append_string(s->value());
   }
 
   void Inspect::operator()(String_Quoted* s)
   {
     if (const char q = s->quote_mark()) {
-      append_token(quote(s->value(), q), s);
+      append_string(quote(s->value(), q));
     } else {
-      append_token(s->value(), s);
+      append_string(s->value());
     }
   }
 
   void Inspect::operator()(Custom_Error* e)
   {
-    append_token(e->message(), e);
+    append_string(e->message());
   }
 
   void Inspect::operator()(Custom_Warning* w)
   {
-    append_token(w->message(), w);
+    append_string(w->message());
   }
 
   void Inspect::operator()(Supports_Operator* so)
@@ -728,11 +726,11 @@ namespace Sass {
 
     if (so->operand() == Supports_Operator::AND) {
       append_mandatory_space();
-      append_token("and", so);
+      append_string("and");
       append_mandatory_space();
     } else if (so->operand() == Supports_Operator::OR) {
       append_mandatory_space();
-      append_token("or", so);
+      append_string("or");
       append_mandatory_space();
     }
 
@@ -743,7 +741,7 @@ namespace Sass {
 
   void Inspect::operator()(Supports_Negation* sn)
   {
-    append_token("not", sn);
+    append_string("not");
     append_mandatory_space();
     if (sn->needs_parens(sn->condition())) append_string("(");
     sn->condition()->perform(this);
@@ -811,13 +809,13 @@ namespace Sass {
   void Inspect::operator()(Null* n)
   {
     // output the final token
-    append_token("null", n);
+    append_string("null");
   }
 
   // parameters and arguments
   void Inspect::operator()(Parameter* p)
   {
-    append_token(p->name(), p);
+    append_string(p->name());
     if (p->default_value()) {
       append_colon_separator();
       p->default_value()->perform(this);
@@ -843,7 +841,7 @@ namespace Sass {
   void Inspect::operator()(Argument* a)
   {
     if (!a->name().empty()) {
-      append_token(a->name(), a);
+      append_string(a->name());
       append_colon_separator();
     }
     // Special case: argument nulls can be ignored
@@ -885,7 +883,7 @@ namespace Sass {
 
   void Inspect::operator()(Placeholder_Selector* s)
   {
-    append_token(s->name(), s);
+    append_string(s->name());
     if (s->has_line_break()) append_optional_linefeed();
     if (s->has_line_break()) append_indentation();
 
@@ -893,7 +891,7 @@ namespace Sass {
 
   void Inspect::operator()(Element_Selector* s)
   {
-    append_token(s->ns_name(), s);
+    append_string(s->ns_name());
   }
 
   void Inspect::operator()(Class_Selector* s)
@@ -937,7 +935,7 @@ namespace Sass {
   {
     bool was = in_wrapped;
     in_wrapped = true;
-    append_token(s->name(), s);
+    append_string(s->name());
     append_string("(");
     bool was_comma_array = in_comma_array;
     in_comma_array = false;

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -139,6 +139,8 @@ namespace Sass {
     if (output_style() == NESTED)
       indentation -= dec->tabs();
     in_declaration = was_decl;
+    // hotfix to fix wrong line offsets for declarations that use variables
+    add_close_mapping(dec);
   }
 
   void Inspect::operator()(Assignment* assn)

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -27,7 +27,7 @@ namespace Sass {
       throw Exception::InvalidValue(*n);
     }
     // output the final token
-    append_token(res, n);
+    append_string(res);
   }
 
   void Output::operator()(Import* imp)
@@ -212,9 +212,11 @@ namespace Sass {
 
     if (output_style() == NESTED) indentation += f->tabs();
     append_indentation();
-    append_token("@supports", f);
+    add_open_mapping(f);
+    append_string("@supports");
     append_mandatory_space();
     c->perform(this);
+    add_close_mapping(f);
     append_scope_opener();
 
     for (size_t i = 0, L = b->length(); i < L; ++i) {
@@ -248,11 +250,13 @@ namespace Sass {
     }
     if (output_style() == NESTED) indentation += m->tabs();
     append_indentation();
-    append_token("@media", m);
+    add_open_mapping(m);
+    append_string("@media");
     append_mandatory_space();
     in_media_block = true;
     q->perform(this);
     in_media_block = false;
+    add_close_mapping(m);
     append_scope_opener();
 
     for (size_t i = 0, L = b->length(); i < L; ++i) {
@@ -272,7 +276,7 @@ namespace Sass {
     Block*      b     = a->block();
 
     append_indentation();
-    append_token(kwd, a);
+    append_string(kwd);
     if (s) {
       append_mandatory_space();
       in_wrapped = true;
@@ -282,7 +286,7 @@ namespace Sass {
     if (v) {
       append_mandatory_space();
       // ruby sass bug? should use options?
-      append_token(v->to_string(/* opt */), v);
+      append_string(v->to_string(/* opt */));
     }
     if (!b) {
       append_delimiter();
@@ -310,11 +314,11 @@ namespace Sass {
   void Output::operator()(String_Quoted* s)
   {
     if (s->quote_mark()) {
-      append_token(quote(s->value(), s->quote_mark()), s);
+      append_string(quote(s->value(), s->quote_mark()));
     } else if (!in_comment) {
-      append_token(string_to_output(s->value()), s);
+      append_string(string_to_output(s->value()));
     } else {
-      append_token(s->value(), s);
+      append_string(s->value());
     }
   }
 
@@ -325,9 +329,9 @@ namespace Sass {
       value.erase(std::remove_if(value.begin(), value.end(), ::isspace), value.end());
     }
     if (!in_comment) {
-      append_token(string_to_output(value), s);
+      append_string(string_to_output(value));
     } else {
-      append_token(value, s);
+      append_string(value);
     }
   }
 


### PR DESCRIPTION
This PR fixes many issues with incorrect source mappings as reported in #2204. Unfortunately with the current design of libsass it's not possible to fix all issues (read on).

### Issues fixed

#### Rules with parent selectors result in incorrect source mappings

`Sequence_Selector::resolve_parent_refs`  replaces `&` with the actual name of the parent selector. The problem is that parent selectors are cloned with their original positions so any rule that directly extends a parent selector gets the original position of the parent selector, resulting in duplicate mappings. This is also why Google Chrome shows the same line numbers for the following rules:

``` scss
.foo { // maps to line 1
  background: red;
  &-bar { // also maps to line 1
    background: green;
  }
}
```

Result:

* [master](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOyB9CiAgLmZvby1iYXIgewogICAgYmFja2dyb3VuZDogZ3JlZW47IH0KCi8qIyBzb3VyY2VNYXBwaW5nVVJMPXRlc3QuY3NzLm1hcCAqLw==,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQUEsQUFBQSxJQUFJLENBQUM7RUFDSCxVQUFVLEVBQUUsR0FBSSxHQUlqQjtFQUxELEFBQUEsUUFBSSxDQUVJO0lBQ0osVUFBVSxFQUFFLEtBQU0sR0FDbkIiLCJuYW1lcyI6W119,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogICYtYmFyIHsKICAgIGJhY2tncm91bmQ6IGdyZWVuOwogIH0KfQo=)
* [fix/sourcemaps-parent-selectors](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOyB9CiAgLmZvby1iYXIgewogICAgYmFja2dyb3VuZDogZ3JlZW47IH0KCi8qIyBzb3VyY2VNYXBwaW5nVVJMPXRlc3QuY3NzLm1hcCAqLw==,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQUEsSUFBSTtFQUNGLGVBQVU7RUFDVCxRQUFJO0lBQ0gsaUJBQVUiLCJuYW1lcyI6W119,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogICYtYmFyIHsKICAgIGJhY2tncm91bmQ6IGdyZWVuOwogIH0KfQo=)

#### Emitted source mappings for compound classes differ from ruby-sass

Nested definitions that result in compound class definitions when compiled result in source mappings for each of the classes:

``` scss
.foo {
  background: red;
  .bar {
    background: green;
  }
}
```

This results in separate source mappings for `.foo` and `.bar`. ruby-sass emits one source mapping for `.foo .bar` which is also more correct and more compatible with tools that rely on those mappings. This was fixed by fleshing out `emitter.cpp` and scheduling the open mapping in `Inspect::operator()(Sequence_Selector* c)`, and the close mapping in `Inspect::operator()(CommaSequence_Selector* g)`.

Result:

* [master](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOyB9CiAgLmZvbyAuYmFyIHsKICAgIGJhY2tncm91bmQ6IGdyZWVuOyB9CgovKiMgc291cmNlTWFwcGluZ1VSTD10ZXN0LmNzcy5tYXAgKi8=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQUEsQUFBQSxJQUFJLENBQUM7RUFDSCxVQUFVLEVBQUUsR0FBSSxHQUlqQjtFQUxELEFBRUUsSUFGRSxDQUVGLElBQUksQ0FBQztJQUNILFVBQVUsRUFBRSxLQUFNLEdBQ25CIiwibmFtZXMiOltdfQ==,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogIC5iYXIgewogICAgYmFja2dyb3VuZDogZ3JlZW47CiAgfQp9Cg==)
* [fix/sourcemaps-parent-selectors](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOyB9CiAgLmZvbyAuYmFyIHsKICAgIGJhY2tncm91bmQ6IGdyZWVuOyB9CgovKiMgc291cmNlTWFwcGluZ1VSTD10ZXN0LmNzcy5tYXAgKi8=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQUEsSUFBSTtFQUNGLGVBQVU7RUFDVixTQUFJO0lBQ0YsaUJBQVUiLCJuYW1lcyI6W119,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogIC5iYXIgewogICAgYmFja2dyb3VuZDogZ3JlZW47CiAgfQp9Cg==)

Furthermore, most of the calls to `append_token` which add source mappings on their own without respecting the context have been replaced by `append_string` and specific source mappings in the callers. Source mappings were also generated for keywords or rules that don't make it into the final CSS, e.g. `@return`, `@warn`, `@debug`. Those have also been removed, because there is no direct representation in the compiled source.

#### Declarations with variables result in incorrect line numbers

When a variable is referenced in a declaration, the name of the variable and trailing semicolon map to the variable definition, but not to the position where it is referenced. This doesn't break Chrome source mappings (they are shown correctly when the classes are mapped correctly), but [Gemini CSS Coverage](https://github.com/gemini-testing/gemini-coverage) or other tools that rely on source mappings for declarations.

``` scss
$color: green;
.foo {
  background: $color; // starts in line 3, ends in line 1
}
```

This was fixed by omitting source mappings for all parts of the declaration, eg. `background`, `: `, `green`, `;` and consolidating it into one mapping `background: green;`. The offset of the mapping in the original source is not absolutely correct, because the length of the value is not included in the parser state, so the mapping ends at the end of `background`.

Result:

* [master](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogZ3JlZW47IH0KCi8qIyBzb3VyY2VNYXBwaW5nVVJMPXRlc3QuY3NzLm1hcCAqLw==,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQ0EsQUFBQSxJQUFJLENBQUM7RUFDSCxVQUFVLEVBRkosS0FBSyxHQUdaIiwibmFtZXMiOltdfQ==,JGNvbG9yOiBncmVlbjsKLmZvbyB7CiAgYmFja2dyb3VuZDogJGNvbG9yOwp9Cg==)
* [fix/sourcemaps-parent-selectors](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogZ3JlZW47IH0KCi8qIyBzb3VyY2VNYXBwaW5nVVJMPXRlc3QuY3NzLm1hcCAqLw==,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQ0EsSUFBSTtFQUNGLGlCQUFVIiwibmFtZXMiOltdfQ==,JGNvbG9yOiBncmVlbjsKLmZvbyB7CiAgYmFja2dyb3VuZDogJGNvbG9yOwp9Cg==)

### Issues that won't fix

While the noise in sourcemaps could be largely reduced and they appear to be actually usable, there are some cases that are, at least in my opinion, not fixable by the current design of libsass.

#### Inline blocks for `@media` and `@supports`

Media queries that do not scope the contained declarations into selectors, but are contained within a selector (inline) do not map correctly. The selector is inserted by the parser (it's an implied `&`), but since there is no direct representation of the implied parent in the original source, the parent refers to the original parent, which results in a double mapping that breaks offsets again.

``` scss
.foo {
  background: red;
  @media only screen {
    background: green;
  }
}
```

Result:

* [master](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOyB9CiAgQG1lZGlhIG9ubHkgc2NyZWVuIHsKICAgIC5mb28gewogICAgICBiYWNrZ3JvdW5kOiBncmVlbjsgfSB9CgovKiMgc291cmNlTWFwcGluZ1VSTD10ZXN0LmNzcy5tYXAgKi8=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQUEsQUFBQSxJQUFJLENBQUM7RUFDSCxVQUFVLEVBQUUsR0FBSSxHQUlqQjtFQUhDLE1BQU0sTUFBRCxNQUFNO0lBRmIsQUFBQSxJQUFJLENBQUM7TUFHRCxVQUFVLEVBQUUsS0FBTSxHQUVyQiIsIm5hbWVzIjpbXX0=,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogIEBtZWRpYSBvbmx5IHNjcmVlbiB7CiAgICBiYWNrZ3JvdW5kOiBncmVlbjsKICB9Cn0K)
* [fix/sourcemaps-parent-selectors](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOyB9CiAgQG1lZGlhIG9ubHkgc2NyZWVuIHsKICAgIC5mb28gewogICAgICBiYWNrZ3JvdW5kOiBncmVlbjsgfSB9CgovKiMgc291cmNlTWFwcGluZ1VSTD10ZXN0LmNzcy5tYXAgKi8=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQUEsSUFBSTtFQUNGLGVBQVU7RUFDVixrQkFBTTtJQUZSLElBQUk7TUFHQSxpQkFBVSIsIm5hbWVzIjpbXX0=,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogIEBtZWRpYSBvbmx5IHNjcmVlbiB7CiAgICBiYWNrZ3JvdW5kOiBncmVlbjsKICB9Cn0K) - double mapping for `.foo`

However, in the proposed PR, this can be omitted by explicitly using the parent selector:

``` scss
.foo {
  background: red;
  @media only screen {
    & {
      background: green;
    }
  }
}
```

Result:

* [master](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOyB9CiAgQG1lZGlhIG9ubHkgc2NyZWVuIHsKICAgIC5mb28gewogICAgICBiYWNrZ3JvdW5kOiBncmVlbjsgfSB9CgovKiMgc291cmNlTWFwcGluZ1VSTD10ZXN0LmNzcy5tYXAgKi8=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQUEsQUFBQSxJQUFJLENBQUM7RUFDSCxVQUFVLEVBQUUsR0FBSSxHQU1qQjtFQUxDLE1BQU0sTUFBRCxNQUFNO0lBRmIsQUFBQSxJQUFJLENBR0U7TUFDQSxVQUFVLEVBQUUsS0FBTSxHQUNuQiIsIm5hbWVzIjpbXX0=,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogIEBtZWRpYSBvbmx5IHNjcmVlbiB7CiAgICAmIHsKICAgICAgYmFja2dyb3VuZDogZ3JlZW47CiAgICB9CiAgfQp9Cg==) - still broken
* [fix/sourcemaps-parent-selectors](http://paulirish.github.io/source-map-visualization/#base64,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOyB9CiAgQG1lZGlhIG9ubHkgc2NyZWVuIHsKICAgIC5mb28gewogICAgICBiYWNrZ3JvdW5kOiBncmVlbjsgfSB9CgovKiMgc291cmNlTWFwcGluZ1VSTD10ZXN0LmNzcy5tYXAgKi8=,eyJ2ZXJzaW9uIjozLCJmaWxlIjoidGVzdC5jc3MiLCJzb3VyY2VzIjpbInRlc3Quc2NzcyJdLCJtYXBwaW5ncyI6IkFBQUEsSUFBSTtFQUNGLGVBQVU7RUFDVixrQkFBTTtJQUNKLElBQUM7TUFDQyxpQkFBVSIsIm5hbWVzIjpbXX0=,LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogIEBtZWRpYSBvbmx5IHNjcmVlbiB7CiAgICAmIHsKICAgICAgYmFja2dyb3VuZDogZ3JlZW47CiAgICB9CiAgfQp9Cg==) - correct mappings

#### Sourcemap offsets are largely incorrect

The fact that libsass implements a multi-step approach (parse, check nesting, expand, check nesting, render) and that during transformation/expansion selectors and expressions are irreversibly overwritten, original offsets are irreversibly lost. Digging into the code and architecture of libsass (which in large parts is very well written!), I come to the conclusion that the emission of correct source mappings – correct lines **and** columns, the latter of which are currently largely incorrect – involves a huge rewrite. Some concrete examples:

* Variables are replaced with their values during expansion, which are registered in an environment variable (a map), so the offsets from the variable declaration kill the offsets of the variable usage.
* Selectors that have no representation in the original code do not get correct source mappings. This is true for the media query and the implied parent selector, but there are also other cases where selectors get generated. This is a general problem with source maps for CSS, which needs to be addressed.
* Parent selectors are kind of hot-fixed in the PR since the column offsets are still incorrect. However, since the line offsets are now correct, everything works reasonably well.

This PR fixes all issues that we currently have with Gemini CSS coverage (using the `@media` workaround). I'm very excited to hear your ideas on this PR and hope it finds its way into master, since it should be of good use for all of us.