### PR TITLE
Remove -ldl flag from OpenBSD too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,10 @@ endif
 
 ifneq (Windows,$(UNAME))
 	ifneq (FreeBSD,$(UNAME))
-		LDFLAGS += -ldl
-		LDLIBS += -ldl
+		ifneq (OpenBSD,$(UNAME))
+			LDFLAGS += -ldl
+			LDLIBS += -ldl
+		endif
 	endif
 endif
 


### PR DESCRIPTION
Probably OpenBSD should be included too. I couldn't compile it