### PR TITLE
Fix some minor memory leaks with context options

### DIFF
--- a/docs/api-context.md
+++ b/docs/api-context.md
@@ -174,6 +174,7 @@ int sass_compiler_execute (struct Sass_Compiler* compiler);
 // Release all memory allocated with the compiler
 // This does _not_ include any contexts or options
 void sass_delete_compiler (struct Sass_Compiler* compiler);
+void sass_delete_options(struct Sass_Options* options);
 
 // Release all memory allocated and also ourself
 void sass_delete_file_context (struct Sass_File_Context* ctx);

--- a/include/sass/context.h
+++ b/include/sass/context.h
@@ -50,6 +50,7 @@ ADDAPI int ADDCALL sass_compiler_execute(struct Sass_Compiler* compiler);
 // Release all memory allocated with the compiler
 // This does _not_ include any contexts or options
 ADDAPI void ADDCALL sass_delete_compiler(struct Sass_Compiler* compiler);
+ADDAPI void ADDCALL sass_delete_options(struct Sass_Options* options);
 
 // Release all memory allocated and also ourself
 ADDAPI void ADDCALL sass_delete_file_context (struct Sass_File_Context* ctx);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -141,10 +141,9 @@ namespace Sass {
     }
 
     selector_stack.push_back(sel);
-    Env* env = 0;
+    Env env(environment());
     if (block_stack.back()->is_root()) {
-      env = new Env(environment());
-      env_stack.push_back(env);
+      env_stack.push_back(&env);
     }
     sel->set_media_block(media_block_stack.back());
     Block* blk = r->block()->perform(this)->block();
@@ -155,8 +154,8 @@ namespace Sass {
     selector_stack.pop_back();
     if (block_stack.back()->is_root()) {
       env_stack.pop_back();
-      delete env;
     }
+
     rr->is_root(r->is_root());
     rr->tabs(r->tabs());
 

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -399,7 +399,13 @@ char *json_encode_string(const char *str)
   SB sb;
   sb_init(&sb);
 
-  emit_string(&sb, str);
+  try {
+    emit_string(&sb, str);
+  }
+  catch (std::exception &e) {
+    sb_free(&sb);
+    throw;
+  }
 
   return sb_finish(&sb);
 }
@@ -409,10 +415,16 @@ char *json_stringify(const JsonNode *node, const char *space)
   SB sb;
   sb_init(&sb);
 
-  if (space != NULL)
-    emit_value_indented(&sb, node, space, 0);
-  else
-    emit_value(&sb, node);
+  try {
+    if (space != NULL)
+      emit_value_indented(&sb, node, space, 0);
+    else
+      emit_value(&sb, node);
+  }
+  catch (std::exception &e) {
+    sb_free(&sb);
+    throw;
+  }
 
   return sb_finish(&sb);
 }


### PR DESCRIPTION
Note: Sass_Context [is also] [2] a Sass_Options, therefore one only needs to call either `sass_delete_compiler` or `sass_delete_options`. They're created via `sass_make_TYPE_compiler` or `sass_make_options` respectively. Therefore if you use `sass_make_options` you probably must add the corresponding `sass_delete_options` now (this ie. is the case with [sassc] [1]).

[1]: https://github.com/sass/sassc/pull/196
[2]: https://github.com/sass/libsass/blob/master/src/sass_context.hpp#L70