### PR TITLE
Bugfix delayed interpolation

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1888,7 +1888,7 @@ namespace Sass {
     virtual void set_media_block(Media_Block* mb) {
       media_block(mb);
     }
-    virtual bool has_wrapped_selector() {
+    virtual bool has_wrapped_selector(std::string name = "") {
       return false;
     }
     virtual bool has_placeholder() {
@@ -2238,9 +2238,9 @@ namespace Sass {
       if (!selector()) return false;
       return selector()->has_real_parent_ref();
     }
-    virtual bool has_wrapped_selector()
+    virtual bool has_wrapped_selector(std::string name = "")
     {
-      return true;
+      return name == "" || name == name_;
     }
     virtual unsigned long specificity()
     {
@@ -2328,11 +2328,11 @@ namespace Sass {
       return sum;
     }
 
-    virtual bool has_wrapped_selector()
+    virtual bool has_wrapped_selector(std::string name = "")
     {
       if (length() == 0) return false;
       if (Simple_Selector* ss = elements().front()) {
-        if (ss->has_wrapped_selector()) return true;
+        if (ss->has_wrapped_selector(name)) return true;
       }
       return false;
     }
@@ -2475,9 +2475,9 @@ namespace Sass {
       if (tail_) tail_->set_media_block(mb);
       if (head_) head_->set_media_block(mb);
     }
-    virtual bool has_wrapped_selector() {
-      if (head_ && head_->has_wrapped_selector()) return true;
-      if (tail_ && tail_->has_wrapped_selector()) return true;
+    virtual bool has_wrapped_selector(std::string name = "") {
+      if (head_ && head_->has_wrapped_selector(name)) return true;
+      if (tail_ && tail_->has_wrapped_selector(name)) return true;
       return false;
     }
     virtual bool has_placeholder() {
@@ -2594,9 +2594,9 @@ namespace Sass {
         cs->set_media_block(mb);
       }
     }
-    virtual bool has_wrapped_selector() {
+    virtual bool has_wrapped_selector(std::string name = "") {
       for (Sequence_Selector* cs : elements()) {
-        if (cs->has_wrapped_selector()) return true;
+        if (cs->has_wrapped_selector(name)) return true;
       }
       return false;
     }

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1982,6 +1982,10 @@ namespace Sass {
                             dynamic_cast<Placeholder_Selector*>(ws_ss->first())
                           )) continue;
                         }
+                        if (ext_cs->first()->has_wrapped_selector(":not")) {
+                          // ignore this case here for now
+                          if (cpy_ws->name() == ":not") continue;
+                        }
                         *cpy_ws_sl << ext_cs->first();
                       }
                       // assign list to clone

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1376,8 +1376,8 @@ namespace Sass {
     }
     else if (peek < sequence < one_plus < alternatives < css_whitespace, exactly<'-'>, exactly<'+'> > >, number > >()) {
       if (parse_number_prefix()) return parse_value(); // prefix is positive
-      Unary_Expression* ex = SASS_MEMORY_NEW(ctx.mem, Unary_Expression, pstate, Unary_Expression::MINUS, parse_value());;
-      if (ex->operand()) ex->is_delayed(ex->operand()->is_delayed());
+      Unary_Expression* ex = SASS_MEMORY_NEW(ctx.mem, Unary_Expression, pstate, Unary_Expression::MINUS, parse_value());
+      if (ex && ex->operand()) ex->is_delayed(ex->operand()->is_delayed());
       return ex;
     }
     else {
@@ -1636,7 +1636,7 @@ namespace Sass {
         if (lex< re_static_expression >()) {
           ex = SASS_MEMORY_NEW(ctx.mem, String_Constant, pstate, lexed);
         } else {
-          ex = parse_list();
+          ex = parse_list(DELAYED);
         }
         ex->is_interpolant(true);
         (*schema) << ex;


### PR DESCRIPTION
@xzyfer this is what I have come up with so far. I don't seem to be able to get it 100% correct for 3.4 as there always seem to be some other subtle regressions (which our specs do not catch currently). AFAIR I also got it correctly in regard to sass 4.0 and the following spec test at some point:

``` scss
tst {
  a01: (#{a} - 5% / 2);
  a11: (#{a} + 5% / 2);
  a02: (#{a} -5% / 2);
  a12: (#{a} +5% / 2);
  a03: (#{a}-5% / 2);
  a13: (#{a}+5% / 2);
  b01: (a - 5% / 2);
  b11: (a + 5% / 2);
  b02: (a -5% / 2);
  b12: (a +5% / 2);
  b03: (a-5px / 2);
  b13: (a+5px / 2);
}

tst {
  a01: (#{a} - 5.0% / 2);
  a11: (#{a} + 5.0% / 2);
  a02: (#{a} -5.0% / 2);
  a12: (#{a} +5.0% / 2);
  a03: (#{a}-5.0% / 2);
  a13: (#{a}+5.0% / 2);
  b01: (a - 5.0% / 2);
  b11: (a + 5.0% / 2);
  b02: (a -5.0% / 2);
  b12: (a +5.0% / 2);
  b03: (a-5.0% / 2);
  b13: (a+5.0% / 2);
}

tst {
  test-01: a #{5.0px / 2};
  test-02: a #{+5.0px / 2};
  test-03: a #{-5.0px / 2};
  test-04: #{+5.0px / 2};
  test-04: #{-5.0px / 2};
  test-04: #{5.0px / 2};
  test-04: #{a} -5.0px / 2;
}

tst {
  test-05: (a 5.0px / 2);
  test-06: (#{a} 9.0px / 2);
  test-0A: (5.0px / 2 a);
  test-07: (9.0px / 2 #{a});
  test-08: (9.0px / 2 #{a} 9.0px / 2);
  test-09: (a 5.0px / 2 #{a} 9.0px / 2);
  test-10: (a, 5.0px / 2 #{a} 5.0px / 2);

  test-11: (9.0px / 2 #{a} 9.0px / 2 #{a});
  test-12: (9.0px / 2 #{a} #{a} 9.0px / 2);
  test-13: (#{a} 9.0px / 2 #{a} 9.0px / 2);
  test-14: (#{a} 5.0px / 2 5.0px / 2 #{a});

  test-15: a 5.0px / 2;
  test-16: #{a} 9.0px / 2;
  test-17: 9.0px / 2 #{a};
  test-18: 9.0px / 2 #{a} 9.0px / 2;
  test-19: a 5.0px / 2 #{a} -9.0px / 2;
  test-20: a, 5.0px / 2 #{a} 5.0px / 2;

  test-21: 9.0px / 2 #{a} 9.0px / 2 #{a};
  test-22: 9.0px / 2 #{a} #{a} 9.0px / 2;
  test-23: #{a} 9.0px / 2 #{a} 9.0px / 2;
  test-24: #{a} 5.0px / 2 5.0px / 2 #{a};
}
```
