### PR TITLE
Bugfixes for source maps

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -1,33 +1,38 @@
 # this is merely a common Makefile multiple implementers can use
+# bigger files (in terms of compile time) tend to go to the top,
+# so they don't end up as the last compile unit when compiling
+# in parallel. But we also want to mix them a little too avoid
+# heavy RAM usage peaks. Other than that the order is arbitrary.
+
 
 SOURCES = \
 	ast.cpp \
-	base64vlq.cpp \
-	bind.cpp \
-	check_nesting.cpp \
-	color_maps.cpp \
-	constants.cpp \
-	context.cpp \
-	cssize.cpp \
-	emitter.cpp \
-	environment.cpp \
-	error_handling.cpp \
-	eval.cpp \
-	expand.cpp \
-	extend.cpp \
-	file.cpp \
-	functions.cpp \
-	inspect.cpp \
-	json.cpp \
-	lexer.cpp \
-	listize.cpp \
-	memory_manager.cpp \
 	node.cpp \
-	output.cpp \
-	parser.cpp \
+	context.cpp \
+	constants.cpp \
+	functions.cpp \
+	color_maps.cpp \
+	environment.cpp \
+	bind.cpp \
+	file.cpp \
+	util.cpp \
+	json.cpp \
+	units.cpp \
+	values.cpp \
 	plugins.cpp \
 	position.cpp \
+	lexer.cpp \
+	parser.cpp \
 	prelexer.cpp \
+	eval.cpp \
+	expand.cpp \
+	listize.cpp \
+	cssize.cpp \
+	extend.cpp \
+	output.cpp \
+	inspect.cpp \
+	emitter.cpp \
+	check_nesting.cpp \
 	remove_placeholders.cpp \
 	sass.cpp \
 	sass_util.cpp \
@@ -35,12 +40,12 @@ SOURCES = \
 	sass_context.cpp \
 	sass_functions.cpp \
 	sass2scss.cpp \
-	source_map.cpp \
 	to_c.cpp \
 	to_value.cpp \
-	units.cpp \
+	source_map.cpp \
+	error_handling.cpp \
+	memory_manager.cpp \
 	utf8_string.cpp \
-	values.cpp \
-	util.cpp
+	base64vlq.cpp
 
 CSOURCES = cencode.c

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -101,6 +101,7 @@ namespace Sass {
     // virtual Block* block() { return 0; }
   public:
     void update_pstate(const ParserState& pstate);
+    void set_pstate_offset(const Offset& offset);
   public:
     Offset off() { return pstate(); }
     Position pos() { return pstate(); }
@@ -235,7 +236,7 @@ namespace Sass {
     T& operator[](size_t i) { return elements_[i]; }
     virtual const T& at(size_t i) const { return elements_.at(i); }
     const T& operator[](size_t i) const { return elements_[i]; }
-    Vectorized& operator<<(T element)
+    virtual Vectorized& operator<<(T element)
     {
       if (!element) return *this;
       reset_hash();
@@ -2291,6 +2292,8 @@ namespace Sass {
       }
       return false;
     };
+
+    SimpleSequence_Selector& operator<<(Simple_Selector* element);
 
     bool is_universal() const
     {

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -502,7 +502,7 @@ namespace Sass {
     // only the last item will be used to eval the binary expression
     if (String_Schema* s_l = dynamic_cast<String_Schema*>(b->left())) {
       if (!s_l->has_interpolant() && (!s_l->is_right_interpolant())) {
-        ret_schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, s_l->pstate());
+        ret_schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, b->pstate());
         Binary_Expression* bin_ex = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, b->pstate(),
                                                     b->op(), s_l->last(), b->right());
         bin_ex->is_delayed(b->left()->is_delayed() || b->right()->is_delayed()); // unverified
@@ -515,7 +515,7 @@ namespace Sass {
     }
     if (String_Schema* s_r = dynamic_cast<String_Schema*>(b->right())) {
       if (!s_r->has_interpolant() && (!s_r->is_left_interpolant() || op_type == Sass_OP::DIV)) {
-        ret_schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, s_r->pstate());
+        ret_schema = SASS_MEMORY_NEW(ctx.mem, String_Schema, b->pstate());
         Binary_Expression* bin_ex = SASS_MEMORY_NEW(ctx.mem, Binary_Expression, b->pstate(),
                                                     b->op(), b->left(), s_r->first());
         bin_ex->is_delayed(b->left()->is_delayed() || b->right()->is_delayed()); // verified
@@ -599,7 +599,7 @@ namespace Sass {
           std::string value(str->value());
           const char* start = value.c_str();
           if (Prelexer::sequence < Prelexer::dimension, Prelexer::end_of_file >(start) != 0) {
-            lhs = SASS_MEMORY_NEW(ctx.mem, Textual, lhs->pstate(), Textual::DIMENSION, str->value());
+            lhs = SASS_MEMORY_NEW(ctx.mem, Textual, b->pstate(), Textual::DIMENSION, str->value());
             lhs = lhs->perform(this);
           }
         }
@@ -607,7 +607,7 @@ namespace Sass {
           std::string value(str->value());
           const char* start = value.c_str();
           if (Prelexer::sequence < Prelexer::number >(start) != 0) {
-            rhs = SASS_MEMORY_NEW(ctx.mem, Textual, rhs->pstate(), Textual::DIMENSION, str->value());
+            rhs = SASS_MEMORY_NEW(ctx.mem, Textual, b->pstate(), Textual::DIMENSION, str->value());
             rhs = rhs->perform(this);
           }
         }
@@ -636,7 +636,7 @@ namespace Sass {
         str += b->separator();
         if (b->op().ws_after) str += " ";
         str += v_r->to_string(ctx.c_options);
-        String_Constant* val = SASS_MEMORY_NEW(ctx.mem, String_Constant, lhs->pstate(), str);
+        String_Constant* val = SASS_MEMORY_NEW(ctx.mem, String_Constant, b->pstate(), str);
         val->is_interpolant(b->left()->has_interpolant());
         return val;
       }
@@ -1545,7 +1545,7 @@ namespace Sass {
          (sep != "/" || !rqstr || !rqstr->quote_mark()) */
     ) {
       // create a new string that might be quoted on output (but do not unquote what we pass)
-      return SASS_MEMORY_NEW(mem, String_Quoted, lhs.pstate(), lstr + rstr, 0, false, true);
+      return SASS_MEMORY_NEW(mem, String_Quoted, pstate ? *pstate : lhs.pstate(), lstr + rstr, 0, false, true);
     }
 
     if (sep != "" && !delayed) {
@@ -1558,7 +1558,7 @@ namespace Sass {
       if (rqstr && rqstr->quote_mark()) rstr = quote(rstr);
     }
 
-    return SASS_MEMORY_NEW(mem, String_Constant, lhs.pstate(), lstr + sep + rstr);
+    return SASS_MEMORY_NEW(mem, String_Constant, pstate ? *pstate : lhs.pstate(), lstr + sep + rstr);
   }
 
   Expression* cval_to_astnode(Memory_Manager& mem, union Sass_Value* v, Context& ctx, Backtrace* backtrace, ParserState pstate)

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -402,7 +402,7 @@ char *json_encode_string(const char *str)
   try {
     emit_string(&sb, str);
   }
-  catch (std::exception &e) {
+  catch (std::exception) {
     sb_free(&sb);
     throw;
   }
@@ -421,7 +421,7 @@ char *json_stringify(const JsonNode *node, const char *space)
     else
       emit_value(&sb, node);
   }
-  catch (std::exception &e) {
+  catch (std::exception) {
     sb_free(&sb);
     throw;
   }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -66,6 +66,10 @@ namespace Sass {
 #endif
 
 
+    // skip current token and next whitespace
+    // moves ParserState right before next token
+    void advanceToNextToken();
+
     bool peek_newline(const char* start = 0);
 
     // skip over spaces, tabs and line comments


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/2204
Replaces https://github.com/sass/libsass/pull/2208

- Fixes parent selector mappings
- Fixes media block/query mappings
- Fixes range over binary expressions
- Don't include semicolon for statics
- Fixes variable assignment mappings

I have already deployed the changes to my source map inspector!

### Parent selector mappings
[SourceMap Inspector] [1] (click [inspect] and use keyboard arrows to navigate)
```scss
.foo {
  background: red;
  &-bar {
    background: green;
  }
}
```

### Media Block expressions
[SourceMap Inspector] [2] (click [inspect] and use keyboard arrows to navigate)
```scss
.foo {
  background: red;
  @media only screen {
    background: green;
  }
}
```

### Binary expressions
[SourceMap Inspector] [3] (click [inspect] and use keyboard arrows to navigate)
```scss
.foo {
  bar: (1px+3px);
}
```

### Static values
[SourceMap Inspector] [4] (click [inspect] and use keyboard arrows to navigate)
```scss
.foo {
  bar: green   ;
}
```

### Variables (last assignment)
[SourceMap Inspector] [5] (click [inspect] and use keyboard arrows to navigate)
```scss
$var: bar;
$var: (foo + $var);
test { val: $var; }
```

[1]: http://libsass.ocbnet.ch/srcmap/#LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogICYtYmFyIHsKICAgIGJhY2tncm91bmQ6IGdyZWVuOwogIH0KfQ==
[2]: http://libsass.ocbnet.ch/srcmap/#LmZvbyB7CiAgYmFja2dyb3VuZDogcmVkOwogIEBtZWRpYSBvbmx5IHNjcmVlbiB7CiAgICBiYWNrZ3JvdW5kOiBncmVlbjsKICB9Cn0=
[3]: http://libsass.ocbnet.ch/srcmap/#LmZvbyB7CiAgYmFyOiAoMXB4KzNweCk7Cn0=
[4]: http://libsass.ocbnet.ch/srcmap/#LmZvbyB7CiAgYmFyOiBncmVlbiAgIDsKfQ==
[5]: http://libsass.ocbnet.ch/srcmap/#JHZhcjogYmFyOwokdmFyOiAoZm9vICsgJHZhcik7CnRlc3QgeyB2YWw6ICR2YXI7IH0K
