### PR TITLE
Implement source_map_file_urls option

### DIFF
--- a/docs/api-context-internal.md
+++ b/docs/api-context-internal.md
@@ -33,6 +33,9 @@ struct Sass_Options {
   // embed include contents in maps
   bool source_map_contents;
 
+  // create file urls for sources
+  bool source_map_file_urls;
+
   // Disable sourceMappingUrl in css output
   bool omit_source_map_url;
 

--- a/docs/api-context.md
+++ b/docs/api-context.md
@@ -34,6 +34,10 @@ bool source_map_embed;
 bool source_map_contents;
 ```
 ```C
+// create file urls for sources
+bool source_map_file_urls;
+```
+```C
 // Disable sourceMappingUrl in css output
 bool omit_source_map_url;
 ```
@@ -225,6 +229,7 @@ enum Sass_Output_Style sass_option_get_output_style (struct Sass_Options* option
 bool sass_option_get_source_comments (struct Sass_Options* options);
 bool sass_option_get_source_map_embed (struct Sass_Options* options);
 bool sass_option_get_source_map_contents (struct Sass_Options* options);
+bool sass_option_get_source_map_file_urls (struct Sass_Options* options);
 bool sass_option_get_omit_source_map_url (struct Sass_Options* options);
 bool sass_option_get_is_indented_syntax_src (struct Sass_Options* options);
 const char* sass_option_get_indent (struct Sass_Options* options);
@@ -244,6 +249,7 @@ void sass_option_set_output_style (struct Sass_Options* options, enum Sass_Outpu
 void sass_option_set_source_comments (struct Sass_Options* options, bool source_comments);
 void sass_option_set_source_map_embed (struct Sass_Options* options, bool source_map_embed);
 void sass_option_set_source_map_contents (struct Sass_Options* options, bool source_map_contents);
+void sass_option_set_source_map_file_urls (struct Sass_Options* options, bool source_map_file_urls);
 void sass_option_set_omit_source_map_url (struct Sass_Options* options, bool omit_source_map_url);
 void sass_option_set_is_indented_syntax_src (struct Sass_Options* options, bool is_indented_syntax_src);
 void sass_option_set_indent (struct Sass_Options* options, const char* indent);

--- a/include/sass/context.h
+++ b/include/sass/context.h
@@ -74,6 +74,7 @@ ADDAPI enum Sass_Output_Style ADDCALL sass_option_get_output_style (struct Sass_
 ADDAPI bool ADDCALL sass_option_get_source_comments (struct Sass_Options* options);
 ADDAPI bool ADDCALL sass_option_get_source_map_embed (struct Sass_Options* options);
 ADDAPI bool ADDCALL sass_option_get_source_map_contents (struct Sass_Options* options);
+ADDAPI bool ADDCALL sass_option_get_source_map_file_urls (struct Sass_Options* options);
 ADDAPI bool ADDCALL sass_option_get_omit_source_map_url (struct Sass_Options* options);
 ADDAPI bool ADDCALL sass_option_get_is_indented_syntax_src (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_indent (struct Sass_Options* options);
@@ -94,6 +95,7 @@ ADDAPI void ADDCALL sass_option_set_output_style (struct Sass_Options* options, 
 ADDAPI void ADDCALL sass_option_set_source_comments (struct Sass_Options* options, bool source_comments);
 ADDAPI void ADDCALL sass_option_set_source_map_embed (struct Sass_Options* options, bool source_map_embed);
 ADDAPI void ADDCALL sass_option_set_source_map_contents (struct Sass_Options* options, bool source_map_contents);
+ADDAPI void ADDCALL sass_option_set_source_map_file_urls (struct Sass_Options* options, bool source_map_file_urls);
 ADDAPI void ADDCALL sass_option_set_omit_source_map_url (struct Sass_Options* options, bool omit_source_map_url);
 ADDAPI void ADDCALL sass_option_set_is_indented_syntax_src (struct Sass_Options* options, bool is_indented_syntax_src);
 ADDAPI void ADDCALL sass_option_set_indent (struct Sass_Options* options, const char* indent);

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -667,6 +667,7 @@ extern "C" {
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, source_comments);
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, source_map_embed);
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, source_map_contents);
+  IMPLEMENT_SASS_OPTION_ACCESSOR(bool, source_map_file_urls);
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, omit_source_map_url);
   IMPLEMENT_SASS_OPTION_ACCESSOR(bool, is_indented_syntax_src);
   IMPLEMENT_SASS_OPTION_ACCESSOR(Sass_Function_List, c_functions);

--- a/src/sass_context.hpp
+++ b/src/sass_context.hpp
@@ -15,6 +15,9 @@ struct Sass_Options : Sass_Output_Options {
   // embed include contents in maps
   bool source_map_contents;
 
+  // create file urls for sources
+  bool source_map_file_urls;
+
   // Disable sourceMappingUrl in css output
   bool omit_source_map_url;
 

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -37,8 +37,20 @@ namespace Sass {
 
     JsonNode *json_includes = json_mkarray();
     for (size_t i = 0; i < source_index.size(); ++i) {
-      const char *include = links[source_index[i]].c_str();
-      JsonNode *json_include = json_mkstring(include);
+      std::string include(links[source_index[i]]);
+      if (ctx.c_options.source_map_file_urls) {
+        include = File::rel2abs(include);
+        // check for windows abs path
+        if (include[0] == '/') {
+          // ends up with three slashes
+          include = "file://" + include;
+        } else {
+          // needs an additional slash
+          include = "file:///" + include;
+        }
+      }
+      const char* inc = include.c_str();
+      JsonNode *json_include = json_mkstring(inc);
       json_append_element(json_includes, json_include);
     }
     json_append_member(json_srcmap, "sources", json_includes);


### PR DESCRIPTION
Equivalent to sass "--sourcemap=file"

In hindsight it might would have been wiser to mimic the option from sass directly in libsass. But we started with booleans and continued from there. IMO this way is also a bit easier for the C API, as we would otherwise need to expose some enum constants for the valid options. I guess it's up to implementers to implement the options compatible with sass if wanted.

Fixes the libsass part of https://github.com/sass/libsass/issues/2195