### PR TITLE
Don't error when an @import is terminated by the end of the block

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -345,7 +345,7 @@ namespace Sass {
       first = false;
     } while (lex_css< exactly<','> >());
 
-    if (!peek_css<alternatives<exactly<';'>,end_of_file>>()) {
+    if (!peek_css< alternatives< exactly<';'>, exactly<'}'>, end_of_file > >()) {
       List* media_queries = parse_media_queries();
       imp->media_queries(media_queries);
     }


### PR DESCRIPTION
Semicolons are optional for the final declaration of a block. In this
case the `}` acts as the declaration's terminator. This was not being
handling correctly with `@import`s because they can be followed by a
media query.

Fixes #2233
Spec sass/sass-spec#982