### PR TITLE
C-API: Add call stack queries (functions and mixins)

### DIFF
--- a/docs/api-context.md
+++ b/docs/api-context.md
@@ -207,6 +207,15 @@ size_t sass_context_get_error_column (struct Sass_Context* ctx);
 const char* sass_context_get_source_map_string (struct Sass_Context* ctx);
 char** sass_context_get_included_files (struct Sass_Context* ctx);
 
+// Getters for Sass_Compiler options (query import stack)
+size_t sass_compiler_get_import_stack_size(struct Sass_Compiler* compiler);
+Sass_Import_Entry sass_compiler_get_last_import(struct Sass_Compiler* compiler);
+Sass_Import_Entry sass_compiler_get_import_entry(struct Sass_Compiler* compiler, size_t idx);
+// Getters for Sass_Compiler options (query function stack)
+size_t sass_compiler_get_callee_stack_size(struct Sass_Compiler* compiler);
+Sass_Callee_Entry sass_compiler_get_last_callee(struct Sass_Compiler* compiler);
+Sass_Callee_Entry sass_compiler_get_callee_entry(struct Sass_Compiler* compiler, size_t idx);
+
 // Take ownership of memory (value on context is set to 0)
 char* sass_context_take_error_json (struct Sass_Context* ctx);
 char* sass_context_take_error_text (struct Sass_Context* ctx);

--- a/docs/api-function-example.md
+++ b/docs/api-function-example.md
@@ -11,7 +11,7 @@ union Sass_Value* call_fn_foo(const union Sass_Value* s_args, Sass_Function_Entr
   struct Sass_Context* ctx = sass_compiler_get_context(comp);
   struct Sass_Options* opts = sass_compiler_get_options(comp);
   // get information about previous importer entry from the stack
-  struct Sass_Import* import = sass_compiler_get_last_import(comp);
+  Sass_Import_Entry import = sass_compiler_get_last_import(comp);
   const char* prev_abs_path = sass_import_get_abs_path(import);
   const char* prev_imp_path = sass_import_get_imp_path(import);
   // get the cookie from function descriptor

--- a/docs/api-function.md
+++ b/docs/api-function.md
@@ -30,17 +30,29 @@ typedef union Sass_Value* (*Sass_Function_Fn)
   (const union Sass_Value*, Sass_Function_Entry cb, struct Sass_Compiler* compiler);
 
 // Creators for sass function list and function descriptors
-ADDAPI Sass_Function_List ADDCALL sass_make_function_list (size_t length);
-ADDAPI Sass_Function_Entry ADDCALL sass_make_function (const char* signature, Sass_Function_Fn cb, void* cookie);
+Sass_Function_List sass_make_function_list (size_t length);
+Sass_Function_Entry sass_make_function (const char* signature, Sass_Function_Fn cb, void* cookie);
 
 // Setters and getters for callbacks on function lists
-ADDAPI Sass_Function_Entry ADDCALL sass_function_get_list_entry(Sass_Function_List list, size_t pos);
-ADDAPI void ADDCALL sass_function_set_list_entry(Sass_Function_List list, size_t pos, Sass_Function_Entry cb);
+Sass_Function_Entry sass_function_get_list_entry(Sass_Function_List list, size_t pos);
+void sass_function_set_list_entry(Sass_Function_List list, size_t pos, Sass_Function_Entry cb);
+
+// Setters to insert an entry into the import list (you may also use [] access directly)
+// Since we are dealing with pointers they should have a guaranteed and fixed size
+void sass_import_set_list_entry (Sass_Import_List list, size_t idx, Sass_Import_Entry entry);
+Sass_Import_Entry sass_import_get_list_entry (Sass_Import_List list, size_t idx);
 
 // Getters for custom function descriptors
-ADDAPI const char* ADDCALL sass_function_get_signature (Sass_Function_Entry cb);
-ADDAPI Sass_Function_Fn ADDCALL sass_function_get_function (Sass_Function_Entry cb);
-ADDAPI void* ADDCALL sass_function_get_cookie (Sass_Function_Entry cb);
+const char* sass_function_get_signature (Sass_Function_Entry cb);
+Sass_Function_Fn sass_function_get_function (Sass_Function_Entry cb);
+void* sass_function_get_cookie (Sass_Function_Entry cb);
+
+// Getters for callee entry
+const char* sass_callee_get_name (Sass_Callee_Entry);
+const char* sass_callee_get_path (Sass_Callee_Entry);
+size_t sass_callee_get_line (Sass_Callee_Entry);
+size_t sass_callee_get_column (Sass_Callee_Entry);
+enum Sass_Callee_Type sass_callee_get_type (Sass_Callee_Entry);
 ```
 
 ### More links

--- a/docs/api-function.md
+++ b/docs/api-function.md
@@ -53,6 +53,15 @@ const char* sass_callee_get_path (Sass_Callee_Entry);
 size_t sass_callee_get_line (Sass_Callee_Entry);
 size_t sass_callee_get_column (Sass_Callee_Entry);
 enum Sass_Callee_Type sass_callee_get_type (Sass_Callee_Entry);
+Sass_Env_Frame sass_callee_get_env (Sass_Callee_Entry);
+
+// Getters and Setters for environments (lexical, local and global)
+union Sass_Value* sass_env_get_lexical (Sass_Env_Frame, const char*);
+void sass_env_set_lexical (Sass_Env_Frame, const char*, union Sass_Value*);
+union Sass_Value* sass_env_get_local (Sass_Env_Frame, const char*);
+void sass_env_set_local (Sass_Env_Frame, const char*, union Sass_Value*);
+union Sass_Value* sass_env_get_global (Sass_Env_Frame, const char*);
+void sass_env_set_global (Sass_Env_Frame, const char*, union Sass_Value*);
 ```
 
 ### More links

--- a/docs/api-importer.md
+++ b/docs/api-importer.md
@@ -5,7 +5,7 @@ By using custom importers, Sass stylesheets can be implemented in any possible w
 You actually have to return a list of imports, since some importers may want to import multiple files from one import statement (ie. a glob/star importer).  The memory you pass with source and srcmap is taken over by LibSass and freed automatically when the import is done. You are also allowed to return `0` instead of a list, which will tell LibSass to handle the import by itself (as if no custom importer was in use).
 
 ```C
-struct Sass_Import** rv = sass_make_import_list(1);
+Sass_Import_Entry* rv = sass_make_import_list(1);
 rv[0] = sass_make_import(rel, abs, source, srcmap);
 ```
 
@@ -31,7 +31,7 @@ struct Sass_C_Import_Descriptor;
 // Typedef defining the custom importer callback
 typedef struct Sass_C_Import_Descriptor (*Sass_C_Import_Callback);
 // Typedef defining the importer c function prototype
-typedef struct Sass_Import** (*Sass_C_Import_Fn) (const char* url, const char* prev, void* cookie);
+typedef Sass_Import_Entry* (*Sass_C_Import_Fn) (const char* url, const char* prev, void* cookie);
 
 // Creators for custom importer callback (with some additional pointer)
 // The pointer is mostly used to store the callback into the actual function
@@ -45,38 +45,38 @@ void* sass_import_get_cookie (Sass_C_Import_Callback fn);
 void sass_delete_importer (Sass_C_Import_Callback fn);
 
 // Creator for sass custom importer return argument list
-struct Sass_Import** sass_make_import_list (size_t length);
+Sass_Import_Entry* sass_make_import_list (size_t length);
 // Creator for a single import entry returned by the custom importer inside the list
-struct Sass_Import* sass_make_import_entry (const char* path, char* source, char* srcmap);
-struct Sass_Import* sass_make_import (const char* rel, const char* abs, char* source, char* srcmap);
+Sass_Import_Entry sass_make_import_entry (const char* path, char* source, char* srcmap);
+Sass_Import_Entry sass_make_import (const char* rel, const char* abs, char* source, char* srcmap);
 
 // set error message to abort import and to print out a message (path from existing object is used in output)
-struct Sass_Import* sass_import_set_error(struct Sass_Import* import, const char* message, size_t line, size_t col);
+Sass_Import_Entry sass_import_set_error(Sass_Import_Entry import, const char* message, size_t line, size_t col);
 
 // Setters to insert an entry into the import list (you may also use [] access directly)
 // Since we are dealing with pointers they should have a guaranteed and fixed size
-void sass_import_set_list_entry (struct Sass_Import** list, size_t idx, struct Sass_Import* entry);
-struct Sass_Import* sass_import_get_list_entry (struct Sass_Import** list, size_t idx);
+void sass_import_set_list_entry (Sass_Import_Entry* list, size_t idx, Sass_Import_Entry entry);
+Sass_Import_Entry sass_import_get_list_entry (Sass_Import_Entry* list, size_t idx);
 
 // Getters for import entry
-const char* sass_import_get_rel_path (struct Sass_Import*);
-const char* sass_import_get_abs_path (struct Sass_Import*);
-const char* sass_import_get_source (struct Sass_Import*);
-const char* sass_import_get_srcmap (struct Sass_Import*);
+const char* sass_import_get_imp_path (Sass_Import_Entry);
+const char* sass_import_get_abs_path (Sass_Import_Entry);
+const char* sass_import_get_source (Sass_Import_Entry);
+const char* sass_import_get_srcmap (Sass_Import_Entry);
 // Explicit functions to take ownership of these items
 // The property on our struct will be reset to NULL
-char* sass_import_take_source (struct Sass_Import*);
-char* sass_import_take_srcmap (struct Sass_Import*);
+char* sass_import_take_source (Sass_Import_Entry);
+char* sass_import_take_srcmap (Sass_Import_Entry);
 
 // Getters for import error entries
-size_t sass_import_get_error_line (struct Sass_Import*);
-size_t sass_import_get_error_column (struct Sass_Import*);
-const char* sass_import_get_error_message (struct Sass_Import*);
+size_t sass_import_get_error_line (Sass_Import_Entry);
+size_t sass_import_get_error_column (Sass_Import_Entry);
+const char* sass_import_get_error_message (Sass_Import_Entry);
 
 // Deallocator for associated memory (incl. entries)
-void sass_delete_import_list (struct Sass_Import**);
+void sass_delete_import_list (Sass_Import_Entry*);
 // Just in case we have some stray import structs
-void sass_delete_import (struct Sass_Import*);
+void sass_delete_import (Sass_Import_Entry);
 ```
 
 ### More links

--- a/include/sass/context.h
+++ b/include/sass/context.h
@@ -143,6 +143,9 @@ ADDAPI struct Sass_Options* ADDCALL sass_compiler_get_options(struct Sass_Compil
 ADDAPI size_t ADDCALL sass_compiler_get_import_stack_size(struct Sass_Compiler* compiler);
 ADDAPI Sass_Import_Entry ADDCALL sass_compiler_get_last_import(struct Sass_Compiler* compiler);
 ADDAPI Sass_Import_Entry ADDCALL sass_compiler_get_import_entry(struct Sass_Compiler* compiler, size_t idx);
+ADDAPI size_t ADDCALL sass_compiler_get_callee_stack_size(struct Sass_Compiler* compiler);
+ADDAPI Sass_Callee_Entry ADDCALL sass_compiler_get_last_callee(struct Sass_Compiler* compiler);
+ADDAPI Sass_Callee_Entry ADDCALL sass_compiler_get_callee_entry(struct Sass_Compiler* compiler, size_t idx);
 
 // Push function for paths (no manipulation support for now)
 ADDAPI void ADDCALL sass_option_push_plugin_path (struct Sass_Options* options, const char* path);

--- a/include/sass/functions.h
+++ b/include/sass/functions.h
@@ -11,6 +11,7 @@ extern "C" {
 
 
 // Forward declaration
+struct Sass_Env;
 struct Sass_Callee;
 struct Sass_Import;
 struct Sass_Options;
@@ -18,6 +19,8 @@ struct Sass_Compiler;
 struct Sass_Importer;
 struct Sass_Function;
 
+// Typedef helpers for callee lists
+typedef struct Sass_Env (*Sass_Env_Frame);
 // Typedef helpers for callee lists
 typedef struct Sass_Callee (*Sass_Callee_Entry);
 // Typedef helpers for import lists
@@ -81,6 +84,16 @@ ADDAPI const char* ADDCALL sass_callee_get_path (Sass_Callee_Entry);
 ADDAPI size_t ADDCALL sass_callee_get_line (Sass_Callee_Entry);
 ADDAPI size_t ADDCALL sass_callee_get_column (Sass_Callee_Entry);
 ADDAPI enum Sass_Callee_Type ADDCALL sass_callee_get_type (Sass_Callee_Entry);
+ADDAPI Sass_Env_Frame ADDCALL sass_callee_get_env (Sass_Callee_Entry);
+
+// Getters and Setters for environments (lexical, local and global)
+ADDAPI union Sass_Value* ADDCALL sass_env_get_lexical (Sass_Env_Frame, const char*);
+ADDAPI void ADDCALL sass_env_set_lexical (Sass_Env_Frame, const char*, union Sass_Value*);
+ADDAPI union Sass_Value* ADDCALL sass_env_get_local (Sass_Env_Frame, const char*);
+ADDAPI void ADDCALL sass_env_set_local (Sass_Env_Frame, const char*, union Sass_Value*);
+ADDAPI union Sass_Value* ADDCALL sass_env_get_global (Sass_Env_Frame, const char*);
+ADDAPI void ADDCALL sass_env_set_global (Sass_Env_Frame, const char*, union Sass_Value*);
+
 // Getters for import entry
 ADDAPI const char* ADDCALL sass_import_get_imp_path (Sass_Import_Entry);
 ADDAPI const char* ADDCALL sass_import_get_abs_path (Sass_Import_Entry);

--- a/include/sass/functions.h
+++ b/include/sass/functions.h
@@ -11,12 +11,15 @@ extern "C" {
 
 
 // Forward declaration
+struct Sass_Callee;
 struct Sass_Import;
 struct Sass_Options;
 struct Sass_Compiler;
 struct Sass_Importer;
 struct Sass_Function;
 
+// Typedef helpers for callee lists
+typedef struct Sass_Callee (*Sass_Callee_Entry);
 // Typedef helpers for import lists
 typedef struct Sass_Import (*Sass_Import_Entry);
 typedef struct Sass_Import* (*Sass_Import_List);
@@ -34,6 +37,12 @@ typedef struct Sass_Function* (*Sass_Function_List);
 typedef union Sass_Value* (*Sass_Function_Fn)
   (const union Sass_Value*, Sass_Function_Entry cb, struct Sass_Compiler* compiler);
 
+// Type of function calls
+enum Sass_Callee_Type {
+  SASS_CALLEE_MIXIN,
+  SASS_CALLEE_FUNCTION,
+  SASS_CALLEE_C_FUNCTION,
+};
 
 // Creator for sass custom importer return argument list
 ADDAPI Sass_Importer_List ADDCALL sass_make_importer_list (size_t length);
@@ -66,6 +75,12 @@ ADDAPI Sass_Import_Entry ADDCALL sass_import_set_error(Sass_Import_Entry import,
 ADDAPI void ADDCALL sass_import_set_list_entry (Sass_Import_List list, size_t idx, Sass_Import_Entry entry);
 ADDAPI Sass_Import_Entry ADDCALL sass_import_get_list_entry (Sass_Import_List list, size_t idx);
 
+// Getters for callee entry
+ADDAPI const char* ADDCALL sass_callee_get_name (Sass_Callee_Entry);
+ADDAPI const char* ADDCALL sass_callee_get_path (Sass_Callee_Entry);
+ADDAPI size_t ADDCALL sass_callee_get_line (Sass_Callee_Entry);
+ADDAPI size_t ADDCALL sass_callee_get_column (Sass_Callee_Entry);
+ADDAPI enum Sass_Callee_Type ADDCALL sass_callee_get_type (Sass_Callee_Entry);
 // Getters for import entry
 ADDAPI const char* ADDCALL sass_import_get_imp_path (Sass_Import_Entry);
 ADDAPI const char* ADDCALL sass_import_get_abs_path (Sass_Import_Entry);

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -52,6 +52,7 @@ namespace Sass {
     std::map<const std::string, const StyleSheet> sheets;
     Subset_Map<std::string, std::pair<Sequence_Selector*, SimpleSequence_Selector*> > subset_map;
     std::vector<Sass_Import_Entry> import_stack;
+    std::vector<Sass_Callee> callee_stack;
 
     struct Sass_Compiler* c_compiler;
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -873,7 +873,8 @@ namespace Sass {
         c->pstate().path,
         c->pstate().line + 1,
         c->pstate().column + 1,
-        SASS_CALLEE_FUNCTION
+        SASS_CALLEE_FUNCTION,
+        { env, &ctx.mem }
       });
 
       // eval the body if user-defined or special, invoke underlying CPP function if native
@@ -907,7 +908,8 @@ namespace Sass {
         c->pstate().path,
         c->pstate().line + 1,
         c->pstate().column + 1,
-        SASS_CALLEE_C_FUNCTION
+        SASS_CALLEE_C_FUNCTION,
+        { env, &ctx.mem }
       });
 
       To_C to_c;

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -8,6 +8,7 @@
 #include "backtrace.hpp"
 #include "context.hpp"
 #include "parser.hpp"
+#include "sass_functions.hpp"
 
 namespace Sass {
 
@@ -678,6 +679,14 @@ namespace Sass {
                                                ->perform(&eval));
     Backtrace new_bt(backtrace(), c->pstate(), ", in mixin `" + c->name() + "`");
     backtrace_stack.push_back(&new_bt);
+    ctx.callee_stack.push_back({
+      c->name().c_str(),
+      c->pstate().path,
+      c->pstate().line + 1,
+      c->pstate().column + 1,
+      SASS_CALLEE_MIXIN
+    });
+
     Env new_env(def->environment());
     env_stack.push_back(&new_env);
     if (c->block()) {
@@ -707,6 +716,7 @@ namespace Sass {
 
     env_stack.pop_back();
     backtrace_stack.pop_back();
+    ctx.callee_stack.pop_back();
 
     recursions --;
     return trace;

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -684,7 +684,8 @@ namespace Sass {
       c->pstate().path,
       c->pstate().line + 1,
       c->pstate().column + 1,
-      SASS_CALLEE_MIXIN
+      SASS_CALLEE_MIXIN,
+      { env, &ctx.mem }
     });
 
     Env new_env(def->environment());

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -656,6 +656,10 @@ extern "C" {
   size_t ADDCALL sass_compiler_get_import_stack_size(struct Sass_Compiler* compiler) { return compiler->cpp_ctx->import_stack.size(); }
   Sass_Import_Entry ADDCALL sass_compiler_get_last_import(struct Sass_Compiler* compiler) { return compiler->cpp_ctx->import_stack.back(); }
   Sass_Import_Entry ADDCALL sass_compiler_get_import_entry(struct Sass_Compiler* compiler, size_t idx) { return compiler->cpp_ctx->import_stack[idx]; }
+  // Getters for Sass_Compiler options (query function stack)
+  size_t ADDCALL sass_compiler_get_callee_stack_size(struct Sass_Compiler* compiler) { return compiler->cpp_ctx->callee_stack.size(); }
+  Sass_Callee_Entry ADDCALL sass_compiler_get_last_callee(struct Sass_Compiler* compiler) { return &compiler->cpp_ctx->callee_stack.back(); }
+  Sass_Callee_Entry ADDCALL sass_compiler_get_callee_entry(struct Sass_Compiler* compiler, size_t idx) { return &compiler->cpp_ctx->callee_stack[idx]; }
 
   // Calculate the size of the stored null terminated array
   size_t ADDCALL sass_context_get_included_files_size (struct Sass_Context* ctx)

--- a/src/sass_functions.cpp
+++ b/src/sass_functions.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include "util.hpp"
 #include "context.hpp"
+#include "values.hpp"
 #include "sass/functions.h"
 #include "sass_functions.hpp"
 
@@ -132,6 +133,30 @@ extern "C" {
   size_t ADDCALL sass_callee_get_line(Sass_Callee_Entry entry) { return entry->line; }
   size_t ADDCALL sass_callee_get_column(Sass_Callee_Entry entry) { return entry->column; }
   enum Sass_Callee_Type ADDCALL sass_callee_get_type(Sass_Callee_Entry entry) { return entry->type; }
+  Sass_Env_Frame ADDCALL sass_callee_get_env (Sass_Callee_Entry entry) { return &entry->env; }
+
+  // Getters and Setters for environments (lexical, local and global)
+  union Sass_Value* ADDCALL sass_env_get_lexical (Sass_Env_Frame env, const char* name) {
+    Expression* ex = dynamic_cast<Expression*>((*env->frame)[name]);
+    return ex != NULL ? ast_node_to_sass_value(ex) : NULL;
+  }
+  void ADDCALL sass_env_set_lexical (Sass_Env_Frame env, const char* name, union Sass_Value* val) {
+    (*env->frame)[name] = sass_value_to_ast_node(*env->mem, val);
+  }
+  union Sass_Value* ADDCALL sass_env_get_local (Sass_Env_Frame env, const char* name) {
+    Expression* ex = dynamic_cast<Expression*>(env->frame->get_local(name));
+    return ex != NULL ? ast_node_to_sass_value(ex) : NULL;
+  }
+  void ADDCALL sass_env_set_local (Sass_Env_Frame env, const char* name, union Sass_Value* val) {
+    env->frame->set_local(name, sass_value_to_ast_node(*env->mem, val));
+  }
+  union Sass_Value* ADDCALL sass_env_get_global (Sass_Env_Frame env, const char* name) {
+    Expression* ex = dynamic_cast<Expression*>(env->frame->get_global(name));
+    return ex != NULL ? ast_node_to_sass_value(ex) : NULL;
+  }
+  void ADDCALL sass_env_set_global (Sass_Env_Frame env, const char* name, union Sass_Value* val) {
+    env->frame->set_global(name, sass_value_to_ast_node(*env->mem, val));
+  }
 
   // Getter for import entry
   const char* ADDCALL sass_import_get_imp_path(Sass_Import_Entry entry) { return entry->imp_path; }

--- a/src/sass_functions.cpp
+++ b/src/sass_functions.cpp
@@ -126,6 +126,13 @@ extern "C" {
     free(import);
   }
 
+  // Getter for callee entry
+  const char* ADDCALL sass_callee_get_name(Sass_Callee_Entry entry) { return entry->name; }
+  const char* ADDCALL sass_callee_get_path(Sass_Callee_Entry entry) { return entry->path; }
+  size_t ADDCALL sass_callee_get_line(Sass_Callee_Entry entry) { return entry->line; }
+  size_t ADDCALL sass_callee_get_column(Sass_Callee_Entry entry) { return entry->column; }
+  enum Sass_Callee_Type ADDCALL sass_callee_get_type(Sass_Callee_Entry entry) { return entry->type; }
+
   // Getter for import entry
   const char* ADDCALL sass_import_get_imp_path(Sass_Import_Entry entry) { return entry->imp_path; }
   const char* ADDCALL sass_import_get_abs_path(Sass_Import_Entry entry) { return entry->abs_path; }

--- a/src/sass_functions.hpp
+++ b/src/sass_functions.hpp
@@ -2,6 +2,8 @@
 #define SASS_SASS_FUNCTIONS_H
 
 #include "sass.h"
+#include "environment.hpp"
+#include "functions.hpp"
 
 // Struct to hold custom function callback
 struct Sass_Function {
@@ -22,6 +24,14 @@ struct Sass_Import {
   size_t column;
 };
 
+// External environments
+struct Sass_Env {
+  // links to parent frames
+  Sass::Env* frame;
+  // to make copies in setters
+  Sass::Memory_Manager* mem;
+};
+
 // External call entry
 struct Sass_Callee {
   const char* name;
@@ -29,6 +39,7 @@ struct Sass_Callee {
   size_t line;
   size_t column;
   enum Sass_Callee_Type type;
+  struct Sass_Env env;
 };
 
 // Struct to hold importer callback

--- a/src/sass_functions.hpp
+++ b/src/sass_functions.hpp
@@ -22,6 +22,15 @@ struct Sass_Import {
   size_t column;
 };
 
+// External call entry
+struct Sass_Callee {
+  const char* name;
+  const char* path;
+  size_t line;
+  size_t column;
+  enum Sass_Callee_Type type;
+};
+
 // Struct to hold importer callback
 struct Sass_Importer {
   Sass_Importer_Fn importer;

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -302,6 +302,8 @@ extern "C" {
         case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(lhs, rhs, "gte"));
         case Sass_OP::LT:  return sass_make_boolean(Eval::lt(lhs, rhs, "lt"));
         case Sass_OP::LTE: return sass_make_boolean(Eval::lt(lhs, rhs, "lte") || Eval::eq(lhs, rhs));
+        case Sass_OP::AND: return ast_node_to_sass_value(lhs->is_false() ? lhs : rhs);
+        case Sass_OP::OR:  return ast_node_to_sass_value(lhs->is_false() ? rhs : lhs);
         default:           break;
       }
 


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/1037 and https://github.com/sass/libsass/issues/1950

## Corresponding commits in [perl-libsass][1]:

- [import stack queries][2]
- [call stack queries (functions and mixins)][3]
- [sass variable environment access][4]

[1]: https://github.com/sass/perl-libsass/commits/latest
[2]: https://github.com/sass/perl-libsass/commit/00ec13fb1877268c22d091af01bd6249d87508d1
[3]: https://github.com/sass/perl-libsass/commit/196fbd310dc28f9b0b6aca105c0ac68e243f9149
[4]: https://github.com/sass/perl-libsass/commit/2a3fa42d00746a59c8cf8a708267d1b6c6b0229c

## Sample perl program

### test.pl
```pl
use strict;
use warnings;

use CSS::Sass qw(get_callee_stack_size);
use CSS::Sass qw(get_callee_type);
use CSS::Sass qw(get_callee_name);
use CSS::Sass qw(get_callee_path);
use CSS::Sass qw(get_callee_line);
use CSS::Sass qw(get_callee_column);
use CSS::Sass qw(get_callee_var);
use CSS::Sass qw(set_callee_var);

my $sass = CSS::Sass->new(
  sass_functions => {
    'get-callee-stack-size()' => sub { get_callee_stack_size() },
    'get-callee-type($back : 0)' => sub { get_callee_type($_[0]) },
    'get-callee-name($back : 0)' => sub { get_callee_name($_[0]) },
    'get-callee-path($back : 0)' => sub { get_callee_path($_[0]) },
    'get-callee-line($back : 0)' => sub { get_callee_line($_[0]) },
    'get-callee-column($back : 0)' => sub { get_callee_column($_[0]) },
    'get-callee-var($name, $back : 0)' => sub { get_callee_var($_[0], $_[1]) },
    'set-callee-var($name, $val, $back : 0)' => sub { set_callee_var($_[0], $_[1], $_[2]) },
    'get-callee($back: 0)' => sub {
      return sprintf("(%d) %s at %s (%d/%d)",
        get_callee_type($_[0]),
        get_callee_name($_[0]),
        get_callee_path($_[0]),
        get_callee_line($_[0]),
        get_callee_column($_[0]),
      );
    }
  }
);

print $sass->compile_file("test.scss");
```

### test.scss
```scss
@function baz($back: 0) {
  @return get-callee($back);
}

@function bar($back: 0) {
  @return baz($back);
}

@function foo($back: 0) {
  @return bar($back);
}

@mixin foo($back: 0) {
  @content;
}

A {
  $foo: "foo";
  @include foo {
    callee-5: foo(5);
    callee-4: foo(4);
    callee-3: foo(3);
    callee-2: foo(2);
    callee-1: foo(1);
    callee-0: foo(0);
    foo: get-callee-var("$foo");
    foo: set-callee-var("$foo", "new");
    foo: get-callee-var("$foo");
  }
}
```

### result
```css
A {
  callee-5: (0) foo at D:/.../perl-libsass/test.scss (19/12);
  callee-4: (0) @content at D:/.../perl-libsass/test.scss (14/3);
  callee-3: (1) foo at D:/.../perl-libsass/test.scss (21/15);
  callee-2: (1) bar at D:/.../perl-libsass/test.scss (10/11);
  callee-1: (1) baz at D:/.../perl-libsass/test.scss (6/11);
  callee-0: (2) get-callee at D:/.../perl-libsass/test.scss (2/11);
  foo: foo;
  foo: new; }
```