### PR TITLE
Fix incorrect str-slice behaviour

### DIFF
--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1020,16 +1020,19 @@ namespace Sass {
         std::string str = unquote(s->value());
 
         size_t size = utf8::distance(str.begin(), str.end());
+
         if (end_at <= size * -1.0 && size > 1) {
-          end_at += size;
-          if (end_at == 0) end_at = 1;
+          end_at = 0;
         }
         if (end_at < 0) {
           end_at += size + 1;
           if (end_at == 0) end_at = 1;
         }
         if (end_at > size) { end_at = (double)size; }
-        if (start_at < 0) { start_at += size + 1; }
+        if (start_at < 0) {
+          start_at += size + 1;
+          if (start_at < 0)  start_at = 0;
+        }
         else if (start_at == 0) { ++ start_at; }
 
         if (start_at <= end_at)


### PR DESCRIPTION
When is `$end-at` is more negative than the length of the string
return an empty string.

Fixes #2240
Spec sass/sass-spec#997