### PR TITLE
Fixes performance bottleneck in subset_map/extend

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -43,6 +43,7 @@ SOURCES = \
 	to_c.cpp \
 	to_value.cpp \
 	source_map.cpp \
+	subset_map.cpp \
 	error_handling.cpp \
 	memory/SharedPtr.cpp \
 	utf8_string.cpp \

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <iostream>
 #include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
 #include "memory/SharedPtr.hpp"
 
 /////////////////////////////////////////////
@@ -350,6 +352,38 @@ namespace Sass {
   IMPL_MEM_OBJ(Compound_Selector);
   IMPL_MEM_OBJ(Complex_Selector);
   IMPL_MEM_OBJ(Selector_List);
+
+
+  struct HashExpression {
+    size_t operator() (Expression_Obj ex) const;
+  };
+  struct CompareExpression {
+    bool operator()(const Expression_Obj& lhs, const Expression_Obj& rhs) const;
+  };
+
+  struct HashSimpleSelector {
+    size_t operator() (Simple_Selector_Obj ex) const;
+  };
+
+  struct CompareSimpleSelector {
+    bool operator()(Simple_Selector_Obj lhs, Simple_Selector_Obj rhs) const;
+  };
+
+  typedef std::unordered_map<
+    Expression_Obj, // key
+    Expression_Obj, // value
+    HashExpression, // hasher
+    CompareExpression // compare
+  > ExpressionMap;
+  typedef std::unordered_set<
+    Expression_Obj, // value
+    HashExpression, // hasher
+    CompareExpression // compare
+  > ExpressionSet;
+
+  typedef std::string Subset_Map_Key;
+  typedef std::vector<size_t> Subset_Map_Arr;
+  typedef std::pair<Complex_Selector_Obj, Compound_Selector_Obj> Subset_Map_Val;
 
 }
 

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -48,7 +48,7 @@ namespace Sass {
     std::vector<char*> strings;
     std::vector<Resource> resources;
     std::map<const std::string, StyleSheet> sheets;
-    Subset_Map<std::string, std::pair<Complex_Selector_Obj, Compound_Selector_Obj> > subset_map;
+    Subset_Map subset_map;
     std::vector<Sass_Import_Entry> import_stack;
 
     struct Sass_Compiler* c_compiler;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -771,7 +771,7 @@ inline void debug_node(const Node* node, std::string ind = "")
   debug_node(const_cast<Node*>(node), ind);
 }
 
-inline void debug_subset_map(Sass::ExtensionSubsetMap& map, std::string ind = "")
+inline void debug_subset_map(Sass::Subset_Map& map, std::string ind = "")
 {
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
   for(auto const &it : map.values()) {

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -619,7 +619,7 @@ namespace Sass {
           sel = ssel;
         }
         // if (c->has_line_feed()) sel->has_line_feed(true);
-        ctx.subset_map.put(placeholder->to_str_vec(), std::make_pair(sel, placeholder));
+        ctx.subset_map.put(placeholder, std::make_pair(sel, placeholder));
       }
     }
 

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -13,29 +13,27 @@ namespace Sass {
   class Context;
   class Node;
 
-  typedef Subset_Map<std::string, std::pair<Complex_Selector_Obj, Compound_Selector_Obj> > ExtensionSubsetMap;
-
   class Extend : public Operation_CRTP<void, Extend> {
 
     Context&            ctx;
-    ExtensionSubsetMap& subset_map;
+    Subset_Map& subset_map;
 
     void fallback_impl(AST_Node_Ptr n) { }
 
   public:
     static Node subweave(Node& one, Node& two, Context& ctx);
-    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
-    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace, bool& extendedSomething);
-    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, bool isReplace = false) {
+    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, Subset_Map& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
+    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, Subset_Map& subset_map, bool isReplace, bool& extendedSomething);
+    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, Subset_Map& subset_map, bool isReplace = false) {
       bool extendedSomething = false;
       return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething);
     }
-    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, ExtensionSubsetMap& subset_map, std::set<Compound_Selector>& seen) {
+    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, Subset_Map& subset_map, std::set<Compound_Selector>& seen) {
       bool isReplace = false;
       bool extendedSomething = false;
       return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething, seen);
     }
-    Extend(Context&, ExtensionSubsetMap&);
+    Extend(Context&, Subset_Map&);
     ~Extend() { }
 
     void operator()(Block_Ptr);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1937,7 +1937,7 @@ namespace Sass {
       Selector_List_Obj  extendee = ARGSEL("$extendee", Selector_List_Obj, p_contextualize);
       Selector_List_Obj  extender = ARGSEL("$extender", Selector_List_Obj, p_contextualize);
 
-      ExtensionSubsetMap subset_map;
+      Subset_Map subset_map;
       extender->populate_extends(extendee, ctx, subset_map);
 
       Selector_List_Obj result = Extend::extendSelectorList(selector, ctx, subset_map, false);
@@ -1952,7 +1952,7 @@ namespace Sass {
       Selector_List_Obj selector = ARGSEL("$selector", Selector_List_Obj, p_contextualize);
       Selector_List_Obj original = ARGSEL("$original", Selector_List_Obj, p_contextualize);
       Selector_List_Obj replacement = ARGSEL("$replacement", Selector_List_Obj, p_contextualize);
-      ExtensionSubsetMap subset_map;
+      Subset_Map subset_map;
       replacement->populate_extends(original, ctx, subset_map);
 
       Selector_List_Obj result = Extend::extendSelectorList(selector, ctx, subset_map, true);

--- a/src/sass_util.hpp
+++ b/src/sass_util.hpp
@@ -40,7 +40,7 @@ namespace Sass {
     bool operator()(const Node& one, const Node& two, Node& out) const {
       // TODO: Is this the correct C++ interpretation?
       // block ||= proc {|a, b| a == b && a}
-      if (one == two) {
+      if (nodesEqual(one, two, true)) {
         out = one;
         return true;
       }
@@ -228,21 +228,21 @@ namespace Sass {
 
       KeyType key = keyFunc(e);
 
-      if (grouped.find(key.hash()) == grouped.end()) {
+      if (grouped.find(key->hash()) == grouped.end()) {
         order.insert(std::make_pair((unsigned int)order.size(), key));
 
         std::vector<EnumType> newCollection;
         newCollection.push_back(e);
-        grouped.insert(std::make_pair(key.hash(), newCollection));
+        grouped.insert(std::make_pair(key->hash(), newCollection));
       } else {
-        std::vector<EnumType>& collection = grouped.at(key.hash());
+        std::vector<EnumType>& collection = grouped.at(key->hash());
         collection.push_back(e);
       }
     }
 
     for (unsigned int index = 0; index < order.size(); index++) {
       KeyType& key = order.at(index);
-      std::vector<EnumType>& values = grouped.at(key.hash());
+      std::vector<EnumType>& values = grouped.at(key->hash());
 
       std::pair<KeyType, std::vector<EnumType> > grouping = std::make_pair(key, values);
 

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -300,6 +300,8 @@ extern "C" {
         case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(&lhs, &rhs, "gte"));
         case Sass_OP::LT:  return sass_make_boolean(Eval::lt(&lhs, &rhs, "lt"));
         case Sass_OP::LTE: return sass_make_boolean(Eval::lt(&lhs, &rhs, "lte") || Eval::eq(&lhs, &rhs));
+        case Sass_OP::AND: return ast_node_to_sass_value(lhs->is_false() ? &lhs : &rhs);
+        case Sass_OP::OR:  return ast_node_to_sass_value(lhs->is_false() ? &rhs : &lhs);
         default:           break;
       }
 

--- a/src/subset_map.cpp
+++ b/src/subset_map.cpp
@@ -1,0 +1,57 @@
+#include "sass.hpp"
+#include "ast.hpp"
+#include "subset_map.hpp"
+
+namespace Sass {
+
+  void Subset_Map::put(const Compound_Selector_Obj& sel, const Subset_Map_Val& value)
+  {
+    if (sel->empty()) throw "internal error: subset map keys may not be empty";
+    size_t index = values_.size();
+    values_.push_back(value);
+    for (size_t i = 0, S = sel->length(); i < S; ++i)
+    {
+      hash_[(*sel)[i]].push_back(std::make_pair(&sel, index));
+    }
+  }
+
+  std::vector<Subset_Map_Val> Subset_Map::get_kv(const Compound_Selector_Obj& sel)
+  {
+    // std::vector<Subset_Map_Key> s = sel->to_str_vec();
+    // std::set<std::string> dict(s.begin(), s.end());
+    std::unordered_set<Simple_Selector_Obj, HashSimpleSelector, CompareSimpleSelector> dict(sel->begin(), sel->end());
+    std::vector<size_t> indices;
+    for (size_t i = 0, S = sel->length(); i < S; ++i) {
+      if (!hash_.count((*sel)[i])) {
+        continue;
+      }
+      const std::vector<std::pair<Compound_Selector_Obj, size_t> >& subsets = hash_[(*sel)[i]];
+      for (const std::pair<Compound_Selector_Obj, size_t>& item : subsets) {
+        bool include = true;
+        for (const Simple_Selector_Obj& it : item.first->elements()) {
+          auto found = dict.find(it);
+          if (found == dict.end()) {
+            include = false;
+            break;
+          }
+        }
+        if (include) indices.push_back(item.second);
+      }
+    }
+    sort(indices.begin(), indices.end());
+    std::vector<size_t>::iterator indices_end = unique(indices.begin(), indices.end());
+    indices.resize(distance(indices.begin(), indices_end));
+
+    std::vector<Subset_Map_Val> results;
+    for (size_t i = 0, S = indices.size(); i < S; ++i) {
+      results.push_back(values_[indices[i]]);
+    }
+    return results;
+  }
+
+  std::vector<Subset_Map_Val> Subset_Map::get_v(const Compound_Selector_Obj& sel)
+  {
+    return get_kv(sel);
+  }
+
+}

--- a/src/subset_map.hpp
+++ b/src/subset_map.hpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <iterator>
 
+#include "ast_fwd_decl.hpp"
+
 
 // #include <iostream>
 // #include <sstream>
@@ -56,88 +58,18 @@
 
 namespace Sass {
 
-  template<typename F, typename S, typename T>
-  struct triple {
-    F first;
-    S second;
-    T third;
-
-    triple(const F& f, const S& s, const T& t) : first(f), second(s), third(t) { }
-  };
-
-  template<typename F, typename S, typename T>
-  triple<F, S, T> make_triple(const F& f, const S& s, const T& t)
-  { return triple<F, S, T>(f, s, t); }
-
-  template<typename K, typename V>
   class Subset_Map {
   private:
-    std::vector<V> values_;
-    std::map<K, std::vector<triple<std::vector<K>, std::set<K>, size_t> > > hash_;
+    std::vector<Subset_Map_Val> values_;
+    std::map<Simple_Selector_Obj, std::vector<std::pair<Compound_Selector_Obj, size_t> > > hash_;
   public:
-    void put(const std::vector<K>& s, const V& value);
-    std::vector<std::pair<V, std::vector<K> > > get_kv(const std::vector<K>& s);
-    std::vector<V> get_v(const std::vector<K>& s);
+    void put(const Compound_Selector_Obj& sel, const Subset_Map_Val& value);
+    std::vector<Subset_Map_Val> get_kv(const Compound_Selector_Obj& s);
+    std::vector<Subset_Map_Val> get_v(const Compound_Selector_Obj& s);
     bool empty() { return values_.empty(); }
     void clear() { values_.clear(); hash_.clear(); }
-    const std::vector<V> values(void) { return values_; }
+    const std::vector<Subset_Map_Val> values(void) { return values_; }
   };
-
-  template<typename K, typename V>
-  void Subset_Map<K, V>::put(const std::vector<K>& s, const V& value)
-  {
-    if (s.empty()) throw "internal error: subset map keys may not be empty";
-    size_t index = values_.size();
-    values_.push_back(value);
-    std::set<K> ss;
-    for (size_t i = 0, S = s.size(); i < S; ++i)
-    { ss.insert(s[i]); }
-    for (size_t i = 0, S = s.size(); i < S; ++i)
-    {
-      hash_[s[i]].push_back(make_triple(s, ss, index));
-    }
-  }
-
-  template<typename K, typename V>
-  std::vector<std::pair<V, std::vector<K> > > Subset_Map<K, V>::get_kv(const std::vector<K>& s)
-  {
-    std::vector<K> sorted = s;
-    sort(sorted.begin(), sorted.end());
-    std::vector<std::pair<size_t, std::vector<K> > > indices;
-    for (size_t i = 0, S = s.size(); i < S; ++i) {
-      if (!hash_.count(s[i])) {
-        continue;
-      }
-      std::vector<triple<std::vector<K>, std::set<K>, size_t> > subsets = hash_[s[i]];
-      // std::cerr << "length of subsets: " << subsets.size() << std::endl;
-      for (size_t j = 0, T = subsets.size(); j < T; ++j) {
-        if (!includes(sorted.begin(), sorted.end(), subsets[j].second.begin(), subsets[j].second.end())) {
-          // std::cout << vector_to_string(s) << " doesn't include " << set_to_string(subsets[j].second) << std::endl;
-          continue;
-        }
-        indices.push_back(std::make_pair(subsets[j].third, subsets[j].first));
-        // std::cerr << "pushed " << subsets[j].third << " and " << vector_to_string(subsets[j].first) << " onto indices" << std::endl;
-      }
-    }
-    sort(indices.begin(), indices.end());
-    typename std::vector<std::pair<size_t, std::vector<K> > >::iterator indices_end = unique(indices.begin(), indices.end());
-    indices.resize(distance(indices.begin(), indices_end));
-
-    std::vector<std::pair<V, std::vector<K> > > results;
-    for (size_t i = 0, S = indices.size(); i < S; ++i) {
-      results.push_back(std::make_pair(values_[indices[i].first], indices[i].second));
-    }
-    return results;
-  }
-
-  template<typename K, typename V>
-  std::vector<V> Subset_Map<K, V>::get_v(const std::vector<K>& s)
-  {
-    std::vector<std::pair<V, std::vector<K> > > kvs = get_kv(s);
-    std::vector<V> results;
-    for (size_t i = 0, S = kvs.size(); i < S; ++i) results.push_back(kvs[i].first);
-    return results;
-  }
 
 }
 

--- a/test/test_subset_map.cpp
+++ b/test/test_subset_map.cpp
@@ -11,39 +11,39 @@ void assertEqual(string std::sExpected, std::string sResult);
 
 void setup() {
   ssm.clear();
-  
+
   //@ssm[Set[1, 2]] = "Foo"
   std::vector<std::string> s1;
   s1.push_back("1");
   s1.push_back("2");
   ssm.put(s1, "Foo");
-  
+
   //@ssm[Set["fizz", "fazz"]] = "Bar"
   std::vector<std::string> s2;
   s2.push_back("fizz");
   s2.push_back("fazz");
   ssm.put(s2, "Bar");
-  
+
   //@ssm[Set[:foo, :bar]] = "Baz"
   std::vector<std::string> s3;
   s3.push_back(":foo");
   s3.push_back(":bar");
   ssm.put(s3, "Baz");
-  
+
   //@ssm[Set[:foo, :bar, :baz]] = "Bang"
   std::vector<std::string> s4;
   s4.push_back(":foo");
   s4.push_back(":bar");
   s4.push_back(":baz");
   ssm.put(s4, "Bang");
-  
+
   //@ssm[Set[:bip, :bop, :blip]] = "Qux"
   std::vector<std::string> s5;
   s5.push_back(":bip");
   s5.push_back(":bop");
   s5.push_back(":blip");
   ssm.put(s5, "Qux");
-  
+
   //@ssm[Set[:bip, :bop]] = "Thram"
   std::vector<std::string> s6;
   s6.push_back(":bip");
@@ -53,119 +53,119 @@ void setup() {
 
 void testEqualKeys() {
   std::cout << "testEqualKeys" << std::endl;
-  
+
   //assert_equal [["Foo", Set[1, 2]]], @ssm.get(Set[1, 2])
   std::vector<std::string> k1;
   k1.push_back("1");
   k1.push_back("2");
   assertEqual("[[Foo, Set[1, 2]]]", toString(ssm.get_kv(k1)));
-  
+
   //assert_equal [["Bar", Set["fizz", "fazz"]]], @ssm.get(Set["fizz", "fazz"])
   std::vector<std::string> k2;
   k2.push_back("fizz");
   k2.push_back("fazz");
   assertEqual("[[Bar, Set[fizz, fazz]]]", toString(ssm.get_kv(k2)));
-  
+
   std::cout << std::endl;
 }
 
 void testSubsetKeys() {
   std::cout << "testSubsetKeys" << std::endl;
-  
+
   //assert_equal [["Foo", Set[1, 2]]], @ssm.get(Set[1, 2, "fuzz"])
   std::vector<std::string> k1;
   k1.push_back("1");
   k1.push_back("2");
   k1.push_back("fuzz");
   assertEqual("[[Foo, Set[1, 2]]]", toString(ssm.get_kv(k1)));
-  
+
   //assert_equal [["Bar", Set["fizz", "fazz"]]], @ssm.get(Set["fizz", "fazz", 3])
   std::vector<std::string> k2;
   k2.push_back("fizz");
   k2.push_back("fazz");
   k2.push_back("3");
   assertEqual("[[Bar, Set[fizz, fazz]]]", toString(ssm.get_kv(k2)));
-  
+
   std::cout << std::endl;
 }
 
 void testSupersetKeys() {
   std::cout << "testSupersetKeys" << std::endl;
-  
+
   //assert_equal [], @ssm.get(Set[1])
   std::vector<std::string> k1;
   k1.push_back("1");
   assertEqual("[]", toString(ssm.get_kv(k1)));
-  
+
   //assert_equal [], @ssm.get(Set[2])
   std::vector<std::string> k2;
   k2.push_back("2");
   assertEqual("[]", toString(ssm.get_kv(k2)));
-  
+
   //assert_equal [], @ssm.get(Set["fizz"])
   std::vector<std::string> k3;
   k3.push_back("fizz");
   assertEqual("[]", toString(ssm.get_kv(k3)));
-  
+
   //assert_equal [], @ssm.get(Set["fazz"])
   std::vector<std::string> k4;
   k4.push_back("fazz");
   assertEqual("[]", toString(ssm.get_kv(k4)));
-  
+
   std::cout << std::endl;
 }
 
 void testDisjointKeys() {
   std::cout << "testDisjointKeys" << std::endl;
-  
+
   //assert_equal [], @ssm.get(Set[3, 4])
   std::vector<std::string> k1;
   k1.push_back("3");
   k1.push_back("4");
   assertEqual("[]", toString(ssm.get_kv(k1)));
-  
+
   //assert_equal [], @ssm.get(Set["fuzz", "frizz"])
   std::vector<std::string> k2;
   k2.push_back("fuzz");
   k2.push_back("frizz");
   assertEqual("[]", toString(ssm.get_kv(k2)));
-  
+
   //assert_equal [], @ssm.get(Set["gran", 15])
   std::vector<std::string> k3;
   k3.push_back("gran");
   k3.push_back("15");
   assertEqual("[]", toString(ssm.get_kv(k3)));
-  
+
   std::cout << std::endl;
 }
 
 void testSemiDisjointKeys() {
   std::cout << "testSemiDisjointKeys" << std::endl;
-  
+
   //assert_equal [], @ssm.get(Set[2, 3])
   std::vector<std::string> k1;
   k1.push_back("2");
   k1.push_back("3");
   assertEqual("[]", toString(ssm.get_kv(k1)));
-  
+
   //assert_equal [], @ssm.get(Set["fizz", "fuzz"])
   std::vector<std::string> k2;
   k2.push_back("fizz");
   k2.push_back("fuzz");
   assertEqual("[]", toString(ssm.get_kv(k2)));
-  
+
   //assert_equal [], @ssm.get(Set[1, "fazz"])
   std::vector<std::string> k3;
   k3.push_back("1");
   k3.push_back("fazz");
   assertEqual("[]", toString(ssm.get_kv(k3)));
-  
+
   std::cout << std::endl;
 }
 
 void testEmptyKeySet() {
   std::cout << "testEmptyKeySet" << std::endl;
-  
+
   //assert_raises(ArgumentError) {@ssm[Set[]] = "Fail"}
   std::vector<std::string> s1;
   try {
@@ -178,16 +178,16 @@ void testEmptyKeySet() {
 
 void testEmptyKeyGet() {
   std::cout << "testEmptyKeyGet" << std::endl;
-  
+
   //assert_equal [], @ssm.get(Set[])
   std::vector<std::string> k1;
   assertEqual("[]", toString(ssm.get_kv(k1)));
-  
+
   std::cout << std::endl;
 }
 void testMultipleSubsets() {
   std::cout << "testMultipleSubsets" << std::endl;
-  
+
   //assert_equal [["Foo", Set[1, 2]], ["Bar", Set["fizz", "fazz"]]], @ssm.get(Set[1, 2, "fizz", "fazz"])
   std::vector<std::string> k1;
   k1.push_back("1");
@@ -195,7 +195,7 @@ void testMultipleSubsets() {
   k1.push_back("fizz");
   k1.push_back("fazz");
   assertEqual("[[Foo, Set[1, 2]], [Bar, Set[fizz, fazz]]]", toString(ssm.get_kv(k1)));
-  
+
   //assert_equal [["Foo", Set[1, 2]], ["Bar", Set["fizz", "fazz"]]], @ssm.get(Set[1, 2, 3, "fizz", "fazz", "fuzz"])
   std::vector<std::string> k2;
   k2.push_back("1");
@@ -205,51 +205,51 @@ void testMultipleSubsets() {
   k2.push_back("fazz");
   k2.push_back("fuzz");
   assertEqual("[[Foo, Set[1, 2]], [Bar, Set[fizz, fazz]]]", toString(ssm.get_kv(k2)));
-  
+
   //assert_equal [["Baz", Set[:foo, :bar]]], @ssm.get(Set[:foo, :bar])
   std::vector<std::string> k3;
   k3.push_back(":foo");
   k3.push_back(":bar");
   assertEqual("[[Baz, Set[:foo, :bar]]]", toString(ssm.get_kv(k3)));
-  
+
   //assert_equal [["Baz", Set[:foo, :bar]], ["Bang", Set[:foo, :bar, :baz]]], @ssm.get(Set[:foo, :bar, :baz])
   std::vector<std::string> k4;
   k4.push_back(":foo");
   k4.push_back(":bar");
   k4.push_back(":baz");
   assertEqual("[[Baz, Set[:foo, :bar]], [Bang, Set[:foo, :bar, :baz]]]", toString(ssm.get_kv(k4)));
-  
+
   std::cout << std::endl;
 }
 void testBracketBracket() {
   std::cout << "testBracketBracket" << std::endl;
-  
+
   //assert_equal ["Foo"], @ssm[Set[1, 2, "fuzz"]]
   std::vector<std::string> k1;
   k1.push_back("1");
   k1.push_back("2");
   k1.push_back("fuzz");
   assertEqual("[Foo]", toString(ssm.get_v(k1)));
-  
+
   //assert_equal ["Baz", "Bang"], @ssm[Set[:foo, :bar, :baz]]
   std::vector<std::string> k2;
   k2.push_back(":foo");
   k2.push_back(":bar");
   k2.push_back(":baz");
   assertEqual("[Baz, Bang]", toString(ssm.get_v(k2)));
-  
+
   std::cout << std::endl;
 }
 
 void testKeyOrder() {
   std::cout << "testEqualKeys" << std::endl;
-  
+
   //assert_equal [["Foo", Set[1, 2]]], @ssm.get(Set[2, 1])
   std::vector<std::string> k1;
   k1.push_back("2");
   k1.push_back("1");
   assertEqual("[[Foo, Set[1, 2]]]", toString(ssm.get_kv(k1)));
-  
+
   std::cout << std::endl;
 }
 
@@ -261,24 +261,24 @@ void testOrderPreserved() {
   s1.push_back("11");
   s1.push_back("12");
   ssm.put(s1, "1");
-  
+
   //@ssm[Set[10, 11]] = 2
   std::vector<std::string> s2;
   s2.push_back("10");
   s2.push_back("11");
   ssm.put(s2, "2");
-  
+
   //@ssm[Set[11]] = 3
   std::vector<std::string> s3;
   s3.push_back("11");
   ssm.put(s3, "3");
-  
+
   //@ssm[Set[11, 12]] = 4
   std::vector<std::string> s4;
   s4.push_back("11");
   s4.push_back("12");
   ssm.put(s4, "4");
-  
+
   //@ssm[Set[9, 10, 11, 12, 13]] = 5
   std::vector<std::string> s5;
   s5.push_back("9");
@@ -287,13 +287,13 @@ void testOrderPreserved() {
   s5.push_back("12");
   s5.push_back("13");
   ssm.put(s5, "5");
-  
+
   //@ssm[Set[10, 13]] = 6
   std::vector<std::string> s6;
   s6.push_back("10");
   s6.push_back("13");
   ssm.put(s6, "6");
-  
+
   //assert_equal([[1, Set[10, 11, 12]], [2, Set[10, 11]], [3, Set[11]], [4, Set[11, 12]], [5, Set[9, 10, 11, 12, 13]], [6, Set[10, 13]]], @ssm.get(Set[9, 10, 11, 12, 13]))
   std::vector<std::string> k1;
   k1.push_back("9");
@@ -302,7 +302,7 @@ void testOrderPreserved() {
   k1.push_back("12");
   k1.push_back("13");
   assertEqual("[[1, Set[10, 11, 12]], [2, Set[10, 11]], [3, Set[11]], [4, Set[11, 12]], [5, Set[9, 10, 11, 12, 13]], [6, Set[10, 13]]]", toString(ssm.get_kv(k1)));
-  
+
   std::cout << std::endl;
 }
 void testMultipleEqualValues() {
@@ -312,25 +312,25 @@ void testMultipleEqualValues() {
   s1.push_back("11");
   s1.push_back("12");
   ssm.put(s1, "1");
-  
+
   //@ssm[Set[12, 13]] = 2
   std::vector<std::string> s2;
   s2.push_back("12");
   s2.push_back("13");
   ssm.put(s2, "2");
-  
+
   //@ssm[Set[13, 14]] = 1
   std::vector<std::string> s3;
   s3.push_back("13");
   s3.push_back("14");
   ssm.put(s3, "1");
-  
+
   //@ssm[Set[14, 15]] = 1
   std::vector<std::string> s4;
   s4.push_back("14");
   s4.push_back("15");
   ssm.put(s4, "1");
-  
+
   //assert_equal([[1, Set[11, 12]], [2, Set[12, 13]], [1, Set[13, 14]], [1, Set[14, 15]]], @ssm.get(Set[11, 12, 13, 14, 15]))
   std::vector<std::string> k1;
   k1.push_back("11");
@@ -339,7 +339,7 @@ void testMultipleEqualValues() {
   k1.push_back("14");
   k1.push_back("15");
   assertEqual("[[1, Set[11, 12]], [2, Set[12, 13]], [1, Set[13, 14]], [1, Set[14, 15]]]", toString(ssm.get_kv(k1)));
-  
+
   std::cout << std::endl;
 }
 
@@ -348,66 +348,66 @@ int main()
   std::vector<std::string> s1;
   s1.push_back("1");
   s1.push_back("2");
-  
+
   std::vector<std::string> s2;
   s2.push_back("2");
   s2.push_back("3");
-  
+
   std::vector<std::string> s3;
   s3.push_back("3");
   s3.push_back("4");
-  
+
   ssm.put(s1, "value1");
   ssm.put(s2, "value2");
   ssm.put(s3, "value3");
-  
+
   std::vector<std::string> s4;
   s4.push_back("1");
   s4.push_back("2");
   s4.push_back("3");
-  
+
   std::vector<std::pair<string, std::vector<std::string> > > fetched(ssm.get_kv(s4));
-  
+
   std::cout << "PRINTING RESULTS:" << std::endl;
   for (size_t i = 0, S = fetched.size(); i < S; ++i) {
     std::cout << fetched[i].first << std::endl;
   }
-  
+
   Subset_Map<string, string> ssm2;
   ssm2.put(s1, "foo");
   ssm2.put(s2, "bar");
   ssm2.put(s4, "hux");
-  
+
   std::vector<std::pair<string, std::vector<std::string> > > fetched2(ssm2.get_kv(s4));
-  
+
   std::cout << std::endl << "PRINTING RESULTS:" << std::endl;
   for (size_t i = 0, S = fetched2.size(); i < S; ++i) {
     std::cout << fetched2[i].first << std::endl;
   }
-  
+
   std::cout << "TRYING ON A SELECTOR-LIKE OBJECT" << std::endl;
-  
+
   Subset_Map<string, string> sel_ssm;
   std::vector<std::string> target;
   target.push_back("desk");
   target.push_back(".wood");
-  
+
   std::vector<std::string> actual;
   actual.push_back("desk");
   actual.push_back(".wood");
   actual.push_back(".mine");
-  
+
   sel_ssm.put(target, "has-aquarium");
   std::vector<std::pair<string, std::vector<std::string> > > fetched3(sel_ssm.get_kv(actual));
   std::cout << "RESULTS:" << std::endl;
   for (size_t i = 0, S = fetched3.size(); i < S; ++i) {
     std::cout << fetched3[i].first << std::endl;
   }
-  
+
   std::cout << std::endl;
-  
+
   // BEGIN PORTED RUBY TESTS FROM /test/sass/util/subset_map_test.rb
-  
+
   setup();
   testEqualKeys();
   testSubsetKeys();
@@ -419,13 +419,13 @@ int main()
   testMultipleSubsets();
   testBracketBracket();
   testKeyOrder();
-  
+
   setup();
   testOrderPreserved();
-  
+
   setup();
   testMultipleEqualValues();
-  
+
   return 0;
 }
 

--- a/win/libsass.targets
+++ b/win/libsass.targets
@@ -104,6 +104,7 @@
     <ClCompile Include="$(LIBSASS_SRC_DIR)\sass_values.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\sass2scss.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\source_map.cpp" />
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\subset_map.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\to_c.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\to_value.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\units.cpp" />

--- a/win/libsass.vcxproj.filters
+++ b/win/libsass.vcxproj.filters
@@ -323,6 +323,9 @@
     <ClCompile Include="$(LIBSASS_SRC_DIR)\source_map.cpp">
       <Filter>Sources</Filter>
     </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\subset_map.cpp">
+      <Filter>Sources</Filter>
+    </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\to_c.cpp">
       <Filter>Sources</Filter>
     </ClCompile>


### PR DESCRIPTION
You can expect to see a 2x performance increase in bigger sass code bases. With more extend usage it can go as high as 10x performance increase.

Test with styles of a real corporate website showed a performance increase of 3x (from 750ms to 250ms). When I imported the main stylesheet 10x times, compile time went from 100s to 5s (~20x increase).

This indecently (according to probe-todo) also fixes https://github.com/sass/libsass/issues/2056 (false positive?)?
