### PR TITLE
Fixes issue with C-API `copy_options` function

### DIFF
--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -259,6 +259,8 @@ extern "C" {
   static void sass_clear_options (struct Sass_Options* options);
   static void sass_reset_options (struct Sass_Options* options);
   static void copy_options(struct Sass_Options* to, struct Sass_Options* from) {
+    // do not overwrite ourself
+    if (to == from) return;
     // free assigned memory
     sass_clear_options(to);
     // move memory


### PR DESCRIPTION
Some options were lost when we overwrite ourselves.