### PR TITLE
Update test bootstrap script to use document environment vars

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,9 +2,12 @@
 
 script/branding
 
-if [ ! -d "sass-spec" ]; then
-  git clone https://github.com/sass/sass-spec.git
+: ${SASS_SPEC_PATH:="sass-spec"}
+: ${SASS_SASSC_PATH:="sassc" }
+
+if [ ! -d $SASS_SPEC_PATH ]; then
+  git clone https://github.com/sass/sass-spec.git $SASS_SPEC_PATH
 fi
-if [ ! -d "sassc" ]; then
-  git clone https://github.com/sass/sassc.git
+if [ ! -d $SASS_SASSC_PATH ]; then
+  git clone https://github.com/sass/sassc.git $SASS_SASSC_PATH
 fi


### PR DESCRIPTION
We have documented `SASS_SPEC_PATH` and `SASS_SASSC_PATH` environment
variables for user defined sass-spec and sassc locations respectively.

The bootstrap script is currently ignoring these.