### PR TITLE
Fix source mappings for selector schema

### DIFF
--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -663,6 +663,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << ind << "String_Schema " << expression;
     std::cerr << " (" << pstate_source_position(expression) << ")";
     std::cerr << " " << expression->concrete_type();
+    std::cerr << " (" << pstate_source_position(node) << ")";
     if (expression->is_delayed()) std::cerr << " [delayed]";
     if (expression->is_interpolant()) std::cerr << " [is interpolant]";
     if (expression->has_interpolant()) std::cerr << " [has interpolant]";


### PR DESCRIPTION
Addresses https://github.com/sass/libsass/issues/2224, but does not fully solve it.

Underlying problem is that the selector schema interpolation is first evaluated into a string and then passed to the parser again to produce the final AST tree. This patch should fix the most urgent error that following lines can be offset when the selector schema has more lines than the evaluated string.

We still output pretty much garbage mappings for the parts in the selector schema itself. I think it should theoretically be possible to re-map the mappings after the second parsing, but I wasn't able to get this working so far. But with this patch following lines should have the correct mappings.

Not perfect, but still much better than before!