### PR TITLE
Fix incorrect validation of mixin definition

### DIFF
--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -11,13 +11,8 @@ namespace Sass {
     current_mixin_definition(0)
   { }
 
-  Statement_Ptr CheckNesting::before(Statement_Ptr s) {
-      if (this->should_visit(s)) return s;
-      return NULL;
-  }
-
-  Statement_Ptr CheckNesting::visit_children(Statement_Ptr parent) {
-
+  Statement_Ptr CheckNesting::visit_children(Statement_Ptr parent)
+  {
     Statement_Ptr old_parent = this->parent;
 
     if (At_Root_Block_Ptr root = SASS_MEMORY_CAST_PTR(At_Root_Block, parent)) {
@@ -86,6 +81,7 @@ namespace Sass {
 
   Statement_Ptr CheckNesting::operator()(Definition_Ptr n)
   {
+    if (!this->should_visit(n)) return NULL;
     if (!is_mixin(n)) return n;
 
     Definition_Ptr old_mixin_definition = this->current_mixin_definition;

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -27,7 +27,11 @@ namespace Sass {
 
     template <typename U>
     Statement_Ptr fallback(U x) {
-        return fallback_impl(this->before(SASS_MEMORY_CAST_PTR(Statement, x)));
+      Statement_Ptr n = SASS_MEMORY_CAST_PTR(Statement, x);
+      if (this->should_visit(n)) {
+        return fallback_impl(n);
+      }
+      return NULL;
     }
 
   private:

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -363,15 +363,6 @@ namespace Sass {
 
   Definition_Obj Parser::parse_definition(Definition::Type which_type)
   {
-    Scope parent = stack.empty() ? Scope::Rules : stack.back();
-    if (parent != Scope::Root && parent != Scope::Rules && parent != Scope::Function) {
-      if (which_type == Definition::FUNCTION) {
-        error("Functions may not be defined within control directives or other mixins.", pstate);
-      } else {
-        error("Mixins may not be defined within control directives or other mixins.", pstate);
-      }
-
-    }
     std::string which_str(lexed);
     if (!lex< identifier >()) error("invalid name in " + which_str + " definition", pstate);
     std::string name(Util::normalize_underscores(lexed));


### PR DESCRIPTION
Removed the duplicate validation check from the parser. The validation
in the check nesting visitor was being skipped.

Looks like there is a bunch of left of AST validation in the parser,
which now belongs in the check nesting visitor. With the current
approach the parser should only ever error when it encounters invalid
tokens. It cannot accurately validate the AST because things like
`at-root` change the structure in important ways.

Closes #2269
Fixes #2095
Spec sass/sass-spec#1031