### PR TITLE
Remove left over AST validation from the parser

### DIFF
--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -82,7 +82,10 @@ namespace Sass {
   Statement_Ptr CheckNesting::operator()(Definition_Ptr n)
   {
     if (!this->should_visit(n)) return NULL;
-    if (!is_mixin(n)) return n;
+    if (!is_mixin(n)) {
+      visit_children(n);
+      return n;
+    }
 
     Definition_Ptr old_mixin_definition = this->current_mixin_definition;
     this->current_mixin_definition = n;
@@ -129,9 +132,8 @@ namespace Sass {
     if (SASS_MEMORY_CAST_PTR(Declaration, node))
     { this->invalid_prop_parent(this->parent); }
 
-    if (
-      SASS_MEMORY_CAST_PTR(Declaration, this->parent)
-    ) { this->invalid_prop_child(node); }
+    if (SASS_MEMORY_CAST_PTR(Declaration, this->parent))
+    { this->invalid_prop_child(node); }
 
     if (SASS_MEMORY_CAST_PTR(Return, node))
     { this->invalid_return_parent(this->parent); }
@@ -258,6 +260,8 @@ namespace Sass {
         SASS_MEMORY_CAST_PTR(Debug, child) ||
         SASS_MEMORY_CAST_PTR(Return, child) ||
         SASS_MEMORY_CAST_PTR(Variable, child) ||
+        // Ruby Sass doesn't distinguish variables and assignments
+        SASS_MEMORY_CAST_PTR(Assignment, child) ||
         SASS_MEMORY_CAST_PTR(Warning, child) ||
         SASS_MEMORY_CAST_PTR(Error, child)
     )) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -222,11 +222,6 @@ namespace Sass {
     else if (lex < kwd_while_directive >(true)) { block->append(&parse_while_directive()); }
     else if (lex < kwd_return_directive >(true)) { block->append(&parse_return_directive()); }
 
-    // abort if we are in function context and have nothing parsed yet
-    else if (stack.back() == Scope::Function) {
-      error("Functions can only contain variable declarations and control directives.", pstate);
-    }
-
     // parse imports to process later
     else if (lex < kwd_import >(true)) {
       Scope parent = stack.empty() ? Scope::Rules : stack.back();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -240,10 +240,6 @@ namespace Sass {
     }
 
     else if (lex < kwd_extend >(true)) {
-      if (block->is_root()) {
-        error("Extend directives may only be used within rules.", pstate);
-      }
-
       Lookahead lookahead = lookahead_for_include(position);
       if (!lookahead.found) css_error("Invalid CSS", " after ", ": expected selector, was ");
       Selector_Obj target;


### PR DESCRIPTION
Continuing on from #2270.

This PR removes some AST validation in the parser left over
from implementing the check nesting visitor in #2062. This
also address a bug that caused some validations to be
skipped.

There's one final AST validation left in the parser which is
for `@import`. Unfortunately due to how we handle 
`@import` nodes there isn't a straight forward way to fix
the validation issues. I'm leaving that alone until I overhaul
`@import` for the module system.