### PR TITLE
Update list equality to take is_bracketed into account

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2225,6 +2225,7 @@ namespace Sass {
     if (List_Ptr_Const r = dynamic_cast<List_Ptr_Const>(&rhs)) {
       if (length() != r->length()) return false;
       if (separator() != r->separator()) return false;
+      if (is_bracketed() != r->is_bracketed()) return false;
       for (size_t i = 0, L = length(); i < L; ++i) {
         Expression_Obj rv = r->at(i);
         Expression_Obj lv = this->at(i);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1082,6 +1082,7 @@ namespace Sass {
     {
       if (hash_ == 0) {
         hash_ = std::hash<std::string>()(sep_string());
+        hash_combine(hash_, std::hash<bool>()(is_bracketed()));
         for (size_t i = 0, L = length(); i < L; ++i)
           hash_combine(hash_, (elements()[i])->hash());
       }


### PR DESCRIPTION
Bracketed lists introduce an `is_bracketed` attribute to lists.
Whether a list is bracketed needs be taken into account when 
determining equality.

See sass/sass#2121
Fixes #2280
Spec sass/sass-spec#896