### PR TITLE
Add list is_bracketed support to the C API

### DIFF
--- a/docs/api-value.md
+++ b/docs/api-value.md
@@ -58,7 +58,7 @@ union Sass_Value* sass_make_string  (const char* val);
 union Sass_Value* sass_make_qstring (const char* val);
 union Sass_Value* sass_make_number  (double val, const char* unit);
 union Sass_Value* sass_make_color   (double r, double g, double b, double a);
-union Sass_Value* sass_make_list    (size_t len, enum Sass_Separator sep);
+union Sass_Value* sass_make_list    (size_t len, enum Sass_Separator sep, bool is_bracketed);
 union Sass_Value* sass_make_map     (size_t len);
 union Sass_Value* sass_make_error   (const char* msg);
 union Sass_Value* sass_make_warning (const char* msg);
@@ -124,6 +124,8 @@ size_t sass_list_get_length (const union Sass_Value* v);
 // Getters and setters for Sass_List
 enum Sass_Separator sass_list_get_separator (const union Sass_Value* v);
 void sass_list_set_separator (union Sass_Value* v, enum Sass_Separator value);
+bool sass_list_get_is_bracketed (const union Sass_Value* v);
+void sass_list_set_is_bracketed (union Sass_Value* v, bool value);
 // Getters and setters for Sass_List values
 union Sass_Value* sass_list_get_value (const union Sass_Value* v, size_t i);
 void sass_list_set_value (union Sass_Value* v, size_t i, union Sass_Value* value);

--- a/docs/custom-functions-internal.md
+++ b/docs/custom-functions-internal.md
@@ -45,14 +45,16 @@ The cookie can hold any pointer you want. In the `perl-libsass` implementation i
 
 ```C
 // allocate memory (copies passed strings)
-union Sass_Value* make_sass_boolean (int val);
-union Sass_Value* make_sass_number  (double val, const char* unit);
-union Sass_Value* make_sass_color   (double r, double g, double b, double a);
-union Sass_Value* make_sass_string  (const char* val);
-union Sass_Value* make_sass_list    (size_t len, enum Sass_Separator sep);
-union Sass_Value* make_sass_map     (size_t len);
-union Sass_Value* make_sass_null    ();
-union Sass_Value* make_sass_error   (const char* msg);
+union Sass_Value* sass_make_null    (void);
+union Sass_Value* sass_make_boolean (bool val);
+union Sass_Value* sass_make_string  (const char* val);
+union Sass_Value* sass_make_qstring (const char* val);
+union Sass_Value* sass_make_number  (double val, const char* unit);
+union Sass_Value* sass_make_color   (double r, double g, double b, double a);
+union Sass_Value* sass_make_list    (size_t len, enum Sass_Separator sep, bool is_bracketed);
+union Sass_Value* sass_make_map     (size_t len);
+union Sass_Value* sass_make_error   (const char* msg);
+union Sass_Value* sass_make_warning (const char* msg);
 
 // Make a deep cloned copy of the given sass value
 union Sass_Value* sass_clone_value (const union Sass_Value* val);

--- a/include/sass/values.h
+++ b/include/sass/values.h
@@ -50,7 +50,7 @@ ADDAPI union Sass_Value* ADDCALL sass_make_string  (const char* val);
 ADDAPI union Sass_Value* ADDCALL sass_make_qstring (const char* val);
 ADDAPI union Sass_Value* ADDCALL sass_make_number  (double val, const char* unit);
 ADDAPI union Sass_Value* ADDCALL sass_make_color   (double r, double g, double b, double a);
-ADDAPI union Sass_Value* ADDCALL sass_make_list    (size_t len, enum Sass_Separator sep);
+ADDAPI union Sass_Value* ADDCALL sass_make_list    (size_t len, enum Sass_Separator sep, bool is_bracketed);
 ADDAPI union Sass_Value* ADDCALL sass_make_map     (size_t len);
 ADDAPI union Sass_Value* ADDCALL sass_make_error   (const char* msg);
 ADDAPI union Sass_Value* ADDCALL sass_make_warning (const char* msg);
@@ -116,6 +116,8 @@ ADDAPI size_t ADDCALL sass_list_get_length (const union Sass_Value* v);
 // Getters and setters for Sass_List
 ADDAPI enum Sass_Separator ADDCALL sass_list_get_separator (const union Sass_Value* v);
 ADDAPI void ADDCALL sass_list_set_separator (union Sass_Value* v, enum Sass_Separator value);
+ADDAPI bool ADDCALL sass_list_get_is_bracketed (const union Sass_Value* v);
+ADDAPI void ADDCALL sass_list_set_is_bracketed (union Sass_Value* v, bool value);
 // Getters and setters for Sass_List values
 ADDAPI union Sass_Value* ADDCALL sass_list_get_value (const union Sass_Value* v, size_t i);
 ADDAPI void ADDCALL sass_list_set_value (union Sass_Value* v, size_t i, union Sass_Value* value);

--- a/src/GNUmakefile.am
+++ b/src/GNUmakefile.am
@@ -34,7 +34,7 @@ include $(top_srcdir)/Makefile.conf
 
 libsass_la_SOURCES = ${CSOURCES} ${SOURCES}
 
-libsass_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined -version-info 0:9:0
+libsass_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined -version-info 1:0:0
 
 if ENABLE_TESTS
 if ENABLE_COVERAGE

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -341,7 +341,7 @@ namespace Sass {
       Sass_Function_Fn c_func = sass_function_get_function(c_function);
 
       To_C to_c;
-      union Sass_Value* c_args = sass_make_list(1, SASS_COMMA);
+      union Sass_Value* c_args = sass_make_list(1, SASS_COMMA, false);
       sass_list_set_value(c_args, 0, message->perform(&to_c));
       union Sass_Value* c_val = c_func(c_args, c_function, ctx.c_compiler);
       ctx.c_options.output_style = outstyle;
@@ -377,7 +377,7 @@ namespace Sass {
       Sass_Function_Fn c_func = sass_function_get_function(c_function);
 
       To_C to_c;
-      union Sass_Value* c_args = sass_make_list(1, SASS_COMMA);
+      union Sass_Value* c_args = sass_make_list(1, SASS_COMMA, false);
       sass_list_set_value(c_args, 0, message->perform(&to_c));
       union Sass_Value* c_val = c_func(c_args, c_function, ctx.c_compiler);
       ctx.c_options.output_style = outstyle;
@@ -410,7 +410,7 @@ namespace Sass {
       Sass_Function_Fn c_func = sass_function_get_function(c_function);
 
       To_C to_c;
-      union Sass_Value* c_args = sass_make_list(1, SASS_COMMA);
+      union Sass_Value* c_args = sass_make_list(1, SASS_COMMA, false);
       sass_list_set_value(c_args, 0, message->perform(&to_c));
       union Sass_Value* c_val = c_func(c_args, c_function, ctx.c_compiler);
       ctx.c_options.output_style = outstyle;
@@ -907,7 +907,7 @@ namespace Sass {
       exp.backtrace_stack.push_back(&here);
 
       To_C to_c;
-      union Sass_Value* c_args = sass_make_list(params->length(), SASS_COMMA);
+      union Sass_Value* c_args = sass_make_list(params->length(), SASS_COMMA, false);
       for(size_t i = 0; i < params->length(); i++) {
         Parameter_Obj param = params->at(i);
         std::string key = param->name();
@@ -1613,6 +1613,7 @@ namespace Sass {
         for (size_t i = 0, L = sass_list_get_length(v); i < L; ++i) {
           l->append(cval_to_astnode(sass_list_get_value(v, i), backtrace, pstate));
         }
+        l->is_bracketed(sass_list_get_is_bracketed(v));
         e = l;
       } break;
       case SASS_MAP: {

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -54,6 +54,8 @@ extern "C" {
   size_t ADDCALL sass_list_get_length(const union Sass_Value* v) { return v->list.length; }
   enum Sass_Separator ADDCALL sass_list_get_separator(const union Sass_Value* v) { return v->list.separator; }
   void ADDCALL sass_list_set_separator(union Sass_Value* v, enum Sass_Separator separator) { v->list.separator = separator; }
+  bool ADDCALL sass_list_get_is_bracketed(const union Sass_Value* v) { return v->list.is_bracketed; }
+  void ADDCALL sass_list_set_is_bracketed(union Sass_Value* v, bool is_bracketed) { v->list.is_bracketed = is_bracketed; }
   // Getters and setters for Sass_List values
   union Sass_Value* ADDCALL sass_list_get_value(const union Sass_Value* v, size_t i) { return v->list.values[i]; }
   void ADDCALL sass_list_set_value(union Sass_Value* v, size_t i, union Sass_Value* value) { v->list.values[i] = value; }
@@ -130,13 +132,14 @@ extern "C" {
     return v;
   }
 
-  union Sass_Value* ADDCALL sass_make_list(size_t len, enum Sass_Separator sep)
+  union Sass_Value* ADDCALL sass_make_list(size_t len, enum Sass_Separator sep, bool is_bracketed)
   {
     union Sass_Value* v = (Sass_Value*) calloc(1, sizeof(Sass_Value));
     if (v == 0) return 0;
     v->list.tag = SASS_LIST;
     v->list.length = len;
     v->list.separator = sep;
+    v->list.is_bracketed = is_bracketed;
     v->list.values = (union Sass_Value**) calloc(len, sizeof(union Sass_Value*));
     if (v->list.values == 0) { free(v); return 0; }
     return v;
@@ -247,7 +250,7 @@ extern "C" {
                 return sass_string_is_quoted(val) ? sass_make_qstring(val->string.value) : sass_make_string(val->string.value);
         }   break;
         case SASS_LIST: {
-                union Sass_Value* list = sass_make_list(val->list.length, val->list.separator);
+                union Sass_Value* list = sass_make_list(val->list.length, val->list.separator, val->list.is_bracketed);
                 for (i = 0; i < list->list.length; i++) {
                     list->list.values[i] = sass_clone_value(val->list.values[i]);
                 }

--- a/src/sass_values.hpp
+++ b/src/sass_values.hpp
@@ -35,6 +35,7 @@ struct Sass_String {
 struct Sass_List {
   enum Sass_Tag       tag;
   enum Sass_Separator separator;
+  bool                is_bracketed;
   size_t              length;
   // null terminated "array"
   union Sass_Value**  values;

--- a/src/to_c.cpp
+++ b/src/to_c.cpp
@@ -36,7 +36,7 @@ namespace Sass {
 
   union Sass_Value* To_C::operator()(List_Ptr l)
   {
-    union Sass_Value* v = sass_make_list(l->length(), l->separator());
+    union Sass_Value* v = sass_make_list(l->length(), l->separator(), l->is_bracketed());
     for (size_t i = 0, L = l->length(); i < L; ++i) {
       sass_list_set_value(v, i, (*l)[i]->perform(this));
     }
@@ -57,7 +57,7 @@ namespace Sass {
 
   union Sass_Value* To_C::operator()(Arguments_Ptr a)
   {
-    union Sass_Value* v = sass_make_list(a->length(), SASS_COMMA);
+    union Sass_Value* v = sass_make_list(a->length(), SASS_COMMA, false);
     for (size_t i = 0, L = a->length(); i < L; ++i) {
       sass_list_set_value(v, i, (*a)[i]->perform(this));
     }

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -22,7 +22,7 @@ namespace Sass {
     else if (val->concrete_type() == Expression::LIST)
     {
       List_Ptr_Const l = dynamic_cast<List_Ptr_Const>(val);
-      union Sass_Value* list = sass_make_list(l->size(), l->separator());
+      union Sass_Value* list = sass_make_list(l->size(), l->separator(), l->is_bracketed());
       for (size_t i = 0, L = l->length(); i < L; ++i) {
         Expression_Obj obj = l->at(i);
         auto val = ast_node_to_sass_value(&obj);
@@ -106,6 +106,7 @@ namespace Sass {
         for (size_t i = 0, L = sass_list_get_length(val); i < L; ++i) {
           l->append(sass_value_to_ast_node(sass_list_get_value(val, i)));
         }
+        l->is_bracketed(sass_list_get_is_bracketed(val));
         return l;
       }
       break;


### PR DESCRIPTION
Lists gained an `is_bracketed` attribute in #2284. The primary 
semantic difference is that the`is_bracketed` changes list equality 
(#2281) which can matter in custom functions.

This is a breaking change so I'd like to get it into the first 3.5
beta.

/cc 
@nex3 to sanity check this actually matters for custom functions
@mgreter because you most about the C API
@chriseppstein because of the implication for eyeglass
