### PR TITLE
 Fix thread-safety for mixin recursions check

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -14,21 +14,21 @@
 namespace Sass {
 
   // simple endless recursion protection
-  const unsigned int maxRecursion = 500;
-  static unsigned int recursions = 0;
+  const size_t maxRecursion = 500;
 
   Expand::Expand(Context& ctx, Env* env, Backtrace* bt, std::vector<Selector_List_Obj>* stack)
   : ctx(ctx),
     eval(Eval(*this)),
+    recursions(0),
+    in_keyframes(false),
+    at_root_without_rule(false),
+    old_at_root_without_rule(false),
     env_stack(std::vector<Env*>()),
     block_stack(std::vector<Block_Ptr>()),
     call_stack(std::vector<AST_Node_Obj>()),
     selector_stack(std::vector<Selector_List_Obj>()),
     media_block_stack(std::vector<Media_Block_Ptr>()),
-    backtrace_stack(std::vector<Backtrace*>()),
-    in_keyframes(false),
-    at_root_without_rule(false),
-    old_at_root_without_rule(false)
+    backtrace_stack(std::vector<Backtrace*>())
   {
     env_stack.push_back(0);
     env_stack.push_back(env);
@@ -685,11 +685,12 @@ namespace Sass {
 
   Statement_Ptr Expand::operator()(Mixin_Call_Ptr c)
   {
-    recursions ++;
 
     if (recursions > maxRecursion) {
       throw Exception::StackError(*c);
     }
+
+    recursions ++;
 
     Env* env = environment();
     std::string full_name(c->name() + "[m]");

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -26,17 +26,18 @@ namespace Sass {
 
     Context&          ctx;
     Eval              eval;
+    size_t            recursions;
+    bool              in_keyframes;
+    bool              at_root_without_rule;
+    bool              old_at_root_without_rule;
 
     // it's easier to work with vectors
-    std::vector<Env*>           env_stack;
+    std::vector<Env*>              env_stack;
     std::vector<Block_Ptr>         block_stack;
     std::vector<AST_Node_Obj>      call_stack;
     std::vector<Selector_List_Obj> selector_stack;
     std::vector<Media_Block_Ptr>   media_block_stack;
-    std::vector<Backtrace*>     backtrace_stack;
-    bool                        in_keyframes;
-    bool                        at_root_without_rule;
-    bool                        old_at_root_without_rule;
+    std::vector<Backtrace*>        backtrace_stack;
 
     Statement_Ptr fallback_impl(AST_Node_Ptr n);
 


### PR DESCRIPTION
Keeping the counter in a static exposed some weird behavior in https://github.com/sass/node-sass/issues/1669#issuecomment-270020822. This PR should fix that particular issue. I believe this is due to thread safety. Not sure how they do it, but the behavior we see is the following:

```c++
static unsigned int recursions = 0;
mixin() {
  if (recursions > 500) {
    throw "stack level too deep";
  }
  recursions ++;
  ... do more work
  ... may call mixin() again
  recursions --;
}
```

At the decrement, `recursions` at some point contains a `0`, therefore the decrement will overflow the unsigned value to 4294967295, which will then trigger the error check. For me this can only mean that the static variable got initialized again on the same thread. Moving the variable to the class will make sure that every context uses their own memory for this counter. Still, LibSass is not guaranteed or considered to be 100% thread safe (mostly due to the lack of anybody really verifying it).

