### PR TITLE
Fix issue with parent selector evaluation

### DIFF
--- a/docs/api-context.md
+++ b/docs/api-context.md
@@ -249,6 +249,9 @@ Sass_C_Import_Callback sass_option_get_importer (struct Sass_Options* options);
 // Getters for Context_Option include path array
 size_t sass_option_get_include_path_size(struct Sass_Options* options);
 const char* sass_option_get_include_path(struct Sass_Options* options, size_t i);
+// Plugin paths to load dynamic libraries work the same
+size_t sass_option_get_plugin_path_size(struct Sass_Options* options);
+const char* sass_option_get_plugin_path(struct Sass_Options* options, size_t i);
 
 // Setters for Context_Option values
 void sass_option_set_precision (struct Sass_Options* options, int precision);

--- a/docs/api-doc.md
+++ b/docs/api-doc.md
@@ -1,6 +1,9 @@
 ## Introduction
 
-LibSass wouldn't be much good without a way to interface with it. These interface documentations describe the various functions and data structures available to implementers. They are split up over three major components, which have all their own source files (plus some common functionality).
+LibSass wouldn't be much good without a way to interface with it. These
+interface documentations describe the various functions and data structures
+available to implementers. They are split up over three major components, which
+have all their own source files (plus some common functionality).
 
 - [Sass Context](api-context.md) - Trigger and handle the main Sass compilation
 - [Sass Value](api-value.md) - Exchange values and its format with LibSass
@@ -41,7 +44,12 @@ gcc -Wall version.c -lsass -o version && ./version
 
 ## Compiling your code
 
-The most important is your sass file (or string of sass code).  With this, you will want to start a LibSass compiler.  Here is some pseudocode describing the process.  The compiler has two different modes: direct input as a string with `Sass_Data_Context` or LibSass will do file reading for you by using `Sass_File_Context`.  See the code for a list of options available [Sass_Options](https://github.com/sass/libsass/blob/36feef0/include/sass/interface.h#L18)
+The most important is your sass file (or string of sass code). With this, you
+will want to start a LibSass compiler. Here is some pseudocode describing the
+process. The compiler has two different modes: direct input as a string with
+`Sass_Data_Context` or LibSass will do file reading for you by using
+`Sass_File_Context`. See the code for a list of options available
+[Sass_Options](https://github.com/sass/libsass/blob/36feef0/include/sass/interface.h#L18)
 
 **Building a file compiler**
 
@@ -97,7 +105,9 @@ struct Sass_Data_context : Sass_Context;
 
 This mirrors very well how `libsass` uses these structures.
 
-- `Sass_Options` holds everything you feed in before the compilation. It also hosts `input_path` and `output_path` options, because they are used to generate/calculate relative links in source-maps. The `input_path` is shared with `Sass_File_Context`.
+- `Sass_Options` holds everything you feed in before the compilation. It also hosts
+`input_path` and `output_path` options, because they are used to generate/calculate
+relative links in source-maps. The `input_path` is shared with `Sass_File_Context`.
 - `Sass_Context` holds all the data returned by the compilation step.
 - `Sass_File_Context` is a specific implementation that requires no additional fields
 - `Sass_Data_Context` is a specific implementation that adds the `input_source` field
@@ -106,8 +116,11 @@ Structs can be down-casted to access `context` or `options`!
 
 ## Memory handling and life-cycles
 
-We keep memory around for as long as the main [context](api-context.md) object is not destroyed (`sass_delete_context`). LibSass will create copies of most inputs/options beside the main sass code.
-You need to allocate and fill that buffer before passing it to LibSass. You may also overtake memory management from libsass for certain return values (i.e. `sass_context_take_output_string`).
+We keep memory around for as long as the main [context](api-context.md) object
+is not destroyed (`sass_delete_context`). LibSass will create copies of most
+inputs/options beside the main sass code. You need to allocate and fill that
+buffer before passing it to LibSass. You may also overtake memory management
+from libsass for certain return values (i.e. `sass_context_take_output_string`).
 
 ```C
 // to allocate buffer to be filled
@@ -137,15 +150,25 @@ const char* libsass_language_version(void);
 
 **input_path**
 
-The `input_path` is part of `Sass_Options`, but it also is the main option for `Sass_File_Context`. It is also used to generate relative file links in source-maps. Therefore it is pretty usefull to pass this information if you have a `Sass_Data_Context` and know the original path.
+The `input_path` is part of `Sass_Options`, but it also is the main option for
+`Sass_File_Context`. It is also used to generate relative file links in source-
+maps. Therefore it is pretty usefull to pass this information if you have a
+`Sass_Data_Context` and know the original path.
 
 **output_path**
 
-Be aware that `libsass` does not write the output file itself. This option merely exists to give `libsass` the proper information to generate links in source-maps. The file has to be written to the disk by the binding/implementation. If the `output_path` is omitted, `libsass` tries to extrapolate one from the `input_path` by replacing (or adding) the file ending with `.css`.
+Be aware that `libsass` does not write the output file itself. This option
+merely exists to give `libsass` the proper information to generate links in
+source-maps. The file has to be written to the disk by the
+binding/implementation. If the `output_path` is omitted, `libsass` tries to
+extrapolate one from the `input_path` by replacing (or adding) the file ending
+with `.css`.
 
 ## Error Codes
 
-The `error_code` is integer value which indicates the type of error that occurred inside the LibSass process. Following is the list of error codes along with the short description:
+The `error_code` is integer value which indicates the type of error that
+occurred inside the LibSass process. Following is the list of error codes along
+with the short description:
 
 * 1: normal errors like parsing or `eval` errors
 * 2: bad allocation error (memory error)
@@ -153,11 +176,15 @@ The `error_code` is integer value which indicates the type of error that occurre
 * 4: legacy string exceptions ( `throw const char*` or `std::string` )
 * 5: Some other unknown exception
 
-Although for the API consumer, error codes do not offer much value except indicating whether *any* error occurred during the compilation, it helps debugging the LibSass internal code paths.
+Although for the API consumer, error codes do not offer much value except
+indicating whether *any* error occurred during the compilation, it helps
+debugging the LibSass internal code paths.
 
 ## Real-World Implementations
 
-The proof is in the pudding, so we have highlighted a few implementations that should be on par with the latest LibSass interface version. Some of them may not have all features implemented!
+The proof is in the pudding, so we have highlighted a few implementations that
+should be on par with the latest LibSass interface version. Some of them may not
+have all features implemented!
 
 1. [Perl Example](https://github.com/sass/perl-libsass/blob/master/lib/CSS/Sass.xs)
 2. [Go Example](http://godoc.org/github.com/wellington/go-libsass#example-Context-Compile)
@@ -165,11 +192,20 @@ The proof is in the pudding, so we have highlighted a few implementations that s
 
 ## ABI forward compatibility
 
-We use a functional API to make dynamic linking more robust and future compatible. The API is not yet 100% stable, so we do not yet guarantee [ABI](https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html) forward compatibility. We will do so, once we increase the shared library version above 1.0.
+We use a functional API to make dynamic linking more robust and future
+compatible. The API is not yet 100% stable, so we do not yet guarantee
+[ABI](https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html) forward
+compatibility.
 
 ## Plugins (experimental)
 
-LibSass can load plugins from directories. Just define `plugin_path` on context options to load all plugins from the given directories. To implement plugins, please consult the [[Wiki-Page for plugins|API-Plugins]].
+LibSass can load plugins from directories. Just define `plugin_path` on context
+options to load all plugins from the directories. To implement plugins, please
+consult the following example implementations.
+
+- https://github.com/mgreter/libsass-glob
+- https://github.com/mgreter/libsass-math
+- https://github.com/mgreter/libsass-digest
 
 ## Internal Structs
 

--- a/docs/api-function.md
+++ b/docs/api-function.md
@@ -32,6 +32,9 @@ typedef union Sass_Value* (*Sass_Function_Fn)
 // Creators for sass function list and function descriptors
 Sass_Function_List sass_make_function_list (size_t length);
 Sass_Function_Entry sass_make_function (const char* signature, Sass_Function_Fn cb, void* cookie);
+// In case you need to free them yourself
+void sass_delete_function (Sass_Function_Entry entry);
+void sass_delete_function_list (Sass_Function_List list);
 
 // Setters and getters for callbacks on function lists
 Sass_Function_Entry sass_function_get_list_entry(Sass_Function_List list, size_t pos);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1748,8 +1748,8 @@ namespace Sass {
     result_str = unquote(Util::rtrim(result_str)) + "\n{";
     Parser p = Parser::from_c_str(result_str.c_str(), ctx, s->pstate());
     p.last_media_block = s->media_block();
-    Selector_List_Obj sl = p.parse_selector_list(exp.block_stack.back()->is_root());
-    if (s->has_parent_ref()) sl->remove_parent_selectors();
+    bool root = exp.block_stack.back()->is_root();
+    Selector_List_Obj sl = p.parse_selector_list(root);
     return operator()(&sl);
   }
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -636,7 +636,11 @@ namespace Sass {
       // convert selector schema to a selector list
       else if (Selector_Schema_Obj schema = SASS_MEMORY_CAST(Selector_Schema, s)) {
         if (schema->has_real_parent_ref()) {
+          // put root block on stack again (ignore parents)
+          // selector schema must not connect in eval!
+          block_stack.push_back(block_stack.at(1));
           sl = eval(&schema);
+          block_stack.pop_back();
         } else {
           selector_stack.push_back(0);
           sl = eval(&schema);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1065,7 +1065,7 @@ namespace Sass {
       return SASS_MEMORY_NEW(List, pstate, 0, SASS_SPACE, false, true);
     }
 
-    bool has_paren = peek_css< exactly<'('> >();
+    bool has_paren = peek_css< exactly<'('> >() != NULL;
 
     // now try to parse a space list
     Expression_Obj list = parse_space_list();
@@ -1077,8 +1077,8 @@ namespace Sass {
         bracketed_list->append(&list);
         return &bracketed_list;
       }
-        l->is_bracketed(&list);
-        return &l;
+      l->is_bracketed(true);
+      return &l;
     }
 
     // if we got so far, we actually do have a comma list


### PR DESCRIPTION
This took me quite a few hours to figure out. In the end the fix is rather small, but it seems to be exactly the one needed. It looks like this was previousely "wrongly" fixed here: https://github.com/sass/libsass/pull/2004 (that probably introduced this regression).