### PR TITLE
Refactor `at_root` and `is_root` flags

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -454,7 +454,6 @@ namespace Sass {
   ////////////////////////
   class Block : public Statement, public Vectorized<Statement_Obj> {
     ADD_PROPERTY(bool, is_root)
-    ADD_PROPERTY(bool, is_at_root);
     // needed for properly formatted CSS emission
   protected:
     void adjust_after_pushing(Statement_Obj s)
@@ -464,14 +463,12 @@ namespace Sass {
     Block(ParserState pstate, size_t s = 0, bool r = false)
     : Statement(pstate),
       Vectorized<Statement_Obj>(s),
-      is_root_(r),
-      is_at_root_(false)
+      is_root_(r)
     { }
     Block(const Block* ptr)
     : Statement(ptr),
       Vectorized<Statement_Obj>(*ptr),
-      is_root_(ptr->is_root_),
-      is_at_root_(ptr->is_at_root_)
+      is_root_(ptr->is_root_)
     { }
     virtual bool has_content()
     {
@@ -510,16 +507,14 @@ namespace Sass {
   /////////////////////////////////////////////////////////////////////////////
   class Ruleset : public Has_Block {
     ADD_PROPERTY(Selector_Obj, selector)
-    ADD_PROPERTY(bool, at_root);
     ADD_PROPERTY(bool, is_root);
   public:
     Ruleset(ParserState pstate, Selector_Obj s = 0, Block_Obj b = 0)
-    : Has_Block(pstate, b), selector_(s), at_root_(false), is_root_(false)
+    : Has_Block(pstate, b), selector_(s), is_root_(false)
     { statement_type(RULESET); }
     Ruleset(const Ruleset* ptr)
     : Has_Block(ptr),
       selector_(ptr->selector_),
-      at_root_(ptr->at_root_),
       is_root_(ptr->is_root_)
     { statement_type(RULESET); }
     bool is_invisible() const;
@@ -2315,15 +2310,17 @@ namespace Sass {
   /////////////////////////////////////////////////////////////////////////
   class Selector_Schema : public Selector {
     ADD_PROPERTY(String_Obj, contents)
-    ADD_PROPERTY(bool, at_root);
+    ADD_PROPERTY(bool, connect_parent);
   public:
     Selector_Schema(ParserState pstate, String_Obj c)
-    : Selector(pstate), contents_(c), at_root_(false)
+    : Selector(pstate),
+      contents_(c),
+      connect_parent_(true)
     { }
     Selector_Schema(const Selector_Schema* ptr)
     : Selector(ptr),
       contents_(ptr->contents_),
-      at_root_(ptr->at_root_)
+      connect_parent_(ptr->connect_parent_)
     { }
     virtual bool has_parent_ref();
     virtual bool has_real_parent_ref();

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -255,8 +255,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     Selector_Schema_Ptr selector = dynamic_cast<Selector_Schema_Ptr>(node);
     std::cerr << ind << "Selector_Schema " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")"
-      << (selector->at_root() && selector->at_root() ? " [@ROOT]" : "")
       << " [@media:" << selector->media_block() << "]"
+      << (selector->connect_parent() ? " [connect-parent]": " -")
       << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
     << std::endl;
@@ -474,7 +474,6 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [indent: " << ruleset->tabs() << "]";
     std::cerr << (ruleset->is_invisible() ? " [INVISIBLE]" : "");
-    std::cerr << (ruleset->at_root() ? " [@ROOT]" : "");
     std::cerr << (ruleset->is_root() ? " [root]" : "");
     std::cerr << std::endl;
     debug_ast(&ruleset->selector(), ind + ">");

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1745,11 +1745,12 @@ namespace Sass {
     // the parser will look for a brace to end the selector
     Expression_Obj sel = s->contents()->perform(this);
     std::string result_str(sel->to_string(ctx.c_options));
-    result_str = unquote(Util::rtrim(result_str)) + "\n{";
+    result_str = unquote(Util::rtrim(result_str));
     Parser p = Parser::from_c_str(result_str.c_str(), ctx, s->pstate());
     p.last_media_block = s->media_block();
-    bool root = exp.block_stack.back()->is_root();
-    Selector_List_Obj sl = p.parse_selector_list(root);
+    // a selector schema may or may not connect to parent?
+    bool chroot = s->connect_parent() == false;
+    Selector_List_Obj sl = p.parse_selector_list(chroot);
     return operator()(&sl);
   }
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -166,7 +166,7 @@ namespace Sass {
       if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, exp)) {
         str->quote_mark(0);
       }
-      std::string exp_src = exp->to_string(ctx.c_options) + "{";
+      std::string exp_src = exp->to_string(ctx.c_options);
       return Parser::parse_selector(exp_src.c_str(), ctx);
     }
 
@@ -181,7 +181,7 @@ namespace Sass {
       if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, exp)) {
         str->quote_mark(0);
       }
-      std::string exp_src = exp->to_string(ctx.c_options) + "{";
+      std::string exp_src = exp->to_string(ctx.c_options);
       Selector_List_Obj sel_list = Parser::parse_selector(exp_src.c_str(), ctx);
       return (sel_list->length() > 0) ? &sel_list->first()->tail()->head() : 0;
     }
@@ -1772,7 +1772,7 @@ namespace Sass {
         if (String_Constant_Obj str = SASS_MEMORY_CAST(String_Constant, exp)) {
           str->quote_mark(0);
         }
-        std::string exp_src = exp->to_string(ctx.c_options) + "{";
+        std::string exp_src = exp->to_string(ctx.c_options);
         Selector_List_Obj sel = Parser::parse_selector(exp_src.c_str(), ctx);
         parsedSelectors.push_back(&sel);
       }
@@ -1825,7 +1825,7 @@ namespace Sass {
         if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, exp)) {
           str->quote_mark(0);
         }
-        std::string exp_src = exp->to_string() + "{";
+        std::string exp_src = exp->to_string();
         Selector_List_Obj sel = Parser::parse_selector(exp_src.c_str(), ctx);
         parsedSelectors.push_back(&sel);
       }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -39,12 +39,11 @@ namespace Sass {
 
 
     Token lexed;
-    bool in_at_root;
 
     Parser(Context& ctx, const ParserState& pstate)
     : ParserState(pstate), ctx(ctx), block_stack(), stack(0), last_media_block(),
       source(0), position(0), end(0), before_token(pstate), after_token(pstate), pstate(pstate), indentation(0)
-    { in_at_root = false; stack.push_back(Scope::Root); }
+    { stack.push_back(Scope::Root); }
 
     // static Parser from_string(const std::string& src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
     static Parser from_c_str(const char* src, Context& ctx, ParserState pstate = ParserState("[CSTRING]"), const char* source = 0);
@@ -240,10 +239,10 @@ namespace Sass {
     Arguments_Obj parse_arguments();
     Argument_Obj parse_argument();
     Assignment_Obj parse_assignment();
-    Ruleset_Obj parse_ruleset(Lookahead lookahead, bool is_root = false);
-    Selector_Schema_Obj parse_selector_schema(const char* end_of_selector);
-    Selector_List_Obj parse_selector_list(bool at_root = false);
-    Complex_Selector_Obj parse_complex_selector(bool in_root = true);
+    Ruleset_Obj parse_ruleset(Lookahead lookahead);
+    Selector_List_Obj parse_selector_list(bool chroot);
+    Complex_Selector_Obj parse_complex_selector(bool chroot);
+    Selector_Schema_Obj parse_selector_schema(const char* end_of_selector, bool chroot);
     Compound_Selector_Obj parse_compound_selector();
     Simple_Selector_Obj parse_simple_selector();
     Wrapped_Selector_Obj parse_negated_selector();


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/2295 (Specs: https://github.com/sass/sass-spec/pull/1061)