### PR TITLE
Cleanup initial shared ptr interface a bit

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -13,6 +13,7 @@ SOURCES = \
 	functions.cpp \
 	color_maps.cpp \
 	environment.cpp \
+	ast_fwd_decl.cpp \
 	bind.cpp \
 	file.cpp \
 	util.cpp \

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2280,7 +2280,7 @@ namespace Sass {
     return is_interpolant() || (right() && right()->is_right_interpolant());
   }
 
-  std::string AST_Node::to_string(Sass_Inspect_Options opt) const
+  const std::string AST_Node::to_string(Sass_Inspect_Options opt) const
   {
     Sass_Output_Options out(opt);
     Emitter emitter(out);
@@ -2291,7 +2291,7 @@ namespace Sass {
     return i.get_buffer();
   }
 
-  std::string AST_Node::to_string() const
+  const std::string AST_Node::to_string() const
   {
     return to_string({ NESTED, 5 });
   }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -829,7 +829,7 @@ namespace Sass {
 
     for (size_t i = 0, iL = length(); i < iL; ++i)
     {
-      Selector_Obj lhs = (*this)[i].ptr();
+      Selector_Obj lhs = (*this)[i];
       // very special case for wrapped matches selector
       if (Wrapped_Selector_Obj wrapped = Cast<Wrapped_Selector>(lhs)) {
         if (wrapped->name() == ":not") {
@@ -867,7 +867,7 @@ namespace Sass {
 
     for (size_t n = 0, nL = rhs->length(); n < nL; ++n)
     {
-      Selector_Obj r = (*rhs)[n].ptr();
+      Selector_Obj r = (*rhs)[n];
       if (Wrapped_Selector_Obj wrapped = Cast<Wrapped_Selector>(r)) {
         if (wrapped->name() == ":not") {
           if (Selector_List_Obj ls = Cast<Selector_List>(wrapped->selector())) {
@@ -2346,7 +2346,7 @@ namespace Sass {
       List_Obj l = SASS_MEMORY_NEW(List, pstate, 2);
       l->append(key);
       l->append(at(key));
-      ret->append(l.ptr());
+      ret->append(l);
     }
 
     return ret;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1628,9 +1628,9 @@ namespace Sass {
     return result;
   }
 
-  void Compound_Selector::mergeSources(SourcesSet& sources, Context& ctx)
+  void Compound_Selector::mergeSources(ComplexSelectorSet& sources, Context& ctx)
   {
-    for (SourcesSet::iterator iterator = sources.begin(), endIterator = sources.end(); iterator != endIterator; ++iterator) {
+    for (ComplexSelectorSet::iterator iterator = sources.begin(), endIterator = sources.end(); iterator != endIterator; ++iterator) {
       this->sources_.insert(SASS_MEMORY_CLONE(*iterator));
     }
   }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1250,8 +1250,12 @@ namespace Sass {
                 ss->tail(t ? SASS_MEMORY_CLONE(t) : NULL);
                 Compound_Selector_Obj h = SASS_MEMORY_COPY(head_);
                 // remove parent selector from sequence
-                if (h->length()) h->erase(h->begin());
-                ss->head(h->length() ? h.ptr() : NULL);
+                if (h->length()) {
+                  h->erase(h->begin());
+                  ss->head(h);
+                } else {
+                  ss->head(NULL);
+                }
                 // adjust for parent selector (1 char)
                 if (h->length()) {
                   ParserState state(h->at(0)->pstate());
@@ -1282,8 +1286,12 @@ namespace Sass {
               ss->tail(tail ? SASS_MEMORY_CLONE(tail) : NULL);
               Compound_Selector_Obj h = SASS_MEMORY_COPY(head_);
               // remove parent selector from sequence
-              if (h->length()) h->erase(h->begin());
-              ss->head(h->length() ? h.ptr() : NULL);
+              if (h->length()) {
+                h->erase(h->begin());
+                ss->head(h);
+              } else {
+                ss->head(NULL);
+              }
               // \/ IMO ruby sass bug \/
               ss->has_line_feed(false);
               // adjust for parent selector (1 char)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -335,29 +335,29 @@ namespace Sass {
 
   bool Selector::operator== (const Selector& rhs) const
   {
-    if (Selector_List_Ptr_Const sl = dynamic_cast<Selector_List_Ptr_Const>(this)) return *sl == rhs;
-    if (Simple_Selector_Ptr_Const sp = dynamic_cast<Simple_Selector_Ptr_Const>(this)) return *sp == rhs;
+    if (const Selector_List* sl = Cast<Selector_List>(this)) return *sl == rhs;
+    if (Simple_Selector_Ptr_Const sp = Cast<Simple_Selector>(this)) return *sp == rhs;
     throw std::runtime_error("invalid selector base classes to compare");
     return false;
   }
 
   bool Selector::operator< (const Selector& rhs) const
   {
-    if (Selector_List_Ptr_Const sl = dynamic_cast<Selector_List_Ptr_Const>(this)) return *sl < rhs;
-    if (Simple_Selector_Ptr_Const sp = dynamic_cast<Simple_Selector_Ptr_Const>(this)) return *sp < rhs;
+    if (Selector_List_Ptr_Const sl = Cast<Selector_List>(this)) return *sl < rhs;
+    if (Simple_Selector_Ptr_Const sp = Cast<Simple_Selector>(this)) return *sp < rhs;
     throw std::runtime_error("invalid selector base classes to compare");
     return false;
   }
 
   bool Simple_Selector::operator== (const Selector& rhs) const
   {
-    if (Simple_Selector_Ptr_Const sp = dynamic_cast<Simple_Selector_Ptr_Const>(&rhs)) return *this == *sp;
+    if (Simple_Selector_Ptr_Const sp = Cast<Simple_Selector>(&rhs)) return *this == *sp;
     return false;
   }
 
   bool Simple_Selector::operator< (const Selector& rhs) const
   {
-    if (Simple_Selector_Ptr_Const sp = dynamic_cast<Simple_Selector_Ptr_Const>(&rhs)) return *this < *sp;
+    if (Simple_Selector_Ptr_Const sp = Cast<Simple_Selector>(&rhs)) return *this < *sp;
     return false;
   }
 
@@ -365,13 +365,13 @@ namespace Sass {
   {
     Simple_Type type = simple_type();
     // dynamic cast is a bottleneck - use concrete type as types are final
-    if (type == PSEUDO_SEL /* Pseudo_Selector_Ptr_Const lp = dynamic_cast<Pseudo_Selector_Ptr_Const>(this) */) {
+    if (type == PSEUDO_SEL /* Pseudo_Selector_Ptr_Const lp = Cast<Pseudo_Selector>(this) */) {
       return *static_cast<Pseudo_Selector_Ptr_Const>(this) == rhs;
     }
-    else if (type == WRAPPED_SEL /* Wrapped_Selector_Ptr_Const lw = dynamic_cast<Wrapped_Selector_Ptr_Const>(this) */) {
+    else if (type == WRAPPED_SEL /* Wrapped_Selector_Ptr_Const lw = Cast<Wrapped_Selector>(this) */) {
       return *static_cast<Wrapped_Selector_Ptr_Const>(this) == rhs;
     }
-    else if (type == ATTR_SEL /* Attribute_Selector_Ptr_Const la = dynamic_cast<Attribute_Selector_Ptr_Const>(this) */) {
+    else if (type == ATTR_SEL /* Attribute_Selector_Ptr_Const la = Cast<Attribute_Selector>(this) */) {
       return *static_cast<Attribute_Selector_Ptr_Const>(this) == rhs;
     }
     else if (name_ == rhs.name_)
@@ -383,13 +383,13 @@ namespace Sass {
   {
     Simple_Type type = simple_type();
     // dynamic cast is a bottleneck - use concrete type as types are final
-    if (type == PSEUDO_SEL /* Pseudo_Selector_Ptr_Const lp = dynamic_cast<Pseudo_Selector_Ptr_Const>(this) */) {
+    if (type == PSEUDO_SEL /* Pseudo_Selector_Ptr_Const lp = Cast<Pseudo_Selector>(this) */) {
       return *static_cast<Pseudo_Selector_Ptr_Const>(this) < rhs;
     }
-    else if (type == WRAPPED_SEL /* Wrapped_Selector_Ptr_Const lw = dynamic_cast<Wrapped_Selector_Ptr_Const>(this) */) {
+    else if (type == WRAPPED_SEL /* Wrapped_Selector_Ptr_Const lw = Cast<Wrapped_Selector>(this) */) {
       return *static_cast<Wrapped_Selector_Ptr_Const>(this) < rhs;
     }
-    else if (type == ATTR_SEL /* Attribute_Selector_Ptr_Const la = dynamic_cast<Attribute_Selector_Ptr_Const>(this) */) {
+    else if (type == ATTR_SEL /* Attribute_Selector_Ptr_Const la = Cast<Attribute_Selector>(this) */) {
       return *static_cast<Attribute_Selector_Ptr_Const>(this) < rhs;
     }
     if (is_ns_eq(ns_, rhs.ns_))
@@ -400,9 +400,9 @@ namespace Sass {
   bool Selector_List::operator== (const Selector& rhs) const
   {
     // solve the double dispatch problem by using RTTI information via dynamic cast
-    if (Selector_List_Ptr_Const ls = dynamic_cast<Selector_List_Ptr_Const>(&rhs)) { return *this == *ls; }
-    else if (Complex_Selector_Ptr_Const ls = dynamic_cast<Complex_Selector_Ptr_Const>(&rhs)) { return *this == *ls; }
-    else if (Compound_Selector_Ptr_Const ls = dynamic_cast<Compound_Selector_Ptr_Const>(&rhs)) { return *this == *ls; }
+    if (Selector_List_Ptr_Const ls = Cast<Selector_List>(&rhs)) { return *this == *ls; }
+    else if (Complex_Selector_Ptr_Const ls = Cast<Complex_Selector>(&rhs)) { return *this == *ls; }
+    else if (Compound_Selector_Ptr_Const ls = Cast<Compound_Selector>(&rhs)) { return *this == *ls; }
     // no compare method
     return this == &rhs;
   }
@@ -411,8 +411,8 @@ namespace Sass {
   bool Selector_List::operator==(const Expression& rhs) const
   {
     // solve the double dispatch problem by using RTTI information via dynamic cast
-    if (List_Ptr_Const ls = dynamic_cast<List_Ptr_Const>(&rhs)) { return *this == *ls; }
-    if (Selector_Ptr_Const ls = dynamic_cast<Selector_Ptr_Const>(&rhs)) { return *this == *ls; }
+    if (List_Ptr_Const ls = Cast<List>(&rhs)) { return *this == *ls; }
+    if (Selector_Ptr_Const ls = Cast<Selector>(&rhs)) { return *this == *ls; }
     // compare invalid (maybe we should error?)
     return false;
   }
@@ -452,7 +452,7 @@ namespace Sass {
 
   bool Selector_List::operator< (const Selector& rhs) const
   {
-    if (Selector_List_Ptr_Const sp = dynamic_cast<Selector_List_Ptr_Const>(&rhs)) return *this < *sp;
+    if (Selector_List_Ptr_Const sp = Cast<Selector_List>(&rhs)) return *this < *sp;
     return false;
   }
 
@@ -626,7 +626,7 @@ namespace Sass {
 
   bool Attribute_Selector::operator< (const Simple_Selector& rhs) const
   {
-    if (Attribute_Selector_Ptr_Const w = dynamic_cast<Attribute_Selector_Ptr_Const>(&rhs))
+    if (Attribute_Selector_Ptr_Const w = Cast<Attribute_Selector>(&rhs))
     {
       return *this < *w;
     }
@@ -660,7 +660,7 @@ namespace Sass {
 
   bool Attribute_Selector::operator== (const Simple_Selector& rhs) const
   {
-    if (Attribute_Selector_Ptr_Const w = dynamic_cast<Attribute_Selector_Ptr_Const>(&rhs))
+    if (Attribute_Selector_Ptr_Const w = Cast<Attribute_Selector>(&rhs))
     {
       return *this == *w;
     }
@@ -683,7 +683,7 @@ namespace Sass {
 
   bool Pseudo_Selector::operator== (const Simple_Selector& rhs) const
   {
-    if (Pseudo_Selector_Ptr_Const w = dynamic_cast<Pseudo_Selector_Ptr_Const>(&rhs))
+    if (Pseudo_Selector_Ptr_Const w = Cast<Pseudo_Selector>(&rhs))
     {
       return *this == *w;
     }
@@ -708,7 +708,7 @@ namespace Sass {
 
   bool Pseudo_Selector::operator< (const Simple_Selector& rhs) const
   {
-    if (Pseudo_Selector_Ptr_Const w = dynamic_cast<Pseudo_Selector_Ptr_Const>(&rhs))
+    if (Pseudo_Selector_Ptr_Const w = Cast<Pseudo_Selector>(&rhs))
     {
       return *this < *w;
     }
@@ -726,7 +726,7 @@ namespace Sass {
 
   bool Wrapped_Selector::operator== (const Simple_Selector& rhs) const
   {
-    if (Wrapped_Selector_Ptr_Const w = dynamic_cast<Wrapped_Selector_Ptr_Const>(&rhs))
+    if (Wrapped_Selector_Ptr_Const w = Cast<Wrapped_Selector>(&rhs))
     {
       return *this == *w;
     }
@@ -746,7 +746,7 @@ namespace Sass {
 
   bool Wrapped_Selector::operator< (const Simple_Selector& rhs) const
   {
-    if (Wrapped_Selector_Ptr_Const w = dynamic_cast<Wrapped_Selector_Ptr_Const>(&rhs))
+    if (Wrapped_Selector_Ptr_Const w = Cast<Wrapped_Selector>(&rhs))
     {
       return *this < *w;
     }
@@ -852,7 +852,7 @@ namespace Sass {
         }
         Simple_Selector_Ptr rhs_sel = NULL;
         if (rhs->elements().size() > i) rhs_sel = (*rhs)[i];
-        if (Wrapped_Selector_Ptr wrapped_r = dynamic_cast<Wrapped_Selector_Ptr>(rhs_sel)) {
+        if (Wrapped_Selector_Ptr wrapped_r = Cast<Wrapped_Selector>(rhs_sel)) {
           if (wrapped->name() == wrapped_r->name()) {
           if (wrapped->is_superselector_of(wrapped_r)) {
              continue;
@@ -2097,7 +2097,7 @@ namespace Sass {
 
   bool Custom_Warning::operator== (const Expression& rhs) const
   {
-    if (Custom_Warning_Ptr_Const r = dynamic_cast<Custom_Warning_Ptr_Const>(&rhs)) {
+    if (Custom_Warning_Ptr_Const r = Cast<Custom_Warning>(&rhs)) {
       return message() == r->message();
     }
     return false;
@@ -2105,7 +2105,7 @@ namespace Sass {
 
   bool Custom_Error::operator== (const Expression& rhs) const
   {
-    if (Custom_Error_Ptr_Const r = dynamic_cast<Custom_Error_Ptr_Const>(&rhs)) {
+    if (Custom_Error_Ptr_Const r = Cast<Custom_Error>(&rhs)) {
       return message() == r->message();
     }
     return false;
@@ -2113,7 +2113,7 @@ namespace Sass {
 
   bool Number::eq (const Expression& rhs) const
   {
-    if (Number_Ptr_Const r = dynamic_cast<Number_Ptr_Const>(&rhs)) {
+    if (Number_Ptr_Const r = Cast<Number>(&rhs)) {
       size_t lhs_units = numerator_units_.size() + denominator_units_.size();
       size_t rhs_units = r->numerator_units_.size() + r->denominator_units_.size();
       if (!lhs_units && !rhs_units) {
@@ -2128,7 +2128,7 @@ namespace Sass {
 
   bool Number::operator== (const Expression& rhs) const
   {
-    if (Number_Ptr_Const r = dynamic_cast<Number_Ptr_Const>(&rhs)) {
+    if (Number_Ptr_Const r = Cast<Number>(&rhs)) {
       size_t lhs_units = numerator_units_.size() + denominator_units_.size();
       size_t rhs_units = r->numerator_units_.size() + r->denominator_units_.size();
       // unitless and only having one unit seems equivalent (will change in future)
@@ -2163,9 +2163,9 @@ namespace Sass {
 
   bool String_Quoted::operator== (const Expression& rhs) const
   {
-    if (String_Quoted_Ptr_Const qstr = dynamic_cast<String_Quoted_Ptr_Const>(&rhs)) {
+    if (String_Quoted_Ptr_Const qstr = Cast<String_Quoted>(&rhs)) {
       return (value() == qstr->value());
-    } else if (String_Constant_Ptr_Const cstr = dynamic_cast<String_Constant_Ptr_Const>(&rhs)) {
+    } else if (String_Constant_Ptr_Const cstr = Cast<String_Constant>(&rhs)) {
       return (value() == cstr->value());
     }
     return false;
@@ -2177,9 +2177,9 @@ namespace Sass {
 
   bool String_Constant::operator== (const Expression& rhs) const
   {
-    if (String_Quoted_Ptr_Const qstr = dynamic_cast<String_Quoted_Ptr_Const>(&rhs)) {
+    if (String_Quoted_Ptr_Const qstr = Cast<String_Quoted>(&rhs)) {
       return (value() == qstr->value());
-    } else if (String_Constant_Ptr_Const cstr = dynamic_cast<String_Constant_Ptr_Const>(&rhs)) {
+    } else if (String_Constant_Ptr_Const cstr = Cast<String_Constant>(&rhs)) {
       return (value() == cstr->value());
     }
     return false;
@@ -2196,7 +2196,7 @@ namespace Sass {
 
   bool String_Schema::operator== (const Expression& rhs) const
   {
-    if (String_Schema_Ptr_Const r = dynamic_cast<String_Schema_Ptr_Const>(&rhs)) {
+    if (String_Schema_Ptr_Const r = Cast<String_Schema>(&rhs)) {
       if (length() != r->length()) return false;
       for (size_t i = 0, L = length(); i < L; ++i) {
         Expression_Obj rv = (*r)[i];
@@ -2211,7 +2211,7 @@ namespace Sass {
 
   bool Boolean::operator== (const Expression& rhs) const
   {
-    if (Boolean_Ptr_Const r = dynamic_cast<Boolean_Ptr_Const>(&rhs)) {
+    if (Boolean_Ptr_Const r = Cast<Boolean>(&rhs)) {
       return (value() == r->value());
     }
     return false;
@@ -2219,7 +2219,7 @@ namespace Sass {
 
   bool Color::operator== (const Expression& rhs) const
   {
-    if (Color_Ptr_Const r = dynamic_cast<Color_Ptr_Const>(&rhs)) {
+    if (Color_Ptr_Const r = Cast<Color>(&rhs)) {
       return r_ == r->r() &&
              g_ == r->g() &&
              b_ == r->b() &&
@@ -2230,7 +2230,7 @@ namespace Sass {
 
   bool List::operator== (const Expression& rhs) const
   {
-    if (List_Ptr_Const r = dynamic_cast<List_Ptr_Const>(&rhs)) {
+    if (List_Ptr_Const r = Cast<List>(&rhs)) {
       if (length() != r->length()) return false;
       if (separator() != r->separator()) return false;
       if (is_bracketed() != r->is_bracketed()) return false;
@@ -2247,7 +2247,7 @@ namespace Sass {
 
   bool Map::operator== (const Expression& rhs) const
   {
-    if (Map_Ptr_Const r = dynamic_cast<Map_Ptr_Const>(&rhs)) {
+    if (Map_Ptr_Const r = Cast<Map>(&rhs)) {
       if (length() != r->length()) return false;
       for (auto key : keys()) {
         Expression_Obj lv = at(key);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -684,7 +684,7 @@ namespace Sass {
       String_Obj lhs_ex = expression();
       String_Obj rhs_ex = rhs.expression();
       if (rhs_ex && lhs_ex) return *lhs_ex == *rhs_ex;
-      else return lhs_ex == rhs_ex;
+      else return &lhs_ex == &rhs_ex;
     }
     else return false;
   }
@@ -707,7 +707,7 @@ namespace Sass {
       String_Obj lhs_ex = expression();
       String_Obj rhs_ex = rhs.expression();
       if (rhs_ex && lhs_ex) return *lhs_ex < *rhs_ex;
-      else return lhs_ex < rhs_ex;
+      else return &lhs_ex < &rhs_ex;
     }
     if (is_ns_eq(ns(), rhs.ns()))
     { return name() < rhs.name(); }
@@ -1403,7 +1403,7 @@ namespace Sass {
   Complex_Selector_Obj Complex_Selector::last()
   {
     // ToDo: implement with a while loop
-    return tail_? tail_->last() : this;
+    return &tail_ ? &tail_->last() : this;
   }
 
   Complex_Selector::Combinator Complex_Selector::clear_innermost()

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -94,7 +94,7 @@ namespace Sass {
   bool At_Root_Query::exclude(std::string str)
   {
     bool with = feature() && unquote(feature()->to_string()).compare("with") == 0;
-    List_Ptr l = static_cast<List_Ptr>(&value());
+    List_Ptr l = static_cast<List_Ptr>(value().ptr());
     std::string v;
 
     if (with)
@@ -189,23 +189,27 @@ namespace Sass {
     // const iterators for tails
     Complex_Selector_Ptr_Const l = this;
     Complex_Selector_Ptr_Const r = &rhs;
-    Compound_Selector_Ptr l_h = l ? &l->head() : 0;
-    Compound_Selector_Ptr r_h = r ? &r->head() : 0;
+    Compound_Selector_Ptr l_h = NULL;
+    Compound_Selector_Ptr r_h = NULL;
+    if (l) l_h = l->head();
+    if (r) r_h = r->head();
     // process all tails
     while (true)
     {
       // skip empty ancestor first
       if (l && l->is_empty_ancestor())
       {
-        l = &l->tail();
-        l_h = l ? &l->head() : 0;
+        l_h = NULL;
+        l = l->tail();
+        if(l) l_h = l->head();
         continue;
       }
       // skip empty ancestor first
       if (r && r->is_empty_ancestor())
       {
-        r = &r->tail();
-        r_h = r ? &r->head() : 0;
+        r_h = NULL;
+        r = r->tail();
+        if (r) r_h = r->head();
         continue;
       }
       // check for valid selectors
@@ -218,11 +222,12 @@ namespace Sass {
         if (l->combinator() != r->combinator())
         { return l->combinator() < r->combinator(); }
         // advance to next tails
-        l = &l->tail();
-        r = &r->tail();
+        l = l->tail();
+        r = r->tail();
         // fetch the next headers
-        l_h = l ? &l->head() : 0;
-        r_h = r ? &r->head() : 0;
+        l_h = NULL; r_h = NULL;
+        if (l) l_h = l->head();
+        if (r) r_h = r->head();
       }
       // one side is null
       else if (!r_h) return true;
@@ -234,11 +239,12 @@ namespace Sass {
         if (l->combinator() != r->combinator())
         { return l->combinator() < r->combinator(); }
         // advance to next tails
-        l = &l->tail();
-        r = &r->tail();
+        l = l->tail();
+        r = r->tail();
         // fetch the next headers
-        l_h = l ? &l->head() : 0;
-        r_h = r ? &r->head() : 0;
+        l_h = NULL; r_h = NULL;
+        if (l) l_h = l->head();
+        if (r) r_h = r->head();
       }
       // heads are not equal
       else return *l_h < *r_h;
@@ -251,23 +257,27 @@ namespace Sass {
     // const iterators for tails
     Complex_Selector_Ptr_Const l = this;
     Complex_Selector_Ptr_Const r = &rhs;
-    Compound_Selector_Ptr l_h = l ? &l->head() : 0;
-    Compound_Selector_Ptr r_h = r ? &r->head() : 0;
+    Compound_Selector_Ptr l_h = NULL;
+    Compound_Selector_Ptr r_h = NULL;
+    if (l) l_h = l->head();
+    if (r) r_h = r->head();
     // process all tails
     while (true)
     {
       // skip empty ancestor first
       if (l && l->is_empty_ancestor())
       {
-        l = &l->tail();
-        l_h = l ? &l->head() : 0;
+        l_h = NULL;
+        l = l->tail();
+        if (l) l_h = l->head();
         continue;
       }
       // skip empty ancestor first
       if (r && r->is_empty_ancestor())
       {
-        r = &r->tail();
-        r_h = r ? &r->head() : 0;
+        r_h = NULL;
+        r = r->tail();
+        if (r) r_h = r->head();
         continue;
       }
       // check the pointers
@@ -280,11 +290,12 @@ namespace Sass {
         if (l->combinator() != r->combinator())
         { return l->combinator() < r->combinator(); }
         // advance to next tails
-        l = &l->tail();
-        r = &r->tail();
+        l = l->tail();
+        r = r->tail();
         // fetch the next heads
-        l_h = l ? &l->head() : 0;
-        r_h = r ? &r->head() : 0;
+        l_h = NULL; r_h = NULL;
+        if (l) l_h = l->head();
+        if (r) r_h = r->head();
       }
       // equals if other head is empty
       else if ((!l_h && !r_h) ||
@@ -296,11 +307,12 @@ namespace Sass {
         if (l->combinator() != r->combinator())
         { return l->combinator() == r->combinator(); }
         // advance to next tails
-        l = &l->tail();
-        r = &r->tail();
+        l = l->tail();
+        r = r->tail();
         // fetch the next heads
-        l_h = l ? &l->head() : 0;
-        r_h = r ? &r->head() : 0;
+        l_h = NULL; r_h = NULL;
+        if (l) l_h = l->head();
+        if (r) r_h = r->head();
       }
       // abort
       else break;
@@ -316,7 +328,7 @@ namespace Sass {
     for (size_t i = 0, L = length(); i < L; ++i)
     {
       if (unified.isNull()) break;
-      unified = at(i)->unify_with(&unified, ctx);
+      unified = at(i)->unify_with(unified, ctx);
     }
     return unified.detach();
   }
@@ -527,7 +539,7 @@ namespace Sass {
       return rhs;
     }
 
-    Simple_Selector_Ptr rhs_0 = &rhs->at(0);
+    Simple_Selector_Ptr rhs_0 = rhs->at(0);
     // otherwise, this is a tag name
     if (name() == "*")
     {
@@ -664,7 +676,7 @@ namespace Sass {
       String_Obj lhs_ex = expression();
       String_Obj rhs_ex = rhs.expression();
       if (rhs_ex && lhs_ex) return *lhs_ex == *rhs_ex;
-      else return &lhs_ex == &rhs_ex;
+      else return lhs_ex.ptr() == rhs_ex.ptr();
     }
     else return false;
   }
@@ -687,7 +699,7 @@ namespace Sass {
       String_Obj lhs_ex = expression();
       String_Obj rhs_ex = rhs.expression();
       if (rhs_ex && lhs_ex) return *lhs_ex < *rhs_ex;
-      else return &lhs_ex < &rhs_ex;
+      else return lhs_ex.ptr() < rhs_ex.ptr();
     }
     if (is_ns_eq(ns(), rhs.ns()))
     { return name() < rhs.name(); }
@@ -761,14 +773,14 @@ namespace Sass {
   bool Compound_Selector::is_superselector_of(Selector_List_Obj rhs, std::string wrapped)
   {
     for (Complex_Selector_Obj item : rhs->elements()) {
-      if (is_superselector_of(&item, wrapped)) return true;
+      if (is_superselector_of(item, wrapped)) return true;
     }
     return false;
   }
 
   bool Compound_Selector::is_superselector_of(Complex_Selector_Obj rhs, std::string wrapped)
   {
-    if (rhs->head()) return is_superselector_of(&rhs->head(), wrapped);
+    if (rhs->head()) return is_superselector_of(rhs->head(), wrapped);
     return false;
   }
 
@@ -817,7 +829,7 @@ namespace Sass {
 
     for (size_t i = 0, iL = length(); i < iL; ++i)
     {
-      Selector_Obj lhs = &(*this)[i];
+      Selector_Obj lhs = (*this)[i].ptr();
       // very special case for wrapped matches selector
       if (Wrapped_Selector_Obj wrapped = SASS_MEMORY_CAST(Wrapped_Selector, lhs)) {
         if (wrapped->name() == ":not") {
@@ -838,7 +850,8 @@ namespace Sass {
             }
           }
         }
-        Simple_Selector_Ptr rhs_sel = rhs->elements().size() > i ? &(*rhs)[i] : 0;
+        Simple_Selector_Ptr rhs_sel = NULL;
+        if (rhs->elements().size() > i) rhs_sel = (*rhs)[i];
         if (Wrapped_Selector_Ptr wrapped_r = dynamic_cast<Wrapped_Selector_Ptr>(rhs_sel)) {
           if (wrapped->name() == wrapped_r->name()) {
           if (wrapped->is_superselector_of(wrapped_r)) {
@@ -854,7 +867,7 @@ namespace Sass {
 
     for (size_t n = 0, nL = rhs->length(); n < nL; ++n)
     {
-      Selector_Obj r = &(*rhs)[n];
+      Selector_Obj r = (*rhs)[n].ptr();
       if (Wrapped_Selector_Obj wrapped = SASS_MEMORY_CAST(Wrapped_Selector, r)) {
         if (wrapped->name() == ":not") {
           if (Selector_List_Obj ls = SASS_MEMORY_CAST(Selector_List, wrapped->selector())) {
@@ -921,7 +934,7 @@ namespace Sass {
     SASS_ASSERT(r_last_head, "rhs head is null");
 
     // get the unification of the last compound selectors
-    Compound_Selector_Obj unified = r_last_head->unify_with(&l_last_head, ctx);
+    Compound_Selector_Obj unified = r_last_head->unify_with(l_last_head, ctx);
 
     // abort if we could not unify heads
     if (unified == 0) return 0;
@@ -946,7 +959,7 @@ namespace Sass {
     {
       // create some temporaries to convert to node
       Complex_Selector_Obj fake = unified->to_complex();
-      Node unified_node = complexSelectorToNode(&fake, ctx);
+      Node unified_node = complexSelectorToNode(fake, ctx);
       // add to permutate the list?
       rhsNode.plus(unified_node);
     }
@@ -1019,7 +1032,7 @@ namespace Sass {
     { return false; }
 
     if (l_len == 1)
-    { return lhs->head()->is_superselector_of(&rhs->last()->head(), wrapping); }
+    { return lhs->head()->is_superselector_of(rhs->last()->head(), wrapping); }
 
     // we have to look one tail deeper, since we cary the
     // combinator around for it (which is important here)
@@ -1030,7 +1043,7 @@ namespace Sass {
       if (lhs_tail->head() && !rhs_tail->head()) return false;
       if (!lhs_tail->head() && rhs_tail->head()) return false;
       if (lhs_tail->head() && rhs_tail->head()) {
-        if (!lhs_tail->head()->is_superselector_of(&rhs_tail->head())) return false;
+        if (!lhs_tail->head()->is_superselector_of(rhs_tail->head())) return false;
       }
     }
 
@@ -1039,7 +1052,7 @@ namespace Sass {
     for (size_t i = 0, L = rhs->length(); i < L; ++i) {
       if (i == L-1)
       { return false; }
-      if (lhs->head() && marker->head() && lhs->head()->is_superselector_of(&marker->head(), wrapping))
+      if (lhs->head() && marker->head() && lhs->head()->is_superselector_of(marker->head(), wrapping))
       { found = true; break; }
       marker = marker->tail();
     }
@@ -1065,17 +1078,17 @@ namespace Sass {
       { return false; }
       if (!(lhs->combinator() == Complex_Selector::PRECEDES ? marker->combinator() != Complex_Selector::PARENT_OF : lhs->combinator() == marker->combinator()))
       { return false; }
-      return lhs->tail()->is_superselector_of(&marker->tail());
+      return lhs->tail()->is_superselector_of(marker->tail());
     }
     else if (marker->combinator() != Complex_Selector::ANCESTOR_OF)
     {
       if (marker->combinator() != Complex_Selector::PARENT_OF)
       { return false; }
-      return lhs->tail()->is_superselector_of(&marker->tail());
+      return lhs->tail()->is_superselector_of(marker->tail());
     }
     else
     {
-      return lhs->tail()->is_superselector_of(&marker->tail());
+      return lhs->tail()->is_superselector_of(marker->tail());
     }
     // catch-all
     return false;
@@ -1126,36 +1139,36 @@ namespace Sass {
             sqs->pstate((*h)[0]->pstate());
             (*rh)[rh->length()-1] = sqs;
             rh->pstate(h->pstate());
-            for (i = 1; i < L; ++i) rh->append(&(*h)[i]);
+            for (i = 1; i < L; ++i) rh->append((*h)[i]);
           } else if (Id_Selector_Ptr sq = SASS_MEMORY_CAST(Id_Selector, rh->last())) {
             Id_Selector_Ptr sqs = SASS_MEMORY_COPY(sq);
             sqs->name(sqs->name() + (*h)[0]->name());
             sqs->pstate((*h)[0]->pstate());
             (*rh)[rh->length()-1] = sqs;
             rh->pstate(h->pstate());
-            for (i = 1; i < L; ++i) rh->append(&(*h)[i]);
+            for (i = 1; i < L; ++i) rh->append((*h)[i]);
           } else if (Element_Selector_Ptr ts = SASS_MEMORY_CAST(Element_Selector, rh->last())) {
             Element_Selector_Ptr tss = SASS_MEMORY_COPY(ts);
             tss->name(tss->name() + (*h)[0]->name());
             tss->pstate((*h)[0]->pstate());
             (*rh)[rh->length()-1] = tss;
             rh->pstate(h->pstate());
-            for (i = 1; i < L; ++i) rh->append(&(*h)[i]);
+            for (i = 1; i < L; ++i) rh->append((*h)[i]);
           } else if (Placeholder_Selector_Ptr ps = SASS_MEMORY_CAST(Placeholder_Selector, rh->last())) {
             Placeholder_Selector_Ptr pss = SASS_MEMORY_COPY(ps);
             pss->name(pss->name() + (*h)[0]->name());
             pss->pstate((*h)[0]->pstate());
             (*rh)[rh->length()-1] = pss;
             rh->pstate(h->pstate());
-            for (i = 1; i < L; ++i) rh->append(&(*h)[i]);
+            for (i = 1; i < L; ++i) rh->append((*h)[i]);
           } else {
-            last()->head_->concat(&h);
+            last()->head_->concat(h);
           }
         } else {
-          last()->head_->concat(&h);
+          last()->head_->concat(h);
         }
       } else {
-        last()->head_->concat(&h);
+        last()->head_->concat(h);
       }
     } else {
       // std::cerr << "has no or empty head\n";
@@ -1184,11 +1197,11 @@ namespace Sass {
   {
     if (!this->has_parent_ref()) return this;
     Selector_List_Ptr ss = SASS_MEMORY_NEW(Selector_List, pstate());
-    Selector_List_Ptr ps = &pstack.back();
+    Selector_List_Ptr ps = pstack.back();
     for (size_t pi = 0, pL = ps->length(); pi < pL; ++pi) {
       for (size_t si = 0, sL = this->length(); si < sL; ++si) {
         Selector_List_Obj rv = at(si)->resolve_parent_refs(ctx, pstack, implicit_parent);
-        ss->concat(&rv);
+        ss->concat(rv);
       }
     }
     return ss;
@@ -1198,7 +1211,7 @@ namespace Sass {
   {
     Complex_Selector_Obj tail = this->tail();
     Compound_Selector_Obj head = this->head();
-    Selector_List_Ptr parents = &pstack.back();
+    Selector_List_Ptr parents = pstack.back();
 
     if (!this->has_real_parent_ref() && !implicit_parent) {
       Selector_List_Ptr retval = SASS_MEMORY_NEW(Selector_List, pstate());
@@ -1222,7 +1235,7 @@ namespace Sass {
         if (parents == NULL && head->has_real_parent_ref()) {
           int i = pstack.size() - 1;
           while (!parents && i > -1) {
-            parents = &pstack.at(i--);
+            parents = pstack.at(i--);
           }
         }
 
@@ -1234,11 +1247,11 @@ namespace Sass {
                 Complex_Selector_Obj parent = (*parents)[i];
                 Complex_Selector_Obj s = SASS_MEMORY_CLONE(parent);
                 Complex_Selector_Obj ss = SASS_MEMORY_CLONE(this);
-                ss->tail(t ? SASS_MEMORY_CLONE(t) : 0);
+                ss->tail(t ? SASS_MEMORY_CLONE(t) : NULL);
                 Compound_Selector_Obj h = SASS_MEMORY_COPY(head_);
                 // remove parent selector from sequence
                 if (h->length()) h->erase(h->begin());
-                ss->head(h->length() ? &h : 0);
+                ss->head(h->length() ? h.ptr() : NULL);
                 // adjust for parent selector (1 char)
                 if (h->length()) {
                   ParserState state(h->at(0)->pstate());
@@ -1264,13 +1277,13 @@ namespace Sass {
               // this is only if valid if the parent has no trailing op
               // otherwise we cannot append more simple selectors to head
               if (parent->last()->combinator() != ANCESTOR_OF) {
-                throw Exception::InvalidParent(&parent, &ss);
+                throw Exception::InvalidParent(parent, ss);
               }
-              ss->tail(tail ? SASS_MEMORY_CLONE(tail) : 0);
+              ss->tail(tail ? SASS_MEMORY_CLONE(tail) : NULL);
               Compound_Selector_Obj h = SASS_MEMORY_COPY(head_);
               // remove parent selector from sequence
               if (h->length()) h->erase(h->begin());
-              ss->head(h->length() ? &h : 0);
+              ss->head(h->length() ? h.ptr() : NULL);
               // \/ IMO ruby sass bug \/
               ss->has_line_feed(false);
               // adjust for parent selector (1 char)
@@ -1283,7 +1296,7 @@ namespace Sass {
               // keep old parser state
               s->pstate(pstate());
               // append new tail
-              s->append(ctx, &ss);
+              s->append(ctx, ss);
               retval->append(s);
             }
           }
@@ -1296,7 +1309,7 @@ namespace Sass {
               cpy->tail(SASS_MEMORY_CLONE(tails->at(n)));
               cpy->head(SASS_MEMORY_NEW(Compound_Selector, head->pstate()));
               for (size_t i = 1, L = this->head()->length(); i < L; ++i)
-                cpy->head()->append(&(*this->head())[i]);
+                cpy->head()->append((*this->head())[i]);
               if (!cpy->head()->length()) cpy->head(0);
               retval->append(cpy->skip_empty_reference());
             }
@@ -1306,7 +1319,7 @@ namespace Sass {
             Complex_Selector_Obj cpy = SASS_MEMORY_CLONE(this);
             cpy->head(SASS_MEMORY_NEW(Compound_Selector, head->pstate()));
             for (size_t i = 1, L = this->head()->length(); i < L; ++i)
-              cpy->head()->append(&(*this->head())[i]);
+              cpy->head()->append((*this->head())[i]);
             if (!cpy->head()->length()) cpy->head(0);
             retval->append(cpy->skip_empty_reference());
           }
@@ -1314,7 +1327,7 @@ namespace Sass {
       }
       // no parent selector in head
       else {
-        retval = this->tails(ctx, &tails);
+        retval = this->tails(ctx, tails);
       }
 
       for (Simple_Selector_Obj ss : head->elements()) {
@@ -1330,7 +1343,7 @@ namespace Sass {
     }
     // has no head
     else {
-      return this->tails(ctx, &tails);
+      return this->tails(ctx, tails);
     }
 
     // unreachable
@@ -1372,14 +1385,20 @@ namespace Sass {
       cur = cur->tail_;
     }
     // result
-    return &cur;
+    return cur;
   }
 
   // return the last tail that is defined
   Complex_Selector_Obj Complex_Selector::last()
   {
-    // ToDo: implement with a while loop
-    return &tail_ ? &tail_->last() : this;
+    Complex_Selector_Ptr cur = this;
+    Complex_Selector_Ptr nxt = cur;
+    // loop until last
+    while (nxt) {
+      cur = nxt;
+      nxt = cur->tail();
+    }
+    return cur;
   }
 
   Complex_Selector::Combinator Complex_Selector::clear_innermost()
@@ -1494,7 +1513,7 @@ namespace Sass {
   {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = sub->length(); i < L; ++i) {
-      if (!is_superselector_of(&(*sub)[i], wrapping)) return false;
+      if (!is_superselector_of((*sub)[i], wrapping)) return false;
     }
     return true;
   }
@@ -1505,7 +1524,7 @@ namespace Sass {
   {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = sub->length(); i < L; ++i) {
-      if (!is_superselector_of(&(*sub)[i], wrapping)) return false;
+      if (!is_superselector_of((*sub)[i], wrapping)) return false;
     }
     return true;
   }
@@ -1538,12 +1557,12 @@ namespace Sass {
     for (size_t lhs_i = 0, lhs_L = length(); lhs_i < lhs_L; ++lhs_i) {
       Complex_Selector_Obj seq1 = (*this)[lhs_i];
       for(size_t rhs_i = 0, rhs_L = rhs->length(); rhs_i < rhs_L; ++rhs_i) {
-        Complex_Selector_Ptr seq2 = &rhs->at(rhs_i);
+        Complex_Selector_Ptr seq2 = rhs->at(rhs_i);
 
         Selector_List_Obj result = seq1->unify_with(seq2, ctx);
         if( result ) {
           for(size_t i = 0, L = result->length(); i < L; ++i) {
-            unified_complex_selectors.push_back( &(*result)[i] );
+            unified_complex_selectors.push_back( (*result)[i] );
           }
         }
       }
@@ -1585,7 +1604,7 @@ namespace Sass {
       compound_sel->is_optional(extendee->is_optional());
 
       for (size_t i = 0, L = extender->length(); i < L; ++i) {
-        extends.put(compound_sel, std::make_pair(&(*extender)[i], &compound_sel));
+        extends.put(compound_sel, std::make_pair((*extender)[i], compound_sel));
       }
     }
   };
@@ -1622,7 +1641,7 @@ namespace Sass {
           break;
         }
       }
-      if (!found) result->append(&(*this)[i]);
+      if (!found) result->append((*this)[i]);
     }
 
     return result;
@@ -2244,7 +2263,7 @@ namespace Sass {
     // so we need to break before keywords
     for (size_t i = 0, L = length(); i < L; ++i) {
       Expression_Obj obj = this->at(i);
-      if (Argument* arg = dynamic_cast<Argument*>(&obj)) {
+      if (Argument_Ptr arg = SASS_MEMORY_CAST(Argument, obj)) {
         if (!arg->name().empty()) return i;
       }
     }
@@ -2299,13 +2318,13 @@ namespace Sass {
   Expression_Obj List::value_at_index(size_t i) {
     Expression_Obj obj = this->at(i);
     if (is_arglist_) {
-      if (Argument* arg = dynamic_cast<Argument*>(&obj)) {
+      if (Argument_Ptr arg = SASS_MEMORY_CAST(Argument, obj)) {
         return arg->value();
       } else {
-        return &obj;
+        return obj;
       }
     } else {
-      return &obj;
+      return obj;
     }
   }
 
@@ -2317,9 +2336,9 @@ namespace Sass {
 
     for (auto key : keys()) {
       List_Obj l = SASS_MEMORY_NEW(List, pstate, 2);
-      l->append(&key);
+      l->append(key);
       l->append(at(key));
-      ret->append(&l);
+      ret->append(l.ptr());
     }
 
     return ret;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -19,15 +19,15 @@ namespace Sass {
   static Null sass_null(ParserState("null"));
 
   bool Supports_Operator::needs_parens(Supports_Condition_Obj cond) const {
-    if (Supports_Operator_Obj op = SASS_MEMORY_CAST(Supports_Operator, cond)) {
+    if (Supports_Operator_Obj op = Cast<Supports_Operator>(cond)) {
       return op->operand() != operand();
     }
-    return SASS_MEMORY_CAST(Supports_Negation, cond) != NULL;
+    return Cast<Supports_Negation>(cond) != NULL;
   }
 
   bool Supports_Negation::needs_parens(Supports_Condition_Obj cond) const {
-    return SASS_MEMORY_CAST(Supports_Negation, cond) ||
-           SASS_MEMORY_CAST(Supports_Operator, cond);
+    return Cast<Supports_Negation>(cond) ||
+           Cast<Supports_Operator>(cond);
   }
 
   std::string & str_ltrim(std::string & str)
@@ -61,13 +61,13 @@ namespace Sass {
   void String_Schema::rtrim()
   {
     if (!empty()) {
-      if (String_Ptr str = SASS_MEMORY_CAST(String, last())) str->rtrim();
+      if (String_Ptr str = Cast<String>(last())) str->rtrim();
     }
   }
   void String_Schema::ltrim()
   {
     if (!empty()) {
-      if (String_Ptr str = SASS_MEMORY_CAST(String, first())) str->ltrim();
+      if (String_Ptr str = Cast<String>(first())) str->ltrim();
     }
   }
   void String_Schema::trim()
@@ -477,7 +477,7 @@ namespace Sass {
     {
       for (i = 0, L = rhs->length(); i < L; ++i)
       {
-        if ((SASS_MEMORY_CAST(Pseudo_Selector, (*rhs)[i]) || SASS_MEMORY_CAST(Wrapped_Selector, (*rhs)[i])) && (*rhs)[L-1]->is_pseudo_element())
+        if ((Cast<Pseudo_Selector>((*rhs)[i]) || Cast<Wrapped_Selector>((*rhs)[i])) && (*rhs)[L-1]->is_pseudo_element())
         { found = true; break; }
       }
     }
@@ -485,7 +485,7 @@ namespace Sass {
     {
       for (i = 0, L = rhs->length(); i < L; ++i)
       {
-        if (SASS_MEMORY_CAST(Pseudo_Selector, (*rhs)[i]) || SASS_MEMORY_CAST(Wrapped_Selector, (*rhs)[i]))
+        if (Cast<Pseudo_Selector>((*rhs)[i]) || Cast<Wrapped_Selector>((*rhs)[i]))
         { found = true; break; }
       }
     }
@@ -546,11 +546,11 @@ namespace Sass {
       if (typeid(*rhs_0) == typeid(Element_Selector))
       {
         // if rhs is universal, just return this tagname + rhs's qualifiers
-        Element_Selector_Ptr ts = SASS_MEMORY_CAST_PTR(Element_Selector, rhs_0);
+        Element_Selector_Ptr ts = Cast<Element_Selector>(rhs_0);
         rhs->at(0) = this->unify_with(ts, ctx);
         return rhs;
       }
-      else if (SASS_MEMORY_CAST_PTR(Class_Selector, rhs_0) || SASS_MEMORY_CAST_PTR(Id_Selector, rhs_0)) {
+      else if (Cast<Class_Selector>(rhs_0) || Cast<Id_Selector>(rhs_0)) {
         // qualifier is `.class`, so we can prefix with `ns|*.class`
         if (has_ns() && !rhs_0->has_ns()) {
           if (ns() != "*") rhs->elements().insert(rhs->begin(), this);
@@ -586,7 +586,7 @@ namespace Sass {
   {
     for (size_t i = 0, L = rhs->length(); i < L; ++i)
     {
-      if (Id_Selector_Ptr sel = SASS_MEMORY_CAST(Id_Selector, rhs->at(i))) {
+      if (Id_Selector_Ptr sel = Cast<Id_Selector>(rhs->at(i))) {
         if (sel->name() != name()) return 0;
       }
     }
@@ -600,7 +600,7 @@ namespace Sass {
     {
       for (size_t i = 0, L = rhs->length(); i < L; ++i)
       {
-        if (Pseudo_Selector_Ptr sel = SASS_MEMORY_CAST(Pseudo_Selector, rhs->at(i))) {
+        if (Pseudo_Selector_Ptr sel = Cast<Pseudo_Selector>(rhs->at(i))) {
           if (sel->is_pseudo_element() && sel->name() != name()) return 0;
         }
       }
@@ -759,8 +759,8 @@ namespace Sass {
   {
     if (this->name() != sub->name()) return false;
     if (this->name() == ":current") return false;
-    if (Selector_List_Obj rhs_list = SASS_MEMORY_CAST(Selector_List, sub->selector())) {
-      if (Selector_List_Obj lhs_list = SASS_MEMORY_CAST(Selector_List, selector())) {
+    if (Selector_List_Obj rhs_list = Cast<Selector_List>(sub->selector())) {
+      if (Selector_List_Obj lhs_list = Cast<Selector_List>(selector())) {
         return lhs_list->is_superselector_of(rhs_list);
       }
       error("is_superselector expected a Selector_List", sub->pstate());
@@ -831,9 +831,9 @@ namespace Sass {
     {
       Selector_Obj lhs = (*this)[i].ptr();
       // very special case for wrapped matches selector
-      if (Wrapped_Selector_Obj wrapped = SASS_MEMORY_CAST(Wrapped_Selector, lhs)) {
+      if (Wrapped_Selector_Obj wrapped = Cast<Wrapped_Selector>(lhs)) {
         if (wrapped->name() == ":not") {
-          if (Selector_List_Obj not_list = SASS_MEMORY_CAST(Selector_List, wrapped->selector())) {
+          if (Selector_List_Obj not_list = Cast<Selector_List>(wrapped->selector())) {
             if (not_list->is_superselector_of(rhs, wrapped->name())) return false;
           } else {
             throw std::runtime_error("wrapped not selector is not a list");
@@ -841,8 +841,8 @@ namespace Sass {
         }
         if (wrapped->name() == ":matches" || wrapped->name() == ":-moz-any") {
           lhs = wrapped->selector();
-          if (Selector_List_Obj list = SASS_MEMORY_CAST(Selector_List, wrapped->selector())) {
-            if (Compound_Selector_Obj comp = SASS_MEMORY_CAST(Compound_Selector, rhs)) {
+          if (Selector_List_Obj list = Cast<Selector_List>(wrapped->selector())) {
+            if (Compound_Selector_Obj comp = Cast<Compound_Selector>(rhs)) {
               if (!wrapping.empty() && wrapping != wrapped->name()) return false;
               if (wrapping.empty() || wrapping != wrapped->name()) {;
                 if (list->is_superselector_of(comp, wrapped->name())) return true;
@@ -868,9 +868,9 @@ namespace Sass {
     for (size_t n = 0, nL = rhs->length(); n < nL; ++n)
     {
       Selector_Obj r = (*rhs)[n].ptr();
-      if (Wrapped_Selector_Obj wrapped = SASS_MEMORY_CAST(Wrapped_Selector, r)) {
+      if (Wrapped_Selector_Obj wrapped = Cast<Wrapped_Selector>(r)) {
         if (wrapped->name() == ":not") {
-          if (Selector_List_Obj ls = SASS_MEMORY_CAST(Selector_List, wrapped->selector())) {
+          if (Selector_List_Obj ls = Cast<Selector_List>(wrapped->selector())) {
             ls->remove_parent_selectors();
             if (is_superselector_of(ls, wrapped->name())) return false;
           }
@@ -879,7 +879,7 @@ namespace Sass {
           if (!wrapping.empty()) {
             if (wrapping != wrapped->name()) return false;
           }
-          if (Selector_List_Obj ls = SASS_MEMORY_CAST(Selector_List, wrapped->selector())) {
+          if (Selector_List_Obj ls = Cast<Selector_List>(wrapped->selector())) {
             ls->remove_parent_selectors();
             return (is_superselector_of(ls, wrapped->name()));
           }
@@ -1132,29 +1132,29 @@ namespace Sass {
       } else if (last()->head_ && last()->head_->length()) {
         Compound_Selector_Obj rh = last()->head();
         size_t i = 0, L = h->length();
-        if (SASS_MEMORY_CAST(Element_Selector, h->first())) {
-          if (Class_Selector_Ptr sq = SASS_MEMORY_CAST(Class_Selector, rh->last())) {
+        if (Cast<Element_Selector>(h->first())) {
+          if (Class_Selector_Ptr sq = Cast<Class_Selector>(rh->last())) {
             Class_Selector_Ptr sqs = SASS_MEMORY_COPY(sq);
             sqs->name(sqs->name() + (*h)[0]->name());
             sqs->pstate((*h)[0]->pstate());
             (*rh)[rh->length()-1] = sqs;
             rh->pstate(h->pstate());
             for (i = 1; i < L; ++i) rh->append((*h)[i]);
-          } else if (Id_Selector_Ptr sq = SASS_MEMORY_CAST(Id_Selector, rh->last())) {
+          } else if (Id_Selector_Ptr sq = Cast<Id_Selector>(rh->last())) {
             Id_Selector_Ptr sqs = SASS_MEMORY_COPY(sq);
             sqs->name(sqs->name() + (*h)[0]->name());
             sqs->pstate((*h)[0]->pstate());
             (*rh)[rh->length()-1] = sqs;
             rh->pstate(h->pstate());
             for (i = 1; i < L; ++i) rh->append((*h)[i]);
-          } else if (Element_Selector_Ptr ts = SASS_MEMORY_CAST(Element_Selector, rh->last())) {
+          } else if (Element_Selector_Ptr ts = Cast<Element_Selector>(rh->last())) {
             Element_Selector_Ptr tss = SASS_MEMORY_COPY(ts);
             tss->name(tss->name() + (*h)[0]->name());
             tss->pstate((*h)[0]->pstate());
             (*rh)[rh->length()-1] = tss;
             rh->pstate(h->pstate());
             for (i = 1; i < L; ++i) rh->append((*h)[i]);
-          } else if (Placeholder_Selector_Ptr ps = SASS_MEMORY_CAST(Placeholder_Selector, rh->last())) {
+          } else if (Placeholder_Selector_Ptr ps = Cast<Placeholder_Selector>(rh->last())) {
             Placeholder_Selector_Ptr pss = SASS_MEMORY_COPY(ps);
             pss->name(pss->name() + (*h)[0]->name());
             pss->pstate((*h)[0]->pstate());
@@ -1227,7 +1227,7 @@ namespace Sass {
       Selector_List_Obj retval;
       // we have a parent selector in a simple compound list
       // mix parent complex selector into the compound list
-      if (SASS_MEMORY_CAST(Parent_Selector, (*head)[0])) {
+      if (Cast<Parent_Selector>((*head)[0])) {
         retval = SASS_MEMORY_NEW(Selector_List, pstate());
 
         // it turns out that real parent references reach
@@ -1339,8 +1339,8 @@ namespace Sass {
       }
 
       for (Simple_Selector_Obj ss : head->elements()) {
-        if (Wrapped_Selector_Ptr ws = SASS_MEMORY_CAST(Wrapped_Selector, ss)) {
-          if (Selector_List_Ptr sl = SASS_MEMORY_CAST(Selector_List, ws->selector())) {
+        if (Wrapped_Selector_Ptr ws = Cast<Wrapped_Selector>(ss)) {
+          if (Selector_List_Ptr sl = Cast<Selector_List>(ws->selector())) {
             if (parents) ws->selector(sl->resolve_parent_refs(ctx, pstack, implicit_parent));
           }
         }
@@ -1386,7 +1386,7 @@ namespace Sass {
       // get the head
       head = cur->head_;
       // abort (and return) if it is not a parent selector
-      if (!head || head->length() != 1 || !SASS_MEMORY_CAST(Parent_Selector, (*head)[0])) {
+      if (!head || head->length() != 1 || !Cast<Parent_Selector>((*head)[0])) {
         break;
       }
       // advance to next
@@ -1495,16 +1495,16 @@ namespace Sass {
 
   bool Selector_Schema::has_parent_ref()
   {
-    if (String_Schema_Obj schema = SASS_MEMORY_CAST(String_Schema, contents())) {
-      return schema->length() > 0 && SASS_MEMORY_CAST(Parent_Selector, schema->at(0)) != NULL;
+    if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
+      return schema->length() > 0 && Cast<Parent_Selector>(schema->at(0)) != NULL;
     }
     return false;
   }
 
   bool Selector_Schema::has_real_parent_ref()
   {
-    if (String_Schema_Obj schema = SASS_MEMORY_CAST(String_Schema, contents())) {
-      Parent_Selector_Obj p = SASS_MEMORY_CAST(Parent_Selector, schema->at(0));
+    if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
+      Parent_Selector_Obj p = Cast<Parent_Selector>(schema->at(0));
       return schema->length() > 0 && p && p->is_real_parent_ref();
     }
     return false;
@@ -1597,7 +1597,7 @@ namespace Sass {
       Complex_Selector_Obj pIter = complex_sel;
       while (pIter) {
         Compound_Selector_Obj pHead = pIter->head();
-        if (pHead && SASS_MEMORY_CAST(Parent_Selector, pHead->elements()[0]) == NULL) {
+        if (pHead && Cast<Parent_Selector>(pHead->elements()[0]) == NULL) {
           compound_sel = pHead;
           break;
         }
@@ -1720,7 +1720,7 @@ namespace Sass {
   }
 
   bool Ruleset::is_invisible() const {
-    if (Selector_List_Ptr sl = SASS_MEMORY_CAST(Selector_List, selector())) {
+    if (Selector_List_Ptr sl = Cast<Selector_List>(selector())) {
       for (size_t i = 0, L = sl->length(); i < L; ++i)
         if (!(*sl)[i]->has_placeholder()) return false;
     }
@@ -2271,7 +2271,7 @@ namespace Sass {
     // so we need to break before keywords
     for (size_t i = 0, L = length(); i < L; ++i) {
       Expression_Obj obj = this->at(i);
-      if (Argument_Ptr arg = SASS_MEMORY_CAST(Argument, obj)) {
+      if (Argument_Ptr arg = Cast<Argument>(obj)) {
         if (!arg->name().empty()) return i;
       }
     }
@@ -2326,7 +2326,7 @@ namespace Sass {
   Expression_Obj List::value_at_index(size_t i) {
     Expression_Obj obj = this->at(i);
     if (is_arglist_) {
-      if (Argument_Ptr arg = SASS_MEMORY_CAST(Argument, obj)) {
+      if (Argument_Ptr arg = Cast<Argument>(obj)) {
         return arg->value();
       } else {
         return obj;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -620,16 +620,13 @@ namespace Sass {
         if (matcher() == rhs.matcher()) {
           bool no_lhs_val = value().isNull();
           bool no_rhs_val = rhs.value().isNull();
-          if (no_lhs_val && no_rhs_val) {
-            return true;
-          }
-          if (!no_lhs_val && !no_rhs_val) {
-            return *value() < *rhs.value();
-          }
+          if (no_lhs_val && no_rhs_val) return false; // equal
+          else if (no_lhs_val) return true; // lhs is null
+          else if (no_rhs_val) return false; // rhs is null
+          return *value() < *rhs.value(); // both are given
         } else { return matcher() < rhs.matcher(); }
       } else { return name() < rhs.name(); }
-    }
-    return false;
+    } else { return ns() < rhs.ns(); }
   }
 
   bool Attribute_Selector::operator< (const Simple_Selector& rhs) const

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -363,17 +363,10 @@ namespace Sass {
 
   bool Simple_Selector::operator== (const Simple_Selector& rhs) const
   {
-    Simple_Type type = simple_type();
-    // dynamic cast is a bottleneck - use concrete type as types are final
-    if (type == PSEUDO_SEL /* Pseudo_Selector_Ptr_Const lp = Cast<Pseudo_Selector>(this) */) {
-      return *static_cast<Pseudo_Selector_Ptr_Const>(this) == rhs;
-    }
-    else if (type == WRAPPED_SEL /* Wrapped_Selector_Ptr_Const lw = Cast<Wrapped_Selector>(this) */) {
-      return *static_cast<Wrapped_Selector_Ptr_Const>(this) == rhs;
-    }
-    else if (type == ATTR_SEL /* Attribute_Selector_Ptr_Const la = Cast<Attribute_Selector>(this) */) {
-      return *static_cast<Attribute_Selector_Ptr_Const>(this) == rhs;
-    }
+    // solve the double dispatch problem by using RTTI information via dynamic cast
+    if (const Pseudo_Selector* lhs = Cast<Pseudo_Selector>(this)) {return *lhs == rhs; }
+    else if (const Wrapped_Selector* lhs = Cast<Wrapped_Selector>(this)) {return *lhs == rhs; }
+    else if (const Attribute_Selector* lhs = Cast<Attribute_Selector>(this)) {return *lhs == rhs; }
     else if (name_ == rhs.name_)
     { return is_ns_eq(ns_, rhs.ns_); }
     else return false;
@@ -381,17 +374,10 @@ namespace Sass {
 
   bool Simple_Selector::operator< (const Simple_Selector& rhs) const
   {
-    Simple_Type type = simple_type();
-    // dynamic cast is a bottleneck - use concrete type as types are final
-    if (type == PSEUDO_SEL /* Pseudo_Selector_Ptr_Const lp = Cast<Pseudo_Selector>(this) */) {
-      return *static_cast<Pseudo_Selector_Ptr_Const>(this) < rhs;
-    }
-    else if (type == WRAPPED_SEL /* Wrapped_Selector_Ptr_Const lw = Cast<Wrapped_Selector>(this) */) {
-      return *static_cast<Wrapped_Selector_Ptr_Const>(this) < rhs;
-    }
-    else if (type == ATTR_SEL /* Attribute_Selector_Ptr_Const la = Cast<Attribute_Selector>(this) */) {
-      return *static_cast<Attribute_Selector_Ptr_Const>(this) < rhs;
-    }
+    // solve the double dispatch problem by using RTTI information via dynamic cast
+    if (const Pseudo_Selector* lhs = Cast<Pseudo_Selector>(this)) {return *lhs < rhs; }
+    else if (const Wrapped_Selector* lhs = Cast<Wrapped_Selector>(this)) {return *lhs < rhs; }
+    else if (const Attribute_Selector* lhs = Cast<Attribute_Selector>(this)) {return *lhs < rhs; }
     if (is_ns_eq(ns_, rhs.ns_))
     { return name_ < rhs.name_; }
     return ns_ < rhs.ns_;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -30,23 +30,14 @@ namespace Sass {
            Cast<Supports_Operator>(cond);
   }
 
-  std::string & str_ltrim(std::string & str)
+  void str_rtrim(std::string& str, const std::string& delimiters = " \f\n\r\t\v")
   {
-    auto it2 =  std::find_if( str.begin() , str.end() , [](char ch){ return !std::isspace<char>(ch , std::locale::classic() ) ; } );
-    str.erase( str.begin() , it2);
-    return str;
-  }
-
-  std::string & str_rtrim(std::string & str)
-  {
-    auto it1 =  std::find_if( str.rbegin() , str.rend() , [](char ch){ return !std::isspace<char>(ch , std::locale::classic() ) ; } );
-    str.erase( it1.base() , str.end() );
-    return str;
+    str.erase( str.find_last_not_of( delimiters ) + 1 );
   }
 
   void String_Constant::rtrim()
   {
-    value_ = str_rtrim(value_);
+    str_rtrim(value_);
   }
 
   void String_Schema::rtrim()

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -166,6 +166,7 @@ namespace Sass {
     // process all tails
     while (true)
     {
+      #ifdef DEBUG
       // skip empty ancestor first
       if (l && l->is_empty_ancestor())
       {
@@ -182,6 +183,7 @@ namespace Sass {
         if (r) r_h = r->head();
         continue;
       }
+      #endif
       // check for valid selectors
       if (!l) return !!r;
       if (!r) return false;
@@ -234,6 +236,7 @@ namespace Sass {
     // process all tails
     while (true)
     {
+      #ifdef DEBUG
       // skip empty ancestor first
       if (l && l->is_empty_ancestor())
       {
@@ -250,6 +253,7 @@ namespace Sass {
         if (r) r_h = r->head();
         continue;
       }
+      #endif
       // check the pointers
       if (!r) return !l;
       if (!l) return !r;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -30,23 +30,6 @@ namespace Sass {
            SASS_MEMORY_CAST(Supports_Operator, cond);
   }
 
-  size_t HashExpression::operator() (Expression_Obj ex) const {
-    return ex ? ex->hash() : 0;
-  }
-
-  size_t HashSimpleSelector::operator() (Simple_Selector_Obj ex) const {
-    return ex ? ex->hash() : 0;
-  }
-
-
-  bool CompareExpression::operator()(const Expression_Obj& lhs, const Expression_Obj& rhs) const {
-    return lhs && rhs && lhs->eq(*rhs);
-  }
-
-  bool CompareSimpleSelector::operator()(Simple_Selector_Obj lhs, Simple_Selector_Obj rhs) const {
-    return &lhs && &rhs && *lhs == *rhs;
-  }
-
   std::string & str_ltrim(std::string & str)
   {
     auto it2 =  std::find_if( str.begin() , str.end() , [](char ch){ return !std::isspace<char>(ch , std::locale::classic() ) ; } );
@@ -431,8 +414,8 @@ namespace Sass {
     // create temporary vectors and sort them
     std::vector<Complex_Selector_Obj> l_lst = this->elements();
     std::vector<Complex_Selector_Obj> r_lst = rhs.elements();
-    std::sort(l_lst.begin(), l_lst.end(), cmp_complex_selector());
-    std::sort(r_lst.begin(), r_lst.end(), cmp_complex_selector());
+    std::sort(l_lst.begin(), l_lst.end(), OrderNodes());
+    std::sort(r_lst.begin(), r_lst.end(), OrderNodes());
     // process loop
     while (true)
     {
@@ -989,8 +972,8 @@ namespace Sass {
     // create temporary vectors and sort them
     std::vector<Simple_Selector_Obj> l_lst = this->elements();
     std::vector<Simple_Selector_Obj> r_lst = rhs.elements();
-    std::sort(l_lst.begin(), l_lst.end(), cmp_simple_selector());
-    std::sort(r_lst.begin(), r_lst.end(), cmp_simple_selector());
+    std::sort(l_lst.begin(), l_lst.end(), OrderNodes());
+    std::sort(r_lst.begin(), r_lst.end(), OrderNodes());
     // process loop
     while (true)
     {
@@ -1011,10 +994,6 @@ namespace Sass {
     }
     // no mismatch
     return true;
-  }
-
-  bool Complex_Selector_Pointer_Compare::operator() (const Complex_Selector_Obj& pLeft, const Complex_Selector_Obj& pRight) const {
-    return *pLeft < *pRight;
   }
 
   bool Complex_Selector::is_superselector_of(Compound_Selector_Obj rhs, std::string wrapping)

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -307,18 +307,63 @@ namespace Sass {
     return unified.detach();
   }
 
-  bool Selector::operator== (const Selector& rhs) const
+  bool Complex_Selector::operator== (const Selector& rhs) const
   {
-    if (const Selector_List* sl = Cast<Selector_List>(this)) return *sl == rhs;
-    if (Simple_Selector_Ptr_Const sp = Cast<Simple_Selector>(this)) return *sp == rhs;
+    if (const Selector_List* sl = Cast<Selector_List>(&rhs)) return *this == *sl;
+    if (const Simple_Selector* sp = Cast<Simple_Selector>(&rhs)) return *this == *sp;
+    if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this == *cs;
+    if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this == *ch;
     throw std::runtime_error("invalid selector base classes to compare");
     return false;
   }
 
-  bool Selector::operator< (const Selector& rhs) const
+
+  bool Complex_Selector::operator< (const Selector& rhs) const
   {
-    if (Selector_List_Ptr_Const sl = Cast<Selector_List>(this)) return *sl < rhs;
-    if (Simple_Selector_Ptr_Const sp = Cast<Simple_Selector>(this)) return *sp < rhs;
+    if (const Selector_List* sl = Cast<Selector_List>(&rhs)) return *this < *sl;
+    if (const Simple_Selector* sp = Cast<Simple_Selector>(&rhs)) return *this < *sp;
+    if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this < *cs;
+    if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this < *ch;
+    throw std::runtime_error("invalid selector base classes to compare");
+    return false;
+  }
+
+  bool Compound_Selector::operator== (const Selector& rhs) const
+  {
+    if (const Selector_List* sl = Cast<Selector_List>(&rhs)) return *this == *sl;
+    if (const Simple_Selector* sp = Cast<Simple_Selector>(&rhs)) return *this == *sp;
+    if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this == *cs;
+    if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this == *ch;
+    throw std::runtime_error("invalid selector base classes to compare");
+    return false;
+  }
+
+  bool Compound_Selector::operator< (const Selector& rhs) const
+  {
+    if (const Selector_List* sl = Cast<Selector_List>(&rhs)) return *this < *sl;
+    if (const Simple_Selector* sp = Cast<Simple_Selector>(&rhs)) return *this < *sp;
+    if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this < *cs;
+    if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this < *ch;
+    throw std::runtime_error("invalid selector base classes to compare");
+    return false;
+  }
+
+  bool Selector_Schema::operator== (const Selector& rhs) const
+  {
+    if (const Selector_List* sl = Cast<Selector_List>(&rhs)) return *this == *sl;
+    if (const Simple_Selector* sp = Cast<Simple_Selector>(&rhs)) return *this == *sp;
+    if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this == *cs;
+    if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this == *ch;
+    throw std::runtime_error("invalid selector base classes to compare");
+    return false;
+  }
+
+  bool Selector_Schema::operator< (const Selector& rhs) const
+  {
+    if (const Selector_List* sl = Cast<Selector_List>(&rhs)) return *this < *sl;
+    if (const Simple_Selector* sp = Cast<Simple_Selector>(&rhs)) return *this < *sp;
+    if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this < *cs;
+    if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this < *ch;
     throw std::runtime_error("invalid selector base classes to compare");
     return false;
   }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -48,32 +48,12 @@ namespace Sass {
   {
     value_ = str_rtrim(value_);
   }
-  void String_Constant::ltrim()
-  {
-    value_ = str_ltrim(value_);
-  }
-  void String_Constant::trim()
-  {
-    rtrim();
-    ltrim();
-  }
 
   void String_Schema::rtrim()
   {
     if (!empty()) {
       if (String_Ptr str = Cast<String>(last())) str->rtrim();
     }
-  }
-  void String_Schema::ltrim()
-  {
-    if (!empty()) {
-      if (String_Ptr str = Cast<String>(first())) str->ltrim();
-    }
-  }
-  void String_Schema::trim()
-  {
-    rtrim();
-    ltrim();
   }
 
   void Argument::set_delayed(bool delayed)
@@ -122,11 +102,6 @@ namespace Sass {
   void AST_Node::update_pstate(const ParserState& pstate)
   {
     pstate_.offset += pstate - pstate_ + pstate.offset;
-  }
-
-  void AST_Node::set_pstate_offset(const Offset& offset)
-  {
-    pstate_.offset = offset;
   }
 
   bool Simple_Selector::is_ns_eq(const Simple_Selector& r) const
@@ -655,9 +630,8 @@ namespace Sass {
     {
       return *this == *w;
     }
-    if (is_ns_eq(rhs))
-    { return name() == rhs.name(); }
-    return ns() == rhs.ns();
+    return is_ns_eq(rhs) &&
+           name() == rhs.name();
   }
 
   bool Pseudo_Selector::operator== (const Pseudo_Selector& rhs) const
@@ -678,9 +652,8 @@ namespace Sass {
     {
       return *this == *w;
     }
-    if (is_ns_eq(rhs))
-    { return name() == rhs.name(); }
-    return ns() == rhs.ns();
+    return is_ns_eq(rhs) &&
+           name() == rhs.name();
   }
 
   bool Pseudo_Selector::operator< (const Pseudo_Selector& rhs) const
@@ -721,9 +694,8 @@ namespace Sass {
     {
       return *this == *w;
     }
-    if (is_ns_eq(rhs))
-    { return name() == rhs.name(); }
-    return ns() == rhs.ns();
+    return is_ns_eq(rhs) &&
+           name() == rhs.name();
   }
 
   bool Wrapped_Selector::operator< (const Wrapped_Selector& rhs) const
@@ -754,10 +726,8 @@ namespace Sass {
       if (Selector_List_Obj lhs_list = Cast<Selector_List>(selector())) {
         return lhs_list->is_superselector_of(rhs_list);
       }
-      error("is_superselector expected a Selector_List", sub->pstate());
-    } else {
-      error("is_superselector expected a Selector_List", sub->pstate());
     }
+    error("is_superselector expected a Selector_List", sub->pstate());
     return false;
   }
 
@@ -1093,15 +1063,6 @@ namespace Sass {
     // TODO: make this iterative
     if (!tail()) return 1;
     return 1 + tail()->length();
-  }
-
-  Complex_Selector_Obj Complex_Selector::context(Context& ctx)
-  {
-    if (!tail()) return 0;
-    if (!head()) return tail()->context(ctx);
-    Complex_Selector_Obj cpy = SASS_MEMORY_NEW(Complex_Selector, pstate(), combinator(), head(), tail()->context(ctx));
-    cpy->media_block(media_block());
-    return cpy;
   }
 
   // append another complex selector at the end
@@ -1611,14 +1572,6 @@ namespace Sass {
     }
   };
 
-  std::vector<std::string> Compound_Selector::to_str_vec()
-  {
-    std::vector<std::string> result(length());
-    for (size_t i = 0, L = length(); i < L; ++i)
-    { result.push_back((*this)[i]->to_string()); }
-    return result;
-  }
-
   void Compound_Selector::append(Simple_Selector_Ptr element)
   {
     Vectorized<Simple_Selector_Obj>::append(element);
@@ -2101,21 +2054,6 @@ namespace Sass {
   {
     if (Custom_Error_Ptr_Const r = Cast<Custom_Error>(&rhs)) {
       return message() == r->message();
-    }
-    return false;
-  }
-
-  bool Number::eq (const Expression& rhs) const
-  {
-    if (Number_Ptr_Const r = Cast<Number>(&rhs)) {
-      size_t lhs_units = numerator_units_.size() + denominator_units_.size();
-      size_t rhs_units = r->numerator_units_.size() + r->denominator_units_.size();
-      if (!lhs_units && !rhs_units) {
-        return std::fabs(value() - r->value()) < NUMBER_EPSILON;
-      }
-      return (numerator_units_ == r->numerator_units_) &&
-             (denominator_units_ == r->denominator_units_) &&
-             std::fabs(value() - r->value()) < NUMBER_EPSILON;
     }
     return false;
   }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1234,7 +1234,7 @@ namespace Sass {
     {
       try
       {
-        Binary_Expression_Ptr_Const m = dynamic_cast<Binary_Expression_Ptr_Const>(&rhs);
+        Binary_Expression_Ptr_Const m = Cast<Binary_Expression>(&rhs);
         if (m == 0) return false;
         return type() == m->type() &&
                *left() == *m->left() &&
@@ -1292,7 +1292,7 @@ namespace Sass {
     {
       try
       {
-        Unary_Expression_Ptr_Const m = dynamic_cast<Unary_Expression_Ptr_Const>(&rhs);
+        Unary_Expression_Ptr_Const m = Cast<Unary_Expression>(&rhs);
         if (m == 0) return false;
         return type() == m->type() &&
                *operand() == *m->operand();
@@ -1350,7 +1350,7 @@ namespace Sass {
     {
       try
       {
-        Argument_Ptr_Const m = dynamic_cast<Argument_Ptr_Const>(&rhs);
+        Argument_Ptr_Const m = Cast<Argument>(&rhs);
         if (!(m && name() == m->name())) return false;
         return *value() == *m->value();
       }
@@ -1439,7 +1439,7 @@ namespace Sass {
     {
       try
       {
-        Function_Call_Ptr_Const m = dynamic_cast<Function_Call_Ptr_Const>(&rhs);
+        Function_Call_Ptr_Const m = Cast<Function_Call>(&rhs);
         if (!(m && name() == m->name())) return false;
         if (!(m && arguments()->length() == m->arguments()->length())) return false;
         for (size_t i =0, L = arguments()->length(); i < L; ++i)
@@ -1502,7 +1502,7 @@ namespace Sass {
     {
       try
       {
-        Variable_Ptr_Const e = dynamic_cast<Variable_Ptr_Const>(&rhs);
+        Variable_Ptr_Const e = Cast<Variable>(&rhs);
         return e && name() == e->name();
       }
       catch (std::bad_cast&)
@@ -1548,7 +1548,7 @@ namespace Sass {
     {
       try
       {
-        Textual_Ptr_Const e = dynamic_cast<Textual_Ptr_Const>(&rhs);
+        Textual_Ptr_Const e = Cast<Textual>(&rhs);
         return e && value() == e->value() && type() == e->type();
       }
       catch (std::bad_cast&)

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1238,8 +1238,8 @@ namespace Sass {
         Binary_Expression_Ptr_Const m = dynamic_cast<Binary_Expression_Ptr_Const>(&rhs);
         if (m == 0) return false;
         return type() == m->type() &&
-               left() == m->left() &&
-               right() == m->right();
+               *left() == *m->left() &&
+               *right() == *m->right();
       }
       catch (std::bad_cast&)
       {
@@ -1296,7 +1296,7 @@ namespace Sass {
         Unary_Expression_Ptr_Const m = dynamic_cast<Unary_Expression_Ptr_Const>(&rhs);
         if (m == 0) return false;
         return type() == m->type() &&
-               operand() == m->operand();
+               *operand() == *m->operand();
       }
       catch (std::bad_cast&)
       {
@@ -1444,7 +1444,7 @@ namespace Sass {
         if (!(m && name() == m->name())) return false;
         if (!(m && arguments()->length() == m->arguments()->length())) return false;
         for (size_t i =0, L = arguments()->length(); i < L; ++i)
-          if (!((*arguments())[i] == (*m->arguments())[i])) return false;
+          if (!(*(*arguments())[i] == *(*m->arguments())[i])) return false;
         return true;
       }
       catch (std::bad_cast&)

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,6 +1,7 @@
 #ifndef SASS_AST_H
 #define SASS_AST_H
 
+#include "sass.hpp"
 #include <set>
 #include <deque>
 #include <vector>
@@ -133,6 +134,21 @@ namespace Sass {
   };
   inline AST_Node::~AST_Node() { }
 
+  //////////////////////////////////////////////////////////////////////
+  // define cast template now (need complete type)
+  //////////////////////////////////////////////////////////////////////
+
+  template<class T>
+  T* Cast(AST_Node* ptr) {
+    return ptr && typeid(T) == typeid(*ptr) ?
+           static_cast<T*>(ptr) : NULL;
+  };
+
+  template<class T>
+  const T* Cast(const AST_Node* ptr) {
+    return ptr && typeid(T) == typeid(*ptr) ?
+           static_cast<const T*>(ptr) : NULL;
+  };
 
   //////////////////////////////////////////////////////////////////////
   // Abstract base class for expressions. This side of the AST hierarchy
@@ -2754,12 +2770,7 @@ namespace Sass {
     // virtual Placeholder_Selector_Ptr find_placeholder();
     virtual bool has_parent_ref();
     virtual bool has_real_parent_ref();
-    Simple_Selector_Ptr base()
-    {
-      // Implement non-const in terms of const. Safe to const_cast since this method is non-const
-      return const_cast<Simple_Selector_Ptr>(static_cast<Compound_Selector_Ptr_Const>(this)->base());
-    }
-    Simple_Selector_Ptr_Const base() const {
+    Simple_Selector_Ptr base() const {
       if (length() == 0) return 0;
       // ToDo: why is this needed?
       if (Cast<Element_Selector>((*this)[0]))

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -916,7 +916,6 @@ namespace Sass {
   // by a type tag.
   /////////////////////////////////////////////////////////////////////////////
   struct Backtrace;
-  typedef Environment<AST_Node_Obj> Env;
   typedef const char* Signature;
   typedef Expression_Ptr (*Native_Function)(Env&, Env&, Context&, Signature, ParserState, Backtrace*, std::vector<Selector_List_Obj>);
   class Definition : public Has_Block {
@@ -2708,15 +2707,10 @@ namespace Sass {
     ATTACH_OPERATIONS()
   };
 
-  struct Complex_Selector_Pointer_Compare {
-    bool operator() (const Complex_Selector_Obj& pLeft, const Complex_Selector_Obj& pRight) const;
-  };
-
   ////////////////////////////////////////////////////////////////////////////
   // Simple selector sequences. Maintains flags indicating whether it contains
   // any parent references or placeholders, to simplify expansion.
   ////////////////////////////////////////////////////////////////////////////
-  typedef std::set<Complex_Selector_Obj, Complex_Selector_Pointer_Compare> SourcesSet;
   class Compound_Selector : public Selector, public Vectorized<Simple_Selector_Obj> {
   private:
     SourcesSet sources_;
@@ -2805,7 +2799,7 @@ namespace Sass {
       return length() == 1 &&
              SASS_MEMORY_CAST(Parent_Selector, (*this)[0]);
     }
-    std::vector<Subset_Map_Key> to_str_vec(); // sometimes need to convert to a flat "by-value" data structure
+    SubSetMapKeys to_str_vec(); // sometimes need to convert to a flat "by-value" data structure
 
     virtual bool operator<(const Compound_Selector& rhs) const;
     virtual bool operator==(const Compound_Selector& rhs) const;
@@ -2949,7 +2943,7 @@ namespace Sass {
       }
 
       if (pTail) {
-        SourcesSet tailSources = pTail->sources();
+        const SourcesSet& tailSources = pTail->sources();
         srcs.insert(tailSources.begin(), tailSources.end());
       }
 
@@ -2985,8 +2979,6 @@ namespace Sass {
     ATTACH_AST_OPERATIONS(Complex_Selector)
     ATTACH_OPERATIONS()
   };
-
-  typedef std::deque<Complex_Selector_Obj> ComplexSelectorDeque;
 
   ///////////////////////////////////
   // Comma-separated selector groups.

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -121,8 +121,8 @@ namespace Sass {
     ATTACH_VIRTUAL_AST_OPERATIONS(AST_Node);
     virtual std::string inspect() const { return to_string({ INSPECT, 5 }); }
     virtual std::string to_sass() const { return to_string({ TO_SASS, 5 }); }
-    virtual std::string to_string(Sass_Inspect_Options opt) const;
-    virtual std::string to_string() const;
+    virtual const std::string to_string(Sass_Inspect_Options opt) const;
+    virtual const std::string to_string() const;
     virtual void cloneChildren() {};
   public:
     void update_pstate(const ParserState& pstate);

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2101,7 +2101,7 @@ namespace Sass {
 
       if (s->statement_type() == Statement::DIRECTIVE)
       {
-        if (Directive_Obj dir = SASS_MEMORY_CAST(Directive, s))
+        if (Directive_Obj dir = Cast<Directive>(s))
         {
           std::string keyword(dir->keyword());
           if (keyword.length() > 0) keyword.erase(0, 1);
@@ -2120,7 +2120,7 @@ namespace Sass {
       {
         return expression()->exclude("supports");
       }
-      if (Directive_Obj dir = SASS_MEMORY_CAST(Directive, s))
+      if (Directive_Obj dir = Cast<Directive>(s))
       {
         if (dir->is_keyframes()) return expression()->exclude("keyframes");
       }
@@ -2762,7 +2762,7 @@ namespace Sass {
     Simple_Selector_Ptr_Const base() const {
       if (length() == 0) return 0;
       // ToDo: why is this needed?
-      if (SASS_MEMORY_CAST(Element_Selector, (*this)[0]))
+      if (Cast<Element_Selector>((*this)[0]))
         return (*this)[0];
       return 0;
     }
@@ -2797,7 +2797,7 @@ namespace Sass {
     bool is_empty_reference()
     {
       return length() == 1 &&
-             SASS_MEMORY_CAST(Parent_Selector, (*this)[0]);
+             Cast<Parent_Selector>((*this)[0]);
     }
     SubSetMapKeys to_str_vec(); // sometimes need to convert to a flat "by-value" data structure
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2713,7 +2713,7 @@ namespace Sass {
   ////////////////////////////////////////////////////////////////////////////
   class Compound_Selector : public Selector, public Vectorized<Simple_Selector_Obj> {
   private:
-    SourcesSet sources_;
+    ComplexSelectorSet sources_;
     ADD_PROPERTY(bool, extended);
     ADD_PROPERTY(bool, has_parent_reference);
   protected:
@@ -2805,9 +2805,9 @@ namespace Sass {
     virtual bool operator==(const Compound_Selector& rhs) const;
     inline bool operator!=(const Compound_Selector& rhs) const { return !(*this == rhs); }
 
-    SourcesSet& sources() { return sources_; }
+    ComplexSelectorSet& sources() { return sources_; }
     void clearSources() { sources_.clear(); }
-    void mergeSources(SourcesSet& sources, Context& ctx);
+    void mergeSources(ComplexSelectorSet& sources, Context& ctx);
 
     Compound_Selector_Ptr minus(Compound_Selector_Ptr rhs, Context& ctx);
     virtual void cloneChildren();
@@ -2926,30 +2926,30 @@ namespace Sass {
     virtual bool operator<(const Complex_Selector& rhs) const;
     virtual bool operator==(const Complex_Selector& rhs) const;
     inline bool operator!=(const Complex_Selector& rhs) const { return !(*this == rhs); }
-    SourcesSet sources()
+    const ComplexSelectorSet sources()
     {
       //s = Set.new
       //seq.map {|sseq_or_op| s.merge sseq_or_op.sources if sseq_or_op.is_a?(SimpleSequence)}
       //s
 
-      SourcesSet srcs;
+      ComplexSelectorSet srcs;
 
       Compound_Selector_Obj pHead = head();
       Complex_Selector_Obj  pTail = tail();
 
       if (pHead) {
-        SourcesSet& headSources = pHead->sources();
+        const ComplexSelectorSet& headSources = pHead->sources();
         srcs.insert(headSources.begin(), headSources.end());
       }
 
       if (pTail) {
-        const SourcesSet& tailSources = pTail->sources();
+        const ComplexSelectorSet& tailSources = pTail->sources();
         srcs.insert(tailSources.begin(), tailSources.end());
       }
 
       return srcs;
     }
-    void addSources(SourcesSet& sources, Context& ctx) {
+    void addSources(ComplexSelectorSet& sources, Context& ctx) {
       // members.map! {|m| m.is_a?(SimpleSequence) ? m.with_more_sources(sources) : m}
       Complex_Selector_Ptr pIter = this;
       while (pIter) {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -3050,24 +3050,6 @@ namespace Sass {
     ATTACH_OPERATIONS()
   };
 
-  template<typename SelectorType>
-  bool selectors_equal(const SelectorType& one, const SelectorType& two, bool simpleSelectorOrderDependent) {
-    // Test for equality among selectors while differentiating between checks that demand the underlying Simple_Selector
-    // ordering to be the same or not. This works because operator< (which doesn't make a whole lot of sense for selectors, but
-    // is required for proper stl collection ordering) is implemented using string comparision. This gives stable sorting
-    // behavior, and can be used to determine if the selectors would have exactly idential output. operator== matches the
-    // ruby sass implementations for eql, which sometimes perform order independent comparisions (like set comparisons of the
-    // members of a SimpleSequence (Compound_Selector)).
-    //
-    // Due to the reliance on operator== and operater< behavior, this templated method is currently only intended for
-    // use with Compound_Selector and Complex_Selector objects.
-    if (simpleSelectorOrderDependent) {
-      return !(one < two) && !(two < one);
-    } else {
-      return one == two;
-    }
-  }
-
   // compare function for sorting and probably other other uses
   struct cmp_complex_selector { inline bool operator() (const Complex_Selector_Obj l, const Complex_Selector_Obj r) { return (*l < *r); } };
   struct cmp_compound_selector { inline bool operator() (const Compound_Selector_Obj l, const Compound_Selector_Obj r) { return (*l < *r); } };

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2307,8 +2307,8 @@ namespace Sass {
       return false;
     }
     // dispatch to correct handlers
-    virtual bool operator<(const Selector& rhs) const;
-    virtual bool operator==(const Selector& rhs) const;
+    virtual bool operator<(const Selector& rhs) const = 0;
+    virtual bool operator==(const Selector& rhs) const = 0;
     ATTACH_VIRTUAL_AST_OPERATIONS(Selector);
   };
   inline Selector::~Selector() { }
@@ -2333,6 +2333,8 @@ namespace Sass {
     { }
     virtual bool has_parent_ref();
     virtual bool has_real_parent_ref();
+    virtual bool operator<(const Selector& rhs) const;
+    virtual bool operator==(const Selector& rhs) const;
     // selector schema is not yet a final selector, so we do not
     // have a specificity for it yet. We need to
     virtual unsigned long specificity() const { return 0; }
@@ -2789,6 +2791,8 @@ namespace Sass {
              Cast<Parent_Selector>((*this)[0]);
     }
 
+    virtual bool operator<(const Selector& rhs) const;
+    virtual bool operator==(const Selector& rhs) const;
     virtual bool operator<(const Compound_Selector& rhs) const;
     virtual bool operator==(const Compound_Selector& rhs) const;
     inline bool operator!=(const Compound_Selector& rhs) const { return !(*this == rhs); }
@@ -2908,6 +2912,8 @@ namespace Sass {
       if (tail_ && tail_->has_placeholder()) return true;
       return false;
     }
+    virtual bool operator<(const Selector& rhs) const;
+    virtual bool operator==(const Selector& rhs) const;
     virtual bool operator<(const Complex_Selector& rhs) const;
     virtual bool operator==(const Complex_Selector& rhs) const;
     inline bool operator!=(const Complex_Selector& rhs) const { return !(*this == rhs); }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2427,7 +2427,6 @@ namespace Sass {
     virtual bool has_parent_ref() { return false; };
     virtual bool has_real_parent_ref() { return false; };
     virtual bool is_pseudo_element() const { return false; }
-    virtual bool is_pseudo_class() { return false; }
 
     virtual bool is_superselector_of(Compound_Selector_Obj sub) { return false; }
 
@@ -2619,14 +2618,6 @@ namespace Sass {
     Pseudo_Selector(const Pseudo_Selector* ptr)
     : Simple_Selector(ptr), expression_(ptr->expression_)
     { simple_type(PSEUDO_SEL); }
-
-    // A pseudo-class always consists of a "colon" (:) followed by the name
-    // of the pseudo-class and optionally by a value between parentheses.
-    virtual bool is_pseudo_class()
-    {
-      return (name_[0] == ':' && name_[1] != ':')
-             && ! is_pseudo_class_element(name_);
-    }
 
     // A pseudo-element is made of two colons (::) followed by the name.
     // The `::` notation is introduced by the current document in order to

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2292,9 +2292,7 @@ namespace Sass {
     { concrete_type(SELECTOR); }
     virtual ~Selector() = 0;
     virtual size_t hash() = 0;
-    virtual unsigned long specificity() const {
-      return 0;
-    }
+    virtual unsigned long specificity() const = 0;
     virtual void set_media_block(Media_Block_Ptr mb) {
       media_block(mb);
     }
@@ -2331,6 +2329,9 @@ namespace Sass {
     { }
     virtual bool has_parent_ref();
     virtual bool has_real_parent_ref();
+    // selector schema is not yet a final selector, so we do not
+    // have a specificity for it yet. We need to
+    virtual unsigned long specificity() const { return 0; }
     virtual size_t hash() {
       if (hash_ == 0) {
         hash_combine(hash_, contents_->hash());
@@ -2368,10 +2369,6 @@ namespace Sass {
       name_(ptr->name_),
       has_ns_(ptr->has_ns_)
     { simple_type(SIMPLE); }
-    virtual bool unique() const
-    {
-      return false;
-    }
     virtual std::string ns_name() const
     {
       std::string name("");
@@ -2527,10 +2524,6 @@ namespace Sass {
     Class_Selector(const Class_Selector* ptr)
     : Simple_Selector(ptr)
     { }
-    virtual bool unique() const
-    {
-      return false;
-    }
     virtual unsigned long specificity() const
     {
       return Constants::Specificity_Class;
@@ -2551,10 +2544,6 @@ namespace Sass {
     Id_Selector(const Id_Selector* ptr)
     : Simple_Selector(ptr)
     { }
-    virtual bool unique() const
-    {
-      return true;
-    }
     virtual unsigned long specificity() const
     {
       return Constants::Specificity_ID;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -126,7 +126,6 @@ namespace Sass {
     virtual void cloneChildren() {};
   public:
     void update_pstate(const ParserState& pstate);
-    void set_pstate_offset(const Offset& offset);
   public:
     Offset off() { return pstate(); }
     Position pos() { return pstate(); }
@@ -1638,7 +1637,6 @@ namespace Sass {
 
     virtual bool operator< (const Number& rhs) const;
     virtual bool operator== (const Expression& rhs) const;
-    virtual bool eq(const Expression& rhs) const;
     ATTACH_AST_OPERATIONS(Number)
     ATTACH_OPERATIONS()
   };
@@ -1771,8 +1769,6 @@ namespace Sass {
     static std::string type_name() { return "string"; }
     virtual ~String() = 0;
     virtual void rtrim() = 0;
-    virtual void ltrim() = 0;
-    virtual void trim() = 0;
     virtual bool operator==(const Expression& rhs) const = 0;
     virtual bool operator<(const Expression& rhs) const {
       return this->to_string() < rhs.to_string();
@@ -1812,8 +1808,6 @@ namespace Sass {
       return false;
     }
     virtual void rtrim();
-    virtual void ltrim();
-    virtual void trim();
 
     virtual size_t hash()
     {
@@ -1866,8 +1860,6 @@ namespace Sass {
     static std::string type_name() { return "string"; }
     virtual bool is_invisible() const;
     virtual void rtrim();
-    virtual void ltrim();
-    virtual void trim();
 
     virtual size_t hash()
     {
@@ -2812,7 +2804,6 @@ namespace Sass {
       return length() == 1 &&
              Cast<Parent_Selector>((*this)[0]);
     }
-    SubSetMapKeys to_str_vec(); // sometimes need to convert to a flat "by-value" data structure
 
     virtual bool operator<(const Compound_Selector& rhs) const;
     virtual bool operator==(const Compound_Selector& rhs) const;
@@ -2885,9 +2876,6 @@ namespace Sass {
       return (!head() || head()->length() == 0) &&
              combinator() == Combinator::ANCESTOR_OF;
     }
-
-    Complex_Selector_Obj context(Context&);
-
 
     Selector_List_Ptr tails(Context& ctx, Selector_List_Ptr tails);
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2276,9 +2276,8 @@ namespace Sass {
   protected:
     size_t hash_;
   public:
-    Selector(ParserState pstate, bool r = false, bool h = false)
+    Selector(ParserState pstate)
     : Expression(pstate),
-      // has_reference_(r),
       has_line_feed_(false),
       has_line_break_(false),
       is_optional_(false),

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2292,7 +2292,7 @@ namespace Sass {
     { concrete_type(SELECTOR); }
     virtual ~Selector() = 0;
     virtual size_t hash() = 0;
-    virtual unsigned long specificity() {
+    virtual unsigned long specificity() const {
       return 0;
     }
     virtual void set_media_block(Media_Block_Ptr mb) {
@@ -2425,7 +2425,7 @@ namespace Sass {
     virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr, Context&);
     virtual bool has_parent_ref() { return false; };
     virtual bool has_real_parent_ref() { return false; };
-    virtual bool is_pseudo_element() { return false; }
+    virtual bool is_pseudo_element() const { return false; }
     virtual bool is_pseudo_class() { return false; }
 
     virtual bool is_superselector_of(Compound_Selector_Obj sub) { return false; }
@@ -2461,7 +2461,7 @@ namespace Sass {
     bool is_real_parent_ref() { return real(); };
     virtual bool has_parent_ref() { return true; };
     virtual bool has_real_parent_ref() { return is_real_parent_ref(); };
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       return 0;
     }
@@ -2482,7 +2482,7 @@ namespace Sass {
     Placeholder_Selector(const Placeholder_Selector* ptr)
     : Simple_Selector(ptr)
     { }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       return Constants::Specificity_Base;
     }
@@ -2505,7 +2505,7 @@ namespace Sass {
     Element_Selector(const Element_Selector* ptr)
     : Simple_Selector(ptr)
     { }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       if (name() == "*") return 0;
       else               return Constants::Specificity_Element;
@@ -2531,7 +2531,7 @@ namespace Sass {
     {
       return false;
     }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       return Constants::Specificity_Class;
     }
@@ -2555,7 +2555,7 @@ namespace Sass {
     {
       return true;
     }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       return Constants::Specificity_ID;
     }
@@ -2589,7 +2589,7 @@ namespace Sass {
       }
       return hash_;
     }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       return Constants::Specificity_Attr;
     }
@@ -2643,7 +2643,7 @@ namespace Sass {
     // in CSS levels 1 and 2 (namely, :first-line, :first-letter, :before and
     // :after). This compatibility is not allowed for the new pseudo-elements
     // introduced in this specification.
-    virtual bool is_pseudo_element()
+    virtual bool is_pseudo_element() const
     {
       return (name_[0] == ':' && name_[1] == ':')
              || is_pseudo_class_element(name_);
@@ -2656,7 +2656,7 @@ namespace Sass {
       }
       return hash_;
     }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       if (is_pseudo_element())
         return Constants::Specificity_Element;
@@ -2704,7 +2704,7 @@ namespace Sass {
       if (!selector()) return false;
       return selector()->has_real_parent_ref();
     }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       return selector_ ? selector_->specificity() : 0;
     }
@@ -2782,7 +2782,7 @@ namespace Sass {
       }
       return Selector::hash_;
     }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       int sum = 0;
       for (size_t i = 0, L = length(); i < L; ++i)
@@ -3017,7 +3017,7 @@ namespace Sass {
       }
       return Selector::hash_;
     }
-    virtual unsigned long specificity()
+    virtual unsigned long specificity() const
     {
       unsigned long sum = 0;
       unsigned long specificity = 0;

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -806,7 +806,7 @@ namespace Sass {
     ADD_PROPERTY(Block_Obj, alternative)
   public:
     If(ParserState pstate, Expression_Obj pred, Block_Obj con, Block_Obj alt = 0)
-    : Has_Block(pstate, &con), predicate_(pred), alternative_(alt)
+    : Has_Block(pstate, con), predicate_(pred), alternative_(alt)
     { statement_type(IF); }
     If(const If* ptr)
     : Has_Block(ptr),
@@ -2763,7 +2763,7 @@ namespace Sass {
       if (length() == 0) return 0;
       // ToDo: why is this needed?
       if (SASS_MEMORY_CAST(Element_Selector, (*this)[0]))
-        return &(*this)[0];
+        return (*this)[0];
       return 0;
     }
     virtual bool is_superselector_of(Compound_Selector_Obj sub, std::string wrapped = "");
@@ -2953,25 +2953,25 @@ namespace Sass {
       // members.map! {|m| m.is_a?(SimpleSequence) ? m.with_more_sources(sources) : m}
       Complex_Selector_Ptr pIter = this;
       while (pIter) {
-        Compound_Selector_Ptr pHead = &pIter->head();
+        Compound_Selector_Ptr pHead = pIter->head();
 
         if (pHead) {
           pHead->mergeSources(sources, ctx);
         }
 
-        pIter = &pIter->tail();
+        pIter = pIter->tail();
       }
     }
     void clearSources() {
       Complex_Selector_Ptr pIter = this;
       while (pIter) {
-        Compound_Selector_Ptr pHead = &pIter->head();
+        Compound_Selector_Ptr pHead = pIter->head();
 
         if (pHead) {
           pHead->clearSources();
         }
 
-        pIter = &pIter->tail();
+        pIter = pIter->tail();
       }
     }
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -562,7 +562,7 @@ namespace Sass {
   // Trace.
   /////////////////
   class Trace : public Has_Block {
-    ADD_PROPERTY(std::string, name)
+    ADD_CONSTREF(std::string, name)
   public:
     Trace(ParserState pstate, std::string n, Block_Obj b = 0)
     : Has_Block(pstate, b), name_(n)
@@ -601,7 +601,7 @@ namespace Sass {
   // optional statement block.
   ///////////////////////////////////////////////////////////////////////
   class Directive : public Has_Block {
-    ADD_PROPERTY(std::string, keyword)
+    ADD_CONSTREF(std::string, keyword)
     ADD_PROPERTY(Selector_Obj, selector)
     ADD_PROPERTY(Expression_Obj, value)
   public:
@@ -677,7 +677,7 @@ namespace Sass {
   // Assignments -- variable and value.
   /////////////////////////////////////
   class Assignment : public Statement {
-    ADD_PROPERTY(std::string, variable)
+    ADD_CONSTREF(std::string, variable)
     ADD_PROPERTY(Expression_Obj, value)
     ADD_PROPERTY(bool, is_default)
     ADD_PROPERTY(bool, is_global)
@@ -841,7 +841,7 @@ namespace Sass {
   // The Sass `@for` control directive.
   /////////////////////////////////////
   class For : public Has_Block {
-    ADD_PROPERTY(std::string, variable)
+    ADD_CONSTREF(std::string, variable)
     ADD_PROPERTY(Expression_Obj, lower_bound)
     ADD_PROPERTY(Expression_Obj, upper_bound)
     ADD_PROPERTY(bool, is_inclusive)
@@ -937,7 +937,7 @@ namespace Sass {
   class Definition : public Has_Block {
   public:
     enum Type { MIXIN, FUNCTION };
-    ADD_PROPERTY(std::string, name)
+    ADD_CONSTREF(std::string, name)
     ADD_PROPERTY(Parameters_Obj, parameters)
     ADD_PROPERTY(Env*, environment)
     ADD_PROPERTY(Type, type)
@@ -1019,7 +1019,7 @@ namespace Sass {
   // Mixin calls (i.e., `@include ...`).
   //////////////////////////////////////
   class Mixin_Call : public Has_Block {
-    ADD_PROPERTY(std::string, name)
+    ADD_CONSTREF(std::string, name)
     ADD_PROPERTY(Arguments_Obj, arguments)
   public:
     Mixin_Call(ParserState pstate, std::string n, Arguments_Obj args, Block_Obj b = 0)
@@ -1177,9 +1177,9 @@ namespace Sass {
   //////////////////////////////////////////////////////////////////////////
   class Binary_Expression : public PreValue {
   private:
-    ADD_HASHED(Operand, op)
-    ADD_HASHED(Expression_Obj, left)
-    ADD_HASHED(Expression_Obj, right)
+    HASH_PROPERTY(Operand, op)
+    HASH_PROPERTY(Expression_Obj, left)
+    HASH_PROPERTY(Expression_Obj, right)
     size_t hash_;
   public:
     Binary_Expression(ParserState pstate,
@@ -1283,8 +1283,8 @@ namespace Sass {
   public:
     enum Type { PLUS, MINUS, NOT };
   private:
-    ADD_HASHED(Type, type)
-    ADD_HASHED(Expression_Obj, operand)
+    HASH_PROPERTY(Type, type)
+    HASH_PROPERTY(Expression_Obj, operand)
     size_t hash_;
   public:
     Unary_Expression(ParserState pstate, Type t, Expression_Obj o)
@@ -1335,8 +1335,8 @@ namespace Sass {
   // Individual argument objects for mixin and function calls.
   ////////////////////////////////////////////////////////////
   class Argument : public Expression {
-    ADD_HASHED(Expression_Obj, value)
-    ADD_HASHED(std::string, name)
+    HASH_PROPERTY(Expression_Obj, value)
+    HASH_CONSTREF(std::string, name)
     ADD_PROPERTY(bool, is_rest_argument)
     ADD_PROPERTY(bool, is_keyword_argument)
     size_t hash_;
@@ -1430,8 +1430,8 @@ namespace Sass {
   // Function calls.
   //////////////////
   class Function_Call : public PreValue {
-    ADD_HASHED(std::string, name)
-    ADD_HASHED(Arguments_Obj, arguments)
+    HASH_CONSTREF(std::string, name)
+    HASH_PROPERTY(Arguments_Obj, arguments)
     ADD_PROPERTY(bool, via_call)
     ADD_PROPERTY(void*, cookie)
     size_t hash_;
@@ -1505,7 +1505,7 @@ namespace Sass {
   // Variable references.
   ///////////////////////
   class Variable : public PreValue {
-    ADD_PROPERTY(std::string, name)
+    ADD_CONSTREF(std::string, name)
   public:
     Variable(ParserState pstate, std::string n)
     : PreValue(pstate), name_(n)
@@ -1545,8 +1545,8 @@ namespace Sass {
   public:
     enum Type { NUMBER, PERCENTAGE, DIMENSION, HEX };
   private:
-    ADD_HASHED(Type, type)
-    ADD_HASHED(std::string, value)
+    HASH_PROPERTY(Type, type)
+    HASH_CONSTREF(std::string, value)
     size_t hash_;
   public:
     Textual(ParserState pstate, Type t, std::string val)
@@ -1591,7 +1591,7 @@ namespace Sass {
   // Numbers, percentages, dimensions, and colors.
   ////////////////////////////////////////////////
   class Number : public Value {
-    ADD_HASHED(double, value)
+    HASH_PROPERTY(double, value)
     ADD_PROPERTY(bool, zero)
     std::vector<std::string> numerator_units_;
     std::vector<std::string> denominator_units_;
@@ -1647,11 +1647,11 @@ namespace Sass {
   // Colors.
   //////////
   class Color : public Value {
-    ADD_HASHED(double, r)
-    ADD_HASHED(double, g)
-    ADD_HASHED(double, b)
-    ADD_HASHED(double, a)
-    ADD_PROPERTY(std::string, disp)
+    HASH_PROPERTY(double, r)
+    HASH_PROPERTY(double, g)
+    HASH_PROPERTY(double, b)
+    HASH_PROPERTY(double, a)
+    ADD_CONSTREF(std::string, disp)
     size_t hash_;
   public:
     Color(ParserState pstate, double r, double g, double b, double a = 1, const std::string disp = "")
@@ -1691,7 +1691,7 @@ namespace Sass {
   // Errors from Sass_Values.
   //////////////////////////////
   class Custom_Error : public Value {
-    ADD_PROPERTY(std::string, message)
+    ADD_CONSTREF(std::string, message)
   public:
     Custom_Error(ParserState pstate, std::string msg)
     : Value(pstate), message_(msg)
@@ -1708,7 +1708,7 @@ namespace Sass {
   // Warnings from Sass_Values.
   //////////////////////////////
   class Custom_Warning : public Value {
-    ADD_PROPERTY(std::string, message)
+    ADD_CONSTREF(std::string, message)
   public:
     Custom_Warning(ParserState pstate, std::string msg)
     : Value(pstate), message_(msg)
@@ -1725,7 +1725,7 @@ namespace Sass {
   // Booleans.
   ////////////
   class Boolean : public Value {
-    ADD_HASHED(bool, value)
+    HASH_PROPERTY(bool, value)
     size_t hash_;
   public:
     Boolean(ParserState pstate, bool val)
@@ -1839,7 +1839,7 @@ namespace Sass {
   class String_Constant : public String {
     ADD_PROPERTY(char, quote_mark)
     ADD_PROPERTY(bool, can_compress_whitespace)
-    ADD_HASHED(std::string, value)
+    HASH_CONSTREF(std::string, value)
   protected:
     size_t hash_;
   public:
@@ -2186,7 +2186,7 @@ namespace Sass {
   // Individual parameter objects for mixins and functions.
   /////////////////////////////////////////////////////////
   class Parameter : public AST_Node {
-    ADD_PROPERTY(std::string, name)
+    ADD_CONSTREF(std::string, name)
     ADD_PROPERTY(Expression_Obj, default_value)
     ADD_PROPERTY(bool, is_rest_parameter)
   public:
@@ -2353,8 +2353,8 @@ namespace Sass {
   // Abstract base class for simple selectors.
   ////////////////////////////////////////////
   class Simple_Selector : public Selector {
-    ADD_PROPERTY(std::string, ns)
-    ADD_PROPERTY(std::string, name)
+    ADD_CONSTREF(std::string, ns)
+    ADD_CONSTREF(std::string, name)
     ADD_PROPERTY(Simple_Type, simple_type)
     ADD_PROPERTY(bool, has_ns)
   public:
@@ -2574,7 +2574,7 @@ namespace Sass {
   // Attribute selectors -- e.g., [src*=".jpg"], etc.
   ///////////////////////////////////////////////////
   class Attribute_Selector : public Simple_Selector {
-    ADD_PROPERTY(std::string, matcher)
+    ADD_CONSTREF(std::string, matcher)
     // this cannot be changed to obj atm!!!!!!????!!!!!!!
     ADD_PROPERTY(String_Obj, value) // might be interpolated
   public:
@@ -2835,10 +2835,10 @@ namespace Sass {
   public:
     enum Combinator { ANCESTOR_OF, PARENT_OF, PRECEDES, ADJACENT_TO, REFERENCE };
   private:
-    ADD_PROPERTY(Combinator, combinator)
-    ADD_PROPERTY(Compound_Selector_Obj, head)
-    ADD_PROPERTY(Complex_Selector_Obj, tail)
-    ADD_PROPERTY(String_Obj, reference);
+    HASH_CONSTREF(Combinator, combinator)
+    HASH_PROPERTY(Compound_Selector_Obj, head)
+    HASH_PROPERTY(Complex_Selector_Obj, tail)
+    HASH_PROPERTY(String_Obj, reference);
   public:
     bool contains_placeholder() {
       if (head() && head()->contains_placeholder()) return true;
@@ -2995,7 +2995,7 @@ namespace Sass {
   // Comma-separated selector groups.
   ///////////////////////////////////
   class Selector_List : public Selector, public Vectorized<Complex_Selector_Obj> {
-    ADD_PROPERTY(std::vector<std::string>, wspace)
+    ADD_CONSTREF(std::vector<std::string>, wspace)
   protected:
     void adjust_after_pushing(Complex_Selector_Obj c);
   public:

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1034,7 +1034,7 @@ namespace Sass {
   // The @content directive for mixin content blocks.
   ///////////////////////////////////////////////////
   class Content : public Statement {
-    ADD_PROPERTY(Media_Block_Obj, media_block)
+    ADD_PROPERTY(Media_Block_Ptr, media_block)
   public:
     Content(ParserState pstate) : Statement(pstate)
     { statement_type(CONTENT); }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2186,9 +2186,11 @@ namespace Sass {
               std::string n, Expression_Obj def = 0, bool rest = false)
     : AST_Node(pstate), name_(n), default_value_(def), is_rest_parameter_(rest)
     {
-      if (default_value_ && is_rest_parameter_) {
-        error("variable-length parameter may not have a default value", pstate_);
-      }
+      // tried to come up with a spec test for this, but it does no longer
+      // get  past the parser (it error out earlier). A spec test was added!
+      // if (default_value_ && is_rest_parameter_) {
+      //   error("variable-length parameter may not have a default value", pstate_);
+      // }
     }
     Parameter(const Parameter* ptr)
     : AST_Node(ptr),
@@ -2196,9 +2198,11 @@ namespace Sass {
       default_value_(ptr->default_value_),
       is_rest_parameter_(ptr->is_rest_parameter_)
     {
-      if (default_value_ && is_rest_parameter_) {
-        error("variable-length parameter may not have a default value", pstate_);
-      }
+      // tried to come up with a spec test for this, but it does no longer
+      // get  past the parser (it error out earlier). A spec test was added!
+      // if (default_value_ && is_rest_parameter_) {
+      //   error("variable-length parameter may not have a default value", pstate_);
+      // }
     }
     ATTACH_AST_OPERATIONS(Parameter)
     ATTACH_OPERATIONS()

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -2396,6 +2396,8 @@ namespace Sass {
       }
       return hash_;
     }
+    // namespace compare functions
+    bool is_ns_eq(const Simple_Selector& r) const;
     // namespace query functions
     bool is_universal_ns() const
     {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -583,9 +583,6 @@ namespace Sass {
     Media_Block(ParserState pstate, List_Obj mqs, Block_Obj b)
     : Has_Block(pstate, b), media_queries_(mqs)
     { statement_type(MEDIA); }
-    Media_Block(ParserState pstate, List_Obj mqs, Block_Obj b, Selector_Obj s)
-    : Has_Block(pstate, b), media_queries_(mqs)
-    { statement_type(MEDIA); }
     Media_Block(const Media_Block* ptr)
     : Has_Block(ptr), media_queries_(ptr->media_queries_)
     { statement_type(MEDIA); }

--- a/src/ast_def_macros.hpp
+++ b/src/ast_def_macros.hpp
@@ -44,12 +44,28 @@ public:\
   type name(type name##__) { return name##_ = name##__; }\
 private:
 
-#define ADD_HASHED(type, name)\
+#define HASH_PROPERTY(type, name)\
 protected:\
   type name##_;\
 public:\
   type name() const        { return name##_; }\
   type name(type name##__) { hash_ = 0; return name##_ = name##__; }\
+private:
+
+#define ADD_CONSTREF(type, name) \
+protected: \
+  type name##_; \
+public: \
+  const type& name() const { return name##_; } \
+  void name(type name##__) { name##_ = name##__; } \
+private:
+
+#define HASH_CONSTREF(type, name) \
+protected: \
+  type name##_; \
+public: \
+  const type& name() const { return name##_; } \
+  void name(type name##__) { hash_ = 0; name##_ = name##__; } \
 private:
 
 #endif

--- a/src/ast_fwd_decl.cpp
+++ b/src/ast_fwd_decl.cpp
@@ -1,0 +1,29 @@
+#include "ast.hpp"
+
+namespace Sass {
+
+  #define IMPLEMENT_BASE_CAST(T) \
+  template<> \
+  T* Cast(AST_Node* ptr) { \
+    return dynamic_cast<T*>(ptr); \
+  }; \
+  \
+  template<> \
+  const T* Cast(const AST_Node* ptr) { \
+    return dynamic_cast<const T*>(ptr); \
+  }; \
+
+  IMPLEMENT_BASE_CAST(AST_Node)
+  IMPLEMENT_BASE_CAST(Expression)
+  IMPLEMENT_BASE_CAST(Statement)
+  IMPLEMENT_BASE_CAST(Has_Block)
+  IMPLEMENT_BASE_CAST(PreValue)
+  IMPLEMENT_BASE_CAST(Value)
+  IMPLEMENT_BASE_CAST(List)
+  IMPLEMENT_BASE_CAST(String)
+  IMPLEMENT_BASE_CAST(String_Constant)
+  IMPLEMENT_BASE_CAST(Supports_Condition)
+  IMPLEMENT_BASE_CAST(Selector)
+  IMPLEMENT_BASE_CAST(Simple_Selector)
+
+}

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -408,7 +408,7 @@ namespace Sass {
 
   typedef std::deque<Complex_Selector_Obj> ComplexSelectorDeque;
   typedef std::set<Simple_Selector_Obj, OrderNodes> SimpleSelectorSet;
-  typedef std::set<Complex_Selector_Obj, OrderNodes> SourcesSet;
+  typedef std::set<Complex_Selector_Obj, OrderNodes> ComplexSelectorSet;
   typedef std::unordered_set<Simple_Selector_Obj, HashNodes, CompareNodes> SimpleSelectorDict;
 
 }

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <deque>
 #include <vector>
+#include <typeinfo>
 #include <iostream>
 #include <algorithm>
 #include <unordered_map>
@@ -416,14 +417,34 @@ namespace Sass {
   // ###########################################################################
 
   template<class T>
-  T* Cast(AST_Node* ptr) {
-    return dynamic_cast<T*>(ptr);
-  };
+  T* Cast(AST_Node* ptr);
 
   template<class T>
-  const T* Cast(const AST_Node* ptr) {
-    return dynamic_cast<const T*>(ptr);
-  };
+  const T* Cast(const AST_Node* ptr);
+
+  // sometimes you know the class you want to cast to is final
+  // in this case a simple typeid check is faster and safe to use
+
+  #define DECLARE_BASE_CAST(T) \
+  template<> T* Cast(AST_Node* ptr); \
+  template<> const T* Cast(const AST_Node* ptr); \
+
+  // ###########################################################################
+  // implement specialization for final classes
+  // ###########################################################################
+
+  DECLARE_BASE_CAST(AST_Node)
+  DECLARE_BASE_CAST(Expression)
+  DECLARE_BASE_CAST(Statement)
+  DECLARE_BASE_CAST(Has_Block)
+  DECLARE_BASE_CAST(PreValue)
+  DECLARE_BASE_CAST(Value)
+  DECLARE_BASE_CAST(List)
+  DECLARE_BASE_CAST(String)
+  DECLARE_BASE_CAST(String_Constant)
+  DECLARE_BASE_CAST(Supports_Condition)
+  DECLARE_BASE_CAST(Selector)
+  DECLARE_BASE_CAST(Simple_Selector)
 
 }
 

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -1,6 +1,9 @@
 #ifndef SASS_AST_FWD_DECL_H
 #define SASS_AST_FWD_DECL_H
 
+#include <map>
+#include <set>
+#include <deque>
 #include <vector>
 #include <iostream>
 #include <algorithm>
@@ -353,37 +356,60 @@ namespace Sass {
   IMPL_MEM_OBJ(Complex_Selector);
   IMPL_MEM_OBJ(Selector_List);
 
+  // ###########################################################################
+  // Implement compare, order and hashing operations for AST Nodes
+  // ###########################################################################
 
-  struct HashExpression {
-    size_t operator() (Expression_Obj ex) const;
+  struct HashNodes {
+    template <class T>
+    size_t operator() (const T& ex) const {
+      return ex.isNull() ? 0 : ex->hash();
+    }
   };
-  struct CompareExpression {
-    bool operator()(const Expression_Obj& lhs, const Expression_Obj& rhs) const;
+  struct OrderNodes {
+    template <class T>
+    bool operator() (const T& lhs, const T& rhs) const {
+      return !lhs.isNull() && !rhs.isNull() && *lhs < *rhs;
+    }
+  };
+  struct CompareNodes {
+    template <class T>
+    bool operator() (const T& lhs, const T& rhs) const {
+      return !lhs.isNull() && !rhs.isNull() && *lhs == *rhs;
+    }
   };
 
-  struct HashSimpleSelector {
-    size_t operator() (Simple_Selector_Obj ex) const;
-  };
-
-  struct CompareSimpleSelector {
-    bool operator()(Simple_Selector_Obj lhs, Simple_Selector_Obj rhs) const;
-  };
+  // ###########################################################################
+  // some often used typedefs
+  // ###########################################################################
 
   typedef std::unordered_map<
     Expression_Obj, // key
     Expression_Obj, // value
-    HashExpression, // hasher
-    CompareExpression // compare
+    HashNodes, // hasher
+    CompareNodes // compare
   > ExpressionMap;
   typedef std::unordered_set<
     Expression_Obj, // value
-    HashExpression, // hasher
-    CompareExpression // compare
+    HashNodes, // hasher
+    CompareNodes // compare
   > ExpressionSet;
 
-  typedef std::string Subset_Map_Key;
-  typedef std::vector<size_t> Subset_Map_Arr;
-  typedef std::pair<Complex_Selector_Obj, Compound_Selector_Obj> Subset_Map_Val;
+  typedef std::string SubSetMapKey;
+  typedef std::vector<std::string> SubSetMapKeys;
+
+  typedef std::pair<Complex_Selector_Obj, Compound_Selector_Obj> SubSetMapPair;
+  typedef std::pair<Compound_Selector_Obj, Complex_Selector_Obj> SubSetMapLookup;
+  typedef std::vector<SubSetMapPair> SubSetMapPairs;
+  typedef std::vector<SubSetMapLookup> SubSetMapLookups;
+
+  typedef std::pair<Complex_Selector_Obj, SubSetMapPairs> SubSetMapResult;
+  typedef std::vector<SubSetMapResult> SubSetMapResults;
+
+  typedef std::deque<Complex_Selector_Obj> ComplexSelectorDeque;
+  typedef std::set<Simple_Selector_Obj, OrderNodes> SimpleSelectorSet;
+  typedef std::set<Complex_Selector_Obj, OrderNodes> SourcesSet;
+  typedef std::unordered_set<Simple_Selector_Obj, HashNodes, CompareNodes> SimpleSelectorDict;
 
 }
 

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -411,6 +411,20 @@ namespace Sass {
   typedef std::set<Complex_Selector_Obj, OrderNodes> ComplexSelectorSet;
   typedef std::unordered_set<Simple_Selector_Obj, HashNodes, CompareNodes> SimpleSelectorDict;
 
+  // ###########################################################################
+  // explicit type conversion functions
+  // ###########################################################################
+
+  template<class T>
+  T* Cast(AST_Node* ptr) {
+    return dynamic_cast<T*>(ptr);
+  };
+
+  template<class T>
+  const T* Cast(const AST_Node* ptr) {
+    return dynamic_cast<const T*>(ptr);
+  };
+
 }
 
 #endif

--- a/src/backtrace.hpp
+++ b/src/backtrace.hpp
@@ -21,7 +21,7 @@ namespace Sass {
       caller(c)
     { }
 
-    std::string to_string(bool warning = false)
+    const std::string to_string(bool warning = false)
     {
       size_t i = -1;
       std::stringstream ss;

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -75,7 +75,7 @@ namespace Sass {
                 } else {
                   arglist->append(SASS_MEMORY_NEW(Argument,
                                                   item->pstate(),
-                                                  &item,
+                                                  item,
                                                   "",
                                                   false,
                                                   false));
@@ -123,7 +123,7 @@ namespace Sass {
 
             Expression_Obj value = a->value();
             if (Argument_Obj arg = SASS_MEMORY_CAST(Argument, value)) {
-              arglist->append(&arg);
+              arglist->append(arg.ptr());
             }
             // check if we have rest argument
             else if (a->is_rest_argument()) {
@@ -135,7 +135,7 @@ namespace Sass {
                   Expression_Obj obj = rest->at(i);
                   arglist->append(SASS_MEMORY_NEW(Argument,
                                                 obj->pstate(),
-                                                &obj,
+                                                obj,
                                                 "",
                                                 false,
                                                 false));
@@ -155,7 +155,7 @@ namespace Sass {
             }
           }
           // assign new arglist to environment
-          env->local_frame()[p->name()] = &arglist;
+          env->local_frame()[p->name()] = arglist.ptr();
         }
         // consumed parameter
         ++ip;
@@ -188,7 +188,7 @@ namespace Sass {
         // otherwise move one of the rest args into the param, converting to argument if necessary
         Expression_Obj obj = arglist->at(0);
         if (!(a = SASS_MEMORY_CAST(Argument, obj))) {
-          Expression_Ptr a_to_convert = &obj;
+          Expression_Ptr a_to_convert = obj;
           a = SASS_MEMORY_NEW(Argument,
                               a_to_convert->pstate(),
                               a_to_convert,
@@ -212,7 +212,7 @@ namespace Sass {
             msg << callee << " has no parameter named " << name;
             error(msg.str(), a->pstate());
           }
-          env->local_frame()[name] = &argmap->at(&key);
+          env->local_frame()[name] = argmap->at(key).ptr();
         }
         ++ia;
         continue;
@@ -228,7 +228,7 @@ namespace Sass {
           error(msg.str(), a->pstate());
         }
         // ordinal arg -- bind it to the next param
-        env->local_frame()[p->name()] = &a->value();
+        env->local_frame()[p->name()] = a->value().ptr();
         ++ip;
       }
       else {
@@ -250,7 +250,7 @@ namespace Sass {
               << "provided more than once in call to " << callee;
           error(msg.str(), a->pstate());
         }
-        env->local_frame()[a->name()] = &a->value();
+        env->local_frame()[a->name()] = a->value().ptr();
       }
     }
     // EO while ia

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -123,7 +123,7 @@ namespace Sass {
 
             Expression_Obj value = a->value();
             if (Argument_Obj arg = Cast<Argument>(value)) {
-              arglist->append(arg.ptr());
+              arglist->append(arg);
             }
             // check if we have rest argument
             else if (a->is_rest_argument()) {
@@ -155,7 +155,7 @@ namespace Sass {
             }
           }
           // assign new arglist to environment
-          env->local_frame()[p->name()] = arglist.ptr();
+          env->local_frame()[p->name()] = arglist;
         }
         // consumed parameter
         ++ip;
@@ -212,7 +212,7 @@ namespace Sass {
             msg << callee << " has no parameter named " << name;
             error(msg.str(), a->pstate());
           }
-          env->local_frame()[name] = argmap->at(key).ptr();
+          env->local_frame()[name] = argmap->at(key);
         }
         ++ia;
         continue;
@@ -228,7 +228,7 @@ namespace Sass {
           error(msg.str(), a->pstate());
         }
         // ordinal arg -- bind it to the next param
-        env->local_frame()[p->name()] = a->value().ptr();
+        env->local_frame()[p->name()] = a->value();
         ++ip;
       }
       else {
@@ -250,7 +250,7 @@ namespace Sass {
               << "provided more than once in call to " << callee;
           error(msg.str(), a->pstate());
         }
-        env->local_frame()[a->name()] = a->value().ptr();
+        env->local_frame()[a->name()] = a->value();
       }
     }
     // EO while ia

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -16,7 +16,7 @@ namespace Sass {
     std::map<std::string, Parameter_Obj> param_map;
 
     for (size_t i = 0, L = as->length(); i < L; ++i) {
-      if (auto str = SASS_MEMORY_CAST(String_Quoted, (*as)[i]->value())) {
+      if (auto str = Cast<String_Quoted>((*as)[i]->value())) {
         // force optional quotes (only if needed)
         if (str->quote_mark()) {
           str->quote_mark('*');
@@ -42,7 +42,7 @@ namespace Sass {
       if (ip >= LP) {
         // skip empty rest arguments
         if (a->is_rest_argument()) {
-          if (List_Obj l = SASS_MEMORY_CAST(List, a->value())) {
+          if (List_Obj l = Cast<List>(a->value())) {
             if (l->length() == 0) {
               ++ ia; continue;
             }
@@ -61,7 +61,7 @@ namespace Sass {
         if (a->is_rest_argument()) {
 
           // We should always get a list for rest arguments
-          if (List_Obj rest = SASS_MEMORY_CAST(List, a->value())) {
+          if (List_Obj rest = Cast<List>(a->value())) {
               // create a new list object for wrapped items
               List_Ptr arglist = SASS_MEMORY_NEW(List,
                                               p->pstate(),
@@ -70,7 +70,7 @@ namespace Sass {
                                               true);
               // wrap each item from list as an argument
               for (Expression_Obj item : rest->elements()) {
-                if (Argument_Obj arg = SASS_MEMORY_CAST(Argument, item)) {
+                if (Argument_Obj arg = Cast<Argument>(item)) {
                   arglist->append(SASS_MEMORY_COPY(arg)); // copy
                 } else {
                   arglist->append(SASS_MEMORY_NEW(Argument,
@@ -93,9 +93,9 @@ namespace Sass {
           // expand keyword arguments into their parameters
           List_Ptr arglist = SASS_MEMORY_NEW(List, p->pstate(), 0, SASS_COMMA, true);
           env->local_frame()[p->name()] = arglist;
-          Map_Obj argmap = SASS_MEMORY_CAST(Map, a->value());
+          Map_Obj argmap = Cast<Map>(a->value());
           for (auto key : argmap->keys()) {
-            std::string name = unquote(SASS_MEMORY_CAST(String_Constant, key)->value());
+            std::string name = unquote(Cast<String_Constant>(key)->value());
             arglist->append(SASS_MEMORY_NEW(Argument,
                                             key->pstate(),
                                             argmap->at(key),
@@ -117,18 +117,18 @@ namespace Sass {
             // get and post inc
             a = (*as)[ia++];
             // maybe we have another list as argument
-            List_Obj ls = SASS_MEMORY_CAST(List, a->value());
+            List_Obj ls = Cast<List>(a->value());
             // skip any list completely if empty
             if (ls && ls->empty() && a->is_rest_argument()) continue;
 
             Expression_Obj value = a->value();
-            if (Argument_Obj arg = SASS_MEMORY_CAST(Argument, value)) {
+            if (Argument_Obj arg = Cast<Argument>(value)) {
               arglist->append(arg.ptr());
             }
             // check if we have rest argument
             else if (a->is_rest_argument()) {
               // preserve the list separator from rest args
-              if (List_Obj rest = SASS_MEMORY_CAST(List, a->value())) {
+              if (List_Obj rest = Cast<List>(a->value())) {
                 arglist->separator(rest->separator());
 
                 for (size_t i = 0, L = rest->size(); i < L; ++i) {
@@ -166,7 +166,7 @@ namespace Sass {
       // If the current argument is the rest argument, extract a value for processing
       else if (a->is_rest_argument()) {
         // normal param and rest arg
-        List_Obj arglist = SASS_MEMORY_CAST(List, a->value());
+        List_Obj arglist = Cast<List>(a->value());
         // empty rest arg - treat all args as default values
         if (!arglist->length()) {
           break;
@@ -187,7 +187,7 @@ namespace Sass {
         }
         // otherwise move one of the rest args into the param, converting to argument if necessary
         Expression_Obj obj = arglist->at(0);
-        if (!(a = SASS_MEMORY_CAST(Argument, obj))) {
+        if (!(a = Cast<Argument>(obj))) {
           Expression_Ptr a_to_convert = obj;
           a = SASS_MEMORY_NEW(Argument,
                               a_to_convert->pstate(),
@@ -202,10 +202,10 @@ namespace Sass {
         }
 
       } else if (a->is_keyword_argument()) {
-        Map_Obj argmap = SASS_MEMORY_CAST(Map, a->value());
+        Map_Obj argmap = Cast<Map>(a->value());
 
         for (auto key : argmap->keys()) {
-          std::string name = "$" + unquote(SASS_MEMORY_CAST(String_Constant, key)->value());
+          std::string name = "$" + unquote(Cast<String_Constant>(key)->value());
 
           if (!param_map.count(name)) {
             std::stringstream msg;

--- a/src/bind.hpp
+++ b/src/bind.hpp
@@ -6,7 +6,6 @@
 #include "ast_fwd_decl.hpp"
 
 namespace Sass {
-  typedef Environment<AST_Node_Obj> Env;
 
   void bind(std::string type, std::string name, Parameters_Obj, Arguments_Obj, Context*, Env*, Eval*);
 }

--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -40,7 +40,7 @@ namespace Sass {
       }
 
       At_Root_Block_Ptr ar = SASS_MEMORY_CAST_PTR(At_Root_Block, parent);
-      Statement_Ptr ret = this->visit_children(&ar->block());
+      Statement_Ptr ret = this->visit_children(ar->block());
 
       this->parent = old_parent;
       this->parents = old_parents;
@@ -57,8 +57,8 @@ namespace Sass {
     Block_Ptr b = SASS_MEMORY_CAST_PTR(Block, parent);
 
     if (!b) {
-      if (Has_Block_Ptr bb = SASS_MEMORY_CAST(Has_Block, *parent)) {
-        b = &bb->block();
+      if (Has_Block_Ptr bb = SASS_MEMORY_CAST_PTR(Has_Block, parent)) {
+        b = bb->block();
       }
     }
 

--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -15,7 +15,7 @@ namespace Sass {
   {
     Statement_Ptr old_parent = this->parent;
 
-    if (At_Root_Block_Ptr root = SASS_MEMORY_CAST_PTR(At_Root_Block, parent)) {
+    if (At_Root_Block_Ptr root = Cast<At_Root_Block>(parent)) {
       std::vector<Statement_Ptr> old_parents = this->parents;
       std::vector<Statement_Ptr> new_parents;
 
@@ -39,7 +39,7 @@ namespace Sass {
         }
       }
 
-      At_Root_Block_Ptr ar = SASS_MEMORY_CAST_PTR(At_Root_Block, parent);
+      At_Root_Block_Ptr ar = Cast<At_Root_Block>(parent);
       Statement_Ptr ret = this->visit_children(ar->block());
 
       this->parent = old_parent;
@@ -54,10 +54,10 @@ namespace Sass {
 
     this->parents.push_back(parent);
 
-    Block_Ptr b = SASS_MEMORY_CAST_PTR(Block, parent);
+    Block_Ptr b = Cast<Block>(parent);
 
     if (!b) {
-      if (Has_Block_Ptr bb = SASS_MEMORY_CAST_PTR(Has_Block, parent)) {
+      if (Has_Block_Ptr bb = Cast<Has_Block>(parent)) {
         b = bb->block();
       }
     }
@@ -99,8 +99,8 @@ namespace Sass {
 
   Statement_Ptr CheckNesting::fallback_impl(Statement_Ptr s)
   {
-    Block_Ptr b1 = SASS_MEMORY_CAST_PTR(Block, s);
-    Has_Block_Ptr b2 = SASS_MEMORY_CAST_PTR(Has_Block, s);
+    Block_Ptr b1 = Cast<Block>(s);
+    Has_Block_Ptr b2 = Cast<Has_Block>(s);
     return b1 || b2 ? visit_children(s) : s;
   }
 
@@ -108,16 +108,16 @@ namespace Sass {
   {
     if (!this->parent) return true;
 
-    if (SASS_MEMORY_CAST_PTR(Content, node))
+    if (Cast<Content>(node))
     { this->invalid_content_parent(this->parent); }
 
     if (is_charset(node))
     { this->invalid_charset_parent(this->parent); }
 
-    if (SASS_MEMORY_CAST_PTR(Extension, node))
+    if (Cast<Extension>(node))
     { this->invalid_extend_parent(this->parent); }
 
-    // if (SASS_MEMORY_CAST(Import, node))
+    // if (Cast<Import>(node))
     // { this->invalid_import_parent(this->parent); }
 
     if (this->is_mixin(node))
@@ -129,13 +129,13 @@ namespace Sass {
     if (this->is_function(this->parent))
     { this->invalid_function_child(node); }
 
-    if (SASS_MEMORY_CAST_PTR(Declaration, node))
+    if (Cast<Declaration>(node))
     { this->invalid_prop_parent(this->parent); }
 
-    if (SASS_MEMORY_CAST_PTR(Declaration, this->parent))
+    if (Cast<Declaration>(this->parent))
     { this->invalid_prop_child(node); }
 
-    if (SASS_MEMORY_CAST_PTR(Return, node))
+    if (Cast<Return>(node))
     { this->invalid_return_parent(this->parent); }
 
     return true;
@@ -166,8 +166,8 @@ namespace Sass {
   void CheckNesting::invalid_extend_parent(Statement_Ptr parent)
   {
     if (!(
-        SASS_MEMORY_CAST_PTR(Ruleset, parent) ||
-        SASS_MEMORY_CAST_PTR(Mixin_Call, parent) ||
+        Cast<Ruleset>(parent) ||
+        Cast<Mixin_Call>(parent) ||
         is_mixin(parent)
     )) {
       throw Exception::InvalidSass(
@@ -181,12 +181,12 @@ namespace Sass {
   // {
   //   for (auto pp : this->parents) {
   //     if (
-  //         SASS_MEMORY_CAST(Each, pp) ||
-  //         SASS_MEMORY_CAST(For, pp) ||
-  //         SASS_MEMORY_CAST(If, pp) ||
-  //         SASS_MEMORY_CAST(While, pp) ||
-  //         SASS_MEMORY_CAST(Trace, pp) ||
-  //         SASS_MEMORY_CAST(Mixin_Call, pp) ||
+  //         Cast<Each>(pp) ||
+  //         Cast<For>(pp) ||
+  //         Cast<If>(pp) ||
+  //         Cast<While>(pp) ||
+  //         Cast<Trace>(pp) ||
+  //         Cast<Mixin_Call>(pp) ||
   //         is_mixin(pp)
   //     ) {
   //       throw Exception::InvalidSass(
@@ -212,12 +212,12 @@ namespace Sass {
   {
     for (Statement_Ptr pp : this->parents) {
       if (
-          SASS_MEMORY_CAST_PTR(Each, pp) ||
-          SASS_MEMORY_CAST_PTR(For, pp) ||
-          SASS_MEMORY_CAST_PTR(If, pp) ||
-          SASS_MEMORY_CAST_PTR(While, pp) ||
-          SASS_MEMORY_CAST_PTR(Trace, pp) ||
-          SASS_MEMORY_CAST_PTR(Mixin_Call, pp) ||
+          Cast<Each>(pp) ||
+          Cast<For>(pp) ||
+          Cast<If>(pp) ||
+          Cast<While>(pp) ||
+          Cast<Trace>(pp) ||
+          Cast<Mixin_Call>(pp) ||
           is_mixin(pp)
       ) {
         throw Exception::InvalidSass(
@@ -232,12 +232,12 @@ namespace Sass {
   {
     for (Statement_Ptr pp : this->parents) {
       if (
-          SASS_MEMORY_CAST_PTR(Each, pp) ||
-          SASS_MEMORY_CAST_PTR(For, pp) ||
-          SASS_MEMORY_CAST_PTR(If, pp) ||
-          SASS_MEMORY_CAST_PTR(While, pp) ||
-          SASS_MEMORY_CAST_PTR(Trace, pp) ||
-          SASS_MEMORY_CAST_PTR(Mixin_Call, pp) ||
+          Cast<Each>(pp) ||
+          Cast<For>(pp) ||
+          Cast<If>(pp) ||
+          Cast<While>(pp) ||
+          Cast<Trace>(pp) ||
+          Cast<Mixin_Call>(pp) ||
           is_mixin(pp)
       ) {
         throw Exception::InvalidSass(
@@ -251,19 +251,19 @@ namespace Sass {
   void CheckNesting::invalid_function_child(Statement_Ptr child)
   {
     if (!(
-        SASS_MEMORY_CAST_PTR(Each, child) ||
-        SASS_MEMORY_CAST_PTR(For, child) ||
-        SASS_MEMORY_CAST_PTR(If, child) ||
-        SASS_MEMORY_CAST_PTR(While, child) ||
-        SASS_MEMORY_CAST_PTR(Trace, child) ||
-        SASS_MEMORY_CAST_PTR(Comment, child) ||
-        SASS_MEMORY_CAST_PTR(Debug, child) ||
-        SASS_MEMORY_CAST_PTR(Return, child) ||
-        SASS_MEMORY_CAST_PTR(Variable, child) ||
+        Cast<Each>(child) ||
+        Cast<For>(child) ||
+        Cast<If>(child) ||
+        Cast<While>(child) ||
+        Cast<Trace>(child) ||
+        Cast<Comment>(child) ||
+        Cast<Debug>(child) ||
+        Cast<Return>(child) ||
+        Cast<Variable>(child) ||
         // Ruby Sass doesn't distinguish variables and assignments
-        SASS_MEMORY_CAST_PTR(Assignment, child) ||
-        SASS_MEMORY_CAST_PTR(Warning, child) ||
-        SASS_MEMORY_CAST_PTR(Error, child)
+        Cast<Assignment>(child) ||
+        Cast<Warning>(child) ||
+        Cast<Error>(child)
     )) {
       throw Exception::InvalidSass(
         child->pstate(),
@@ -275,14 +275,14 @@ namespace Sass {
   void CheckNesting::invalid_prop_child(Statement_Ptr child)
   {
     if (!(
-        SASS_MEMORY_CAST_PTR(Each, child) ||
-        SASS_MEMORY_CAST_PTR(For, child) ||
-        SASS_MEMORY_CAST_PTR(If, child) ||
-        SASS_MEMORY_CAST_PTR(While, child) ||
-        SASS_MEMORY_CAST_PTR(Trace, child) ||
-        SASS_MEMORY_CAST_PTR(Comment, child) ||
-        SASS_MEMORY_CAST_PTR(Declaration, child) ||
-        SASS_MEMORY_CAST_PTR(Mixin_Call, child)
+        Cast<Each>(child) ||
+        Cast<For>(child) ||
+        Cast<If>(child) ||
+        Cast<While>(child) ||
+        Cast<Trace>(child) ||
+        Cast<Comment>(child) ||
+        Cast<Declaration>(child) ||
+        Cast<Mixin_Call>(child)
     )) {
       throw Exception::InvalidSass(
         child->pstate(),
@@ -296,10 +296,10 @@ namespace Sass {
     if (!(
         is_mixin(parent) ||
         is_directive_node(parent) ||
-        SASS_MEMORY_CAST_PTR(Ruleset, parent) ||
-        SASS_MEMORY_CAST_PTR(Keyframe_Rule, parent) ||
-        SASS_MEMORY_CAST_PTR(Declaration, parent) ||
-        SASS_MEMORY_CAST_PTR(Mixin_Call, parent)
+        Cast<Ruleset>(parent) ||
+        Cast<Keyframe_Rule>(parent) ||
+        Cast<Declaration>(parent) ||
+        Cast<Mixin_Call>(parent)
     )) {
       throw Exception::InvalidSass(
         parent->pstate(),
@@ -326,51 +326,51 @@ namespace Sass {
                              !is_root_node(grandparent) &&
                              !is_at_root_node(grandparent);
 
-    return SASS_MEMORY_CAST_PTR(Import, parent) ||
-           SASS_MEMORY_CAST_PTR(Each, parent) ||
-           SASS_MEMORY_CAST_PTR(For, parent) ||
-           SASS_MEMORY_CAST_PTR(If, parent) ||
-           SASS_MEMORY_CAST_PTR(While, parent) ||
-           SASS_MEMORY_CAST_PTR(Trace, parent) ||
+    return Cast<Import>(parent) ||
+           Cast<Each>(parent) ||
+           Cast<For>(parent) ||
+           Cast<If>(parent) ||
+           Cast<While>(parent) ||
+           Cast<Trace>(parent) ||
            valid_bubble_node;
   }
 
   bool CheckNesting::is_charset(Statement_Ptr n)
   {
-    Directive_Ptr d = SASS_MEMORY_CAST_PTR(Directive, n);
+    Directive_Ptr d = Cast<Directive>(n);
     return d && d->keyword() == "charset";
   }
 
   bool CheckNesting::is_mixin(Statement_Ptr n)
   {
-    Definition_Ptr def = SASS_MEMORY_CAST_PTR(Definition, n);
+    Definition_Ptr def = Cast<Definition>(n);
     return def && def->type() == Definition::MIXIN;
   }
 
   bool CheckNesting::is_function(Statement_Ptr n)
   {
-    Definition_Ptr def = SASS_MEMORY_CAST_PTR(Definition, n);
+    Definition_Ptr def = Cast<Definition>(n);
     return def && def->type() == Definition::FUNCTION;
   }
 
   bool CheckNesting::is_root_node(Statement_Ptr n)
   {
-    if (SASS_MEMORY_CAST_PTR(Ruleset, n)) return false;
+    if (Cast<Ruleset>(n)) return false;
 
-    Block_Ptr b = SASS_MEMORY_CAST_PTR(Block, n);
+    Block_Ptr b = Cast<Block>(n);
     return b && b->is_root();
   }
 
   bool CheckNesting::is_at_root_node(Statement_Ptr n)
   {
-    return SASS_MEMORY_CAST_PTR(At_Root_Block, n) != NULL;
+    return Cast<At_Root_Block>(n) != NULL;
   }
 
   bool CheckNesting::is_directive_node(Statement_Ptr n)
   {
-    return SASS_MEMORY_CAST_PTR(Directive, n) ||
-           SASS_MEMORY_CAST_PTR(Import, n) ||
-           SASS_MEMORY_CAST_PTR(Media_Block, n) ||
-           SASS_MEMORY_CAST_PTR(Supports_Block, n);
+    return Cast<Directive>(n) ||
+           Cast<Import>(n) ||
+           Cast<Media_Block>(n) ||
+           Cast<Supports_Block>(n);
   }
 }

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -25,7 +25,7 @@ namespace Sass {
 
     template <typename U>
     Statement_Ptr fallback(U x) {
-      Statement_Ptr n = SASS_MEMORY_CAST_PTR(Statement, x);
+      Statement_Ptr n = Cast<Statement>(x);
       if (this->should_visit(n)) {
         return fallback_impl(n);
       }

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -6,8 +6,6 @@
 
 namespace Sass {
 
-  typedef Environment<AST_Node_Obj> Env;
-
   class CheckNesting : public Operation_CRTP<Statement_Ptr, CheckNesting> {
 
     std::vector<Statement_Ptr>  parents;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -392,8 +392,8 @@ namespace Sass {
       String_Constant_Ptr loc = SASS_MEMORY_NEW(String_Constant, pstate, unquote(load_path));
       Argument_Obj loc_arg = SASS_MEMORY_NEW(Argument, pstate, loc);
       Arguments_Obj loc_args = SASS_MEMORY_NEW(Arguments, pstate);
-      loc_args->append(&loc_arg);
-      Function_Call_Ptr new_url = SASS_MEMORY_NEW(Function_Call, pstate, "url", &loc_args);
+      loc_args->append(loc_arg);
+      Function_Call_Ptr new_url = SASS_MEMORY_NEW(Function_Call, pstate, "url", loc_args);
       imp->urls().push_back(new_url);
     }
     else {
@@ -529,11 +529,11 @@ namespace Sass {
     Import_Obj imp = SASS_MEMORY_NEW(Import, pstate);
     // dispatch headers which will add custom functions
     // custom headers are added to the import instance
-    call_headers(entry_path, ctx_path, pstate, &imp);
+    call_headers(entry_path, ctx_path, pstate, imp);
     // increase head count to skip later
     head_imports += resources.size() - 1;
     // add the statement if we have urls
-    if (!imp->urls().empty()) root->append(&imp);
+    if (!imp->urls().empty()) root->append(imp.ptr());
     // process all other resources (add Import_Stub nodes)
     for (size_t i = 0, S = imp->incs().size(); i < S; ++i) {
       root->append(SASS_MEMORY_NEW(Import_Stub, pstate, imp->incs()[i]));
@@ -651,19 +651,19 @@ namespace Sass {
     Cssize cssize(*this, &backtrace);
     CheckNesting check_nesting;
     // check nesting
-    check_nesting(&root);
+    check_nesting(root);
     // expand and eval the tree
-    root = expand(&root);
+    root = expand(root);
     // check nesting
-    check_nesting(&root);
+    check_nesting(root);
     // merge and bubble certain rules
-    root = cssize(&root);
+    root = cssize(root);
     // should we extend something?
     if (!subset_map.empty()) {
       // create crtp visitor object
       Extend extend(*this, subset_map);
       // extend tree nodes
-      extend(&root);
+      extend(root);
     }
 
     // clean up by removing empty placeholders

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -533,7 +533,7 @@ namespace Sass {
     // increase head count to skip later
     head_imports += resources.size() - 1;
     // add the statement if we have urls
-    if (!imp->urls().empty()) root->append(imp.ptr());
+    if (!imp->urls().empty()) root->append(imp);
     // process all other resources (add Import_Stub nodes)
     for (size_t i = 0, S = imp->incs().size(); i < S; ++i) {
       root->append(SASS_MEMORY_NEW(Import_Stub, pstate, imp->incs()[i]));

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -58,13 +58,13 @@ namespace Sass {
     dd->is_indented(d->is_indented());
     dd->tabs(d->tabs());
 
-    p_stack.push_back(&dd);
-    Block_Obj bb = d->block() ? operator()(&d->block()) : NULL;
+    p_stack.push_back(dd);
+    Block_Obj bb = d->block() ? operator()(d->block()) : NULL;
     p_stack.pop_back();
 
     if (bb && bb->length()) {
       if (dd->value() && !dd->value()->is_invisible()) {
-        bb->unshift(&dd);
+        bb->unshift(dd.ptr());
       }
       return bb.detach();
     }
@@ -89,7 +89,7 @@ namespace Sass {
                                   r->pstate(),
                                   r->keyword(),
                                   r->selector(),
-                                  r->block() ? operator()(&r->block()) : 0);
+                                  r->block() ? operator()(r->block()) : 0);
     if (r->value()) rr->value(r->value());
     p_stack.pop_back();
 
@@ -102,7 +102,7 @@ namespace Sass {
         Bubble_Obj s_obj = SASS_MEMORY_CAST(Bubble, s);
         s = s_obj->node();
         if (s->statement_type() != Statement::DIRECTIVE) directive_exists = false;
-        else directive_exists = (static_cast<Directive_Ptr>(&s)->keyword() == rr->keyword());
+        else directive_exists = (SASS_MEMORY_CAST(Directive, s)->keyword() == rr->keyword());
       }
 
     }
@@ -115,7 +115,9 @@ namespace Sass {
       result->append(empty_node);
     }
 
-    Block_Obj ss = debubble(rr->block() ? &rr->block() : SASS_MEMORY_NEW(Block, rr->pstate()), &rr);
+    Block_Obj db = rr->block();
+    if (db.isNull()) db = SASS_MEMORY_NEW(Block, rr->pstate());
+    Block_Obj ss = debubble(db, rr);
     for (size_t i = 0, L = ss->length(); i < L; ++i) {
       result->append(ss->at(i));
     }
@@ -129,10 +131,10 @@ namespace Sass {
 
     Keyframe_Rule_Obj rr = SASS_MEMORY_NEW(Keyframe_Rule,
                                         r->pstate(),
-                                        operator()(&r->block()));
-    if (&r->name()) rr->name(r->name());
+                                        operator()(r->block()));
+    if (!r->name().isNull()) rr->name(r->name());
 
-    return debubble(&rr->block(), &rr);
+    return debubble(rr->block(), rr);
   }
 
   Statement_Ptr Cssize::operator()(Ruleset_Ptr r)
@@ -142,7 +144,7 @@ namespace Sass {
     // string schema is not a statement!
     // r->block() is already a string schema
     // and that is comming from propset expand
-    Block_Ptr bb = operator()(&r->block());
+    Block_Ptr bb = operator()(r->block());
     // this should protect us (at least a bit) from our mess
     // fixing this properly is harder that it should be ...
     if (dynamic_cast<Statement_Ptr>(bb) == NULL) {
@@ -165,7 +167,7 @@ namespace Sass {
     Block_Ptr rules = SASS_MEMORY_NEW(Block, rr->block()->pstate());
     for (size_t i = 0, L = rr->block()->length(); i < L; i++)
     {
-      Statement_Ptr s = &rr->block()->at(i);
+      Statement_Ptr s = rr->block()->at(i);
       if (bubblable(s)) rules->append(s);
       if (!bubblable(s)) props->append(s);
     }
@@ -173,16 +175,16 @@ namespace Sass {
     if (props->length())
     {
       Block_Obj bb = SASS_MEMORY_NEW(Block, rr->block()->pstate());
-      bb->concat(&props);
+      bb->concat(props);
       rr->block(bb);
 
       for (size_t i = 0, L = rules->length(); i < L; i++)
       {
-        Statement_Ptr stm = &rules->at(i);
+        Statement_Ptr stm = rules->at(i);
         stm->tabs(stm->tabs() + 1);
       }
 
-      rules->unshift(&rr);
+      rules->unshift(rr.ptr());
     }
 
     Block_Ptr ptr = rules;
@@ -194,7 +196,7 @@ namespace Sass {
     }
 
     if (!(!rules->length() ||
-          !bubblable(&rules->last()) ||
+          !bubblable(rules->last()) ||
           parent()->statement_type() == Statement::RULESET))
     {
       rules->last()->group_end(true);
@@ -219,13 +221,13 @@ namespace Sass {
 
     Media_Block_Obj mm = SASS_MEMORY_NEW(Media_Block,
                                       m->pstate(),
-                                      &m->media_queries(),
-                                      operator()(&m->block()));
+                                      m->media_queries(),
+                                      operator()(m->block()));
     mm->tabs(m->tabs());
 
     p_stack.pop_back();
 
-    return debubble(&mm->block(), &mm);
+    return debubble(mm->block(), mm);
   }
 
   Statement_Ptr Cssize::operator()(Supports_Block_Ptr m)
@@ -240,13 +242,13 @@ namespace Sass {
 
     Supports_Block_Obj mm = SASS_MEMORY_NEW(Supports_Block,
                                        m->pstate(),
-                                       &m->condition(),
-                                       operator()(&m->block()));
+                                       m->condition(),
+                                       operator()(m->block()));
     mm->tabs(m->tabs());
 
     p_stack.pop_back();
 
-    return debubble(&mm->block(), &mm);
+    return debubble(mm->block(), mm);
   }
 
   Statement_Ptr Cssize::operator()(At_Root_Block_Ptr m)
@@ -259,13 +261,13 @@ namespace Sass {
 
     if (!tmp)
     {
-      Block_Ptr bb = operator()(&m->block());
+      Block_Ptr bb = operator()(m->block());
       for (size_t i = 0, L = bb->length(); i < L; ++i) {
         // (bb->elements())[i]->tabs(m->tabs());
         Statement_Obj stm = bb->at(i);
-        if (bubblable(&stm)) stm->tabs(stm->tabs() + m->tabs());
+        if (bubblable(stm)) stm->tabs(stm->tabs() + m->tabs());
       }
-      if (bb->length() && bubblable(&bb->last())) bb->last()->group_end(m->group_end());
+      if (bb->length() && bubblable(bb->last())) bb->last()->group_end(m->group_end());
       return bb;
     }
 
@@ -283,10 +285,10 @@ namespace Sass {
     Has_Block_Obj new_rule = static_cast<Has_Block_Ptr>(SASS_MEMORY_COPY(this->parent()));
     new_rule->block(bb);
     new_rule->tabs(this->parent()->tabs());
-    new_rule->block()->concat(&m->block());
+    new_rule->block()->concat(m->block());
 
     Block_Obj wrapper_block = SASS_MEMORY_NEW(Block, m->block() ? m->block()->pstate() : m->pstate());
-    wrapper_block->append(&new_rule);
+    wrapper_block->append(new_rule.ptr());
     Directive_Obj mm = SASS_MEMORY_NEW(Directive,
                                   m->pstate(),
                                   m->keyword(),
@@ -294,7 +296,7 @@ namespace Sass {
                                   wrapper_block);
     if (m->value()) mm->value(m->value());
 
-    Bubble_Ptr bubble = SASS_MEMORY_NEW(Bubble, mm->pstate(), &mm);
+    Bubble_Ptr bubble = SASS_MEMORY_NEW(Bubble, mm->pstate(), mm.ptr());
     return bubble;
   }
 
@@ -304,10 +306,10 @@ namespace Sass {
     Has_Block_Obj new_rule = static_cast<Has_Block_Ptr>(SASS_MEMORY_COPY(this->parent()));
     new_rule->block(bb);
     new_rule->tabs(this->parent()->tabs());
-    new_rule->block()->concat(&m->block());
+    new_rule->block()->concat(m->block());
 
     Block_Ptr wrapper_block = SASS_MEMORY_NEW(Block, m->block()->pstate());
-    wrapper_block->append(&new_rule);
+    wrapper_block->append(new_rule.ptr());
     At_Root_Block_Ptr mm = SASS_MEMORY_NEW(At_Root_Block,
                                         m->pstate(),
                                         wrapper_block,
@@ -326,13 +328,13 @@ namespace Sass {
                                         parent->selector(),
                                         bb);
     new_rule->tabs(parent->tabs());
-    new_rule->block()->concat(&m->block());
+    new_rule->block()->concat(m->block());
 
     Block_Ptr wrapper_block = SASS_MEMORY_NEW(Block, m->block()->pstate());
     wrapper_block->append(new_rule);
     Supports_Block_Ptr mm = SASS_MEMORY_NEW(Supports_Block,
                                        m->pstate(),
-                                       &m->condition(),
+                                       m->condition(),
                                        wrapper_block);
 
     mm->tabs(m->tabs());
@@ -351,19 +353,19 @@ namespace Sass {
                                         parent->selector(),
                                         bb);
     new_rule->tabs(parent->tabs());
-    new_rule->block()->concat(&m->block());
+    new_rule->block()->concat(m->block());
 
     Block_Ptr wrapper_block = SASS_MEMORY_NEW(Block, m->block()->pstate());
     wrapper_block->append(new_rule);
     Media_Block_Obj mm = SASS_MEMORY_NEW(Media_Block,
                                       m->pstate(),
-                                      &m->media_queries(),
+                                      m->media_queries(),
                                       wrapper_block,
                                       0);
 
     mm->tabs(m->tabs());
 
-    return SASS_MEMORY_NEW(Bubble, mm->pstate(), &mm);
+    return SASS_MEMORY_NEW(Bubble, mm->pstate(), mm.ptr());
   }
 
   bool Cssize::bubblable(Statement_Ptr s)
@@ -375,7 +377,7 @@ namespace Sass {
   {
     Block_Ptr result = SASS_MEMORY_NEW(Block, b->pstate(), 0, b->is_root());
     for (size_t i = 0, L = b->length(); i < L; ++i) {
-      Statement_Ptr ss = &b->at(i);
+      Statement_Ptr ss = b->at(i);
       if (Block_Ptr bb = SASS_MEMORY_CAST_PTR(Block, ss)) {
         Block_Obj bs = flatten(bb);
         for (size_t j = 0, K = bs->length(); j < K; ++j) {
@@ -395,7 +397,7 @@ namespace Sass {
 
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       Statement_Obj value = b->at(i);
-      bool key = dynamic_cast<Bubble_Ptr>(&value) != NULL;
+      bool key = SASS_MEMORY_CAST(Bubble, value) != NULL;
 
       if (!results.empty() && results.back().first == key)
       {
@@ -424,17 +426,17 @@ namespace Sass {
 
       if (!is_bubble) {
         if (!parent) {
-          result->append(&slice);
+          result->append(slice.ptr());
         }
         else if (previous_parent) {
-          previous_parent->block()->concat(&slice);
+          previous_parent->block()->concat(slice);
         }
         else {
           previous_parent = static_cast<Has_Block_Ptr>(SASS_MEMORY_COPY(parent));
           previous_parent->block(slice);
           previous_parent->tabs(parent->tabs());
 
-          result->append(&previous_parent);
+          result->append(previous_parent.ptr());
         }
         continue;
       }
@@ -447,22 +449,27 @@ namespace Sass {
         Bubble_Obj node = SASS_MEMORY_CAST(Bubble, stm);
         Media_Block_Ptr m1 = NULL;
         Media_Block_Ptr m2 = NULL;
-        if (parent) m1 = SASS_MEMORY_CAST(Media_Block, *parent);
+        if (parent) m1 = SASS_MEMORY_CAST_PTR(Media_Block, parent);
         if (node) m2 = SASS_MEMORY_CAST(Media_Block, node->node());
         if (!parent ||
             parent->statement_type() != Statement::MEDIA ||
             node->node()->statement_type() != Statement::MEDIA ||
-            (m1 && m2 && &m1->media_queries() == &m2->media_queries())
+            (m1 && m2 && *m1->media_queries() == *m2->media_queries())
           )
         {
-          ss = &node->node();
+          ss = node->node();
         }
         else
         {
-          List_Obj mq = merge_media_queries(static_cast<Media_Block_Ptr>(&node->node()), static_cast<Media_Block_Ptr>(parent));
+          List_Obj mq = merge_media_queries(
+            SASS_MEMORY_CAST(Media_Block, node->node()),
+            SASS_MEMORY_CAST_PTR(Media_Block, parent)
+          );
           if (!mq->length()) continue;
-          static_cast<Media_Block_Ptr>(&node->node())->media_queries(mq);
-          ss = &node->node();
+          if (Media_Block* b = SASS_MEMORY_CAST(Media_Block, node->node())) {
+            b->media_queries(mq);
+          }
+          ss = node->node();
         }
 
         if (!ss) continue;
@@ -483,7 +490,7 @@ namespace Sass {
                                               children->length(),
                                               children->is_root());
 
-        Block_Ptr wrapper = flatten(&bb);
+        Block_Ptr wrapper = flatten(bb);
         wrapper_block->append(wrapper);
 
         if (wrapper->length()) {
@@ -491,12 +498,12 @@ namespace Sass {
         }
 
         if (wrapper_block) {
-          result->append(&wrapper_block);
+          result->append(wrapper_block.ptr());
         }
       }
     }
 
-    return flatten(&result);
+    return flatten(result);
   }
 
   Statement_Ptr Cssize::fallback_impl(AST_Node_Ptr n)
@@ -548,9 +555,9 @@ namespace Sass {
     std::string mod;
 
     std::string m1 = std::string(mq1->is_restricted() ? "only" : mq1->is_negated() ? "not" : "");
-    std::string t1 = &mq1->media_type() ? mq1->media_type()->to_string(ctx.c_options) : "";
+    std::string t1 = mq1->media_type() ? mq1->media_type()->to_string(ctx.c_options) : "";
     std::string m2 = std::string(mq2->is_restricted() ? "only" : mq1->is_negated() ? "not" : "");
-    std::string t2 = &mq2->media_type() ? mq2->media_type()->to_string(ctx.c_options) : "";
+    std::string t2 = mq2->media_type() ? mq2->media_type()->to_string(ctx.c_options) : "";
 
 
     if (t1.empty()) t1 = t2;

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -282,7 +282,7 @@ namespace Sass {
   Statement_Ptr Cssize::bubble(Directive_Ptr m)
   {
     Block_Ptr bb = SASS_MEMORY_NEW(Block, this->parent()->pstate());
-    Has_Block_Obj new_rule = static_cast<Has_Block_Ptr>(SASS_MEMORY_COPY(this->parent()));
+    Has_Block_Obj new_rule = Cast<Has_Block>(SASS_MEMORY_COPY(this->parent()));
     new_rule->block(bb);
     new_rule->tabs(this->parent()->tabs());
     new_rule->block()->concat(m->block());
@@ -303,7 +303,7 @@ namespace Sass {
   Statement_Ptr Cssize::bubble(At_Root_Block_Ptr m)
   {
     Block_Ptr bb = SASS_MEMORY_NEW(Block, this->parent()->pstate());
-    Has_Block_Obj new_rule = static_cast<Has_Block_Ptr>(SASS_MEMORY_COPY(this->parent()));
+    Has_Block_Obj new_rule = Cast<Has_Block>(SASS_MEMORY_COPY(this->parent()));
     new_rule->block(bb);
     new_rule->tabs(this->parent()->tabs());
     new_rule->block()->concat(m->block());
@@ -320,7 +320,7 @@ namespace Sass {
 
   Statement_Ptr Cssize::bubble(Supports_Block_Ptr m)
   {
-    Ruleset_Obj parent = static_cast<Ruleset_Ptr>(SASS_MEMORY_COPY(this->parent()));
+    Ruleset_Obj parent = Cast<Ruleset>(SASS_MEMORY_COPY(this->parent()));
 
     Block_Ptr bb = SASS_MEMORY_NEW(Block, parent->block()->pstate());
     Ruleset_Ptr new_rule = SASS_MEMORY_NEW(Ruleset,
@@ -345,7 +345,7 @@ namespace Sass {
 
   Statement_Ptr Cssize::bubble(Media_Block_Ptr m)
   {
-    Ruleset_Obj parent = static_cast<Ruleset_Ptr>(SASS_MEMORY_COPY(this->parent()));
+    Ruleset_Obj parent = Cast<Ruleset>(SASS_MEMORY_COPY(this->parent()));
 
     Block_Ptr bb = SASS_MEMORY_NEW(Block, parent->block()->pstate());
     Ruleset_Ptr new_rule = SASS_MEMORY_NEW(Ruleset,
@@ -432,7 +432,7 @@ namespace Sass {
           previous_parent->block()->concat(slice);
         }
         else {
-          previous_parent = static_cast<Has_Block_Ptr>(SASS_MEMORY_COPY(parent));
+          previous_parent = Cast<Has_Block>(SASS_MEMORY_COPY(parent));
           previous_parent->block(slice);
           previous_parent->tabs(parent->tabs());
 

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -64,7 +64,7 @@ namespace Sass {
 
     if (bb && bb->length()) {
       if (dd->value() && !dd->value()->is_invisible()) {
-        bb->unshift(dd.ptr());
+        bb->unshift(dd);
       }
       return bb.detach();
     }
@@ -184,7 +184,7 @@ namespace Sass {
         stm->tabs(stm->tabs() + 1);
       }
 
-      rules->unshift(rr.ptr());
+      rules->unshift(rr);
     }
 
     Block_Ptr ptr = rules;
@@ -288,7 +288,7 @@ namespace Sass {
     new_rule->block()->concat(m->block());
 
     Block_Obj wrapper_block = SASS_MEMORY_NEW(Block, m->block() ? m->block()->pstate() : m->pstate());
-    wrapper_block->append(new_rule.ptr());
+    wrapper_block->append(new_rule);
     Directive_Obj mm = SASS_MEMORY_NEW(Directive,
                                   m->pstate(),
                                   m->keyword(),
@@ -296,7 +296,7 @@ namespace Sass {
                                   wrapper_block);
     if (m->value()) mm->value(m->value());
 
-    Bubble_Ptr bubble = SASS_MEMORY_NEW(Bubble, mm->pstate(), mm.ptr());
+    Bubble_Ptr bubble = SASS_MEMORY_NEW(Bubble, mm->pstate(), mm);
     return bubble;
   }
 
@@ -309,7 +309,7 @@ namespace Sass {
     new_rule->block()->concat(m->block());
 
     Block_Ptr wrapper_block = SASS_MEMORY_NEW(Block, m->block()->pstate());
-    wrapper_block->append(new_rule.ptr());
+    wrapper_block->append(new_rule);
     At_Root_Block_Ptr mm = SASS_MEMORY_NEW(At_Root_Block,
                                         m->pstate(),
                                         wrapper_block,
@@ -365,7 +365,7 @@ namespace Sass {
 
     mm->tabs(m->tabs());
 
-    return SASS_MEMORY_NEW(Bubble, mm->pstate(), mm.ptr());
+    return SASS_MEMORY_NEW(Bubble, mm->pstate(), mm);
   }
 
   bool Cssize::bubblable(Statement_Ptr s)
@@ -426,7 +426,7 @@ namespace Sass {
 
       if (!is_bubble) {
         if (!parent) {
-          result->append(slice.ptr());
+          result->append(slice);
         }
         else if (previous_parent) {
           previous_parent->block()->concat(slice);
@@ -436,7 +436,7 @@ namespace Sass {
           previous_parent->block(slice);
           previous_parent->tabs(parent->tabs());
 
-          result->append(previous_parent.ptr());
+          result->append(previous_parent);
         }
         continue;
       }
@@ -498,7 +498,7 @@ namespace Sass {
         }
 
         if (wrapper_block) {
-          result->append(wrapper_block.ptr());
+          result->append(wrapper_block);
         }
       }
     }

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -40,7 +40,7 @@ namespace Sass {
   {
     String_Obj property = Cast<String>(d->property());
 
-    if (Declaration_Ptr dd = dynamic_cast<Declaration_Ptr>(parent())) {
+    if (Declaration_Ptr dd = Cast<Declaration>(parent())) {
       String_Obj parent_property = Cast<String>(dd->property());
       property = SASS_MEMORY_NEW(String_Constant,
                                  d->property()->pstate(),
@@ -147,7 +147,7 @@ namespace Sass {
     Block_Ptr bb = operator()(r->block());
     // this should protect us (at least a bit) from our mess
     // fixing this properly is harder that it should be ...
-    if (dynamic_cast<Statement_Ptr>(bb) == NULL) {
+    if (Cast<Statement>(bb) == NULL) {
       error("Illegal nesting: Only properties may be nested beneath properties.", r->block()->pstate());
     }
     Ruleset_Obj rr = SASS_MEMORY_NEW(Ruleset,
@@ -370,7 +370,7 @@ namespace Sass {
 
   bool Cssize::bubblable(Statement_Ptr s)
   {
-    return dynamic_cast<Ruleset_Ptr>(s) || s->bubbles();
+    return Cast<Ruleset>(s) || s->bubbles();
   }
 
   Block_Ptr Cssize::flatten(Block_Ptr b)

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -38,10 +38,10 @@ namespace Sass {
 
   Statement_Ptr Cssize::operator()(Declaration_Ptr d)
   {
-    String_Obj property = SASS_MEMORY_CAST(String, d->property());
+    String_Obj property = Cast<String>(d->property());
 
     if (Declaration_Ptr dd = dynamic_cast<Declaration_Ptr>(parent())) {
-      String_Obj parent_property = SASS_MEMORY_CAST(String, dd->property());
+      String_Obj parent_property = Cast<String>(dd->property());
       property = SASS_MEMORY_NEW(String_Constant,
                                  d->property()->pstate(),
                                  parent_property->to_string() + "-" + property->to_string());
@@ -99,10 +99,10 @@ namespace Sass {
       Statement_Obj s = r->block()->at(i);
       if (s->statement_type() != Statement::BUBBLE) directive_exists = true;
       else {
-        Bubble_Obj s_obj = SASS_MEMORY_CAST(Bubble, s);
+        Bubble_Obj s_obj = Cast<Bubble>(s);
         s = s_obj->node();
         if (s->statement_type() != Statement::DIRECTIVE) directive_exists = false;
-        else directive_exists = (SASS_MEMORY_CAST(Directive, s)->keyword() == rr->keyword());
+        else directive_exists = (Cast<Directive>(s)->keyword() == rr->keyword());
       }
 
     }
@@ -110,7 +110,7 @@ namespace Sass {
     Block_Ptr result = SASS_MEMORY_NEW(Block, rr->pstate());
     if (!(directive_exists || rr->is_keyframes()))
     {
-      Directive_Ptr empty_node = SASS_MEMORY_CAST(Directive, rr);
+      Directive_Ptr empty_node = Cast<Directive>(rr);
       empty_node->block(SASS_MEMORY_NEW(Block, rr->block() ? rr->block()->pstate() : rr->pstate()));
       result->append(empty_node);
     }
@@ -378,7 +378,7 @@ namespace Sass {
     Block_Ptr result = SASS_MEMORY_NEW(Block, b->pstate(), 0, b->is_root());
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       Statement_Ptr ss = b->at(i);
-      if (Block_Ptr bb = SASS_MEMORY_CAST_PTR(Block, ss)) {
+      if (Block_Ptr bb = Cast<Block>(ss)) {
         Block_Obj bs = flatten(bb);
         for (size_t j = 0, K = bs->length(); j < K; ++j) {
           result->append(bs->at(j));
@@ -397,7 +397,7 @@ namespace Sass {
 
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       Statement_Obj value = b->at(i);
-      bool key = SASS_MEMORY_CAST(Bubble, value) != NULL;
+      bool key = Cast<Bubble>(value) != NULL;
 
       if (!results.empty() && results.back().first == key)
       {
@@ -446,11 +446,11 @@ namespace Sass {
         Statement_Ptr ss = NULL;
         Statement_Obj stm = slice->at(j);
         // this has to go now here (too bad)
-        Bubble_Obj node = SASS_MEMORY_CAST(Bubble, stm);
+        Bubble_Obj node = Cast<Bubble>(stm);
         Media_Block_Ptr m1 = NULL;
         Media_Block_Ptr m2 = NULL;
-        if (parent) m1 = SASS_MEMORY_CAST_PTR(Media_Block, parent);
-        if (node) m2 = SASS_MEMORY_CAST(Media_Block, node->node());
+        if (parent) m1 = Cast<Media_Block>(parent);
+        if (node) m2 = Cast<Media_Block>(node->node());
         if (!parent ||
             parent->statement_type() != Statement::MEDIA ||
             node->node()->statement_type() != Statement::MEDIA ||
@@ -462,11 +462,11 @@ namespace Sass {
         else
         {
           List_Obj mq = merge_media_queries(
-            SASS_MEMORY_CAST(Media_Block, node->node()),
-            SASS_MEMORY_CAST_PTR(Media_Block, parent)
+            Cast<Media_Block>(node->node()),
+            Cast<Media_Block>(parent)
           );
           if (!mq->length()) continue;
-          if (Media_Block* b = SASS_MEMORY_CAST(Media_Block, node->node())) {
+          if (Media_Block* b = Cast<Media_Block>(node->node())) {
             b->media_queries(mq);
           }
           ss = node->node();
@@ -515,7 +515,7 @@ namespace Sass {
   {
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       Statement_Obj ith = b->at(i)->perform(this);
-      if (Block_Ptr bb = SASS_MEMORY_CAST(Block, ith)) {
+      if (Block_Ptr bb = Cast<Block>(ith)) {
         for (size_t j = 0, K = bb->length(); j < K; ++j) {
           cur->append(bb->at(j));
         }
@@ -537,8 +537,8 @@ namespace Sass {
       for (size_t j = 0, K = m2->media_queries()->length(); j < K; j++) {
         Expression_Obj l1 = m1->media_queries()->at(i);
         Expression_Obj l2 = m2->media_queries()->at(j);
-        Media_Query_Ptr mq1 = SASS_MEMORY_CAST(Media_Query, l1);
-        Media_Query_Ptr mq2 = SASS_MEMORY_CAST(Media_Query, l2);
+        Media_Query_Ptr mq1 = Cast<Media_Query>(l1);
+        Media_Query_Ptr mq2 = Cast<Media_Query>(l2);
         Media_Query_Ptr mq = merge_media_query(mq1, mq2);
         if (mq) qq->append(mq);
       }

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -360,8 +360,7 @@ namespace Sass {
     Media_Block_Obj mm = SASS_MEMORY_NEW(Media_Block,
                                       m->pstate(),
                                       m->media_queries(),
-                                      wrapper_block,
-                                      0);
+                                      wrapper_block);
 
     mm->tabs(m->tabs());
 

--- a/src/cssize.hpp
+++ b/src/cssize.hpp
@@ -8,7 +8,6 @@
 
 namespace Sass {
 
-  typedef Environment<AST_Node_Obj> Env;
   struct Backtrace;
 
   class Cssize : public Operation_CRTP<Statement_Ptr, Cssize> {

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -18,7 +18,7 @@ inline void debug_sources_set(ComplexSelectorSet& set, std::string ind = "")
 {
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
   for(auto const &pair : set) {
-    debug_ast(&pair, ind + "");
+    debug_ast(pair, ind + "");
     // debug_ast(set[pair], ind + "first: ");
   }
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
@@ -74,22 +74,22 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << bubble->tabs();
     std::cerr << std::endl;
-    debug_ast(&bubble->node(), ind + " ", env);
+    debug_ast(bubble->node(), ind + " ", env);
   } else if (dynamic_cast<Trace_Ptr>(node)) {
     Trace_Ptr trace = dynamic_cast<Trace_Ptr>(node);
     std::cerr << ind << "Trace " << trace;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << " [name:" << trace->name() << "]"
     << std::endl;
-    debug_ast(&trace->block(), ind + " ", env);
+    debug_ast(trace->block(), ind + " ", env);
   } else if (dynamic_cast<At_Root_Block_Ptr>(node)) {
     At_Root_Block_Ptr root_block = dynamic_cast<At_Root_Block_Ptr>(node);
     std::cerr << ind << "At_Root_Block " << root_block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << root_block->tabs();
     std::cerr << std::endl;
-    debug_ast(&root_block->expression(), ind + ":", env);
-    debug_ast(&root_block->block(), ind + " ", env);
+    debug_ast(root_block->expression(), ind + ":", env);
+    debug_ast(root_block->block(), ind + " ", env);
   } else if (dynamic_cast<Selector_List_Ptr>(node)) {
     Selector_List_Ptr selector = dynamic_cast<Selector_List_Ptr>(node);
     std::cerr << ind << "Selector_List " << selector;
@@ -104,7 +104,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
 
-    for(const Complex_Selector_Obj& i : selector->elements()) { debug_ast(&i, ind + " ", env); }
+    for(const Complex_Selector_Obj& i : selector->elements()) { debug_ast(i, ind + " ", env); }
 
 //  } else if (dynamic_cast<Expression_Ptr>(node)) {
 //    Expression_Ptr expression = dynamic_cast<Expression_Ptr>(node);
@@ -145,9 +145,9 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
       }
       // if (del = "/") del += selector->reference()->perform(&to_string) + "/";
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
-    debug_ast(&selector->head(), ind + " " /* + "[" + del + "]" */, env);
+    debug_ast(selector->head(), ind + " " /* + "[" + del + "]" */, env);
     if (selector->tail()) {
-      debug_ast(&selector->tail(), ind + "{" + del + "}", env);
+      debug_ast(selector->tail(), ind + "{" + del + "}", env);
     } else if(del != " ") {
       std::cerr << ind << " |" << del << "| {trailing op}" << std::endl;
     }
@@ -166,7 +166,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
-    for(const Simple_Selector_Obj& i : selector->elements()) { debug_ast(&i, ind + " ", env); }
+    for(const Simple_Selector_Obj& i : selector->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Wrapped_Selector_Ptr>(node)) {
     Wrapped_Selector_Ptr selector = dynamic_cast<Wrapped_Selector_Ptr>(node);
     std::cerr << ind << "Wrapped_Selector " << selector;
@@ -178,7 +178,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
-    debug_ast(&selector->selector(), ind + " () ", env);
+    debug_ast(selector->selector(), ind + " () ", env);
   } else if (dynamic_cast<Pseudo_Selector_Ptr>(node)) {
     Pseudo_Selector_Ptr selector = dynamic_cast<Pseudo_Selector_Ptr>(node);
     std::cerr << ind << "Pseudo_Selector " << selector;
@@ -190,7 +190,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
-    debug_ast(&selector->expression(), ind + " <= ", env);
+    debug_ast(selector->expression(), ind + " <= ", env);
   } else if (dynamic_cast<Attribute_Selector_Ptr>(node)) {
     Attribute_Selector_Ptr selector = dynamic_cast<Attribute_Selector_Ptr>(node);
     std::cerr << ind << "Attribute_Selector " << selector;
@@ -202,7 +202,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
-    debug_ast(&selector->value(), ind + "[" + selector->matcher() + "] ", env);
+    debug_ast(selector->value(), ind + "[" + selector->matcher() + "] ", env);
   } else if (dynamic_cast<Class_Selector_Ptr>(node)) {
     Class_Selector_Ptr selector = dynamic_cast<Class_Selector_Ptr>(node);
     std::cerr << ind << "Class_Selector " << selector;
@@ -265,7 +265,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
       << (selector->has_line_feed() ? " [line-feed]": " -")
     << std::endl;
 
-    debug_ast(&selector->contents(), ind + " ");
+    debug_ast(selector->contents(), ind + " ");
     // for(auto i : selector->elements()) { debug_ast(i, ind + " ", env); }
 
   } else if (dynamic_cast<Selector_Ptr>(node)) {
@@ -282,8 +282,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << (block->is_interpolated() ? " [is_interpolated]": " -")
     << std::endl;
-    debug_ast(&block->feature(), ind + " feature) ");
-    debug_ast(&block->value(), ind + " value) ");
+    debug_ast(block->feature(), ind + " feature) ");
+    debug_ast(block->value(), ind + " value) ");
 
   } else if (dynamic_cast<Media_Query_Ptr>(node)) {
     Media_Query_Ptr block = dynamic_cast<Media_Query_Ptr>(node);
@@ -292,63 +292,63 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (block->is_negated() ? " [is_negated]": " -")
       << (block->is_restricted() ? " [is_restricted]": " -")
     << std::endl;
-    debug_ast(&block->media_type(), ind + " ");
-    for(const auto& i : block->elements()) { debug_ast(&i, ind + " ", env); }
+    debug_ast(block->media_type(), ind + " ");
+    for(const auto& i : block->elements()) { debug_ast(i, ind + " ", env); }
 
   } else if (dynamic_cast<Media_Block_Ptr>(node)) {
     Media_Block_Ptr block = dynamic_cast<Media_Block_Ptr>(node);
     std::cerr << ind << "Media_Block " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    debug_ast(&block->media_queries(), ind + " =@ ");
-    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(&i, ind + " ", env); }
+    debug_ast(block->media_queries(), ind + " =@ ");
+    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Supports_Block_Ptr>(node)) {
     Supports_Block_Ptr block = dynamic_cast<Supports_Block_Ptr>(node);
     std::cerr << ind << "Supports_Block " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    debug_ast(&block->condition(), ind + " =@ ");
-    debug_ast(&block->block(), ind + " <>");
+    debug_ast(block->condition(), ind + " =@ ");
+    debug_ast(block->block(), ind + " <>");
   } else if (dynamic_cast<Supports_Operator_Ptr>(node)) {
     Supports_Operator_Ptr block = dynamic_cast<Supports_Operator_Ptr>(node);
     std::cerr << ind << "Supports_Operator " << block;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << std::endl;
-    debug_ast(&block->left(), ind + " left) ");
-    debug_ast(&block->right(), ind + " right) ");
+    debug_ast(block->left(), ind + " left) ");
+    debug_ast(block->right(), ind + " right) ");
   } else if (dynamic_cast<Supports_Negation_Ptr>(node)) {
     Supports_Negation_Ptr block = dynamic_cast<Supports_Negation_Ptr>(node);
     std::cerr << ind << "Supports_Negation " << block;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << std::endl;
-    debug_ast(&block->condition(), ind + " condition) ");
+    debug_ast(block->condition(), ind + " condition) ");
   } else if (dynamic_cast<At_Root_Query_Ptr>(node)) {
     At_Root_Query_Ptr block = dynamic_cast<At_Root_Query_Ptr>(node);
     std::cerr << ind << "At_Root_Query " << block;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << std::endl;
-    debug_ast(&block->feature(), ind + " feature) ");
-    debug_ast(&block->value(), ind + " value) ");
+    debug_ast(block->feature(), ind + " feature) ");
+    debug_ast(block->value(), ind + " value) ");
   } else if (dynamic_cast<Supports_Declaration_Ptr>(node)) {
     Supports_Declaration_Ptr block = dynamic_cast<Supports_Declaration_Ptr>(node);
     std::cerr << ind << "Supports_Declaration " << block;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << std::endl;
-    debug_ast(&block->feature(), ind + " feature) ");
-    debug_ast(&block->value(), ind + " value) ");
+    debug_ast(block->feature(), ind + " feature) ");
+    debug_ast(block->value(), ind + " value) ");
   } else if (dynamic_cast<Block_Ptr>(node)) {
     Block_Ptr root_block = dynamic_cast<Block_Ptr>(node);
     std::cerr << ind << "Block " << root_block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     if (root_block->is_root()) std::cerr << " [root]";
     std::cerr << " " << root_block->tabs() << std::endl;
-    for(const Statement_Obj& i : root_block->elements()) { debug_ast(&i, ind + " ", env); }
+    for(const Statement_Obj& i : root_block->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Warning_Ptr>(node)) {
     Warning_Ptr block = dynamic_cast<Warning_Ptr>(node);
     std::cerr << ind << "Warning " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    debug_ast(&block->message(), ind + " : ");
+    debug_ast(block->message(), ind + " : ");
   } else if (dynamic_cast<Error_Ptr>(node)) {
     Error_Ptr block = dynamic_cast<Error_Ptr>(node);
     std::cerr << ind << "Error " << block;
@@ -359,22 +359,22 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << ind << "Debug " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    debug_ast(&block->value(), ind + " ");
+    debug_ast(block->value(), ind + " ");
   } else if (dynamic_cast<Comment_Ptr>(node)) {
     Comment_Ptr block = dynamic_cast<Comment_Ptr>(node);
     std::cerr << ind << "Comment " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() <<
       " <" << prettyprint(block->pstate().token.ws_before()) << ">" << std::endl;
-    debug_ast(&block->text(), ind + "// ", env);
+    debug_ast(block->text(), ind + "// ", env);
   } else if (dynamic_cast<If_Ptr>(node)) {
     If_Ptr block = dynamic_cast<If_Ptr>(node);
     std::cerr << ind << "If " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    debug_ast(&block->predicate(), ind + " = ");
-    debug_ast(&block->block(), ind + " <>");
-    debug_ast(&block->alternative(), ind + " ><");
+    debug_ast(block->predicate(), ind + " = ");
+    debug_ast(block->block(), ind + " <>");
+    debug_ast(block->alternative(), ind + " ><");
   } else if (dynamic_cast<Return_Ptr>(node)) {
     Return_Ptr block = dynamic_cast<Return_Ptr>(node);
     std::cerr << ind << "Return " << block;
@@ -385,12 +385,12 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << ind << "Extension " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    debug_ast(&block->selector(), ind + "-> ", env);
+    debug_ast(block->selector(), ind + "-> ", env);
   } else if (dynamic_cast<Content_Ptr>(node)) {
     Content_Ptr block = dynamic_cast<Content_Ptr>(node);
     std::cerr << ind << "Content " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [@media:" << block->media_block() << "]";
+    std::cerr << " [@media:" << block->media_block().ptr() << "]";
     std::cerr << " " << block->tabs() << std::endl;
   } else if (dynamic_cast<Import_Stub_Ptr>(node)) {
     Import_Stub_Ptr block = dynamic_cast<Import_Stub_Ptr>(node);
@@ -404,55 +404,55 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     // std::vector<std::string>         files_;
-    for (auto imp : block->urls()) debug_ast(&imp, ind + "@: ", env);
-    debug_ast(&block->import_queries(), ind + "@@ ");
+    for (auto imp : block->urls()) debug_ast(imp, ind + "@: ", env);
+    debug_ast(block->import_queries(), ind + "@@ ");
   } else if (dynamic_cast<Assignment_Ptr>(node)) {
     Assignment_Ptr block = dynamic_cast<Assignment_Ptr>(node);
     std::cerr << ind << "Assignment " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <<" << block->variable() << ">> " << block->tabs() << std::endl;
-    debug_ast(&block->value(), ind + "=", env);
+    debug_ast(block->value(), ind + "=", env);
   } else if (dynamic_cast<Declaration_Ptr>(node)) {
     Declaration_Ptr block = dynamic_cast<Declaration_Ptr>(node);
     std::cerr << ind << "Declaration " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    debug_ast(&block->property(), ind + " prop: ", env);
-    debug_ast(&block->value(), ind + " value: ", env);
-    debug_ast(&block->block(), ind + " ", env);
+    debug_ast(block->property(), ind + " prop: ", env);
+    debug_ast(block->value(), ind + " value: ", env);
+    debug_ast(block->block(), ind + " ", env);
   } else if (dynamic_cast<Keyframe_Rule_Ptr>(node)) {
     Keyframe_Rule_Ptr has_block = dynamic_cast<Keyframe_Rule_Ptr>(node);
     std::cerr << ind << "Keyframe_Rule " << has_block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << has_block->tabs() << std::endl;
-    if (has_block->name()) debug_ast(&has_block->name(), ind + "@");
-    if (has_block->block()) for(const Statement_Obj& i : has_block->block()->elements()) { debug_ast(&i, ind + " ", env); }
+    if (has_block->name()) debug_ast(has_block->name(), ind + "@");
+    if (has_block->block()) for(const Statement_Obj& i : has_block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Directive_Ptr>(node)) {
     Directive_Ptr block = dynamic_cast<Directive_Ptr>(node);
     std::cerr << ind << "Directive " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << block->keyword() << "] " << block->tabs() << std::endl;
-    debug_ast(&block->selector(), ind + "~", env);
-    debug_ast(&block->value(), ind + "+", env);
-    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(&i, ind + " ", env); }
+    debug_ast(block->selector(), ind + "~", env);
+    debug_ast(block->value(), ind + "+", env);
+    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Each_Ptr>(node)) {
     Each_Ptr block = dynamic_cast<Each_Ptr>(node);
     std::cerr << ind << "Each " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(&i, ind + " ", env); }
+    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<For_Ptr>(node)) {
     For_Ptr block = dynamic_cast<For_Ptr>(node);
     std::cerr << ind << "For " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(&i, ind + " ", env); }
+    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<While_Ptr>(node)) {
     While_Ptr block = dynamic_cast<While_Ptr>(node);
     std::cerr << ind << "While " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(&i, ind + " ", env); }
+    if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Definition_Ptr>(node)) {
     Definition_Ptr block = dynamic_cast<Definition_Ptr>(node);
     std::cerr << ind << "Definition " << block;
@@ -463,16 +463,16 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     // std::cerr << " [signature: " << block->signature() << "] ";
     std::cerr << " [native: " << block->native_function() << "] ";
     std::cerr << " " << block->tabs() << std::endl;
-    debug_ast(&block->parameters(), ind + " params: ", env);
-    if (block->block()) debug_ast(&block->block(), ind + " ", env);
+    debug_ast(block->parameters(), ind + " params: ", env);
+    if (block->block()) debug_ast(block->block(), ind + " ", env);
   } else if (dynamic_cast<Mixin_Call_Ptr>(node)) {
     Mixin_Call_Ptr block = dynamic_cast<Mixin_Call_Ptr>(node);
     std::cerr << ind << "Mixin_Call " << block << " " << block->tabs();
     std::cerr << " (" << pstate_source_position(block) << ")";
     std::cerr << " [" <<  block->name() << "]";
     std::cerr << " [has_content: " << block->has_content() << "] " << std::endl;
-    debug_ast(&block->arguments(), ind + " args: ");
-    if (block->block()) debug_ast(&block->block(), ind + " ", env);
+    debug_ast(block->arguments(), ind + " args: ");
+    if (block->block()) debug_ast(block->block(), ind + " ", env);
   } else if (Ruleset_Ptr ruleset = dynamic_cast<Ruleset_Ptr>(node)) {
     std::cerr << ind << "Ruleset " << ruleset;
     std::cerr << " (" << pstate_source_position(node) << ")";
@@ -480,15 +480,15 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (ruleset->is_invisible() ? " [INVISIBLE]" : "");
     std::cerr << (ruleset->is_root() ? " [root]" : "");
     std::cerr << std::endl;
-    debug_ast(&ruleset->selector(), ind + ">");
-    debug_ast(&ruleset->block(), ind + " ");
+    debug_ast(ruleset->selector(), ind + ">");
+    debug_ast(ruleset->block(), ind + " ");
   } else if (dynamic_cast<Block_Ptr>(node)) {
     Block_Ptr block = dynamic_cast<Block_Ptr>(node);
     std::cerr << ind << "Block " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << (block->is_invisible() ? " [INVISIBLE]" : "");
     std::cerr << " [indent: " << block->tabs() << "]" << std::endl;
-    for(const Statement_Obj& i : block->elements()) { debug_ast(&i, ind + " ", env); }
+    for(const Statement_Obj& i : block->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Textual_Ptr>(node)) {
     Textual_Ptr expression = dynamic_cast<Textual_Ptr>(node);
     std::cerr << ind << "Textual " << expression;
@@ -515,8 +515,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << "" << std::endl;
-    debug_ast(&expression->name(), ind + "name: ", env);
-    debug_ast(&expression->arguments(), ind + " args: ", env);
+    debug_ast(expression->name(), ind + "name: ", env);
+    debug_ast(expression->arguments(), ind + " args: ", env);
   } else if (dynamic_cast<Function_Call_Ptr>(node)) {
     Function_Call_Ptr expression = dynamic_cast<Function_Call_Ptr>(node);
     std::cerr << ind << "Function_Call " << expression;
@@ -526,7 +526,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     if (expression->is_delayed()) std::cerr << " [delayed]";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     std::cerr << std::endl;
-    debug_ast(&expression->arguments(), ind + " args: ", env);
+    debug_ast(expression->arguments(), ind + " args: ", env);
   } else if (dynamic_cast<Arguments_Ptr>(node)) {
     Arguments_Ptr expression = dynamic_cast<Arguments_Ptr>(node);
     std::cerr << ind << "Arguments " << expression;
@@ -536,16 +536,16 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     if (expression->has_rest_argument()) std::cerr << " [has_rest_argument]";
     if (expression->has_keyword_argument()) std::cerr << " [has_keyword_argument]";
     std::cerr << std::endl;
-    for(const Argument_Obj& i : expression->elements()) { debug_ast(&i, ind + " ", env); }
+    for(const Argument_Obj& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Argument_Ptr>(node)) {
     Argument_Ptr expression = dynamic_cast<Argument_Ptr>(node);
     std::cerr << ind << "Argument " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << expression->value() << "]";
+    std::cerr << " [" << expression->value().ptr() << "]";
     std::cerr << " [name: " << expression->name() << "] ";
     std::cerr << " [rest: " << expression->is_rest_argument() << "] ";
     std::cerr << " [keyword: " << expression->is_keyword_argument() << "] " << std::endl;
-    debug_ast(&expression->value(), ind + " value: ", env);
+    debug_ast(expression->value(), ind + " value: ", env);
   } else if (dynamic_cast<Parameters_Ptr>(node)) {
     Parameters_Ptr expression = dynamic_cast<Parameters_Ptr>(node);
     std::cerr << ind << "Parameters " << expression;
@@ -553,13 +553,13 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " [has_optional: " << expression->has_optional_parameters() << "] ";
     std::cerr << " [has_rest: " << expression->has_rest_parameter() << "] ";
     std::cerr << std::endl;
-    for(const Parameter_Obj& i : expression->elements()) { debug_ast(&i, ind + " ", env); }
+    for(const Parameter_Obj& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Parameter_Ptr>(node)) {
     Parameter_Ptr expression = dynamic_cast<Parameter_Ptr>(node);
     std::cerr << ind << "Parameter " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [name: " << expression->name() << "] ";
-    std::cerr << " [default: " << expression->default_value() << "] ";
+    std::cerr << " [default: " << expression->default_value().ptr() << "] ";
     std::cerr << " [rest: " << expression->is_rest_parameter() << "] " << std::endl;
   } else if (dynamic_cast<Unary_Expression_Ptr>(node)) {
     Unary_Expression_Ptr expression = dynamic_cast<Unary_Expression_Ptr>(node);
@@ -568,7 +568,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " [delayed: " << expression->is_delayed() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->type() << "]" << std::endl;
-    debug_ast(&expression->operand(), ind + " operand: ", env);
+    debug_ast(expression->operand(), ind + " operand: ", env);
   } else if (dynamic_cast<Binary_Expression_Ptr>(node)) {
     Binary_Expression_Ptr expression = dynamic_cast<Binary_Expression_Ptr>(node);
     std::cerr << ind << "Binary_Expression " << expression;
@@ -580,8 +580,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " [ws_after: " << expression->op().ws_after << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->type_name() << "]" << std::endl;
-    debug_ast(&expression->left(), ind + " left:  ", env);
-    debug_ast(&expression->right(), ind + " right: ", env);
+    debug_ast(expression->left(), ind + " left:  ", env);
+    debug_ast(expression->right(), ind + " right: ", env);
   } else if (dynamic_cast<Map_Ptr>(node)) {
     Map_Ptr expression = dynamic_cast<Map_Ptr>(node);
     std::cerr << ind << "Map " << expression;
@@ -589,8 +589,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [Hashed]" << std::endl;
     for (const auto& i : expression->elements()) {
-      debug_ast(&i.first, ind + " key: ");
-      debug_ast(&i.second, ind + " val: ");
+      debug_ast(i.first, ind + " key: ");
+      debug_ast(i.second, ind + " val: ");
     }
   } else if (dynamic_cast<List_Ptr>(node)) {
     List_Ptr expression = dynamic_cast<List_Ptr>(node);
@@ -606,12 +606,12 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
       " [expanded: " << expression->is_expanded() << "] " <<
       " [hash: " << expression->hash() << "] " <<
       std::endl;
-    for(const auto& i : expression->elements()) { debug_ast(&i, ind + " ", env); }
+    for(const auto& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Content_Ptr>(node)) {
     Content_Ptr expression = dynamic_cast<Content_Ptr>(node);
     std::cerr << ind << "Content " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [@media:" << expression->media_block() << "]";
+    std::cerr << " [@media:" << expression->media_block().ptr() << "]";
     std::cerr << " [Statement]" << std::endl;
   } else if (dynamic_cast<Boolean_Ptr>(node)) {
     Boolean_Ptr expression = dynamic_cast<Boolean_Ptr>(node);
@@ -673,7 +673,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     if (expression->is_left_interpolant()) std::cerr << " [left interpolant] ";
     if (expression->is_right_interpolant()) std::cerr << " [right interpolant] ";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
-    for(const auto& i : expression->elements()) { debug_ast(&i, ind + " ", env); }
+    for(const auto& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<String_Ptr>(node)) {
     String_Ptr expression = dynamic_cast<String_Ptr>(node);
     std::cerr << ind << "String " << expression;
@@ -706,7 +706,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << ind << "Has_Block " << has_block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << has_block->tabs() << std::endl;
-    if (has_block->block()) for(const Statement_Obj& i : has_block->block()->elements()) { debug_ast(&i, ind + " ", env); }
+    if (has_block->block()) for(const Statement_Obj& i : has_block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (dynamic_cast<Statement_Ptr>(node)) {
     Statement_Ptr statement = dynamic_cast<Statement_Ptr>(node);
     std::cerr << ind << "Statement " << statement;
@@ -740,7 +740,7 @@ inline void debug_node(Node* node, std::string ind = "")
     std::cerr << node << " ";
     if (node->got_line_feed) std::cerr << "[LF] ";
     std::cerr << std::endl;
-    debug_ast(&node->selector(), ind + "  ");
+    debug_ast(node->selector(), ind + "  ");
   } else if (node->isCollection()) {
     std::cerr << ind;
     std::cerr << "Collection ";
@@ -781,8 +781,8 @@ inline void debug_subset_map(Sass::Subset_Map& map, std::string ind = "")
 {
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
   for(auto const &it : map.values()) {
-    debug_ast(&it.first, ind + "first: ");
-    debug_ast(&it.second, ind + "second: ");
+    debug_ast(it.first, ind + "first: ");
+    debug_ast(it.second, ind + "second: ");
   }
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
 }
@@ -791,8 +791,8 @@ inline void debug_subset_entries(SubSetMapPairs* entries, std::string ind = "")
 {
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
   for(auto const &pair : *entries) {
-    debug_ast(&pair.first, ind + "first: ");
-    debug_ast(&pair.second, ind + "second: ");
+    debug_ast(pair.first, ind + "first: ");
+    debug_ast(pair.second, ind + "second: ");
   }
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
 }

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -10,6 +10,10 @@ using namespace Sass;
 
 inline void debug_ast(AST_Node_Ptr node, std::string ind = "", Env* env = 0);
 
+inline void debug_ast(const AST_Node* node, std::string ind = "", Env* env = 0) {
+  debug_ast(const_cast<AST_Node*>(node), ind, env);
+}
+
 inline void debug_sources_set(SourcesSet& set, std::string ind = "")
 {
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -508,7 +508,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->name() << "]" << std::endl;
     std::string name(expression->name());
-    if (env && env->has(name)) debug_ast(SASS_MEMORY_CAST(Expression, (*env)[name]), ind + " -> ", env);
+    if (env && env->has(name)) debug_ast(Cast<Expression>((*env)[name]), ind + " -> ", env);
   } else if (dynamic_cast<Function_Call_Schema_Ptr>(node)) {
     Function_Call_Schema_Ptr expression = dynamic_cast<Function_Call_Schema_Ptr>(node);
     std::cerr << ind << "Function_Call_Schema " << expression;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -68,30 +68,30 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
 {
   if (node == 0) return;
   if (ind == "") std::cerr << "####################################################################\n";
-  if (dynamic_cast<Bubble_Ptr>(node)) {
-    Bubble_Ptr bubble = dynamic_cast<Bubble_Ptr>(node);
+  if (Cast<Bubble>(node)) {
+    Bubble_Ptr bubble = Cast<Bubble>(node);
     std::cerr << ind << "Bubble " << bubble;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << bubble->tabs();
     std::cerr << std::endl;
     debug_ast(bubble->node(), ind + " ", env);
-  } else if (dynamic_cast<Trace_Ptr>(node)) {
-    Trace_Ptr trace = dynamic_cast<Trace_Ptr>(node);
+  } else if (Cast<Trace>(node)) {
+    Trace_Ptr trace = Cast<Trace>(node);
     std::cerr << ind << "Trace " << trace;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << " [name:" << trace->name() << "]"
     << std::endl;
     debug_ast(trace->block(), ind + " ", env);
-  } else if (dynamic_cast<At_Root_Block_Ptr>(node)) {
-    At_Root_Block_Ptr root_block = dynamic_cast<At_Root_Block_Ptr>(node);
+  } else if (Cast<At_Root_Block>(node)) {
+    At_Root_Block_Ptr root_block = Cast<At_Root_Block>(node);
     std::cerr << ind << "At_Root_Block " << root_block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << root_block->tabs();
     std::cerr << std::endl;
     debug_ast(root_block->expression(), ind + ":", env);
     debug_ast(root_block->block(), ind + " ", env);
-  } else if (dynamic_cast<Selector_List_Ptr>(node)) {
-    Selector_List_Ptr selector = dynamic_cast<Selector_List_Ptr>(node);
+  } else if (Cast<Selector_List>(node)) {
+    Selector_List_Ptr selector = Cast<Selector_List>(node);
     std::cerr << ind << "Selector_List " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
@@ -106,12 +106,12 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
 
     for(const Complex_Selector_Obj& i : selector->elements()) { debug_ast(i, ind + " ", env); }
 
-//  } else if (dynamic_cast<Expression_Ptr>(node)) {
-//    Expression_Ptr expression = dynamic_cast<Expression_Ptr>(node);
+//  } else if (Cast<Expression>(node)) {
+//    Expression_Ptr expression = Cast<Expression>(node);
 //    std::cerr << ind << "Expression " << expression << " " << expression->concrete_type() << std::endl;
 
-  } else if (dynamic_cast<Parent_Selector_Ptr>(node)) {
-    Parent_Selector_Ptr selector = dynamic_cast<Parent_Selector_Ptr>(node);
+  } else if (Cast<Parent_Selector>(node)) {
+    Parent_Selector_Ptr selector = Cast<Parent_Selector>(node);
     std::cerr << ind << "Parent_Selector " << selector;
 //    if (selector->not_selector()) cerr << " [in_declaration]";
     std::cerr << " (" << pstate_source_position(node) << ")";
@@ -120,8 +120,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
 //    debug_ast(selector->selector(), ind + "->", env);
 
-  } else if (dynamic_cast<Complex_Selector_Ptr>(node)) {
-    Complex_Selector_Ptr selector = dynamic_cast<Complex_Selector_Ptr>(node);
+  } else if (Cast<Complex_Selector>(node)) {
+    Complex_Selector_Ptr selector = Cast<Complex_Selector>(node);
     std::cerr << ind << "Complex_Selector " << selector
       << " (" << pstate_source_position(node) << ")"
       << " <" << selector->hash() << ">"
@@ -153,8 +153,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     }
     ComplexSelectorSet set = selector->sources();
     // debug_sources_set(set, ind + "  @--> ");
-  } else if (dynamic_cast<Compound_Selector_Ptr>(node)) {
-    Compound_Selector_Ptr selector = dynamic_cast<Compound_Selector_Ptr>(node);
+  } else if (Cast<Compound_Selector>(node)) {
+    Compound_Selector_Ptr selector = Cast<Compound_Selector>(node);
     std::cerr << ind << "Compound_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
@@ -167,8 +167,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
     for(const Simple_Selector_Obj& i : selector->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Wrapped_Selector_Ptr>(node)) {
-    Wrapped_Selector_Ptr selector = dynamic_cast<Wrapped_Selector_Ptr>(node);
+  } else if (Cast<Wrapped_Selector>(node)) {
+    Wrapped_Selector_Ptr selector = Cast<Wrapped_Selector>(node);
     std::cerr << ind << "Wrapped_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
@@ -179,8 +179,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
     debug_ast(selector->selector(), ind + " () ", env);
-  } else if (dynamic_cast<Pseudo_Selector_Ptr>(node)) {
-    Pseudo_Selector_Ptr selector = dynamic_cast<Pseudo_Selector_Ptr>(node);
+  } else if (Cast<Pseudo_Selector>(node)) {
+    Pseudo_Selector_Ptr selector = Cast<Pseudo_Selector>(node);
     std::cerr << ind << "Pseudo_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
@@ -191,8 +191,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
     debug_ast(selector->expression(), ind + " <= ", env);
-  } else if (dynamic_cast<Attribute_Selector_Ptr>(node)) {
-    Attribute_Selector_Ptr selector = dynamic_cast<Attribute_Selector_Ptr>(node);
+  } else if (Cast<Attribute_Selector>(node)) {
+    Attribute_Selector_Ptr selector = Cast<Attribute_Selector>(node);
     std::cerr << ind << "Attribute_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
@@ -203,8 +203,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
     debug_ast(selector->value(), ind + "[" + selector->matcher() + "] ", env);
-  } else if (dynamic_cast<Class_Selector_Ptr>(node)) {
-    Class_Selector_Ptr selector = dynamic_cast<Class_Selector_Ptr>(node);
+  } else if (Cast<Class_Selector>(node)) {
+    Class_Selector_Ptr selector = Cast<Class_Selector>(node);
     std::cerr << ind << "Class_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
@@ -214,8 +214,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
-  } else if (dynamic_cast<Id_Selector_Ptr>(node)) {
-    Id_Selector_Ptr selector = dynamic_cast<Id_Selector_Ptr>(node);
+  } else if (Cast<Id_Selector>(node)) {
+    Id_Selector_Ptr selector = Cast<Id_Selector>(node);
     std::cerr << ind << "Id_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
@@ -225,8 +225,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
-  } else if (dynamic_cast<Element_Selector_Ptr>(node)) {
-    Element_Selector_Ptr selector = dynamic_cast<Element_Selector_Ptr>(node);
+  } else if (Cast<Element_Selector>(node)) {
+    Element_Selector_Ptr selector = Cast<Element_Selector>(node);
     std::cerr << ind << "Element_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
@@ -237,9 +237,9 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">";
     std::cerr << std::endl;
-  } else if (dynamic_cast<Placeholder_Selector_Ptr>(node)) {
+  } else if (Cast<Placeholder_Selector>(node)) {
 
-    Placeholder_Selector_Ptr selector = dynamic_cast<Placeholder_Selector_Ptr>(node);
+    Placeholder_Selector_Ptr selector = Cast<Placeholder_Selector>(node);
     std::cerr << ind << "Placeholder_Selector [" << selector->ns_name() << "] " << selector;
     std::cerr << " (" << pstate_source_position(selector) << ")"
       << " <" << selector->hash() << ">"
@@ -249,14 +249,14 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
       << (selector->has_line_feed() ? " [line-feed]": " -")
     << std::endl;
 
-  } else if (dynamic_cast<Simple_Selector*>(node)) {
-    Simple_Selector* selector = dynamic_cast<Simple_Selector*>(node);
+  } else if (Cast<Simple_Selector>(node)) {
+    Simple_Selector* selector = Cast<Simple_Selector>(node);
     std::cerr << ind << "Simple_Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << (selector->has_line_break() ? " [line-break]": " -") << (selector->has_line_feed() ? " [line-feed]": " -") << std::endl;
 
-  } else if (dynamic_cast<Selector_Schema_Ptr>(node)) {
-    Selector_Schema_Ptr selector = dynamic_cast<Selector_Schema_Ptr>(node);
+  } else if (Cast<Selector_Schema>(node)) {
+    Selector_Schema_Ptr selector = Cast<Selector_Schema>(node);
     std::cerr << ind << "Selector_Schema " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")"
       << " [@media:" << selector->media_block() << "]"
@@ -268,16 +268,16 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     debug_ast(selector->contents(), ind + " ");
     // for(auto i : selector->elements()) { debug_ast(i, ind + " ", env); }
 
-  } else if (dynamic_cast<Selector_Ptr>(node)) {
-    Selector_Ptr selector = dynamic_cast<Selector_Ptr>(node);
+  } else if (Cast<Selector>(node)) {
+    Selector_Ptr selector = Cast<Selector>(node);
     std::cerr << ind << "Selector " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << (selector->has_line_break() ? " [line-break]": " -")
       << (selector->has_line_feed() ? " [line-feed]": " -")
     << std::endl;
 
-  } else if (dynamic_cast<Media_Query_Expression_Ptr>(node)) {
-    Media_Query_Expression_Ptr block = dynamic_cast<Media_Query_Expression_Ptr>(node);
+  } else if (Cast<Media_Query_Expression>(node)) {
+    Media_Query_Expression_Ptr block = Cast<Media_Query_Expression>(node);
     std::cerr << ind << "Media_Query_Expression " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << (block->is_interpolated() ? " [is_interpolated]": " -")
@@ -285,8 +285,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     debug_ast(block->feature(), ind + " feature) ");
     debug_ast(block->value(), ind + " value) ");
 
-  } else if (dynamic_cast<Media_Query_Ptr>(node)) {
-    Media_Query_Ptr block = dynamic_cast<Media_Query_Ptr>(node);
+  } else if (Cast<Media_Query>(node)) {
+    Media_Query_Ptr block = Cast<Media_Query>(node);
     std::cerr << ind << "Media_Query " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << (block->is_negated() ? " [is_negated]": " -")
@@ -295,166 +295,166 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     debug_ast(block->media_type(), ind + " ");
     for(const auto& i : block->elements()) { debug_ast(i, ind + " ", env); }
 
-  } else if (dynamic_cast<Media_Block_Ptr>(node)) {
-    Media_Block_Ptr block = dynamic_cast<Media_Block_Ptr>(node);
+  } else if (Cast<Media_Block>(node)) {
+    Media_Block_Ptr block = Cast<Media_Block>(node);
     std::cerr << ind << "Media_Block " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->media_queries(), ind + " =@ ");
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Supports_Block_Ptr>(node)) {
-    Supports_Block_Ptr block = dynamic_cast<Supports_Block_Ptr>(node);
+  } else if (Cast<Supports_Block>(node)) {
+    Supports_Block_Ptr block = Cast<Supports_Block>(node);
     std::cerr << ind << "Supports_Block " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->condition(), ind + " =@ ");
     debug_ast(block->block(), ind + " <>");
-  } else if (dynamic_cast<Supports_Operator_Ptr>(node)) {
-    Supports_Operator_Ptr block = dynamic_cast<Supports_Operator_Ptr>(node);
+  } else if (Cast<Supports_Operator>(node)) {
+    Supports_Operator_Ptr block = Cast<Supports_Operator>(node);
     std::cerr << ind << "Supports_Operator " << block;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << std::endl;
     debug_ast(block->left(), ind + " left) ");
     debug_ast(block->right(), ind + " right) ");
-  } else if (dynamic_cast<Supports_Negation_Ptr>(node)) {
-    Supports_Negation_Ptr block = dynamic_cast<Supports_Negation_Ptr>(node);
+  } else if (Cast<Supports_Negation>(node)) {
+    Supports_Negation_Ptr block = Cast<Supports_Negation>(node);
     std::cerr << ind << "Supports_Negation " << block;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << std::endl;
     debug_ast(block->condition(), ind + " condition) ");
-  } else if (dynamic_cast<At_Root_Query_Ptr>(node)) {
-    At_Root_Query_Ptr block = dynamic_cast<At_Root_Query_Ptr>(node);
+  } else if (Cast<At_Root_Query>(node)) {
+    At_Root_Query_Ptr block = Cast<At_Root_Query>(node);
     std::cerr << ind << "At_Root_Query " << block;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << std::endl;
     debug_ast(block->feature(), ind + " feature) ");
     debug_ast(block->value(), ind + " value) ");
-  } else if (dynamic_cast<Supports_Declaration_Ptr>(node)) {
-    Supports_Declaration_Ptr block = dynamic_cast<Supports_Declaration_Ptr>(node);
+  } else if (Cast<Supports_Declaration>(node)) {
+    Supports_Declaration_Ptr block = Cast<Supports_Declaration>(node);
     std::cerr << ind << "Supports_Declaration " << block;
     std::cerr << " (" << pstate_source_position(node) << ")"
     << std::endl;
     debug_ast(block->feature(), ind + " feature) ");
     debug_ast(block->value(), ind + " value) ");
-  } else if (dynamic_cast<Block_Ptr>(node)) {
-    Block_Ptr root_block = dynamic_cast<Block_Ptr>(node);
+  } else if (Cast<Block>(node)) {
+    Block_Ptr root_block = Cast<Block>(node);
     std::cerr << ind << "Block " << root_block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     if (root_block->is_root()) std::cerr << " [root]";
     std::cerr << " " << root_block->tabs() << std::endl;
     for(const Statement_Obj& i : root_block->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Warning_Ptr>(node)) {
-    Warning_Ptr block = dynamic_cast<Warning_Ptr>(node);
+  } else if (Cast<Warning>(node)) {
+    Warning_Ptr block = Cast<Warning>(node);
     std::cerr << ind << "Warning " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->message(), ind + " : ");
-  } else if (dynamic_cast<Error_Ptr>(node)) {
-    Error_Ptr block = dynamic_cast<Error_Ptr>(node);
+  } else if (Cast<Error>(node)) {
+    Error_Ptr block = Cast<Error>(node);
     std::cerr << ind << "Error " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-  } else if (dynamic_cast<Debug_Ptr>(node)) {
-    Debug_Ptr block = dynamic_cast<Debug_Ptr>(node);
+  } else if (Cast<Debug>(node)) {
+    Debug_Ptr block = Cast<Debug>(node);
     std::cerr << ind << "Debug " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->value(), ind + " ");
-  } else if (dynamic_cast<Comment_Ptr>(node)) {
-    Comment_Ptr block = dynamic_cast<Comment_Ptr>(node);
+  } else if (Cast<Comment>(node)) {
+    Comment_Ptr block = Cast<Comment>(node);
     std::cerr << ind << "Comment " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() <<
       " <" << prettyprint(block->pstate().token.ws_before()) << ">" << std::endl;
     debug_ast(block->text(), ind + "// ", env);
-  } else if (dynamic_cast<If_Ptr>(node)) {
-    If_Ptr block = dynamic_cast<If_Ptr>(node);
+  } else if (Cast<If>(node)) {
+    If_Ptr block = Cast<If>(node);
     std::cerr << ind << "If " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->predicate(), ind + " = ");
     debug_ast(block->block(), ind + " <>");
     debug_ast(block->alternative(), ind + " ><");
-  } else if (dynamic_cast<Return_Ptr>(node)) {
-    Return_Ptr block = dynamic_cast<Return_Ptr>(node);
+  } else if (Cast<Return>(node)) {
+    Return_Ptr block = Cast<Return>(node);
     std::cerr << ind << "Return " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
-  } else if (dynamic_cast<Extension_Ptr>(node)) {
-    Extension_Ptr block = dynamic_cast<Extension_Ptr>(node);
+  } else if (Cast<Extension>(node)) {
+    Extension_Ptr block = Cast<Extension>(node);
     std::cerr << ind << "Extension " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->selector(), ind + "-> ", env);
-  } else if (dynamic_cast<Content_Ptr>(node)) {
-    Content_Ptr block = dynamic_cast<Content_Ptr>(node);
+  } else if (Cast<Content>(node)) {
+    Content_Ptr block = Cast<Content>(node);
     std::cerr << ind << "Content " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [@media:" << block->media_block().ptr() << "]";
     std::cerr << " " << block->tabs() << std::endl;
-  } else if (dynamic_cast<Import_Stub_Ptr>(node)) {
-    Import_Stub_Ptr block = dynamic_cast<Import_Stub_Ptr>(node);
+  } else if (Cast<Import_Stub>(node)) {
+    Import_Stub_Ptr block = Cast<Import_Stub>(node);
     std::cerr << ind << "Import_Stub " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << block->imp_path() << "] ";
     std::cerr << " " << block->tabs() << std::endl;
-  } else if (dynamic_cast<Import_Ptr>(node)) {
-    Import_Ptr block = dynamic_cast<Import_Ptr>(node);
+  } else if (Cast<Import>(node)) {
+    Import_Ptr block = Cast<Import>(node);
     std::cerr << ind << "Import " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     // std::vector<std::string>         files_;
     for (auto imp : block->urls()) debug_ast(imp, ind + "@: ", env);
     debug_ast(block->import_queries(), ind + "@@ ");
-  } else if (dynamic_cast<Assignment_Ptr>(node)) {
-    Assignment_Ptr block = dynamic_cast<Assignment_Ptr>(node);
+  } else if (Cast<Assignment>(node)) {
+    Assignment_Ptr block = Cast<Assignment>(node);
     std::cerr << ind << "Assignment " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <<" << block->variable() << ">> " << block->tabs() << std::endl;
     debug_ast(block->value(), ind + "=", env);
-  } else if (dynamic_cast<Declaration_Ptr>(node)) {
-    Declaration_Ptr block = dynamic_cast<Declaration_Ptr>(node);
+  } else if (Cast<Declaration>(node)) {
+    Declaration_Ptr block = Cast<Declaration>(node);
     std::cerr << ind << "Declaration " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->property(), ind + " prop: ", env);
     debug_ast(block->value(), ind + " value: ", env);
     debug_ast(block->block(), ind + " ", env);
-  } else if (dynamic_cast<Keyframe_Rule_Ptr>(node)) {
-    Keyframe_Rule_Ptr has_block = dynamic_cast<Keyframe_Rule_Ptr>(node);
+  } else if (Cast<Keyframe_Rule>(node)) {
+    Keyframe_Rule_Ptr has_block = Cast<Keyframe_Rule>(node);
     std::cerr << ind << "Keyframe_Rule " << has_block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << has_block->tabs() << std::endl;
     if (has_block->name()) debug_ast(has_block->name(), ind + "@");
     if (has_block->block()) for(const Statement_Obj& i : has_block->block()->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Directive_Ptr>(node)) {
-    Directive_Ptr block = dynamic_cast<Directive_Ptr>(node);
+  } else if (Cast<Directive>(node)) {
+    Directive_Ptr block = Cast<Directive>(node);
     std::cerr << ind << "Directive " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << block->keyword() << "] " << block->tabs() << std::endl;
     debug_ast(block->selector(), ind + "~", env);
     debug_ast(block->value(), ind + "+", env);
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Each_Ptr>(node)) {
-    Each_Ptr block = dynamic_cast<Each_Ptr>(node);
+  } else if (Cast<Each>(node)) {
+    Each_Ptr block = Cast<Each>(node);
     std::cerr << ind << "Each " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<For_Ptr>(node)) {
-    For_Ptr block = dynamic_cast<For_Ptr>(node);
+  } else if (Cast<For>(node)) {
+    For_Ptr block = Cast<For>(node);
     std::cerr << ind << "For " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<While_Ptr>(node)) {
-    While_Ptr block = dynamic_cast<While_Ptr>(node);
+  } else if (Cast<While>(node)) {
+    While_Ptr block = Cast<While>(node);
     std::cerr << ind << "While " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << block->tabs() << std::endl;
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Definition_Ptr>(node)) {
-    Definition_Ptr block = dynamic_cast<Definition_Ptr>(node);
+  } else if (Cast<Definition>(node)) {
+    Definition_Ptr block = Cast<Definition>(node);
     std::cerr << ind << "Definition " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [name: " << block->name() << "] ";
@@ -465,15 +465,15 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->parameters(), ind + " params: ", env);
     if (block->block()) debug_ast(block->block(), ind + " ", env);
-  } else if (dynamic_cast<Mixin_Call_Ptr>(node)) {
-    Mixin_Call_Ptr block = dynamic_cast<Mixin_Call_Ptr>(node);
+  } else if (Cast<Mixin_Call>(node)) {
+    Mixin_Call_Ptr block = Cast<Mixin_Call>(node);
     std::cerr << ind << "Mixin_Call " << block << " " << block->tabs();
     std::cerr << " (" << pstate_source_position(block) << ")";
     std::cerr << " [" <<  block->name() << "]";
     std::cerr << " [has_content: " << block->has_content() << "] " << std::endl;
     debug_ast(block->arguments(), ind + " args: ");
     if (block->block()) debug_ast(block->block(), ind + " ", env);
-  } else if (Ruleset_Ptr ruleset = dynamic_cast<Ruleset_Ptr>(node)) {
+  } else if (Ruleset_Ptr ruleset = Cast<Ruleset>(node)) {
     std::cerr << ind << "Ruleset " << ruleset;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [indent: " << ruleset->tabs() << "]";
@@ -482,15 +482,15 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << std::endl;
     debug_ast(ruleset->selector(), ind + ">");
     debug_ast(ruleset->block(), ind + " ");
-  } else if (dynamic_cast<Block_Ptr>(node)) {
-    Block_Ptr block = dynamic_cast<Block_Ptr>(node);
+  } else if (Cast<Block>(node)) {
+    Block_Ptr block = Cast<Block>(node);
     std::cerr << ind << "Block " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << (block->is_invisible() ? " [INVISIBLE]" : "");
     std::cerr << " [indent: " << block->tabs() << "]" << std::endl;
     for(const Statement_Obj& i : block->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Textual_Ptr>(node)) {
-    Textual_Ptr expression = dynamic_cast<Textual_Ptr>(node);
+  } else if (Cast<Textual>(node)) {
+    Textual_Ptr expression = Cast<Textual>(node);
     std::cerr << ind << "Textual " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     if (expression->type() == Textual::NUMBER) std::cerr << " [NUMBER]";
@@ -501,24 +501,24 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     if (expression->is_delayed()) std::cerr << " [delayed]";
     std::cerr << std::endl;
-  } else if (dynamic_cast<Variable_Ptr>(node)) {
-    Variable_Ptr expression = dynamic_cast<Variable_Ptr>(node);
+  } else if (Cast<Variable>(node)) {
+    Variable_Ptr expression = Cast<Variable>(node);
     std::cerr << ind << "Variable " << expression;
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->name() << "]" << std::endl;
     std::string name(expression->name());
     if (env && env->has(name)) debug_ast(Cast<Expression>((*env)[name]), ind + " -> ", env);
-  } else if (dynamic_cast<Function_Call_Schema_Ptr>(node)) {
-    Function_Call_Schema_Ptr expression = dynamic_cast<Function_Call_Schema_Ptr>(node);
+  } else if (Cast<Function_Call_Schema>(node)) {
+    Function_Call_Schema_Ptr expression = Cast<Function_Call_Schema>(node);
     std::cerr << ind << "Function_Call_Schema " << expression;
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << "" << std::endl;
     debug_ast(expression->name(), ind + "name: ", env);
     debug_ast(expression->arguments(), ind + " args: ", env);
-  } else if (dynamic_cast<Function_Call_Ptr>(node)) {
-    Function_Call_Ptr expression = dynamic_cast<Function_Call_Ptr>(node);
+  } else if (Cast<Function_Call>(node)) {
+    Function_Call_Ptr expression = Cast<Function_Call>(node);
     std::cerr << ind << "Function_Call " << expression;
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
@@ -527,8 +527,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     std::cerr << std::endl;
     debug_ast(expression->arguments(), ind + " args: ", env);
-  } else if (dynamic_cast<Arguments_Ptr>(node)) {
-    Arguments_Ptr expression = dynamic_cast<Arguments_Ptr>(node);
+  } else if (Cast<Arguments>(node)) {
+    Arguments_Ptr expression = Cast<Arguments>(node);
     std::cerr << ind << "Arguments " << expression;
     if (expression->is_delayed()) std::cerr << " [delayed]";
     std::cerr << " (" << pstate_source_position(node) << ")";
@@ -537,8 +537,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     if (expression->has_keyword_argument()) std::cerr << " [has_keyword_argument]";
     std::cerr << std::endl;
     for(const Argument_Obj& i : expression->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Argument_Ptr>(node)) {
-    Argument_Ptr expression = dynamic_cast<Argument_Ptr>(node);
+  } else if (Cast<Argument>(node)) {
+    Argument_Ptr expression = Cast<Argument>(node);
     std::cerr << ind << "Argument " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->value().ptr() << "]";
@@ -546,31 +546,31 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " [rest: " << expression->is_rest_argument() << "] ";
     std::cerr << " [keyword: " << expression->is_keyword_argument() << "] " << std::endl;
     debug_ast(expression->value(), ind + " value: ", env);
-  } else if (dynamic_cast<Parameters_Ptr>(node)) {
-    Parameters_Ptr expression = dynamic_cast<Parameters_Ptr>(node);
+  } else if (Cast<Parameters>(node)) {
+    Parameters_Ptr expression = Cast<Parameters>(node);
     std::cerr << ind << "Parameters " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [has_optional: " << expression->has_optional_parameters() << "] ";
     std::cerr << " [has_rest: " << expression->has_rest_parameter() << "] ";
     std::cerr << std::endl;
     for(const Parameter_Obj& i : expression->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Parameter_Ptr>(node)) {
-    Parameter_Ptr expression = dynamic_cast<Parameter_Ptr>(node);
+  } else if (Cast<Parameter>(node)) {
+    Parameter_Ptr expression = Cast<Parameter>(node);
     std::cerr << ind << "Parameter " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [name: " << expression->name() << "] ";
     std::cerr << " [default: " << expression->default_value().ptr() << "] ";
     std::cerr << " [rest: " << expression->is_rest_parameter() << "] " << std::endl;
-  } else if (dynamic_cast<Unary_Expression_Ptr>(node)) {
-    Unary_Expression_Ptr expression = dynamic_cast<Unary_Expression_Ptr>(node);
+  } else if (Cast<Unary_Expression>(node)) {
+    Unary_Expression_Ptr expression = Cast<Unary_Expression>(node);
     std::cerr << ind << "Unary_Expression " << expression;
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [delayed: " << expression->is_delayed() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << expression->type() << "]" << std::endl;
     debug_ast(expression->operand(), ind + " operand: ", env);
-  } else if (dynamic_cast<Binary_Expression_Ptr>(node)) {
-    Binary_Expression_Ptr expression = dynamic_cast<Binary_Expression_Ptr>(node);
+  } else if (Cast<Binary_Expression>(node)) {
+    Binary_Expression_Ptr expression = Cast<Binary_Expression>(node);
     std::cerr << ind << "Binary_Expression " << expression;
     if (expression->is_interpolant()) std::cerr << " [is interpolant] ";
     if (expression->is_left_interpolant()) std::cerr << " [left interpolant] ";
@@ -582,8 +582,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " [" << expression->type_name() << "]" << std::endl;
     debug_ast(expression->left(), ind + " left:  ", env);
     debug_ast(expression->right(), ind + " right: ", env);
-  } else if (dynamic_cast<Map_Ptr>(node)) {
-    Map_Ptr expression = dynamic_cast<Map_Ptr>(node);
+  } else if (Cast<Map>(node)) {
+    Map_Ptr expression = Cast<Map>(node);
     std::cerr << ind << "Map " << expression;
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " (" << pstate_source_position(node) << ")";
@@ -592,8 +592,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
       debug_ast(i.first, ind + " key: ");
       debug_ast(i.second, ind + " val: ");
     }
-  } else if (dynamic_cast<List_Ptr>(node)) {
-    List_Ptr expression = dynamic_cast<List_Ptr>(node);
+  } else if (Cast<List>(node)) {
+    List_Ptr expression = Cast<List>(node);
     std::cerr << ind << "List " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " (" << expression->length() << ") " <<
@@ -607,42 +607,42 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
       " [hash: " << expression->hash() << "] " <<
       std::endl;
     for(const auto& i : expression->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Content_Ptr>(node)) {
-    Content_Ptr expression = dynamic_cast<Content_Ptr>(node);
+  } else if (Cast<Content>(node)) {
+    Content_Ptr expression = Cast<Content>(node);
     std::cerr << ind << "Content " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [@media:" << expression->media_block().ptr() << "]";
     std::cerr << " [Statement]" << std::endl;
-  } else if (dynamic_cast<Boolean_Ptr>(node)) {
-    Boolean_Ptr expression = dynamic_cast<Boolean_Ptr>(node);
+  } else if (Cast<Boolean>(node)) {
+    Boolean_Ptr expression = Cast<Boolean>(node);
     std::cerr << ind << "Boolean " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->value() << "]" << std::endl;
-  } else if (dynamic_cast<Color_Ptr>(node)) {
-    Color_Ptr expression = dynamic_cast<Color_Ptr>(node);
+  } else if (Cast<Color>(node)) {
+    Color_Ptr expression = Cast<Color>(node);
     std::cerr << ind << "Color " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [delayed: " << expression->is_delayed() << "] ";
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->r() << ":"  << expression->g() << ":" << expression->b() << "@" << expression->a() << "]" << std::endl;
-  } else if (dynamic_cast<Number_Ptr>(node)) {
-    Number_Ptr expression = dynamic_cast<Number_Ptr>(node);
+  } else if (Cast<Number>(node)) {
+    Number_Ptr expression = Cast<Number>(node);
     std::cerr << ind << "Number " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
     std::cerr << " [" << expression->value() << expression->unit() << "]" <<
       " [hash: " << expression->hash() << "] " <<
       std::endl;
-  } else if (dynamic_cast<Null_Ptr>(node)) {
-    Null_Ptr expression = dynamic_cast<Null_Ptr>(node);
+  } else if (Cast<Null>(node)) {
+    Null_Ptr expression = Cast<Null>(node);
     std::cerr << ind << "Null " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [interpolant: " << expression->is_interpolant() << "] "
       // " [hash: " << expression->hash() << "] "
       << std::endl;
-  } else if (dynamic_cast<String_Quoted_Ptr>(node)) {
-    String_Quoted_Ptr expression = dynamic_cast<String_Quoted_Ptr>(node);
+  } else if (Cast<String_Quoted>(node)) {
+    String_Quoted_Ptr expression = Cast<String_Quoted>(node);
     std::cerr << ind << "String_Quoted " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " [" << prettyprint(expression->value()) << "]";
@@ -650,8 +650,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     if (expression->quote_mark()) std::cerr << " [quote_mark: " << expression->quote_mark() << "]";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
-  } else if (dynamic_cast<String_Constant_Ptr>(node)) {
-    String_Constant_Ptr expression = dynamic_cast<String_Constant_Ptr>(node);
+  } else if (Cast<String_Constant>(node)) {
+    String_Constant_Ptr expression = Cast<String_Constant>(node);
     std::cerr << ind << "String_Constant " << expression;
     if (expression->concrete_type()) {
       std::cerr << " " << expression->concrete_type();
@@ -661,8 +661,8 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     if (expression->is_delayed()) std::cerr << " [delayed]";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
-  } else if (dynamic_cast<String_Schema_Ptr>(node)) {
-    String_Schema_Ptr expression = dynamic_cast<String_Schema_Ptr>(node);
+  } else if (Cast<String_Schema>(node)) {
+    String_Schema_Ptr expression = Cast<String_Schema>(node);
     std::cerr << ind << "String_Schema " << expression;
     std::cerr << " (" << pstate_source_position(expression) << ")";
     std::cerr << " " << expression->concrete_type();
@@ -674,15 +674,15 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     if (expression->is_right_interpolant()) std::cerr << " [right interpolant] ";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
     for(const auto& i : expression->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<String_Ptr>(node)) {
-    String_Ptr expression = dynamic_cast<String_Ptr>(node);
+  } else if (Cast<String>(node)) {
+    String_Ptr expression = Cast<String>(node);
     std::cerr << ind << "String " << expression;
     std::cerr << " " << expression->concrete_type();
     std::cerr << " (" << pstate_source_position(node) << ")";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
-  } else if (dynamic_cast<Expression_Ptr>(node)) {
-    Expression_Ptr expression = dynamic_cast<Expression_Ptr>(node);
+  } else if (Cast<Expression>(node)) {
+    Expression_Ptr expression = Cast<Expression>(node);
     std::cerr << ind << "Expression " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
     switch (expression->concrete_type()) {
@@ -701,14 +701,14 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
       case Expression::Concrete_Type::NUM_TYPES: std::cerr << " [NUM_TYPES]"; break;
     }
     std::cerr << std::endl;
-  } else if (dynamic_cast<Has_Block_Ptr>(node)) {
-    Has_Block_Ptr has_block = dynamic_cast<Has_Block_Ptr>(node);
+  } else if (Cast<Has_Block>(node)) {
+    Has_Block_Ptr has_block = Cast<Has_Block>(node);
     std::cerr << ind << "Has_Block " << has_block;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << has_block->tabs() << std::endl;
     if (has_block->block()) for(const Statement_Obj& i : has_block->block()->elements()) { debug_ast(i, ind + " ", env); }
-  } else if (dynamic_cast<Statement_Ptr>(node)) {
-    Statement_Ptr statement = dynamic_cast<Statement_Ptr>(node);
+  } else if (Cast<Statement>(node)) {
+    Statement_Ptr statement = Cast<Statement>(node);
     std::cerr << ind << "Statement " << statement;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " " << statement->tabs() << std::endl;

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -14,7 +14,7 @@ inline void debug_ast(const AST_Node* node, std::string ind = "", Env* env = 0) 
   debug_ast(const_cast<AST_Node*>(node), ind, env);
 }
 
-inline void debug_sources_set(SourcesSet& set, std::string ind = "")
+inline void debug_sources_set(ComplexSelectorSet& set, std::string ind = "")
 {
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
   for(auto const &pair : set) {
@@ -151,7 +151,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     } else if(del != " ") {
       std::cerr << ind << " |" << del << "| {trailing op}" << std::endl;
     }
-    SourcesSet set = selector->sources();
+    ComplexSelectorSet set = selector->sources();
     // debug_sources_set(set, ind + "  @--> ");
   } else if (dynamic_cast<Compound_Selector_Ptr>(node)) {
     Compound_Selector_Ptr selector = dynamic_cast<Compound_Selector_Ptr>(node);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -787,10 +787,7 @@ inline void debug_subset_map(Sass::Subset_Map& map, std::string ind = "")
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
 }
 
-typedef std::pair<Complex_Selector_Obj, Compound_Selector_Obj> ExtensionPair;
-typedef std::vector<ExtensionPair> SubsetMapEntries;
-
-inline void debug_subset_entries(SubsetMapEntries* entries, std::string ind = "")
+inline void debug_subset_entries(SubSetMapPairs* entries, std::string ind = "")
 {
   if (ind == "") std::cerr << "#%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%\n";
   for(auto const &pair : *entries) {

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -178,8 +178,8 @@ namespace Sass {
     std::cerr << prefix << std::string(indent, ' ') << "== " << this << std::endl;
     for (typename std::map<std::string, T>::iterator i = local_frame_.begin(); i != local_frame_.end(); ++i) {
       if (!ends_with(i->first, "[f]") && !ends_with(i->first, "[f]4") && !ends_with(i->first, "[f]2")) {
-        std::cerr << prefix << std::string(indent, ' ') << i->first << " "  << i->second;
-        if (Value_Ptr val = SASS_MEMORY_CAST_PTR(Value, i->second))
+        std::cerr << prefix << std::string(indent, ' ') << i->first << " " << i->second;
+        if (Value_Ptr val = Cast<Value>(i->second))
         { std::cerr << " : " << val->to_string(); }
         std::cerr << std::endl;
       }

--- a/src/environment.hpp
+++ b/src/environment.hpp
@@ -87,6 +87,9 @@ namespace Sass {
 
   };
 
+  // define typedef for our use case
+  typedef Environment<AST_Node_Obj> Env;
+
 }
 
 #endif

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -87,7 +87,7 @@ namespace Sass {
     if (a->is_global()) {
       if (a->is_default()) {
         if (env->has_global(var)) {
-          Expression_Ptr e = SASS_MEMORY_CAST(Expression, env->get_global(var));
+          Expression_Ptr e = Cast<Expression>(env->get_global(var));
           if (!e || e->concrete_type() == Expression::NULL_VAL) {
             env->set_global(var, a->value()->perform(this));
           }
@@ -106,7 +106,7 @@ namespace Sass {
         while (cur && cur->is_lexical()) {
           if (cur->has_local(var)) {
             if (AST_Node_Obj node = cur->get_local(var)) {
-              Expression_Ptr e = SASS_MEMORY_CAST(Expression, node);
+              Expression_Ptr e = Cast<Expression>(node);
               if (!e || e->concrete_type() == Expression::NULL_VAL) {
                 cur->set_local(var, a->value()->perform(this));
               }
@@ -122,7 +122,7 @@ namespace Sass {
       }
       else if (env->has_global(var)) {
         if (AST_Node_Obj node = env->get_global(var)) {
-          Expression_Ptr e = SASS_MEMORY_CAST(Expression, node);
+          Expression_Ptr e = Cast<Expression>(node);
           if (!e || e->concrete_type() == Expression::NULL_VAL) {
             env->set_global(var, a->value()->perform(this));
           }
@@ -171,8 +171,8 @@ namespace Sass {
     if (high->concrete_type() != Expression::NUMBER) {
       throw Exception::TypeMismatch(*high, "integer");
     }
-    Number_Obj sass_start = SASS_MEMORY_CAST(Number, low);
-    Number_Obj sass_end = SASS_MEMORY_CAST(Number, high);
+    Number_Obj sass_start = Cast<Number>(low);
+    Number_Obj sass_end = Cast<Number>(high);
     // check if units are valid for sequence
     if (sass_start->unit() != sass_end->unit()) {
       std::stringstream msg; msg << "Incompatible units: '"
@@ -225,19 +225,19 @@ namespace Sass {
     List_Obj list = 0;
     Map_Ptr map = 0;
     if (expr->concrete_type() == Expression::MAP) {
-      map = SASS_MEMORY_CAST(Map, expr);
+      map = Cast<Map>(expr);
     }
-    else if (Selector_List_Ptr ls = SASS_MEMORY_CAST(Selector_List, expr)) {
+    else if (Selector_List_Ptr ls = Cast<Selector_List>(expr)) {
       Listize listize;
       Expression_Obj rv = ls->perform(&listize);
-      list = SASS_MEMORY_CAST(List, rv);
+      list = Cast<List>(rv);
     }
     else if (expr->concrete_type() != Expression::LIST) {
       list = SASS_MEMORY_NEW(List, expr->pstate(), 1, SASS_COMMA);
       list->append(expr);
     }
     else {
-      list = SASS_MEMORY_CAST(List, expr);
+      list = Cast<List>(expr);
     }
 
     Block_Obj body = e->block();
@@ -262,15 +262,15 @@ namespace Sass {
       }
     }
     else {
-      if (list->length() == 1 && SASS_MEMORY_CAST(Selector_List, list)) {
-        list = SASS_MEMORY_CAST(List, list);
+      if (list->length() == 1 && Cast<Selector_List>(list)) {
+        list = Cast<List>(list);
       }
       for (size_t i = 0, L = list->length(); i < L; ++i) {
         Expression_Ptr e = list->at(i);
         // unwrap value if the expression is an argument
-        if (Argument_Ptr arg = SASS_MEMORY_CAST_PTR(Argument, e)) e = arg->value();
+        if (Argument_Ptr arg = Cast<Argument>(e)) e = arg->value();
         // check if we got passed a list of args (investigate)
-        if (List_Ptr scalars = SASS_MEMORY_CAST_PTR(List, e)) {
+        if (List_Ptr scalars = Cast<List>(e)) {
           if (variables.size() == 1) {
             Expression_Ptr var = scalars;
             env.set_local(variables[0], var);
@@ -345,7 +345,7 @@ namespace Sass {
         { env }
       });
 
-      Definition_Ptr def = SASS_MEMORY_CAST(Definition, (*env)["@warn[f]"]);
+      Definition_Ptr def = Cast<Definition>((*env)["@warn[f]"]);
       // Block_Obj          body   = def->block();
       // Native_Function func   = def->native_function();
       Sass_Function_Entry c_function = def->c_function();
@@ -392,7 +392,7 @@ namespace Sass {
         { env }
       });
 
-      Definition_Ptr def = SASS_MEMORY_CAST(Definition, (*env)["@error[f]"]);
+      Definition_Ptr def = Cast<Definition>((*env)["@error[f]"]);
       // Block_Obj          body   = def->block();
       // Native_Function func   = def->native_function();
       Sass_Function_Entry c_function = def->c_function();
@@ -436,7 +436,7 @@ namespace Sass {
         { env }
       });
 
-      Definition_Ptr def = SASS_MEMORY_CAST(Definition, (*env)["@debug[f]"]);
+      Definition_Ptr def = Cast<Definition>((*env)["@debug[f]"]);
       // Block_Obj          body   = def->block();
       // Native_Function func   = def->native_function();
       Sass_Function_Entry c_function = def->c_function();
@@ -542,7 +542,7 @@ namespace Sass {
     enum Sass_OP op_type = b->type();
 
     // only the last item will be used to eval the binary expression
-    if (String_Schema_Ptr s_l = SASS_MEMORY_CAST(String_Schema, b->left())) {
+    if (String_Schema_Ptr s_l = Cast<String_Schema>(b->left())) {
       if (!s_l->has_interpolant() && (!s_l->is_right_interpolant())) {
         ret_schema = SASS_MEMORY_NEW(String_Schema, b->pstate());
         Binary_Expression_Obj bin_ex = SASS_MEMORY_NEW(Binary_Expression, b->pstate(),
@@ -555,7 +555,7 @@ namespace Sass {
         return ret_schema->perform(this);
       }
     }
-    if (String_Schema_Ptr s_r = SASS_MEMORY_CAST(String_Schema, b->right())) {
+    if (String_Schema_Ptr s_r = Cast<String_Schema>(b->right())) {
 
       if (!s_r->has_interpolant() && (!s_r->is_left_interpolant() || op_type == Sass_OP::DIV)) {
         ret_schema = SASS_MEMORY_NEW(String_Schema, b->pstate());
@@ -622,10 +622,10 @@ namespace Sass {
     Expression::Concrete_Type r_type = rhs->concrete_type();
 
     // Is one of the operands an interpolant?
-    String_Schema_Obj s1 = SASS_MEMORY_CAST(String_Schema, b->left());
-    String_Schema_Obj s2 = SASS_MEMORY_CAST(String_Schema, b->right());
-    Binary_Expression_Obj b1 = SASS_MEMORY_CAST(Binary_Expression, b->left());
-    Binary_Expression_Obj b2 = SASS_MEMORY_CAST(Binary_Expression, b->right());
+    String_Schema_Obj s1 = Cast<String_Schema>(b->left());
+    String_Schema_Obj s2 = Cast<String_Schema>(b->right());
+    Binary_Expression_Obj b1 = Cast<Binary_Expression>(b->left());
+    Binary_Expression_Obj b2 = Cast<Binary_Expression>(b->right());
 
     bool schema_op = false;
 
@@ -639,7 +639,7 @@ namespace Sass {
       if (op_type == Sass_OP::DIV || op_type == Sass_OP::MUL || op_type == Sass_OP::MOD || op_type == Sass_OP::ADD || op_type == Sass_OP::SUB ||
           op_type == Sass_OP::EQ) {
         // If possible upgrade LHS to a number (for number to string compare)
-        if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, lhs)) {
+        if (String_Constant_Ptr str = Cast<String_Constant>(lhs)) {
           std::string value(str->value());
           const char* start = value.c_str();
           if (Prelexer::sequence < Prelexer::dimension, Prelexer::end_of_file >(start) != 0) {
@@ -648,7 +648,7 @@ namespace Sass {
           }
         }
         // If possible upgrade RHS to a number (for string to number compare)
-        if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, rhs)) {
+        if (String_Constant_Ptr str = Cast<String_Constant>(rhs)) {
           std::string value(str->value());
           const char* start = value.c_str();
           if (Prelexer::sequence < Prelexer::dimension, Prelexer::number >(start) != 0) {
@@ -665,7 +665,7 @@ namespace Sass {
       r_type = rhs->concrete_type();
 
       if (s2 && s2->has_interpolants() && s2->length()) {
-        Textual_Obj front = SASS_MEMORY_CAST(Textual, s2->elements().front());
+        Textual_Obj front = Cast<Textual>(s2->elements().front());
         if (front && !front->is_interpolant())
         {
           // XXX: this is never hit via spec tests
@@ -714,30 +714,30 @@ namespace Sass {
     try {
       ParserState pstate(b->pstate());
       if (l_type == Expression::NUMBER && r_type == Expression::NUMBER) {
-        Number_Ptr l_n = SASS_MEMORY_CAST(Number, lhs);
-        Number_Ptr r_n = SASS_MEMORY_CAST(Number, rhs);
+        Number_Ptr l_n = Cast<Number>(lhs);
+        Number_Ptr r_n = Cast<Number>(rhs);
         rv = op_numbers(op_type, *l_n, *r_n, ctx.c_options, &pstate);
       }
       else if (l_type == Expression::NUMBER && r_type == Expression::COLOR) {
-        Number_Ptr l_n = SASS_MEMORY_CAST(Number, lhs);
-        Color_Ptr r_c = SASS_MEMORY_CAST(Color, rhs);
+        Number_Ptr l_n = Cast<Number>(lhs);
+        Color_Ptr r_c = Cast<Color>(rhs);
         rv = op_number_color(op_type, *l_n, *r_c, ctx.c_options, &pstate);
       }
       else if (l_type == Expression::COLOR && r_type == Expression::NUMBER) {
-        Color_Ptr l_c = SASS_MEMORY_CAST(Color, lhs);
-        Number_Ptr r_n = SASS_MEMORY_CAST(Number, rhs);
+        Color_Ptr l_c = Cast<Color>(lhs);
+        Number_Ptr r_n = Cast<Number>(rhs);
         rv = op_color_number(op_type, *l_c, *r_n, ctx.c_options, &pstate);
       }
       else if (l_type == Expression::COLOR && r_type == Expression::COLOR) {
-        Color_Ptr l_c = SASS_MEMORY_CAST(Color, lhs);
-        Color_Ptr r_c = SASS_MEMORY_CAST(Color, rhs);
+        Color_Ptr l_c = Cast<Color>(lhs);
+        Color_Ptr r_c = Cast<Color>(rhs);
         rv = op_colors(op_type, *l_c, *r_c, ctx.c_options, &pstate);
       }
       else {
         To_Value to_value(ctx);
         // this will leak if perform does not return a value!
-        Value_Obj v_l = SASS_MEMORY_CAST_PTR(Value, lhs->perform(&to_value));
-        Value_Obj v_r = SASS_MEMORY_CAST_PTR(Value, rhs->perform(&to_value));
+        Value_Obj v_l = Cast<Value>(lhs->perform(&to_value));
+        Value_Obj v_r = Cast<Value>(rhs->perform(&to_value));
         bool interpolant = b->is_right_interpolant() ||
                            b->is_left_interpolant() ||
                            b->is_interpolant();
@@ -755,8 +755,8 @@ namespace Sass {
         {
           if (str->concrete_type() == Expression::STRING)
           {
-            String_Constant_Ptr lstr = SASS_MEMORY_CAST(String_Constant, lhs);
-            String_Constant_Ptr rstr = SASS_MEMORY_CAST(String_Constant, rhs);
+            String_Constant_Ptr lstr = Cast<String_Constant>(lhs);
+            String_Constant_Ptr rstr = Cast<String_Constant>(rhs);
             if (op_type != Sass_OP::SUB) {
               if (String_Constant_Ptr org = lstr ? lstr : rstr)
               { str->quote_mark(org->quote_mark()); }
@@ -806,7 +806,7 @@ namespace Sass {
     else {
       // Special cases: +/- variables which evaluate to null ouput just +/-,
       // but +/- null itself outputs the string
-      if (operand->concrete_type() == Expression::NULL_VAL && SASS_MEMORY_CAST(Variable, u->operand())) {
+      if (operand->concrete_type() == Expression::NULL_VAL && Cast<Variable>(u->operand())) {
         u->operand(SASS_MEMORY_NEW(String_Quoted, u->pstate(), ""));
       }
       // Never apply unary opertions on colors @see #2140
@@ -846,11 +846,11 @@ namespace Sass {
     if (!env->has(full_name) || (!c->via_call() && Prelexer::re_special_fun(name.c_str()))) {
       if (!env->has("*[f]")) {
         for (Argument_Obj arg : args->elements()) {
-          if (List_Obj ls = SASS_MEMORY_CAST(List, arg->value())) {
+          if (List_Obj ls = Cast<List>(arg->value())) {
             if (ls->size() == 0) error("() isn't a valid CSS value.", c->pstate());
           }
         }
-        args = SASS_MEMORY_CAST_PTR(Arguments, args->perform(this));
+        args = Cast<Arguments>(args->perform(this));
         Function_Call_Obj lit = SASS_MEMORY_NEW(Function_Call,
                                              c->pstate(),
                                              c->name(),
@@ -874,9 +874,9 @@ namespace Sass {
       args->set_delayed(false); // verified
     }
     if (full_name != "if[f]") {
-      args = SASS_MEMORY_CAST_PTR(Arguments, args->perform(this));
+      args = Cast<Arguments>(args->perform(this));
     }
-    Definition_Ptr def = SASS_MEMORY_CAST(Definition, (*env)[full_name]);
+    Definition_Ptr def = Cast<Definition>((*env)[full_name]);
 
     if (def->is_overload_stub()) {
       std::stringstream ss;
@@ -884,7 +884,7 @@ namespace Sass {
       // account for rest arguments
       if (args->has_rest_argument() && args->length() > 0) {
         // get the rest arguments list
-        List_Ptr rest = SASS_MEMORY_CAST(List, args->last()->value());
+        List_Ptr rest = Cast<List>(args->last()->value());
         // arguments before rest argument plus rest
         if (rest) L += rest->length() - 1;
       }
@@ -892,7 +892,7 @@ namespace Sass {
       full_name = ss.str();
       std::string resolved_name(full_name);
       if (!env->has(resolved_name)) error("overloaded function `" + std::string(c->name()) + "` given wrong number of arguments", c->pstate());
-      def = SASS_MEMORY_CAST(Definition, (*env)[resolved_name]);
+      def = Cast<Definition>((*env)[resolved_name]);
     }
 
     Expression_Obj     result = c;
@@ -964,7 +964,7 @@ namespace Sass {
         Parameter_Obj param = params->at(i);
         std::string key = param->name();
         AST_Node_Obj node = fn_env.get_local(key);
-        Expression_Obj arg = SASS_MEMORY_CAST(Expression, node);
+        Expression_Obj arg = Cast<Expression>(node);
         sass_list_set_value(c_args, i, arg->perform(&to_c));
       }
       union Sass_Value* c_val = c_func(c_args, c_function, ctx.c_compiler);
@@ -1009,15 +1009,15 @@ namespace Sass {
     Expression_Obj value = 0;
     Env* env = environment();
     if (env->has(name)) {
-      value = SASS_MEMORY_CAST(Expression, (*env)[name]);
+      value = Cast<Expression>((*env)[name]);
     }
     else error("Undefined variable: \"" + v->name() + "\".", v->pstate());
-    if (Argument* arg = SASS_MEMORY_CAST(Argument, value)) {
+    if (Argument* arg = Cast<Argument>(value)) {
       value = arg->value();
     }
 
     // behave according to as ruby sass (add leading zero)
-    if (Number_Ptr nr = SASS_MEMORY_CAST(Number, value)) {
+    if (Number_Ptr nr = Cast<Number>(value)) {
       nr->zero(true);
     }
 
@@ -1122,7 +1122,7 @@ namespace Sass {
 
     bool needs_closing_brace = false;
 
-    if (Arguments_Ptr args = SASS_MEMORY_CAST(Arguments, ex)) {
+    if (Arguments_Ptr args = Cast<Arguments>(ex)) {
       List_Ptr ll = SASS_MEMORY_NEW(List, args->pstate(), 0, SASS_COMMA);
       for(auto arg : args->elements()) {
         ll->append(arg->value());
@@ -1132,15 +1132,15 @@ namespace Sass {
       res += "(";
       ex = ll;
     }
-    if (Number_Ptr nr = SASS_MEMORY_CAST(Number, ex)) {
+    if (Number_Ptr nr = Cast<Number>(ex)) {
       if (!nr->is_valid_css_unit()) {
         throw Exception::InvalidValue(*nr);
       }
     }
-    if (Argument_Ptr arg = SASS_MEMORY_CAST(Argument, ex)) {
+    if (Argument_Ptr arg = Cast<Argument>(ex)) {
       ex = arg->value();
     }
-    if (String_Quoted_Ptr sq = SASS_MEMORY_CAST(String_Quoted, ex)) {
+    if (String_Quoted_Ptr sq = Cast<String_Quoted>(ex)) {
       if (was_itpl) {
         bool was_interpolant = ex->is_interpolant();
         ex = SASS_MEMORY_NEW(String_Constant, sq->pstate(), sq->value());
@@ -1148,22 +1148,22 @@ namespace Sass {
       }
     }
 
-    if (SASS_MEMORY_CAST(Null, ex)) { return; }
+    if (Cast<Null>(ex)) { return; }
 
     // parent selector needs another go
-    if (SASS_MEMORY_CAST(Parent_Selector, ex)) {
+    if (Cast<Parent_Selector>(ex)) {
       // XXX: this is never hit via spec tests
       ex = ex->perform(this);
     }
 
-    if (List_Ptr l = SASS_MEMORY_CAST(List, ex)) {
+    if (List_Ptr l = Cast<List>(ex)) {
       List_Obj ll = SASS_MEMORY_NEW(List, l->pstate(), 0, l->separator());
       // this fixes an issue with bourbon sample, not really sure why
       // if (l->size() && dynamic_cast<Null_Ptr>((*l)[0])) { res += ""; }
       for(Expression_Obj item : *l) {
         item->is_interpolant(l->is_interpolant());
         std::string rl(""); interpolation(ctx, rl, item, into_quotes, l->is_interpolant());
-        bool is_null = SASS_MEMORY_CAST(Null, item) != 0; // rl != ""
+        bool is_null = Cast<Null>(item) != 0; // rl != ""
         if (!is_null) ll->append(SASS_MEMORY_NEW(String_Quoted, item->pstate(), rl));
       }
       // Check indicates that we probably should not get a list
@@ -1205,9 +1205,9 @@ namespace Sass {
     size_t L = s->length();
     bool into_quotes = false;
     if (L > 1) {
-      if (!SASS_MEMORY_CAST(String_Quoted, (*s)[0]) && !SASS_MEMORY_CAST(String_Quoted, (*s)[L - 1])) {
-      if (String_Constant_Ptr l = SASS_MEMORY_CAST(String_Constant, (*s)[0])) {
-        if (String_Constant_Ptr r = SASS_MEMORY_CAST(String_Constant, (*s)[L - 1])) {
+      if (!Cast<String_Quoted>((*s)[0]) && !Cast<String_Quoted>((*s)[L - 1])) {
+      if (String_Constant_Ptr l = Cast<String_Constant>((*s)[0])) {
+        if (String_Constant_Ptr r = Cast<String_Constant>((*s)[L - 1])) {
           if (r->value().size() > 0) {
             if (l->value()[0] == '"' && r->value()[r->value().size() - 1] == '"') into_quotes = true;
             if (l->value()[0] == '\'' && r->value()[r->value().size() - 1] == '\'') into_quotes = true;
@@ -1220,12 +1220,12 @@ namespace Sass {
     bool was_interpolant = false;
     std::string res("");
     for (size_t i = 0; i < L; ++i) {
-      bool is_quoted = SASS_MEMORY_CAST(String_Quoted, (*s)[i]) != NULL;
+      bool is_quoted = Cast<String_Quoted>((*s)[i]) != NULL;
       if (was_quoted && !(*s)[i]->is_interpolant() && !was_interpolant) { res += " "; }
       else if (i > 0 && is_quoted && !(*s)[i]->is_interpolant() && !was_interpolant) { res += " "; }
       Expression_Obj ex = (*s)[i]->perform(this);
       interpolation(ctx, res, ex, into_quotes, ex->is_interpolant());
-      was_quoted = SASS_MEMORY_CAST(String_Quoted, (*s)[i]) != NULL;
+      was_quoted = Cast<String_Quoted>((*s)[i]) != NULL;
       was_interpolant = (*s)[i]->is_interpolant();
 
     }
@@ -1314,7 +1314,7 @@ namespace Sass {
     value = (value ? value->perform(this) : 0);
     Expression_Ptr ee = SASS_MEMORY_NEW(At_Root_Query,
                                      e->pstate(),
-                                     SASS_MEMORY_CAST(String, feature),
+                                     Cast<String>(feature),
                                      value);
     return ee;
   }
@@ -1339,18 +1339,18 @@ namespace Sass {
   {
     Expression_Obj feature = e->feature();
     feature = (feature ? feature->perform(this) : 0);
-    if (feature && SASS_MEMORY_CAST(String_Quoted, feature)) {
+    if (feature && Cast<String_Quoted>(feature)) {
       feature = SASS_MEMORY_NEW(String_Quoted,
                                   feature->pstate(),
-                                  SASS_MEMORY_CAST(String_Quoted, feature)->value());
+                                  Cast<String_Quoted>(feature)->value());
     }
     Expression_Obj value = e->value();
     value = (value ? value->perform(this) : 0);
-    if (value && SASS_MEMORY_CAST(String_Quoted, value)) {
+    if (value && Cast<String_Quoted>(value)) {
       // XXX: this is never hit via spec tests
       value = SASS_MEMORY_NEW(String_Quoted,
                                 value->pstate(),
-                                SASS_MEMORY_CAST(String_Quoted, value)->value());
+                                Cast<String_Quoted>(value)->value());
     }
     return SASS_MEMORY_NEW(Media_Query_Expression,
                            e->pstate(),
@@ -1399,7 +1399,7 @@ namespace Sass {
     if (a->length() == 0) return aa.detach();
     for (size_t i = 0, L = a->length(); i < L; ++i) {
       Expression_Obj rv = (*a)[i]->perform(this);
-      Argument_Ptr arg = SASS_MEMORY_CAST(Argument, rv);
+      Argument_Ptr arg = Cast<Argument>(rv);
       if (!(arg->is_rest_argument() || arg->is_keyword_argument())) {
         aa->append(arg);
       }
@@ -1407,11 +1407,11 @@ namespace Sass {
 
     if (a->has_rest_argument()) {
       Expression_Obj rest = a->get_rest_argument()->perform(this);
-      Expression_Obj splat = SASS_MEMORY_CAST(Argument, rest)->value()->perform(this);
+      Expression_Obj splat = Cast<Argument>(rest)->value()->perform(this);
 
       Sass_Separator separator = SASS_COMMA;
-      List_Ptr ls = SASS_MEMORY_CAST(List, splat);
-      Map_Ptr ms = SASS_MEMORY_CAST(Map, splat);
+      List_Ptr ls = Cast<List>(splat);
+      Map_Ptr ms = Cast<Map>(splat);
 
       List_Obj arglist = SASS_MEMORY_NEW(List,
                                       splat->pstate(),
@@ -1435,7 +1435,7 @@ namespace Sass {
 
     if (a->has_keyword_argument()) {
       Expression_Obj rv = a->get_keyword_argument()->perform(this);
-      Argument_Ptr rvarg = SASS_MEMORY_CAST(Argument, rv);
+      Argument_Ptr rvarg = Cast<Argument>(rv);
       Expression_Obj kwarg = rvarg->value()->perform(this);
 
       aa->append(SASS_MEMORY_NEW(Argument, kwarg->pstate(), kwarg, "", false, true));
@@ -1463,8 +1463,8 @@ namespace Sass {
 
   bool Eval::lt(Expression_Obj lhs, Expression_Obj rhs, std::string op)
   {
-    Number_Obj l = SASS_MEMORY_CAST(Number, lhs);
-    Number_Obj r = SASS_MEMORY_CAST(Number, rhs);
+    Number_Obj l = Cast<Number>(lhs);
+    Number_Obj r = Cast<Number>(rhs);
     // use compare operator from ast node
     if (!l || !r) throw Exception::UndefinedOperation(lhs, rhs, op);
     // use compare operator from ast node

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -253,8 +253,8 @@ namespace Sass {
           variable->append(value);
           env.set_local(variables[0], variable);
         } else {
-          env.set_local(variables[0], key.ptr());
-          env.set_local(variables[1], value.ptr());
+          env.set_local(variables[0], key);
+          env.set_local(variables[1], value);
         }
 
         val = body->perform(this);
@@ -615,8 +615,8 @@ namespace Sass {
     }
     // not a logical connective, so go ahead and eval the rhs
     rhs = rhs->perform(this);
-    AST_Node_Obj lu = lhs.ptr();
-    AST_Node_Obj ru = rhs.ptr();
+    AST_Node_Obj lu = lhs;
+    AST_Node_Obj ru = rhs;
 
     Expression::Concrete_Type l_type = lhs->concrete_type();
     Expression::Concrete_Type r_type = rhs->concrete_type();
@@ -938,7 +938,7 @@ namespace Sass {
       if (full_name == "*[f]") {
         String_Quoted_Obj str = SASS_MEMORY_NEW(String_Quoted, c->pstate(), c->name());
         Arguments_Obj new_args = SASS_MEMORY_NEW(Arguments, c->pstate());
-        new_args->append(SASS_MEMORY_NEW(Argument, c->pstate(), str.ptr()));
+        new_args->append(SASS_MEMORY_NEW(Argument, c->pstate(), str));
         new_args->concat(args);
         args = new_args;
       }
@@ -1025,7 +1025,7 @@ namespace Sass {
     if (force) value->is_expanded(false);
     value->set_delayed(false); // verified
     value = value->perform(this);
-    if(!force) (*env)[name] = value.ptr();
+    if(!force) (*env)[name] = value;
     return value.detach();
   }
 
@@ -1382,7 +1382,7 @@ namespace Sass {
                                         SASS_COMMA,
                                         true);
         wrapper->append(val);
-        val = wrapper.ptr();
+        val = wrapper;
       }
     }
     return SASS_MEMORY_NEW(Argument,
@@ -1429,7 +1429,7 @@ namespace Sass {
         arglist->append(splat);
       }
       if (arglist->length()) {
-        aa->append(SASS_MEMORY_NEW(Argument, splat->pstate(), arglist.ptr(), "", true));
+        aa->append(SASS_MEMORY_NEW(Argument, splat->pstate(), arglist, "", true));
       }
     }
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -659,8 +659,8 @@ namespace Sass {
       }
 
       To_Value to_value(ctx);
-      Value_Obj v_l = dynamic_cast<Value_Ptr>(lhs->perform(&to_value));
-      Value_Obj v_r = dynamic_cast<Value_Ptr>(rhs->perform(&to_value));
+      Value_Obj v_l = Cast<Value>(lhs->perform(&to_value));
+      Value_Obj v_r = Cast<Value>(rhs->perform(&to_value));
       l_type = lhs->concrete_type();
       r_type = rhs->concrete_type();
 
@@ -751,7 +751,7 @@ namespace Sass {
           throw Exception::InvalidValue(*v_r);
         }
         Value_Ptr ex = op_strings(b->op(), *v_l, *v_r, ctx.c_options, &pstate, !interpolant); // pass true to compress
-        if (String_Constant_Ptr str = dynamic_cast<String_Constant_Ptr>(ex))
+        if (String_Constant_Ptr str = Cast<String_Constant>(ex))
         {
           if (str->concrete_type() == Expression::STRING)
           {
@@ -1159,7 +1159,7 @@ namespace Sass {
     if (List_Ptr l = Cast<List>(ex)) {
       List_Obj ll = SASS_MEMORY_NEW(List, l->pstate(), 0, l->separator());
       // this fixes an issue with bourbon sample, not really sure why
-      // if (l->size() && dynamic_cast<Null_Ptr>((*l)[0])) { res += ""; }
+      // if (l->size() && Cast<Null>((*l)[0])) { res += ""; }
       for(Expression_Obj item : *l) {
         item->is_interpolant(l->is_interpolant());
         std::string rl(""); interpolation(ctx, rl, item, into_quotes, l->is_interpolant());
@@ -1271,8 +1271,8 @@ namespace Sass {
     Expression_Ptr right = c->right()->perform(this);
     Supports_Operator_Ptr cc = SASS_MEMORY_NEW(Supports_Operator,
                                  c->pstate(),
-                                 dynamic_cast<Supports_Condition_Ptr>(left),
-                                 dynamic_cast<Supports_Condition_Ptr>(right),
+                                 Cast<Supports_Condition>(left),
+                                 Cast<Supports_Condition>(right),
                                  c->operand());
     return cc;
   }
@@ -1282,7 +1282,7 @@ namespace Sass {
     Expression_Ptr condition = c->condition()->perform(this);
     Supports_Negation_Ptr cc = SASS_MEMORY_NEW(Supports_Negation,
                                  c->pstate(),
-                                 dynamic_cast<Supports_Condition_Ptr>(condition));
+                                 Cast<Supports_Condition>(condition));
     return cc;
   }
 
@@ -1594,8 +1594,8 @@ namespace Sass {
     Expression::Concrete_Type rtype = rhs.concrete_type();
     enum Sass_OP op = operand.operand;
 
-    String_Quoted_Ptr lqstr = dynamic_cast<String_Quoted_Ptr>(&lhs);
-    String_Quoted_Ptr rqstr = dynamic_cast<String_Quoted_Ptr>(&rhs);
+    String_Quoted_Ptr lqstr = Cast<String_Quoted>(&lhs);
+    String_Quoted_Ptr rqstr = Cast<String_Quoted>(&rhs);
 
     std::string lstr(lqstr ? lqstr->value() : lhs.to_string(opt));
     std::string rstr(rqstr ? rqstr->value() : rhs.to_string(opt));

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -100,7 +100,7 @@ namespace Sass {
       Keyframe_Rule_Obj k = SASS_MEMORY_NEW(Keyframe_Rule, r->pstate(), bb);
       if (r->selector()) {
         selector_stack.push_back(0);
-        k->name(SASS_MEMORY_CAST_PTR(Selector_List, r->selector()->perform(&eval)));
+        k->name(Cast<Selector_List>(r->selector()->perform(&eval)));
         selector_stack.pop_back();
       }
       return k.detach();
@@ -118,17 +118,17 @@ namespace Sass {
 
     Expression_Obj ex = 0;
     if (r->selector()) ex = r->selector()->perform(&eval);
-    Selector_List_Obj sel = SASS_MEMORY_CAST(Selector_List, ex);
+    Selector_List_Obj sel = Cast<Selector_List>(ex);
     if (sel == 0) throw std::runtime_error("Expanded null selector");
 
     // check for parent selectors in base level rules
     if (r->is_root()) {
-      if (Selector_List_Ptr selector_list = SASS_MEMORY_CAST(Selector_List, r->selector())) {
+      if (Selector_List_Ptr selector_list = Cast<Selector_List>(r->selector())) {
         for (Complex_Selector_Obj complex_selector : selector_list->elements()) {
           Complex_Selector_Ptr tail = complex_selector;
           while (tail) {
             if (tail->head()) for (Simple_Selector_Obj header : tail->head()->elements()) {
-              Parent_Selector_Ptr ptr = SASS_MEMORY_CAST(Parent_Selector, header);
+              Parent_Selector_Ptr ptr = Cast<Parent_Selector>(header);
               if (ptr == NULL || (!ptr->real() || has_parent_selector)) continue;
               std::string sel_str(complex_selector->to_string(ctx.c_options));
               error("Base-level rules cannot contain the parent-selector-referencing character '&'.", header->pstate(), backtrace());
@@ -174,7 +174,7 @@ namespace Sass {
     Expression_Obj condition = f->condition()->perform(&eval);
     Supports_Block_Obj ff = SASS_MEMORY_NEW(Supports_Block,
                                        f->pstate(),
-                                       SASS_MEMORY_CAST(Supports_Condition, condition),
+                                       Cast<Supports_Condition>(condition),
                                        operator()(f->block()));
     return ff.detach();
   }
@@ -188,7 +188,7 @@ namespace Sass {
     ctx.strings.push_back(str);
     Parser p(Parser::from_c_str(str, ctx, mq->pstate()));
     mq = p.parse_media_queries().ptr(); // re-assign now
-    List_Obj ls = SASS_MEMORY_CAST_PTR(List, mq->perform(&eval));
+    List_Obj ls = Cast<List>(mq->perform(&eval));
     Block_Obj blk = operator()(m->block());
     Media_Block_Ptr mm = SASS_MEMORY_NEW(Media_Block,
                                       m->pstate(),
@@ -217,7 +217,7 @@ namespace Sass {
     At_Root_Block_Obj aa = SASS_MEMORY_NEW(At_Root_Block,
                                         a->pstate(),
                                         bb,
-                                        SASS_MEMORY_CAST(At_Root_Query, ae));
+                                        Cast<At_Root_Query>(ae));
     return aa.detach();
   }
 
@@ -229,7 +229,7 @@ namespace Sass {
     Expression_Ptr av = a->value();
     selector_stack.push_back(0);
     if (av) av = av->perform(&eval);
-    if (as) as = SASS_MEMORY_CAST_PTR(Selector, as->perform(&eval));
+    if (as) as = Cast<Selector>(as->perform(&eval));
     selector_stack.pop_back();
     Block_Ptr bb = ab ? operator()(ab) : NULL;
     Directive_Ptr aa = SASS_MEMORY_NEW(Directive,
@@ -246,7 +246,7 @@ namespace Sass {
     Block_Obj ab = d->block();
     String_Obj old_p = d->property();
     Expression_Obj prop = old_p->perform(&eval);
-    String_Obj new_p = SASS_MEMORY_CAST(String, prop);
+    String_Obj new_p = Cast<String>(prop);
     // we might get a color back
     if (!new_p) {
       std::string str(prop->to_string(ctx.c_options));
@@ -274,7 +274,7 @@ namespace Sass {
     if (a->is_global()) {
       if (a->is_default()) {
         if (env->has_global(var)) {
-          Expression_Obj e = SASS_MEMORY_CAST(Expression, env->get_global(var));
+          Expression_Obj e = Cast<Expression>(env->get_global(var));
           if (!e || e->concrete_type() == Expression::NULL_VAL) {
             env->set_global(var, a->value()->perform(&eval));
           }
@@ -293,7 +293,7 @@ namespace Sass {
         while (cur && cur->is_lexical()) {
           if (cur->has_local(var)) {
             if (AST_Node_Obj node = cur->get_local(var)) {
-              Expression_Obj e = SASS_MEMORY_CAST(Expression, node);
+              Expression_Obj e = Cast<Expression>(node);
               if (!e || e->concrete_type() == Expression::NULL_VAL) {
                 cur->set_local(var, a->value()->perform(&eval));
               }
@@ -309,7 +309,7 @@ namespace Sass {
       }
       else if (env->has_global(var)) {
         if (AST_Node_Obj node = env->get_global(var)) {
-          Expression_Obj e = SASS_MEMORY_CAST(Expression, node);
+          Expression_Obj e = Cast<Expression>(node);
           if (!e || e->concrete_type() == Expression::NULL_VAL) {
             env->set_global(var, a->value()->perform(&eval));
           }
@@ -333,7 +333,7 @@ namespace Sass {
     Import_Obj result = SASS_MEMORY_NEW(Import, imp->pstate());
     if (imp->import_queries() && imp->import_queries()->size()) {
       Expression_Obj ex = imp->import_queries()->perform(&eval);
-      result->import_queries(SASS_MEMORY_CAST(List, ex));
+      result->import_queries(Cast<List>(ex));
     }
     for ( size_t i = 0, S = imp->urls().size(); i < S; ++i) {
       result->urls().push_back(imp->urls()[i]->perform(&eval));
@@ -347,7 +347,7 @@ namespace Sass {
   {
     // get parent node from call stack
     AST_Node_Obj parent = call_stack.back();
-    if (SASS_MEMORY_CAST(Block, parent) == NULL) {
+    if (Cast<Block>(parent) == NULL) {
       error("Import directives may not be used within control directives or mixins.", i->pstate());
     }
     // we don't seem to need that actually afterall
@@ -388,7 +388,7 @@ namespace Sass {
   Statement_Ptr Expand::operator()(Comment_Ptr c)
   {
     eval.is_in_comment = true;
-    Comment_Ptr rv = SASS_MEMORY_NEW(Comment, c->pstate(), SASS_MEMORY_CAST_PTR(String, c->text()->perform(&eval)), c->is_important());
+    Comment_Ptr rv = SASS_MEMORY_NEW(Comment, c->pstate(), Cast<String>(c->text()->perform(&eval)), c->is_important());
     eval.is_in_comment = false;
     // TODO: eval the text, once we're parsing/storing it as a String_Schema
     return rv;
@@ -425,8 +425,8 @@ namespace Sass {
     if (high->concrete_type() != Expression::NUMBER) {
       throw Exception::TypeMismatch(*high, "integer");
     }
-    Number_Obj sass_start = SASS_MEMORY_CAST(Number, low);
-    Number_Obj sass_end = SASS_MEMORY_CAST(Number, high);
+    Number_Obj sass_start = Cast<Number>(low);
+    Number_Obj sass_end = Cast<Number>(high);
     // check if units are valid for sequence
     if (sass_start->unit() != sass_end->unit()) {
       std::stringstream msg; msg << "Incompatible units: '"
@@ -478,19 +478,19 @@ namespace Sass {
     List_Obj list = 0;
     Map_Obj map;
     if (expr->concrete_type() == Expression::MAP) {
-      map = SASS_MEMORY_CAST(Map, expr);
+      map = Cast<Map>(expr);
     }
-    else if (Selector_List_Ptr ls = SASS_MEMORY_CAST(Selector_List, expr)) {
+    else if (Selector_List_Ptr ls = Cast<Selector_List>(expr)) {
       Listize listize;
       Expression_Obj rv = ls->perform(&listize);
-      list = SASS_MEMORY_CAST(List, rv);
+      list = Cast<List>(rv);
     }
     else if (expr->concrete_type() != Expression::LIST) {
       list = SASS_MEMORY_NEW(List, expr->pstate(), 1, SASS_COMMA);
       list->append(expr);
     }
     else {
-      list = SASS_MEMORY_CAST(List, expr);
+      list = Cast<List>(expr);
     }
     // remember variables and then reset them
     Env env(environment(), true);
@@ -517,15 +517,15 @@ namespace Sass {
     }
     else {
       // bool arglist = list->is_arglist();
-      if (list->length() == 1 && SASS_MEMORY_CAST(Selector_List, list)) {
-        list = SASS_MEMORY_CAST(List, list);
+      if (list->length() == 1 && Cast<Selector_List>(list)) {
+        list = Cast<List>(list);
       }
       for (size_t i = 0, L = list->length(); i < L; ++i) {
         Expression_Obj e = list->at(i);
         // unwrap value if the expression is an argument
-        if (Argument_Obj arg = SASS_MEMORY_CAST(Argument, e)) e = arg->value();
+        if (Argument_Obj arg = Cast<Argument>(e)) e = arg->value();
         // check if we got passed a list of args (investigate)
-        if (List_Obj scalars = SASS_MEMORY_CAST(List, e)) {
+        if (List_Obj scalars = Cast<List>(e)) {
           if (variables.size() == 1) {
             List_Obj var = scalars;
             // if (arglist) var = (*scalars)[0];
@@ -581,12 +581,12 @@ namespace Sass {
 
   void Expand::expand_selector_list(Selector_Obj s, Selector_List_Obj extender) {
 
-    if (Selector_List_Obj sl = SASS_MEMORY_CAST(Selector_List, s)) {
+    if (Selector_List_Obj sl = Cast<Selector_List>(s)) {
       for (Complex_Selector_Obj complex_selector : sl->elements()) {
         Complex_Selector_Obj tail = complex_selector;
         while (tail) {
           if (tail->head()) for (Simple_Selector_Obj header : tail->head()->elements()) {
-            if (SASS_MEMORY_CAST(Parent_Selector, header) == NULL) continue; // skip all others
+            if (Cast<Parent_Selector>(header) == NULL) continue; // skip all others
             std::string sel_str(complex_selector->to_string(ctx.c_options));
             error("Can't extend " + sel_str + ": can't extend parent selectors", header->pstate(), backtrace());
           }
@@ -596,7 +596,7 @@ namespace Sass {
     }
 
 
-    Selector_List_Obj contextualized = SASS_MEMORY_CAST_PTR(Selector_List, s->perform(&eval));
+    Selector_List_Obj contextualized = Cast<Selector_List>(s->perform(&eval));
     if (contextualized == false) return;
     for (auto complex_sel : contextualized->elements()) {
       Complex_Selector_Obj c = complex_sel;
@@ -609,7 +609,7 @@ namespace Sass {
       for (size_t i = 0, L = extender->length(); i < L; ++i) {
         Complex_Selector_Obj sel = (*extender)[i];
         if (!(sel->head() && sel->head()->length() > 0 &&
-            SASS_MEMORY_CAST(Parent_Selector, (*sel->head())[0])))
+            Cast<Parent_Selector>((*sel->head())[0])))
         {
           Compound_Selector_Obj hh = SASS_MEMORY_NEW(Compound_Selector, (*extender)[i]->pstate());
           hh->media_block((*extender)[i]->media_block());
@@ -632,13 +632,13 @@ namespace Sass {
 
   Statement* Expand::operator()(Extension_Ptr e)
   {
-    if (Selector_List_Obj extender = SASS_MEMORY_CAST(Selector_List, selector())) {
+    if (Selector_List_Obj extender = Cast<Selector_List>(selector())) {
       Selector_Obj s = e->selector();
       Selector_List_Obj sl = NULL;
       // check if we already have a valid selector list
-      if ((sl = SASS_MEMORY_CAST(Selector_List, s))) {}
+      if ((sl = Cast<Selector_List>(s))) {}
       // convert selector schema to a selector list
-      else if (Selector_Schema_Obj schema = SASS_MEMORY_CAST(Selector_Schema, s)) {
+      else if (Selector_Schema_Obj schema = Cast<Selector_Schema>(s)) {
         if (schema->has_real_parent_ref()) {
           // put root block on stack again (ignore parents)
           // selector schema must not connect in eval!
@@ -705,7 +705,7 @@ namespace Sass {
     if (!env->has(full_name)) {
       error("no mixin named " + c->name(), c->pstate(), backtrace());
     }
-    Definition_Obj def = SASS_MEMORY_CAST(Definition, (*env)[full_name]);
+    Definition_Obj def = Cast<Definition>((*env)[full_name]);
     Block_Obj body = def->block();
     Parameters_Obj params = def->parameters();
 
@@ -713,7 +713,7 @@ namespace Sass {
       error("Mixin \"" + c->name() + "\" does not accept a content block.", c->pstate(), backtrace());
     }
     Expression_Obj rv = c->arguments()->perform(&eval);
-    Arguments_Obj args = SASS_MEMORY_CAST(Arguments, rv);
+    Arguments_Obj args = Cast<Arguments>(rv);
     Backtrace new_bt(backtrace(), c->pstate(), ", in mixin `" + c->name() + "`");
     backtrace_stack.push_back(&new_bt);
     ctx.callee_stack.push_back({
@@ -775,7 +775,7 @@ namespace Sass {
                                        "@content",
                                        SASS_MEMORY_NEW(Arguments, c->pstate()));
 
-    Trace_Obj trace = SASS_MEMORY_CAST_PTR(Trace, call->perform(this));
+    Trace_Obj trace = Cast<Trace>(call->perform(this));
 
     if (block_stack.back()->is_root()) {
       selector_stack.pop_back();

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -156,7 +156,7 @@ namespace Sass {
     if (r->block()) blk = operator()(r->block());
     Ruleset_Ptr rr = SASS_MEMORY_NEW(Ruleset,
                                   r->pstate(),
-                                  sel.ptr(),
+                                  sel,
                                   blk);
     selector_stack.pop_back();
     if (block_stack.back()->is_root()) {
@@ -187,7 +187,7 @@ namespace Sass {
     char* str = sass_copy_c_string(str_mq.c_str());
     ctx.strings.push_back(str);
     Parser p(Parser::from_c_str(str, ctx, mq->pstate()));
-    mq = p.parse_media_queries().ptr(); // re-assign now
+    mq = p.parse_media_queries(); // re-assign now
     List_Obj ls = Cast<List>(mq->perform(&eval));
     Block_Obj blk = operator()(m->block());
     Media_Block_Ptr mm = SASS_MEMORY_NEW(Media_Block,
@@ -203,7 +203,7 @@ namespace Sass {
   Statement_Ptr Expand::operator()(At_Root_Block_Ptr a)
   {
     Block_Obj ab = a->block();
-    Expression_Obj ae = a->expression().ptr();
+    Expression_Obj ae = a->expression();
 
     if (ae) ae = ae->perform(&eval);
     else ae = SASS_MEMORY_NEW(At_Root_Query, a->pstate());
@@ -441,7 +441,7 @@ namespace Sass {
     env_stack.push_back(&env);
     call_stack.push_back(f);
     Number_Obj it = SASS_MEMORY_NEW(Number, low->pstate(), start, sass_end->unit());
-    env.set_local(variable, it.ptr());
+    env.set_local(variable, it);
     Block_Ptr body = f->block();
     if (start < end) {
       if (f->is_inclusive()) ++end;
@@ -450,7 +450,7 @@ namespace Sass {
            ++i) {
         it = SASS_MEMORY_COPY(it);
         it->value(i);
-        env.set_local(variable, it.ptr());
+        env.set_local(variable, it);
         append_block(body);
       }
     } else {
@@ -460,7 +460,7 @@ namespace Sass {
            --i) {
         it = SASS_MEMORY_COPY(it);
         it->value(i);
-        env.set_local(variable, it.ptr());
+        env.set_local(variable, it);
         append_block(body);
       }
     }
@@ -507,10 +507,10 @@ namespace Sass {
           List_Obj variable = SASS_MEMORY_NEW(List, map->pstate(), 2, SASS_SPACE);
           variable->append(k);
           variable->append(v);
-          env.set_local(variables[0], variable.ptr());
+          env.set_local(variables[0], variable);
         } else {
-          env.set_local(variables[0], k.ptr());
-          env.set_local(variables[1], v.ptr());
+          env.set_local(variables[0], k);
+          env.set_local(variables[1], v);
         }
         append_block(body);
       }
@@ -529,21 +529,21 @@ namespace Sass {
           if (variables.size() == 1) {
             List_Obj var = scalars;
             // if (arglist) var = (*scalars)[0];
-            env.set_local(variables[0], var.ptr());
+            env.set_local(variables[0], var);
           } else {
             for (size_t j = 0, K = variables.size(); j < K; ++j) {
               Expression_Obj res = j >= scalars->length()
                 ? SASS_MEMORY_NEW(Null, expr->pstate())
                 : (*scalars)[j]->perform(&eval);
-              env.set_local(variables[j], res.ptr());
+              env.set_local(variables[j], res);
             }
           }
         } else {
           if (variables.size() > 0) {
-            env.set_local(variables.at(0), e.ptr());
+            env.set_local(variables.at(0), e);
             for (size_t j = 1, K = variables.size(); j < K; ++j) {
               Expression_Obj res = SASS_MEMORY_NEW(Null, expr->pstate());
-              env.set_local(variables[j], res.ptr());
+              env.set_local(variables[j], res);
             }
           }
         }
@@ -660,7 +660,7 @@ namespace Sass {
         }
       }
       selector_stack.push_back(0);
-      expand_selector_list(sl.ptr(), extender);
+      expand_selector_list(sl, extender);
       selector_stack.pop_back();
     }
     return 0;
@@ -671,7 +671,7 @@ namespace Sass {
     Env* env = environment();
     Definition_Obj dd = SASS_MEMORY_COPY(d);
     env->local_frame()[d->name() +
-                        (d->type() == Definition::MIXIN ? "[m]" : "[f]")] = dd.ptr();
+                        (d->type() == Definition::MIXIN ? "[m]" : "[f]")] = dd;
 
     if (d->type() == Definition::FUNCTION && (
       Prelexer::calc_fn_call(d->name().c_str()) ||
@@ -736,7 +736,7 @@ namespace Sass {
                                           c->block(),
                                           Definition::MIXIN);
       thunk->environment(env);
-      new_env.local_frame()["@content[m]"] = thunk.ptr();
+      new_env.local_frame()["@content[m]"] = thunk;
     }
 
     bind(std::string("Mixin"), c->name(), params, args, &ctx, &new_env, &eval);
@@ -790,7 +790,7 @@ namespace Sass {
     std::string err =std:: string("`Expand` doesn't handle ") + typeid(*n).name();
     String_Quoted_Obj msg = SASS_MEMORY_NEW(String_Quoted, ParserState("[WARN]"), err);
     error("unknown internal error; please contact the LibSass maintainers", n->pstate(), backtrace());
-    return SASS_MEMORY_NEW(Warning, ParserState("[WARN]"), msg.ptr());
+    return SASS_MEMORY_NEW(Warning, ParserState("[WARN]"), msg);
   }
 
   // process and add to last block on stack

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -41,11 +41,6 @@ namespace Sass {
     backtrace_stack.push_back(bt);
   }
 
-  Context& Expand::context()
-  {
-    return ctx;
-  }
-
   Env* Expand::environment()
   {
     if (env_stack.size() > 0)

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -188,8 +188,7 @@ namespace Sass {
     Media_Block_Ptr mm = SASS_MEMORY_NEW(Media_Block,
                                       m->pstate(),
                                       ls,
-                                      blk,
-                                      0);
+                                      blk);
     media_block_stack.pop_back();
     mm->tabs(m->tabs());
     return mm;

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -13,7 +13,6 @@ namespace Sass {
   class Listize;
   class Context;
   class Eval;
-  typedef Environment<AST_Node_Obj> Env;
   struct Backtrace;
 
   class Expand : public Operation_CRTP<Statement_Ptr, Expand> {

--- a/src/expand.hpp
+++ b/src/expand.hpp
@@ -19,7 +19,6 @@ namespace Sass {
   public:
 
     Env* environment();
-    Context& context();
     Selector_List_Obj selector();
     Backtrace* backtrace();
 

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -205,8 +205,8 @@ namespace Sass {
     }
   }
 
-  // Print a string representation of a SourcesSet
-  static void printSourcesSet(SourcesSet& sources, Context& ctx, const char* message=NULL, bool newline=true) {
+  // Print a string representation of a ComplexSelectorSet
+  static void printSourcesSet(ComplexSelectorSet& sources, Context& ctx, const char* message=NULL, bool newline=true) {
 
     if (message) {
       std::cerr << message;
@@ -216,7 +216,7 @@ namespace Sass {
     // the differences we see when debug printing.
     typedef std::deque<std::string> SourceStrings;
     SourceStrings sourceStrings;
-    for (SourcesSet::iterator iterator = sources.begin(), iteratorEnd = sources.end(); iterator != iteratorEnd; ++iterator) {
+    for (ComplexSelectorSet::iterator iterator = sources.begin(), iteratorEnd = sources.end(); iterator != iteratorEnd; ++iterator) {
       Complex_Selector_Ptr pSource = *iterator;
       std::stringstream sstream;
       sstream << complexSelectorToNode(pSource, ctx);
@@ -226,7 +226,7 @@ namespace Sass {
     // Sort to get consistent output
     std::sort(sourceStrings.begin(), sourceStrings.end());
 
-    std::cerr << "SourcesSet[";
+    std::cerr << "ComplexSelectorSet[";
     for (SourceStrings::iterator iterator = sourceStrings.begin(), iteratorEnd = sourceStrings.end(); iterator != iteratorEnd; ++iterator) {
       std::string source = *iterator;
       if (iterator != sourceStrings.begin()) {
@@ -562,12 +562,12 @@ namespace Sass {
         // best guess at this point is that we're cloning an object somewhere and maintaining the sources when we shouldn't be. This is purely
         // a guess though.
         unsigned long maxSpecificity = isReplace ? pSeq1->specificity() : 0;
-        SourcesSet sources = pSeq1->sources();
+        ComplexSelectorSet sources = pSeq1->sources();
 
         DEBUG_PRINTLN(TRIM, "TRIM SEQ1: " << seq1)
         DEBUG_EXEC(TRIM, printSourcesSet(sources, ctx, "TRIM SOURCES: "))
 
-        for (SourcesSet::iterator sourcesSetIterator = sources.begin(), sourcesSetIteratorEnd = sources.end(); sourcesSetIterator != sourcesSetIteratorEnd; ++sourcesSetIterator) {
+        for (ComplexSelectorSet::iterator sourcesSetIterator = sources.begin(), sourcesSetIteratorEnd = sources.end(); sourcesSetIterator != sourcesSetIteratorEnd; ++sourcesSetIterator) {
           const Complex_Selector_Obj& pCurrentSelector = *sourcesSetIterator;
           maxSpecificity = std::max(maxSpecificity, pCurrentSelector->specificity());
         }
@@ -1611,7 +1611,7 @@ namespace Sass {
       pNewSelector->set_innermost(&pNewInnerMost, combinator);
 
 #ifdef DEBUG
-      SourcesSet debugSet;
+      ComplexSelectorSet debugSet;
       debugSet = pNewSelector->sources();
       if (debugSet.size() > 0) {
         throw std::runtime_error("The new selector should start with no sources. Something needs to be cloned to fix this.");
@@ -1627,10 +1627,10 @@ namespace Sass {
       // Set the sources on our new Complex_Selector to the sources of this simple sequence plus the thing we're extending.
       DEBUG_PRINTLN(EXTEND_COMPOUND, "SOURCES SETTING ON NEW SEQ: " << complexSelectorToNode(pNewSelector, ctx))
 
-      DEBUG_EXEC(EXTEND_COMPOUND, SourcesSet oldSet = pNewSelector->sources(); printSourcesSet(oldSet, ctx, "SOURCES NEW SEQ BEGIN: "))
+      DEBUG_EXEC(EXTEND_COMPOUND, ComplexSelectorSet oldSet = pNewSelector->sources(); printSourcesSet(oldSet, ctx, "SOURCES NEW SEQ BEGIN: "))
 
       // I actually want to create a copy here (performance!)
-      SourcesSet newSourcesSet = pSelector->sources();
+      ComplexSelectorSet newSourcesSet = pSelector->sources(); // XXX
       DEBUG_EXEC(EXTEND_COMPOUND, printSourcesSet(newSourcesSet, ctx, "SOURCES THIS EXTEND: "))
 
       newSourcesSet.insert(pExtComplexSelector);
@@ -1639,7 +1639,7 @@ namespace Sass {
       // RUBY: new_seq.add_sources!(sources + [seq])
       pNewSelector->addSources(newSourcesSet, ctx);
 
-      DEBUG_EXEC(EXTEND_COMPOUND, SourcesSet newSet = pNewSelector->sources(); printSourcesSet(newSet, ctx, "SOURCES ON NEW SELECTOR AFTER ADD: "))
+      DEBUG_EXEC(EXTEND_COMPOUND, ComplexSelectorSet newSet = pNewSelector->sources(); printSourcesSet(newSet, ctx, "SOURCES ON NEW SELECTOR AFTER ADD: "))
       DEBUG_EXEC(EXTEND_COMPOUND, printSourcesSet(pSelector->sources(), ctx, "SOURCES THIS EXTEND WHICH SHOULD BE SAME STILL: "))
 
 
@@ -1798,7 +1798,7 @@ namespace Sass {
 
       // RUBY: extended.first.add_sources!([self]) if original && !has_placeholder?
       if (isOriginal && !pComplexSelector->has_placeholder()) {
-        SourcesSet srcset;
+        ComplexSelectorSet srcset;
         srcset.insert(pComplexSelector);
         pJustCurrentCompoundSelector->addSources(srcset, ctx);
         DEBUG_PRINTLN(EXTEND_COMPLEX, "ADD SOURCES: " << *pComplexSelector)

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -841,7 +841,7 @@ namespace Sass {
     DefaultLcsComparator lcsDefaultComparator;
     Node opsLcs = lcs(ops1, ops2, lcsDefaultComparator, ctx);
 
-    if (!(nodesEqual(opsLcs, ops1, true) || nodesEqual(opsLcs, ops2, true))) {
+    if (!(opsLcs == ops1 || opsLcs == ops2)) {
       return Node::createNil();
     }
 
@@ -938,7 +938,7 @@ namespace Sass {
 
       // If there are multiple operators, something hacky's going on. If one is a supersequence of the other, use that, otherwise give up.
 
-      if (!(nodesEqual(opsLcs, ops1, true) || nodesEqual(opsLcs, ops2, true))) {
+      if (!(opsLcs == ops1 || opsLcs == ops2)) {
         return Node::createNil();
       }
 

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -334,7 +334,7 @@ namespace Sass {
         end
       */
 
-      if (selectors_equal(*pOne, *pTwo, true /*simpleSelectorOrderDependent*/)) {
+      if (*pOne == *pTwo) {
         pOut = pOne;
         return true;
       }

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -285,7 +285,7 @@ namespace Sass {
     Position noPosition(-1, -1, -1);
     Element_Selector_Obj fakeParent = SASS_MEMORY_NEW(Element_Selector, ParserState("[FAKE]"), "temp");
     Compound_Selector_Obj fakeHead = SASS_MEMORY_NEW(Compound_Selector, ParserState("[FAKE]"), 1 /*size*/);
-    fakeHead->elements().push_back(fakeParent.ptr());
+    fakeHead->elements().push_back(fakeParent);
     Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, fakeHead /*head*/, NULL /*tail*/);
 
     pOne->set_innermost(fakeParentContainer, Complex_Selector::ANCESTOR_OF);
@@ -648,7 +648,7 @@ namespace Sass {
     Position noPosition(-1, -1, -1);
     Element_Selector_Obj fakeParent = SASS_MEMORY_NEW(Element_Selector, ParserState("[FAKE]"), "temp");
     Compound_Selector_Obj fakeHead = SASS_MEMORY_NEW(Compound_Selector, ParserState("[FAKE]"), 1 /*size*/);
-    fakeHead->elements().push_back(fakeParent.ptr());
+    fakeHead->elements().push_back(fakeParent);
     Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, fakeHead /*head*/, NULL /*tail*/);
 
     Complex_Selector_Obj pOneWithFakeParent = nodeToComplexSelector(one, ctx);
@@ -1969,7 +1969,7 @@ namespace Sass {
                         cpy_ws_sl->append(ext_cs->first());
                       }
                       // assign list to clone
-                      cpy_ws->selector(cpy_ws_sl.ptr());
+                      cpy_ws->selector(cpy_ws_sl);
                       // append the clone
                       cpy_head->append(cpy_ws);
                     }
@@ -2046,7 +2046,7 @@ namespace Sass {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << static_cast<Selector_List_Ptr>(pObject->selector())->to_string(ctx.c_options))
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND SETTING NEW SELECTORS: " << pNewSelectorList->to_string(ctx.c_options))
       pNewSelectorList->remove_parent_selectors();
-      pObject->selector(pNewSelectorList.ptr());
+      pObject->selector(pNewSelectorList);
     } else {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND DID NOT TRY TO EXTEND ANYTHING")
     }

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -2030,7 +2030,7 @@ namespace Sass {
   template <typename ObjectType>
   static void extendObjectWithSelectorAndBlock(ObjectType* pObject, Context& ctx, Subset_Map& subset_map) {
 
-    DEBUG_PRINTLN(EXTEND_OBJECT, "FOUND SELECTOR: " << static_cast<Selector_List_Ptr>(pObject->selector())->to_string(ctx.c_options))
+    DEBUG_PRINTLN(EXTEND_OBJECT, "FOUND SELECTOR: " << Cast<Selector_List>(pObject->selector())->to_string(ctx.c_options))
 
     // Ruby sass seems to filter nodes that don't have any content well before we get here. I'm not sure the repercussions
     // of doing so, so for now, let's just not extend things that won't be output later.
@@ -2043,7 +2043,7 @@ namespace Sass {
     Selector_List_Obj pNewSelectorList = Extend::extendSelectorList(Cast<Selector_List>(pObject->selector()), ctx, subset_map, false, extendedSomething);
 
     if (extendedSomething && pNewSelectorList) {
-      DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << static_cast<Selector_List_Ptr>(pObject->selector())->to_string(ctx.c_options))
+      DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << Cast<Selector_List>(pObject->selector())->to_string(ctx.c_options))
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND SETTING NEW SELECTORS: " << pNewSelectorList->to_string(ctx.c_options))
       pNewSelectorList->remove_parent_selectors();
       pObject->selector(pNewSelectorList);
@@ -2105,7 +2105,7 @@ namespace Sass {
 
   void Extend::operator()(Directive_Ptr a)
   {
-    // Selector_List_Ptr ls = dynamic_cast<Selector_List_Ptr>(a->selector());
+    // Selector_List_Ptr ls = Cast<Selector_List>(a->selector());
     // selector_stack.push_back(ls);
     if (a->block()) a->block()->perform(this);
     // exp.selector_stack.pop_back();

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1937,9 +1937,9 @@ namespace Sass {
           // create a copy since we add multiple items if stuff get unwrapped
           Compound_Selector_Obj cpy_head = SASS_MEMORY_NEW(Compound_Selector, cur->pstate());
           for (Simple_Selector_Obj hs : *cur->head()) {
-            if (Wrapped_Selector_Obj ws = SASS_MEMORY_CAST(Wrapped_Selector, hs)) {
+            if (Wrapped_Selector_Obj ws = Cast<Wrapped_Selector>(hs)) {
               ws->selector(SASS_MEMORY_CLONE(ws->selector()));
-              if (Selector_List_Obj sl = SASS_MEMORY_CAST(Selector_List, ws->selector())) {
+              if (Selector_List_Obj sl = Cast<Selector_List>(ws->selector())) {
                 // special case for ruby ass
                 if (sl->empty()) {
                   // this seems inconsistent but it is how ruby sass seems to remove parentheses
@@ -1956,14 +1956,14 @@ namespace Sass {
                       Selector_List_Obj cpy_ws_sl = SASS_MEMORY_NEW(Selector_List, sl->pstate());
                       // remove parent selectors from inner selector
                       if (ext_cs->first() && ext_cs->first()->head()->length() > 0) {
-                        Wrapped_Selector_Ptr ext_ws = SASS_MEMORY_CAST(Wrapped_Selector, ext_cs->first()->head()->first());
+                        Wrapped_Selector_Ptr ext_ws = Cast<Wrapped_Selector>(ext_cs->first()->head()->first());
                         if (ext_ws/* && ext_cs->length() == 1*/) {
-                          Selector_List_Obj ws_cs = SASS_MEMORY_CAST(Selector_List, ext_ws->selector());
+                          Selector_List_Obj ws_cs = Cast<Selector_List>(ext_ws->selector());
                           Compound_Selector_Obj ws_ss = ws_cs->first()->head();
                           if (!(
-                            SASS_MEMORY_CAST(Pseudo_Selector, ws_ss->first()) ||
-                            SASS_MEMORY_CAST(Element_Selector, ws_ss->first()) ||
-                            SASS_MEMORY_CAST(Placeholder_Selector, ws_ss->first())
+                            Cast<Pseudo_Selector>(ws_ss->first()) ||
+                            Cast<Element_Selector>(ws_ss->first()) ||
+                            Cast<Placeholder_Selector>(ws_ss->first())
                           )) continue;
                         }
                         cpy_ws_sl->append(ext_cs->first());
@@ -2012,7 +2012,7 @@ namespace Sass {
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       Statement_Obj stm = b->at(i);
 
-      if (SASS_MEMORY_CAST(Ruleset, stm)) {
+      if (Cast<Ruleset>(stm)) {
         // Do nothing. This doesn't count as a statement that causes extension since we'll
         // iterate over this rule set in a future visit and try to extend it.
       }
@@ -2040,7 +2040,7 @@ namespace Sass {
     }
 
     bool extendedSomething = false;
-    Selector_List_Obj pNewSelectorList = Extend::extendSelectorList(SASS_MEMORY_CAST(Selector_List, pObject->selector()), ctx, subset_map, false, extendedSomething);
+    Selector_List_Obj pNewSelectorList = Extend::extendSelectorList(Cast<Selector_List>(pObject->selector()), ctx, subset_map, false, extendedSomething);
 
     if (extendedSomething && pNewSelectorList) {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << static_cast<Selector_List_Ptr>(pObject->selector())->to_string(ctx.c_options))

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -285,11 +285,11 @@ namespace Sass {
     Position noPosition(-1, -1, -1);
     Element_Selector_Obj fakeParent = SASS_MEMORY_NEW(Element_Selector, ParserState("[FAKE]"), "temp");
     Compound_Selector_Obj fakeHead = SASS_MEMORY_NEW(Compound_Selector, ParserState("[FAKE]"), 1 /*size*/);
-    fakeHead->elements().push_back(&fakeParent);
-    Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
+    fakeHead->elements().push_back(fakeParent.ptr());
+    Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, fakeHead /*head*/, NULL /*tail*/);
 
-    pOne->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
-    pTwo->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
+    pOne->set_innermost(fakeParentContainer, Complex_Selector::ANCESTOR_OF);
+    pTwo->set_innermost(fakeParentContainer, Complex_Selector::ANCESTOR_OF);
 
     bool isSuperselector = pOne->is_superselector_of(pTwo);
 
@@ -311,7 +311,7 @@ namespace Sass {
 
     for (ComplexSelectorDeque::const_iterator iter = deque.begin(), iterEnd = deque.end(); iter != iterEnd; iter++) {
       Complex_Selector_Obj pChild = *iter;
-      result.collection()->push_back(complexSelectorToNode(&pChild, ctx));
+      result.collection()->push_back(complexSelectorToNode(pChild, ctx));
     }
 
     return result;
@@ -343,12 +343,12 @@ namespace Sass {
         return false;
       }
 
-      if (parentSuperselector(&pOne, &pTwo, mCtx)) {
+      if (parentSuperselector(pOne, pTwo, mCtx)) {
         pOut = pTwo;
         return true;
       }
 
-      if (parentSuperselector(&pTwo, &pOne, mCtx)) {
+      if (parentSuperselector(pTwo, pOne, mCtx)) {
         pOut = pOne;
         return true;
       }
@@ -413,7 +413,7 @@ namespace Sass {
       for (size_t j = 1; j < y.size(); j++) {
         Complex_Selector_Obj pCompareOut;
 
-        if (comparator(&x[i], &y[j], pCompareOut)) {
+        if (comparator(x[i], y[j], pCompareOut)) {
           c[i][j] = c[i - 1][j - 1] + 1;
         } else {
           c[i][j] = std::max(c[i][j - 1], c[i - 1][j]);
@@ -648,13 +648,13 @@ namespace Sass {
     Position noPosition(-1, -1, -1);
     Element_Selector_Obj fakeParent = SASS_MEMORY_NEW(Element_Selector, ParserState("[FAKE]"), "temp");
     Compound_Selector_Obj fakeHead = SASS_MEMORY_NEW(Compound_Selector, ParserState("[FAKE]"), 1 /*size*/);
-    fakeHead->elements().push_back(&fakeParent);
-    Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, &fakeHead /*head*/, NULL /*tail*/);
+    fakeHead->elements().push_back(fakeParent.ptr());
+    Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, fakeHead /*head*/, NULL /*tail*/);
 
     Complex_Selector_Obj pOneWithFakeParent = nodeToComplexSelector(one, ctx);
-    pOneWithFakeParent->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
+    pOneWithFakeParent->set_innermost(fakeParentContainer, Complex_Selector::ANCESTOR_OF);
     Complex_Selector_Obj pTwoWithFakeParent = nodeToComplexSelector(two, ctx);
-    pTwoWithFakeParent->set_innermost(&fakeParentContainer, Complex_Selector::ANCESTOR_OF);
+    pTwoWithFakeParent->set_innermost(fakeParentContainer, Complex_Selector::ANCESTOR_OF);
 
     return pOneWithFakeParent->is_superselector_of(pTwoWithFakeParent);
   }
@@ -981,7 +981,7 @@ namespace Sass {
 
           Complex_Selector_Obj pMergedWrapper = SASS_MEMORY_CLONE(sel1.selector()); // Clone the Complex_Selector to get back to something we can transform to a node once we replace the head with the unification result
           // TODO: does subject matter? Ruby: return unless merged = sel1.unify(sel2.members, sel2.subject?)
-          Compound_Selector_Ptr pMerged = sel1.selector()->head()->unify_with(&sel2.selector()->head(), ctx);
+          Compound_Selector_Ptr pMerged = sel1.selector()->head()->unify_with(sel2.selector()->head(), ctx);
           pMergedWrapper->head(pMerged);
 
           DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
@@ -1004,7 +1004,7 @@ namespace Sass {
 
           if (pMerged) {
             Node mergedPerm = Node::createCollection();
-            mergedPerm.collection()->push_back(Node::createSelector(&pMergedWrapper, ctx));
+            mergedPerm.collection()->push_back(Node::createSelector(pMergedWrapper, ctx));
             mergedPerm.collection()->push_back(Node::createCombinator(Complex_Selector::PRECEDES));
             newRes.collection()->push_back(mergedPerm);
           }
@@ -1040,7 +1040,7 @@ namespace Sass {
 
             Complex_Selector_Obj pMergedWrapper = SASS_MEMORY_CLONE(plusSel.selector()); // Clone the Complex_Selector to get back to something we can transform to a node once we replace the head with the unification result
             // TODO: does subject matter? Ruby: merged = plus_sel.unify(tilde_sel.members, tilde_sel.subject?)
-            Compound_Selector_Ptr pMerged = plusSel.selector()->head()->unify_with(&tildeSel.selector()->head(), ctx);
+            Compound_Selector_Ptr pMerged = plusSel.selector()->head()->unify_with(tildeSel.selector()->head(), ctx);
             pMergedWrapper->head(pMerged);
 
             DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
@@ -1056,7 +1056,7 @@ namespace Sass {
 
             if (pMerged) {
               Node mergedPerm = Node::createCollection();
-              mergedPerm.collection()->push_back(Node::createSelector(&pMergedWrapper, ctx));
+              mergedPerm.collection()->push_back(Node::createSelector(pMergedWrapper, ctx));
               mergedPerm.collection()->push_back(Node::createCombinator(Complex_Selector::ADJACENT_TO));
               newRes.collection()->push_back(mergedPerm);
             }
@@ -1089,7 +1089,7 @@ namespace Sass {
 
         Complex_Selector_Obj pMergedWrapper = SASS_MEMORY_CLONE(sel1.selector()); // Clone the Complex_Selector to get back to something we can transform to a node once we replace the head with the unification result
         // TODO: does subject matter? Ruby: return unless merged = sel1.unify(sel2.members, sel2.subject?)
-        Compound_Selector_Ptr pMerged = sel1.selector()->head()->unify_with(&sel2.selector()->head(), ctx);
+        Compound_Selector_Ptr pMerged = sel1.selector()->head()->unify_with(sel2.selector()->head(), ctx);
         pMergedWrapper->head(pMerged);
 
         DEBUG_EXEC(ALL, printCompoundSelector(pMerged, "MERGED: "))
@@ -1099,7 +1099,7 @@ namespace Sass {
         }
 
         res.collection()->push_front(op1);
-        res.collection()->push_front(Node::createSelector(&pMergedWrapper, ctx));
+        res.collection()->push_front(Node::createSelector(pMergedWrapper, ctx));
 
         DEBUG_PRINTLN(ALL, "RESULT: " << res)
 
@@ -1525,7 +1525,7 @@ namespace Sass {
   public:
     KeyType operator()(SubSetMapPair& extPair) const {
       Complex_Selector_Obj pSelector = extPair.first;
-      return &pSelector;
+      return pSelector;
     }
   };
   static Node extendCompoundSelector(
@@ -1555,7 +1555,7 @@ namespace Sass {
       Complex_Selector_Obj seq = groupedPair.first;
       SubSetMapPairs& group = groupedPair.second;
 
-      DEBUG_EXEC(EXTEND_COMPOUND, printComplexSelector(&seq, "SEQ: "))
+      DEBUG_EXEC(EXTEND_COMPOUND, printComplexSelector(seq, "SEQ: "))
 
 // changing this makes aua
       Compound_Selector_Obj pSels = SASS_MEMORY_NEW(Compound_Selector, pSelector->pstate());
@@ -1564,18 +1564,18 @@ namespace Sass {
         Compound_Selector_Obj pCompound = pair.second;
         for (size_t index = 0; index < pCompound->length(); index++) {
           Simple_Selector_Obj pSimpleSelector = (*pCompound)[index];
-          pSels->append(&pSimpleSelector);
+          pSels->append(pSimpleSelector);
           pCompound->extended(true);
         }
       }
 
-      DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(&pSels, "SELS: "))
+      DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSels, "SELS: "))
 
-      Complex_Selector_Ptr pExtComplexSelector = &seq;    // The selector up to where the @extend is (ie, the thing to merge)
+      Complex_Selector_Ptr pExtComplexSelector = seq;    // The selector up to where the @extend is (ie, the thing to merge)
 
       // TODO: This can return a Compound_Selector with no elements. Should that just be returning NULL?
       // RUBY: self_without_sel = Sass::Util.array_minus(members, sels)
-      Compound_Selector_Obj pSelectorWithoutExtendSelectors = pSelector->minus(&pSels, ctx);
+      Compound_Selector_Obj pSelectorWithoutExtendSelectors = pSelector->minus(pSels, ctx);
 
       DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelector, "MEMBERS: "))
       DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelectorWithoutExtendSelectors, "SELF_WO_SEL: "))
@@ -1585,7 +1585,7 @@ namespace Sass {
       if (!pInnermostCompoundSelector) {
         pInnermostCompoundSelector = SASS_MEMORY_NEW(Compound_Selector, pSelector->pstate());
       }
-      Compound_Selector_Obj pUnifiedSelector = pInnermostCompoundSelector->unify_with(&pSelectorWithoutExtendSelectors, ctx);
+      Compound_Selector_Obj pUnifiedSelector = pInnermostCompoundSelector->unify_with(pSelectorWithoutExtendSelectors, ctx);
 
       DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pInnermostCompoundSelector, "LHS: "))
       DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelectorWithoutExtendSelectors, "RHS: "))
@@ -1608,7 +1608,7 @@ namespace Sass {
       Complex_Selector_Obj pNewInnerMost = SASS_MEMORY_NEW(Complex_Selector, pSelector->pstate(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, NULL);
 
       Complex_Selector::Combinator combinator = pNewSelector->clear_innermost();
-      pNewSelector->set_innermost(&pNewInnerMost, combinator);
+      pNewSelector->set_innermost(pNewInnerMost, combinator);
 
 #ifdef DEBUG
       ComplexSelectorSet debugSet;
@@ -1667,7 +1667,7 @@ namespace Sass {
 
 
       DEBUG_PRINTLN(EXTEND_COMPOUND, "RECURSING DO EXTEND: " << complexSelectorToNode(pNewSelector, ctx))
-      Node recurseExtendedSelectors = extendComplexSelector(&pNewSelector, ctx, subset_map, recurseSeen, isReplace, false); // !:isOriginal
+      Node recurseExtendedSelectors = extendComplexSelector(pNewSelector, ctx, subset_map, recurseSeen, isReplace, false); // !:isOriginal
 
       DEBUG_PRINTLN(EXTEND_COMPOUND, "RECURSING DO EXTEND RETURN: " << recurseExtendedSelectors)
 
@@ -1787,7 +1787,7 @@ namespace Sass {
       Compound_Selector_Obj pCompoundSelector = sseqOrOp.selector()->head();
 
       // RUBY: extended = sseq_or_op.do_extend(extends, parent_directives, replace, seen)
-      Node extended = extendCompoundSelector(&pCompoundSelector, ctx, subset_map, seen, isReplace);
+      Node extended = extendCompoundSelector(pCompoundSelector, ctx, subset_map, seen, isReplace);
       if (sseqOrOp.got_line_feed) extended.got_line_feed = true;
       DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTENDED: " << extended)
 
@@ -1817,7 +1817,7 @@ namespace Sass {
 
       if (!isSuperselector) {
         if (sseqOrOp.got_line_feed) pJustCurrentCompoundSelector->has_line_feed(sseqOrOp.got_line_feed);
-        extended.collection()->push_front(complexSelectorToNode(&pJustCurrentCompoundSelector, ctx));
+        extended.collection()->push_front(complexSelectorToNode(pJustCurrentCompoundSelector, ctx));
       }
 
       DEBUG_PRINTLN(EXTEND_COMPLEX, "CHOICES UNSHIFTED: " << extended)
@@ -1897,16 +1897,16 @@ namespace Sass {
       // run through the extend code (which does a data model transformation), check if there is anything to extend before doing
       // the extend. We might be able to optimize extendComplexSelector, but this approach keeps us closer to ruby sass (which helps
       // when debugging).
-      if (!complexSelectorHasExtension(&pSelector, ctx, subset_map, seen)) {
-        pNewSelectors->append(&pSelector);
+      if (!complexSelectorHasExtension(pSelector, ctx, subset_map, seen)) {
+        pNewSelectors->append(pSelector);
         continue;
       }
 
       extendedSomething = true;
 
-      Node extendedSelectors = extendComplexSelector(&pSelector, ctx, subset_map, seen, isReplace, true);
+      Node extendedSelectors = extendComplexSelector(pSelector, ctx, subset_map, seen, isReplace, true);
       if (!pSelector->has_placeholder()) {
-        if (!extendedSelectors.contains(complexSelectorToNode(&pSelector, ctx), true /*simpleSelectorOrderDependent*/)) {
+        if (!extendedSelectors.contains(complexSelectorToNode(pSelector, ctx), true /*simpleSelectorOrderDependent*/)) {
           pNewSelectors->append(pSelector);
           continue;
         }
@@ -1924,7 +1924,7 @@ namespace Sass {
     Remove_Placeholders remove_placeholders;
     // it seems that we have to remove the place holders early here
     // normally we do this as the very last step (compare to ruby sass)
-    pNewSelectors = remove_placeholders.remove_placeholders(&pNewSelectors);
+    pNewSelectors = remove_placeholders.remove_placeholders(pNewSelectors);
 
     // unwrap all wrapped selectors with inner lists
     for (Complex_Selector_Obj cur : pNewSelectors->elements()) {
@@ -1952,7 +1952,7 @@ namespace Sass {
                   for (size_t i = 0; i < ext_sl->length(); i += 1) {
                     if (Complex_Selector_Obj ext_cs = ext_sl->at(i)) {
                       // create clones for wrapped selector and the inner list
-                      Wrapped_Selector_Obj cpy_ws = SASS_MEMORY_COPY(&ws);
+                      Wrapped_Selector_Obj cpy_ws = SASS_MEMORY_COPY(ws);
                       Selector_List_Obj cpy_ws_sl = SASS_MEMORY_NEW(Selector_List, sl->pstate());
                       // remove parent selectors from inner selector
                       if (ext_cs->first() && ext_cs->first()->head()->length() > 0) {
@@ -1969,17 +1969,17 @@ namespace Sass {
                         cpy_ws_sl->append(ext_cs->first());
                       }
                       // assign list to clone
-                      cpy_ws->selector(&cpy_ws_sl);
+                      cpy_ws->selector(cpy_ws_sl.ptr());
                       // append the clone
-                      cpy_head->append(&cpy_ws);
+                      cpy_head->append(cpy_ws);
                     }
                   }
                 }
               } else {
-                cpy_head->append(&hs);
+                cpy_head->append(hs);
               }
             } else {
-              cpy_head->append(&hs);
+              cpy_head->append(hs);
             }
           }
           // replace header
@@ -2012,8 +2012,9 @@ namespace Sass {
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       Statement_Obj stm = b->at(i);
 
-      if (dynamic_cast<Ruleset_Ptr>(&stm)) {
-        // Do nothing. This doesn't count as a statement that causes extension since we'll iterate over this rule set in a future visit and try to extend it.
+      if (SASS_MEMORY_CAST(Ruleset, stm)) {
+        // Do nothing. This doesn't count as a statement that causes extension since we'll
+        // iterate over this rule set in a future visit and try to extend it.
       }
       else {
         return true;
@@ -2045,7 +2046,7 @@ namespace Sass {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND ORIGINAL SELECTORS: " << static_cast<Selector_List_Ptr>(pObject->selector())->to_string(ctx.c_options))
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND SETTING NEW SELECTORS: " << pNewSelectorList->to_string(ctx.c_options))
       pNewSelectorList->remove_parent_selectors();
-      pObject->selector(&pNewSelectorList);
+      pObject->selector(pNewSelectorList.ptr());
     } else {
       DEBUG_PRINTLN(EXTEND_OBJECT, "EXTEND DID NOT TRY TO EXTEND ANYTHING")
     }
@@ -2068,8 +2069,10 @@ namespace Sass {
     if (b->is_root()) {
       // debug_subset_map(subset_map);
       for(auto const &it : subset_map.values()) {
-        Complex_Selector_Ptr sel = it.first ? &it.first->first() : NULL;
-        Compound_Selector_Ptr ext = it.second ? &it.second : NULL;
+        Complex_Selector_Ptr sel = NULL;
+        Compound_Selector_Ptr ext = NULL;
+        if (it.first) sel = it.first->first();
+        if (it.second) ext = it.second;
         if (ext && (ext->extended() || ext->is_optional())) continue;
         std::string str_sel(sel->to_string({ NESTED, 5 }));
         std::string str_ext(ext->to_string({ NESTED, 5 }));

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1233,7 +1233,7 @@ namespace Sass {
         return SASS_MEMORY_NEW(Number, pstate, (double)(map ? map->length() : 1));
       }
       if (v->concrete_type() == Expression::SELECTOR) {
-        if (Compound_Selector_Ptr h = dynamic_cast<Compound_Selector_Ptr>(v)) {
+        if (Compound_Selector_Ptr h = Cast<Compound_Selector>(v)) {
           return SASS_MEMORY_NEW(Number, pstate, (double)h->length());
         } else if (Selector_List_Ptr ls = Cast<Selector_List>(v)) {
           return SASS_MEMORY_NEW(Number, pstate, (double)ls->length());

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -124,10 +124,10 @@ namespace Sass {
     Map_Ptr get_arg_m(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace, Context& ctx)
     {
       // Minimal error handling -- the expectation is that built-ins will be written correctly!
-      Map_Ptr val = SASS_MEMORY_CAST(Map, env[argname]);
+      Map_Ptr val = Cast<Map>(env[argname]);
       if (val) return val;
 
-      List_Ptr lval = SASS_MEMORY_CAST(List, env[argname]);
+      List_Ptr lval = Cast<List>(env[argname]);
       if (lval && lval->length() == 0) return SASS_MEMORY_NEW(Map, pstate, 0);
 
       // fallback on get_arg for error handling
@@ -163,7 +163,7 @@ namespace Sass {
         msg << "a list of strings, or a list of lists of strings for `" << function_name(sig) << "'";
         error(msg.str(), pstate);
       }
-      if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, exp)) {
+      if (String_Constant_Ptr str = Cast<String_Constant>(exp)) {
         str->quote_mark(0);
       }
       std::string exp_src = exp->to_string(ctx.c_options);
@@ -178,7 +178,7 @@ namespace Sass {
         msg << argname << ": null is not a string for `" << function_name(sig) << "'";
         error(msg.str(), pstate);
       }
-      if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, exp)) {
+      if (String_Constant_Ptr str = Cast<String_Constant>(exp)) {
         str->quote_mark(0);
       }
       std::string exp_src = exp->to_string(ctx.c_options);
@@ -509,7 +509,7 @@ namespace Sass {
     BUILT_IN(saturate)
     {
       // CSS3 filter function overload: pass literal through directly
-      Number_Ptr amount = SASS_MEMORY_CAST(Number, env["$amount"]);
+      Number_Ptr amount = Cast<Number>(env["$amount"]);
       if (!amount) {
         return SASS_MEMORY_NEW(String_Quoted, pstate, "saturate(" + env["$color"]->to_string(ctx.c_options) + ")");
       }
@@ -569,7 +569,7 @@ namespace Sass {
     BUILT_IN(grayscale)
     {
       // CSS3 filter function overload: pass literal through directly
-      Number_Ptr amount = SASS_MEMORY_CAST(Number, env["$color"]);
+      Number_Ptr amount = Cast<Number>(env["$color"]);
       if (amount) {
         return SASS_MEMORY_NEW(String_Quoted, pstate, "grayscale(" + amount->to_string(ctx.c_options) + ")");
       }
@@ -605,7 +605,7 @@ namespace Sass {
     BUILT_IN(invert)
     {
       // CSS3 filter function overload: pass literal through directly
-      Number_Ptr amount = SASS_MEMORY_CAST(Number, env["$color"]);
+      Number_Ptr amount = Cast<Number>(env["$color"]);
       if (amount) {
         return SASS_MEMORY_NEW(String_Quoted, pstate, "invert(" + amount->to_string(ctx.c_options) + ")");
       }
@@ -628,13 +628,13 @@ namespace Sass {
     Signature opacity_sig = "opacity($color)";
     BUILT_IN(alpha)
     {
-      String_Constant_Ptr ie_kwd = SASS_MEMORY_CAST(String_Constant, env["$color"]);
+      String_Constant_Ptr ie_kwd = Cast<String_Constant>(env["$color"]);
       if (ie_kwd) {
         return SASS_MEMORY_NEW(String_Quoted, pstate, "alpha(" + ie_kwd->value() + ")");
       }
 
       // CSS3 filter function overload: pass literal through directly
-      Number_Ptr amount = SASS_MEMORY_CAST(Number, env["$color"]);
+      Number_Ptr amount = Cast<Number>(env["$color"]);
       if (amount) {
         return SASS_MEMORY_NEW(String_Quoted, pstate, "opacity(" + amount->to_string(ctx.c_options) + ")");
       }
@@ -680,13 +680,13 @@ namespace Sass {
     BUILT_IN(adjust_color)
     {
       Color_Ptr color = ARG("$color", Color);
-      Number_Ptr r = SASS_MEMORY_CAST(Number, env["$red"]);
-      Number_Ptr g = SASS_MEMORY_CAST(Number, env["$green"]);
-      Number_Ptr b = SASS_MEMORY_CAST(Number, env["$blue"]);
-      Number_Ptr h = SASS_MEMORY_CAST(Number, env["$hue"]);
-      Number_Ptr s = SASS_MEMORY_CAST(Number, env["$saturation"]);
-      Number_Ptr l = SASS_MEMORY_CAST(Number, env["$lightness"]);
-      Number_Ptr a = SASS_MEMORY_CAST(Number, env["$alpha"]);
+      Number_Ptr r = Cast<Number>(env["$red"]);
+      Number_Ptr g = Cast<Number>(env["$green"]);
+      Number_Ptr b = Cast<Number>(env["$blue"]);
+      Number_Ptr h = Cast<Number>(env["$hue"]);
+      Number_Ptr s = Cast<Number>(env["$saturation"]);
+      Number_Ptr l = Cast<Number>(env["$lightness"]);
+      Number_Ptr a = Cast<Number>(env["$alpha"]);
 
       bool rgb = r || g || b;
       bool hsl = h || s || l;
@@ -735,13 +735,13 @@ namespace Sass {
     BUILT_IN(scale_color)
     {
       Color_Ptr color = ARG("$color", Color);
-      Number_Ptr r = SASS_MEMORY_CAST(Number, env["$red"]);
-      Number_Ptr g = SASS_MEMORY_CAST(Number, env["$green"]);
-      Number_Ptr b = SASS_MEMORY_CAST(Number, env["$blue"]);
-      Number_Ptr h = SASS_MEMORY_CAST(Number, env["$hue"]);
-      Number_Ptr s = SASS_MEMORY_CAST(Number, env["$saturation"]);
-      Number_Ptr l = SASS_MEMORY_CAST(Number, env["$lightness"]);
-      Number_Ptr a = SASS_MEMORY_CAST(Number, env["$alpha"]);
+      Number_Ptr r = Cast<Number>(env["$red"]);
+      Number_Ptr g = Cast<Number>(env["$green"]);
+      Number_Ptr b = Cast<Number>(env["$blue"]);
+      Number_Ptr h = Cast<Number>(env["$hue"]);
+      Number_Ptr s = Cast<Number>(env["$saturation"]);
+      Number_Ptr l = Cast<Number>(env["$lightness"]);
+      Number_Ptr a = Cast<Number>(env["$alpha"]);
 
       bool rgb = r || g || b;
       bool hsl = h || s || l;
@@ -791,13 +791,13 @@ namespace Sass {
     BUILT_IN(change_color)
     {
       Color_Ptr color = ARG("$color", Color);
-      Number_Ptr r = SASS_MEMORY_CAST(Number, env["$red"]);
-      Number_Ptr g = SASS_MEMORY_CAST(Number, env["$green"]);
-      Number_Ptr b = SASS_MEMORY_CAST(Number, env["$blue"]);
-      Number_Ptr h = SASS_MEMORY_CAST(Number, env["$hue"]);
-      Number_Ptr s = SASS_MEMORY_CAST(Number, env["$saturation"]);
-      Number_Ptr l = SASS_MEMORY_CAST(Number, env["$lightness"]);
-      Number_Ptr a = SASS_MEMORY_CAST(Number, env["$alpha"]);
+      Number_Ptr r = Cast<Number>(env["$red"]);
+      Number_Ptr g = Cast<Number>(env["$green"]);
+      Number_Ptr b = Cast<Number>(env["$blue"]);
+      Number_Ptr h = Cast<Number>(env["$hue"]);
+      Number_Ptr s = Cast<Number>(env["$saturation"]);
+      Number_Ptr l = Cast<Number>(env["$lightness"]);
+      Number_Ptr a = Cast<Number>(env["$alpha"]);
 
       bool rgb = r || g || b;
       bool hsl = h || s || l;
@@ -873,20 +873,20 @@ namespace Sass {
     BUILT_IN(sass_unquote)
     {
       AST_Node_Obj arg = env["$string"];
-      if (String_Quoted_Ptr string_quoted = SASS_MEMORY_CAST(String_Quoted, arg)) {
+      if (String_Quoted_Ptr string_quoted = Cast<String_Quoted>(arg)) {
         String_Constant_Ptr result = SASS_MEMORY_NEW(String_Constant, pstate, string_quoted->value());
         // remember if the string was quoted (color tokens)
         result->is_delayed(true); // delay colors
         return result;
       }
-      else if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, arg)) {
+      else if (String_Constant_Ptr str = Cast<String_Constant>(arg)) {
         return str;
       }
-      else if (Expression_Ptr ex = SASS_MEMORY_CAST(Expression, arg)) {
+      else if (Expression_Ptr ex = Cast<Expression>(arg)) {
         Sass_Output_Style oldstyle = ctx.c_options.output_style;
         ctx.c_options.output_style = SASS_STYLE_NESTED;
         std::string val(arg->to_string(ctx.c_options));
-        val = SASS_MEMORY_CAST(Null, arg) ? "null" : val;
+        val = Cast<Null>(arg) ? "null" : val;
         ctx.c_options.output_style = oldstyle;
 
         deprecated_function("Passing " + val + ", a non-string value, to unquote()", pstate);
@@ -900,7 +900,7 @@ namespace Sass {
     {
       AST_Node_Obj arg = env["$string"];
       // only set quote mark to true if already a string
-      if (String_Quoted_Ptr qstr = SASS_MEMORY_CAST(String_Quoted, arg)) {
+      if (String_Quoted_Ptr qstr = Cast<String_Quoted>(arg)) {
         qstr->quote_mark('*');
         return qstr;
       }
@@ -964,7 +964,7 @@ namespace Sass {
           str = ins + str;
         }
 
-        if (String_Quoted_Ptr ss = SASS_MEMORY_CAST_PTR(String_Quoted, s)) {
+        if (String_Quoted_Ptr ss = Cast<String_Quoted>(s)) {
           if (ss->quote_mark()) str = quote(str);
         }
       }
@@ -1007,13 +1007,13 @@ namespace Sass {
         String_Constant_Ptr s = ARG("$string", String_Constant);
         double start_at = ARG("$start-at", Number)->value();
         double end_at = ARG("$end-at", Number)->value();
-        String_Quoted_Ptr ss = SASS_MEMORY_CAST_PTR(String_Quoted, s);
+        String_Quoted_Ptr ss = Cast<String_Quoted>(s);
 
         std::string str = unquote(s->value());
 
         size_t size = utf8::distance(str.begin(), str.end());
 
-        if (!SASS_MEMORY_CAST(Number, env["$end-at"])) {
+        if (!Cast<Number>(env["$end-at"])) {
           end_at = -1;
         }
 
@@ -1063,7 +1063,7 @@ namespace Sass {
         }
       }
 
-      if (String_Quoted_Ptr ss = SASS_MEMORY_CAST_PTR(String_Quoted, s)) {
+      if (String_Quoted_Ptr ss = Cast<String_Quoted>(s)) {
         String_Quoted_Ptr cpy = SASS_MEMORY_COPY(ss);
         cpy->value(str);
         return cpy;
@@ -1084,7 +1084,7 @@ namespace Sass {
         }
       }
 
-      if (String_Quoted_Ptr ss = SASS_MEMORY_CAST_PTR(String_Quoted, s)) {
+      if (String_Quoted_Ptr ss = Cast<String_Quoted>(s)) {
         String_Quoted_Ptr cpy = SASS_MEMORY_COPY(ss);
         cpy->value(str);
         return cpy;
@@ -1152,7 +1152,7 @@ namespace Sass {
       Number_Obj least = NULL;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression_Obj val = arglist->value_at_index(i);
-        Number_Obj xi = SASS_MEMORY_CAST(Number, val);
+        Number_Obj xi = Cast<Number>(val);
         if (!xi) {
           error("\"" + val->to_string(ctx.c_options) + "\" is not a number for `min'", pstate);
         }
@@ -1170,7 +1170,7 @@ namespace Sass {
       Number_Obj greatest = NULL;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression_Obj val = arglist->value_at_index(i);
-        Number_Obj xi = SASS_MEMORY_CAST(Number, val);
+        Number_Obj xi = Cast<Number>(val);
         if (!xi) {
           error("\"" + val->to_string(ctx.c_options) + "\" is not a number for `max'", pstate);
         }
@@ -1185,9 +1185,9 @@ namespace Sass {
     BUILT_IN(random)
     {
       AST_Node_Obj arg = env["$limit"];
-      Value_Ptr v = SASS_MEMORY_CAST(Value, arg);
-      Number_Ptr l = SASS_MEMORY_CAST(Number, arg);
-      Boolean_Ptr b = SASS_MEMORY_CAST(Boolean, arg);
+      Value_Ptr v = Cast<Value>(arg);
+      Number_Ptr l = Cast<Number>(arg);
+      Boolean_Ptr b = Cast<Boolean>(arg);
       if (l) {
         double v = l->value();
         if (v < 1) {
@@ -1224,25 +1224,25 @@ namespace Sass {
     Signature length_sig = "length($list)";
     BUILT_IN(length)
     {
-      if (Selector_List_Ptr sl = SASS_MEMORY_CAST(Selector_List, env["$list"])) {
+      if (Selector_List_Ptr sl = Cast<Selector_List>(env["$list"])) {
         return SASS_MEMORY_NEW(Number, pstate, (double)sl->length());
       }
       Expression_Ptr v = ARG("$list", Expression);
       if (v->concrete_type() == Expression::MAP) {
-        Map_Ptr map = SASS_MEMORY_CAST(Map, env["$list"]);
+        Map_Ptr map = Cast<Map>(env["$list"]);
         return SASS_MEMORY_NEW(Number, pstate, (double)(map ? map->length() : 1));
       }
       if (v->concrete_type() == Expression::SELECTOR) {
         if (Compound_Selector_Ptr h = dynamic_cast<Compound_Selector_Ptr>(v)) {
           return SASS_MEMORY_NEW(Number, pstate, (double)h->length());
-        } else if (Selector_List_Ptr ls = SASS_MEMORY_CAST_PTR(Selector_List, v)) {
+        } else if (Selector_List_Ptr ls = Cast<Selector_List>(v)) {
           return SASS_MEMORY_NEW(Number, pstate, (double)ls->length());
         } else {
           return SASS_MEMORY_NEW(Number, pstate, 1);
         }
       }
 
-      List_Ptr list = SASS_MEMORY_CAST(List, env["$list"]);
+      List_Ptr list = Cast<List>(env["$list"]);
       return SASS_MEMORY_NEW(Number,
                              pstate,
                              (double)(list ? list->size() : 1));
@@ -1252,8 +1252,8 @@ namespace Sass {
     BUILT_IN(nth)
     {
       Number_Ptr n = ARG("$n", Number);
-      Map_Ptr m = SASS_MEMORY_CAST(Map, env["$list"]);
-      if (Selector_List_Ptr sl = SASS_MEMORY_CAST(Selector_List, env["$list"])) {
+      Map_Ptr m = Cast<Map>(env["$list"]);
+      if (Selector_List_Ptr sl = Cast<Selector_List>(env["$list"])) {
         size_t len = m ? m->length() : sl->length();
         bool empty = m ? m->empty() : sl->empty();
         if (empty) error("argument `$list` of `" + std::string(sig) + "` must not be empty", pstate);
@@ -1263,7 +1263,7 @@ namespace Sass {
         Listize listize;
         return (*sl)[static_cast<int>(index)]->perform(&listize);
       }
-      List_Obj l = SASS_MEMORY_CAST(List, env["$list"]);
+      List_Obj l = Cast<List>(env["$list"]);
       if (n->value() == 0) error("argument `$n` of `" + std::string(sig) + "` must be non-zero", pstate);
       // if the argument isn't a list, then wrap it in a singleton list
       if (!m && !l) {
@@ -1292,8 +1292,8 @@ namespace Sass {
     Signature set_nth_sig = "set-nth($list, $n, $value)";
     BUILT_IN(set_nth)
     {
-      Map_Obj m = SASS_MEMORY_CAST(Map, env["$list"]);
-      List_Obj l = SASS_MEMORY_CAST(List, env["$list"]);
+      Map_Obj m = Cast<Map>(env["$list"]);
+      List_Obj l = Cast<List>(env["$list"]);
       Number_Obj n = ARG("$n", Number);
       Expression_Obj v = ARG("$value", Expression);
       if (!l) {
@@ -1316,8 +1316,8 @@ namespace Sass {
     Signature index_sig = "index($list, $value)";
     BUILT_IN(index)
     {
-      Map_Obj m = SASS_MEMORY_CAST(Map, env["$list"]);
-      List_Obj l = SASS_MEMORY_CAST(List, env["$list"]);
+      Map_Obj m = Cast<Map>(env["$list"]);
+      List_Obj l = Cast<List>(env["$list"]);
       Expression_Obj v = ARG("$value", Expression);
       if (!l) {
         l = SASS_MEMORY_NEW(List, pstate, 1);
@@ -1335,10 +1335,10 @@ namespace Sass {
     Signature join_sig = "join($list1, $list2, $separator: auto, $bracketed: auto)";
     BUILT_IN(join)
     {
-      Map_Obj m1 = SASS_MEMORY_CAST(Map, env["$list1"]);
-      Map_Obj m2 = SASS_MEMORY_CAST(Map, env["$list2"]);
-      List_Obj l1 = SASS_MEMORY_CAST(List, env["$list1"]);
-      List_Obj l2 = SASS_MEMORY_CAST(List, env["$list2"]);
+      Map_Obj m1 = Cast<Map>(env["$list1"]);
+      Map_Obj m2 = Cast<Map>(env["$list2"]);
+      List_Obj l1 = Cast<List>(env["$list1"]);
+      List_Obj l2 = Cast<List>(env["$list2"]);
       String_Constant_Obj sep = ARG("$separator", String_Constant);
       enum Sass_Separator sep_val = (l1 ? l1->separator() : SASS_SPACE);
       Value* bracketed = ARG("$bracketed", Value);
@@ -1365,7 +1365,7 @@ namespace Sass {
       if (sep_str == "space") sep_val = SASS_SPACE;
       else if (sep_str == "comma") sep_val = SASS_COMMA;
       else if (sep_str != "auto") error("argument `$separator` of `" + std::string(sig) + "` must be `space`, `comma`, or `auto`", pstate);
-      String_Constant_Obj bracketed_as_str = SASS_MEMORY_CAST_PTR(String_Constant, bracketed);
+      String_Constant_Obj bracketed_as_str = Cast<String_Constant>(bracketed);
       bool bracketed_is_auto = bracketed_as_str && unquote(bracketed_as_str->value()) == "auto";
       if (!bracketed_is_auto) {
         is_bracketed = !bracketed->is_false();
@@ -1379,12 +1379,12 @@ namespace Sass {
     Signature append_sig = "append($list, $val, $separator: auto)";
     BUILT_IN(append)
     {
-      Map_Obj m = SASS_MEMORY_CAST(Map, env["$list"]);
-      List_Obj l = SASS_MEMORY_CAST(List, env["$list"]);
+      Map_Obj m = Cast<Map>(env["$list"]);
+      List_Obj l = Cast<List>(env["$list"]);
       Expression_Obj v = ARG("$val", Expression);
-      if (Selector_List_Ptr sl = SASS_MEMORY_CAST(Selector_List, env["$list"])) {
+      if (Selector_List_Ptr sl = Cast<Selector_List>(env["$list"])) {
         Listize listize;
-        l = SASS_MEMORY_CAST_PTR(List, sl->perform(&listize));
+        l = Cast<List>(sl->perform(&listize));
       }
       String_Constant_Obj sep = ARG("$separator", String_Constant);
       if (!l) {
@@ -1421,8 +1421,8 @@ namespace Sass {
       List_Obj arglist = SASS_MEMORY_COPY(ARG("$lists", List));
       size_t shortest = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        List_Obj ith = SASS_MEMORY_CAST(List, arglist->value_at_index(i));
-        Map_Obj mith = SASS_MEMORY_CAST(Map, arglist->value_at_index(i));
+        List_Obj ith = Cast<List>(arglist->value_at_index(i));
+        Map_Obj mith = Cast<Map>(arglist->value_at_index(i));
         if (!ith) {
           if (mith) {
             ith = mith->to_list(ctx, pstate);
@@ -1444,7 +1444,7 @@ namespace Sass {
       for (size_t i = 0; i < shortest; ++i) {
         List_Ptr zipper = SASS_MEMORY_NEW(List, pstate, L);
         for (size_t j = 0; j < L; ++j) {
-          zipper->append(SASS_MEMORY_CAST(List, arglist->value_at_index(j))->at(i));
+          zipper->append(Cast<List>(arglist->value_at_index(j))->at(i));
         }
         zippers->append(zipper);
       }
@@ -1454,7 +1454,7 @@ namespace Sass {
     Signature list_separator_sig = "list_separator($list)";
     BUILT_IN(list_separator)
     {
-      List_Obj l = SASS_MEMORY_CAST(List, env["$list"]);
+      List_Obj l = Cast<List>(env["$list"]);
       if (!l) {
         l = SASS_MEMORY_NEW(List, pstate, 1);
         l->append(ARG("$list", Expression));
@@ -1674,7 +1674,7 @@ namespace Sass {
         Expression_Obj expr = arglist->value_at_index(i);
         // if (params && params->has_rest_parameter()) {
         //   Parameter_Obj p = param_size > i ? (*params)[i] : 0;
-        //   List_Ptr list = SASS_MEMORY_CAST(List, expr);
+        //   List_Ptr list = Cast<List>(expr);
         //   if (list && p && !p->is_rest_parameter()) expr = (*list)[0];
         // }
         if (arglist->is_arglist()) {
@@ -1764,14 +1764,14 @@ namespace Sass {
       // Parse args into vector of selectors
       std::vector<Selector_List_Obj> parsedSelectors;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        Expression_Obj exp = SASS_MEMORY_CAST(Expression, arglist->value_at_index(i));
+        Expression_Obj exp = Cast<Expression>(arglist->value_at_index(i));
         if (exp->concrete_type() == Expression::NULL_VAL) {
           std::stringstream msg;
           msg << "$selectors: null is not a valid selector: it must be a string,\n";
           msg << "a list of strings, or a list of lists of strings for 'selector-nest'";
           error(msg.str(), pstate);
         }
-        if (String_Constant_Obj str = SASS_MEMORY_CAST(String_Constant, exp)) {
+        if (String_Constant_Obj str = Cast<String_Constant>(exp)) {
           str->quote_mark(0);
         }
         std::string exp_src = exp->to_string(ctx.c_options);
@@ -1817,14 +1817,14 @@ namespace Sass {
       // Parse args into vector of selectors
       std::vector<Selector_List_Obj> parsedSelectors;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
-        Expression_Obj exp = SASS_MEMORY_CAST(Expression, arglist->value_at_index(i));
+        Expression_Obj exp = Cast<Expression>(arglist->value_at_index(i));
         if (exp->concrete_type() == Expression::NULL_VAL) {
           std::stringstream msg;
           msg << "$selectors: null is not a valid selector: it must be a string,\n";
           msg << "a list of strings, or a list of lists of strings for 'selector-append'";
           error(msg.str(), pstate);
         }
-        if (String_Constant_Ptr str = SASS_MEMORY_CAST(String_Constant, exp)) {
+        if (String_Constant_Ptr str = Cast<String_Constant>(exp)) {
           str->quote_mark(0);
         }
         std::string exp_src = exp->to_string();
@@ -1870,7 +1870,7 @@ namespace Sass {
             }
 
             // Cannot be a Universal selector
-            Element_Selector_Obj pType = SASS_MEMORY_CAST(Element_Selector, childSeq->head()->first());
+            Element_Selector_Obj pType = Cast<Element_Selector>(childSeq->head()->first());
             if(pType && pType->name() == "*") {
               std::string msg("Can't append \"");
               msg += childSeq->to_string();
@@ -1990,7 +1990,7 @@ namespace Sass {
     BUILT_IN(is_bracketed)
     {
       Value_Obj value = ARG("$list", Value);
-      List_Obj list = SASS_MEMORY_CAST(List, value);
+      List_Obj list = Cast<List>(value);
       return SASS_MEMORY_NEW(Boolean, pstate, list && list->is_bracketed());
     }
   }

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1476,7 +1476,7 @@ namespace Sass {
       Map_Obj m = ARGM("$map", Map, ctx);
       Expression_Obj v = ARG("$key", Expression);
       try {
-        Expression_Obj val = m->at(v); // XXX
+        Expression_Obj val = m->at(v);
         return val ? val.detach() : SASS_MEMORY_NEW(Null, pstate);
       } catch (const std::out_of_range&) {
         return SASS_MEMORY_NEW(Null, pstate);
@@ -1667,7 +1667,7 @@ namespace Sass {
 
       Arguments_Obj args = SASS_MEMORY_NEW(Arguments, pstate);
       // std::string full_name(name + "[f]");
-      // Definition_Ptr def = d_env.has(full_name) ? static_cast<Definition_Ptr>((d_env)[full_name]) : 0;
+      // Definition_Ptr def = d_env.has(full_name) ? Cast<Definition>((d_env)[full_name]) : 0;
       // Parameters_Ptr params = def ? def->parameters() : 0;
       // size_t param_size = params ? params->length() : 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -108,7 +108,7 @@ namespace Sass {
     T* get_arg(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtrace* backtrace)
     {
       // Minimal error handling -- the expectation is that built-ins will be written correctly!
-      T* val = dynamic_cast<T*>(env[argname].ptr());
+      T* val = Cast<T>(env[argname]);
       if (!val) {
         std::string msg("argument `");
         msg += argname;
@@ -1432,9 +1432,9 @@ namespace Sass {
           }
           if (arglist->is_arglist()) {
             Argument_Obj arg = (Argument_Ptr)(arglist->at(i).ptr()); // XXX
-            arg->value(ith.ptr());
+            arg->value(ith);
           } else {
-            (*arglist)[i] = ith.ptr();
+            (*arglist)[i] = ith;
           }
         }
         shortest = (i ? std::min(shortest, ith->length()) : ith->length());

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -12,7 +12,6 @@ name(Env& env, Env& d_env, Context& ctx, Signature sig, ParserState pstate, Back
 
 namespace Sass {
   struct Backtrace;
-  typedef Environment<AST_Node_Obj> Env;
   typedef const char* Signature;
   typedef Expression_Ptr (*Native_Function)(Env&, Env&, Context&, Signature, ParserState, Backtrace*, std::vector<Selector_List_Obj>);
 

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -166,7 +166,7 @@ namespace Sass {
 
       import->urls().front()->perform(this);
       if (import->urls().size() == 1) {
-        if (&import->import_queries()) {
+        if (import->import_queries()) {
           append_mandatory_space();
           import->import_queries()->perform(this);
         }
@@ -179,7 +179,7 @@ namespace Sass {
 
         import->urls()[i]->perform(this);
         if (import->urls().size() - 1 == i) {
-          if (&import->import_queries()) {
+          if (import->import_queries()) {
             append_mandatory_space();
             import->import_queries()->perform(this);
           }
@@ -768,9 +768,9 @@ namespace Sass {
   {
     append_token("not", sn);
     append_mandatory_space();
-    if (sn->needs_parens(&sn->condition())) append_string("(");
+    if (sn->needs_parens(sn->condition())) append_string("(");
     sn->condition()->perform(this);
-    if (sn->needs_parens(&sn->condition())) append_string(")");
+    if (sn->needs_parens(sn->condition())) append_string(")");
   }
 
   void Inspect::operator()(Supports_Declaration_Ptr sd)
@@ -790,7 +790,7 @@ namespace Sass {
   void Inspect::operator()(Media_Query_Ptr mq)
   {
     size_t i = 0;
-    if (&mq->media_type()) {
+    if (mq->media_type()) {
       if      (mq->is_negated())    append_string("not ");
       else if (mq->is_restricted()) append_string("only ");
       mq->media_type()->perform(this);
@@ -943,7 +943,7 @@ namespace Sass {
     append_token(s->ns_name(), s);
     if (!s->matcher().empty()) {
       append_string(s->matcher());
-      if (&s->value() && *s->value()) {
+      if (s->value() && *s->value()) {
         s->value()->perform(this);
       }
     }
@@ -1077,7 +1077,7 @@ namespace Sass {
     for (size_t i = 0, L = g->length(); i < L; ++i) {
       if (!in_wrapped && i == 0) append_indentation();
       if ((*g)[i] == 0) continue;
-      schedule_mapping(&g->at(i)->last());
+      schedule_mapping(g->at(i)->last());
       // add_open_mapping((*g)[i]->last());
       (*g)[i]->perform(this);
       // add_close_mapping((*g)[i]->last());

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -391,8 +391,8 @@ namespace Sass {
     else if (output_style() == TO_SASS &&
         list->length() == 1 &&
         !list->from_selector() &&
-        !SASS_MEMORY_CAST(List, list->at(0)) &&
-        !SASS_MEMORY_CAST(Selector_List, list->at(0))
+        !Cast<List>(list->at(0)) &&
+        !Cast<Selector_List>(list->at(0))
     ) {
       append_string(lbracket(list));
     }
@@ -413,7 +413,7 @@ namespace Sass {
       if (output_style() != TO_SASS) {
         if (list_item->is_invisible()) {
           // this fixes an issue with "" in a list
-          if (!SASS_MEMORY_CAST(String_Constant, list_item)) {
+          if (!Cast<String_Constant>(list_item)) {
             continue;
           }
         }
@@ -441,8 +441,8 @@ namespace Sass {
     else if (output_style() == TO_SASS &&
         list->length() == 1 &&
         !list->from_selector() &&
-        !SASS_MEMORY_CAST(List, list->at(0)) &&
-        !SASS_MEMORY_CAST(Selector_List, list->at(0))
+        !Cast<List>(list->at(0)) &&
+        !Cast<Selector_List>(list->at(0))
     ) {
       append_string(",");
       append_string(rbracket(list));
@@ -875,7 +875,7 @@ namespace Sass {
       return;
     }
     if (a->value()->concrete_type() == Expression::STRING) {
-      String_Constant_Ptr s = SASS_MEMORY_CAST(String_Constant, a->value());
+      String_Constant_Ptr s = Cast<String_Constant>(a->value());
       if (s) s->perform(this);
     } else {
       a->value()->perform(this);
@@ -1064,8 +1064,8 @@ namespace Sass {
     bool was_comma_array = in_comma_array;
     // probably ruby sass eqivalent of element_needs_parens
     if (output_style() == TO_SASS && g->length() == 1 &&
-      (!SASS_MEMORY_CAST(List, (*g)[0]) &&
-       !SASS_MEMORY_CAST(Selector_List, (*g)[0]))) {
+      (!Cast<List>((*g)[0]) &&
+       !Cast<Selector_List>((*g)[0]))) {
       append_string("(");
     }
     else if (!in_declaration && in_comma_array) {
@@ -1090,8 +1090,8 @@ namespace Sass {
     in_comma_array = was_comma_array;
     // probably ruby sass eqivalent of element_needs_parens
     if (output_style() == TO_SASS && g->length() == 1 &&
-      (!SASS_MEMORY_CAST(List, (*g)[0]) &&
-       !SASS_MEMORY_CAST(Selector_List, (*g)[0]))) {
+      (!Cast<List>((*g)[0]) &&
+       !Cast<Selector_List>((*g)[0]))) {
       append_string(",)");
     }
     else if (!in_declaration && in_comma_array) {

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -79,7 +79,7 @@ namespace Sass {
 
   Expression_Ptr Listize::fallback_impl(AST_Node_Ptr n)
   {
-    return dynamic_cast<Expression_Ptr>(n);
+    return Cast<Expression>(n);
   }
 
 }

--- a/src/listize.cpp
+++ b/src/listize.cpp
@@ -70,7 +70,7 @@ namespace Sass {
     if (tail)
     {
       Expression_Obj tt = tail->perform(this);
-      if (List_Ptr ls = SASS_MEMORY_CAST(List, tt))
+      if (List_Ptr ls = Cast<List>(tt))
       { l->concat(ls); }
     }
     if (l->length() == 0) return 0;

--- a/src/listize.hpp
+++ b/src/listize.hpp
@@ -11,7 +11,6 @@
 
 namespace Sass {
 
-  typedef Environment<AST_Node_Obj> Env;
   struct Backtrace;
 
   class Listize : public Operation_CRTP<Expression_Ptr, Listize> {

--- a/src/memory/SharedPtr.cpp
+++ b/src/memory/SharedPtr.cpp
@@ -18,7 +18,7 @@ namespace Sass {
       std::cerr << "# REPORTING MISSING DEALLOCATIONS #\n";
       std::cerr << "###################################\n";
       for (auto var : all) {
-        if (AST_Node_Ptr ast = SASS_MEMORY_CAST_PTR(AST_Node, var)) {
+        if (AST_Node_Ptr ast = Cast<AST_Node>(var)) {
           debug_ast(ast);
         } else {
           std::cerr << "LEAKED " << var << "\n";
@@ -62,7 +62,7 @@ namespace Sass {
       #endif
       if (node->refcounter == 0) {
         #ifdef DEBUG_SHARED_PTR
-          AST_Node_Ptr ptr = SASS_MEMORY_CAST_PTR(AST_Node, node);
+          AST_Node_Ptr ptr = Cast<AST_Node>(node);
           if (node->dbg) std::cerr << "DELETE NODE " << node << "\n";
         #endif
         if (!node->detached) {

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -17,7 +17,7 @@ namespace Sass {
   #ifdef DEBUG_SHARED_PTR
 
     #define SASS_MEMORY_NEW(Class, ...) \
-      static_cast<Class##_Ptr>((new Class(__VA_ARGS__))->trace(__FILE__, __LINE__)) \
+      ((new Class(__VA_ARGS__))->trace(__FILE__, __LINE__)) \
 
     #define SASS_MEMORY_COPY(obj) \
       ((obj)->copy(__FILE__, __LINE__)) \

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -39,7 +39,7 @@ namespace Sass {
   #endif
 
   #define SASS_MEMORY_CAST(Class, obj) \
-    (dynamic_cast<Class##_Ptr>(&obj)) \
+    (dynamic_cast<Class##_Ptr>((obj).ptr())) \
 
   #define SASS_MEMORY_CAST_PTR(Class, ptr) \
     (dynamic_cast<Class##_Ptr>(ptr)) \
@@ -154,17 +154,12 @@ namespace Sass {
     : SharedPtr(node) {};
     ~SharedImpl() {};
   public:
-
-    T* operator& () const {
-      return static_cast<T*>(this->obj());
-    };
     operator T*() const {
       return static_cast<T*>(this->obj());
     }
     operator T&() const {
       return *static_cast<T*>(this->obj());
     }
-
     T& operator* () const {
       return *static_cast<T*>(this->obj());
     };

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -170,6 +170,9 @@ namespace Sass {
     bool isNull() const {
       return this->obj() == NULL;
     }
+    bool operator<(const T& rhs) const {
+      return *this->ptr() < rhs;
+    };
     operator bool() const {
       return this->obj() != NULL;
     };

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -114,13 +114,10 @@ namespace Sass {
     // destructor
     ~SharedPtr();
   public:
-    SharedObj* obj () {
-      return node;
-    };
     SharedObj* obj () const {
       return node;
     };
-    SharedObj* operator-> () {
+    SharedObj* operator-> () const {
       return node;
     };
     bool isNull () {
@@ -129,18 +126,11 @@ namespace Sass {
     bool isNull () const {
       return node == NULL;
     };
-    SharedObj* detach() {
-      node->detached = true;
-      return node;
-    };
     SharedObj* detach() const {
       if (node) {
         node->detached = true;
       }
       return node;
-    };
-    operator bool() {
-      return node != NULL;
     };
     operator bool() const {
       return node != NULL;
@@ -148,50 +138,49 @@ namespace Sass {
 
   };
 
-  template < typename T >
+  template < class T >
   class SharedImpl : private SharedPtr {
   public:
     SharedImpl()
     : SharedPtr(NULL) {};
     SharedImpl(T* node)
     : SharedPtr(node) {};
+    template < class U >
+    SharedImpl(SharedImpl<U> obj)
+    : SharedPtr(static_cast<T*>(obj.ptr())) {}
     SharedImpl(T&& node)
     : SharedPtr(node) {};
     SharedImpl(const T& node)
     : SharedPtr(node) {};
     ~SharedImpl() {};
   public:
-    T* operator& () {
-      return static_cast<T*>(this->obj());
-    };
+
     T* operator& () const {
       return static_cast<T*>(this->obj());
     };
-    T& operator* () {
+    operator T*() const {
+      return static_cast<T*>(this->obj());
+    }
+    operator T&() const {
       return *static_cast<T*>(this->obj());
-    };
+    }
+
     T& operator* () const {
       return *static_cast<T*>(this->obj());
-    };
-    T* operator-> () {
-      return static_cast<T*>(this->obj());
     };
     T* operator-> () const {
       return static_cast<T*>(this->obj());
     };
-    T* ptr () {
+    T* ptr () const {
       return static_cast<T*>(this->obj());
     };
-    T* detach() {
+    T* detach() const {
       if (this->obj() == NULL) return NULL;
       return static_cast<T*>(SharedPtr::detach());
     }
-    bool isNull() {
+    bool isNull() const {
       return this->obj() == NULL;
     }
-    operator bool() {
-      return this->obj() != NULL;
-    };
     operator bool() const {
       return this->obj() != NULL;
     };

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -38,12 +38,6 @@ namespace Sass {
 
   #endif
 
-  #define SASS_MEMORY_CAST(Class, obj) \
-    (dynamic_cast<Class##_Ptr>((obj).ptr())) \
-
-  #define SASS_MEMORY_CAST_PTR(Class, ptr) \
-    (dynamic_cast<Class##_Ptr>(ptr)) \
-
   class SharedObj {
   protected:
   friend class SharedPtr;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -101,7 +101,7 @@ namespace Sass {
 
     } else if (lhs.isSelector()){
 
-      return selectors_equal(*&lhs.selector(), *&rhs.selector(), simpleSelectorOrderDependent);
+      return selectors_equal(*lhs.selector().ptr(), *rhs.selector().ptr(), simpleSelectorOrderDependent); // XXX
 
     } else if (lhs.isCollection()) {
 
@@ -189,7 +189,7 @@ namespace Sass {
     if (pToConvert->head() && pToConvert->head()->has_parent_ref()) {
       Complex_Selector_Obj tail = pToConvert->tail();
       if (tail) tail->has_line_feed(pToConvert->has_line_feed());
-      pToConvert = &tail;
+      pToConvert = tail;
     }
 
     while (pToConvert) {
@@ -216,7 +216,7 @@ namespace Sass {
         // pToConvert->tail()->has_line_feed(pToConvert->has_line_feed());
       }
 
-      pToConvert = &pToConvert->tail();
+      pToConvert = pToConvert->tail();
     }
 
     return node;
@@ -254,7 +254,7 @@ namespace Sass {
         // collections, and can result in an infinite loop during the call to parentSuperselector()
         pCurrent->tail(SASS_MEMORY_COPY(child.selector()));
         // if (child.got_line_feed) pCurrent->has_line_feed(child.got_line_feed);
-        pCurrent = &pCurrent->tail();
+        pCurrent = pCurrent->tail();
       } else if (child.isCombinator()) {
         pCurrent->combinator(child.combinator());
         if (child.got_line_feed) pCurrent->has_line_feed(child.got_line_feed);
@@ -265,7 +265,7 @@ namespace Sass {
           if (nextNode.isCombinator()) {
             pCurrent->tail(SASS_MEMORY_NEW(Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL));
             if (nextNode.got_line_feed) pCurrent->tail()->has_line_feed(nextNode.got_line_feed);
-            pCurrent = &pCurrent->tail();
+            pCurrent = pCurrent->tail();
           }
         }
       } else {

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -71,7 +71,7 @@ namespace Sass {
     for (NodeDeque::iterator iter = mpCollection->begin(), iterEnd = mpCollection->end(); iter != iterEnd; iter++) {
       Node& toTest = *iter;
 
-      if (nodesEqual(toTest, potentialChild, simpleSelectorOrderDependent)) {
+      if (toTest == potentialChild) {
         found = true;
         break;
       }
@@ -82,37 +82,32 @@ namespace Sass {
 
 
   bool Node::operator==(const Node& rhs) const {
-    return nodesEqual(*this, rhs, true /*simpleSelectorOrderDependent*/);
-  }
-
-
-  bool nodesEqual(const Node& lhs, const Node& rhs, bool simpleSelectorOrderDependent) {
-    if (lhs.type() != rhs.type()) {
+    if (this->type() != rhs.type()) {
       return false;
     }
 
-    if (lhs.isCombinator()) {
+    if (this->isCombinator()) {
 
-      return lhs.combinator() == rhs.combinator();
+      return this->combinator() == rhs.combinator();
 
-    } else if (lhs.isNil()) {
+    } else if (this->isNil()) {
 
       return true; // no state to check
 
-    } else if (lhs.isSelector()){
+    } else if (this->isSelector()){
 
-      return *lhs.selector() == *rhs.selector();
+      return *this->selector() == *rhs.selector();
 
-    } else if (lhs.isCollection()) {
+    } else if (this->isCollection()) {
 
-      if (lhs.collection()->size() != rhs.collection()->size()) {
+      if (this->collection()->size() != rhs.collection()->size()) {
         return false;
       }
 
-      for (NodeDeque::iterator lhsIter = lhs.collection()->begin(), lhsIterEnd = lhs.collection()->end(),
+      for (NodeDeque::iterator lhsIter = this->collection()->begin(), lhsIterEnd = this->collection()->end(),
            rhsIter = rhs.collection()->begin(); lhsIter != lhsIterEnd; lhsIter++, rhsIter++) {
 
-        if (!nodesEqual(*lhsIter, *rhsIter, simpleSelectorOrderDependent)) {
+        if (*lhsIter != *rhsIter) {
           return false;
         }
 

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -66,7 +66,7 @@ namespace Sass {
 
 
   bool Node::contains(const Node& potentialChild, bool simpleSelectorOrderDependent) const {
-  	bool found = false;
+    bool found = false;
 
     for (NodeDeque::iterator iter = mpCollection->begin(), iterEnd = mpCollection->end(); iter != iterEnd; iter++) {
       Node& toTest = *iter;
@@ -82,7 +82,7 @@ namespace Sass {
 
 
   bool Node::operator==(const Node& rhs) const {
-  	return nodesEqual(*this, rhs, true /*simpleSelectorOrderDependent*/);
+    return nodesEqual(*this, rhs, true /*simpleSelectorOrderDependent*/);
   }
 
 
@@ -93,7 +93,7 @@ namespace Sass {
 
     if (lhs.isCombinator()) {
 
-    	return lhs.combinator() == rhs.combinator();
+      return lhs.combinator() == rhs.combinator();
 
     } else if (lhs.isNil()) {
 
@@ -101,7 +101,7 @@ namespace Sass {
 
     } else if (lhs.isSelector()){
 
-      return selectors_equal(*lhs.selector().ptr(), *rhs.selector().ptr(), simpleSelectorOrderDependent); // XXX
+      return *lhs.selector() == *rhs.selector();
 
     } else if (lhs.isCollection()) {
 
@@ -128,10 +128,10 @@ namespace Sass {
 
 
   void Node::plus(Node& rhs) {
-  	if (!this->isCollection() || !rhs.isCollection()) {
-    	throw "Both the current node and rhs must be collections.";
+    if (!this->isCollection() || !rhs.isCollection()) {
+      throw "Both the current node and rhs must be collections.";
     }
-  	this->collection()->insert(this->collection()->end(), rhs.collection()->begin(), rhs.collection()->end());
+    this->collection()->insert(this->collection()->end(), rhs.collection()->begin(), rhs.collection()->end());
   }
 
 #ifdef DEBUG

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -113,8 +113,6 @@ namespace Sass {
   Node complexSelectorToNode(Complex_Selector_Ptr pToConvert, Context& ctx);
   Complex_Selector_Ptr nodeToComplexSelector(const Node& toConvert, Context& ctx);
 
-  bool nodesEqual(const Node& one, const Node& two, bool simpleSelectorOrderDependent);
-
 }
 
 #endif

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -116,8 +116,8 @@ namespace Sass {
     if (!Util::isPrintable(r, output_style())) {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         const Statement_Obj& stm = b->at(i);
-        if (SASS_MEMORY_CAST(Has_Block, stm)) {
-          if (!SASS_MEMORY_CAST(Declaration, stm)) {
+        if (Cast<Has_Block>(stm)) {
+          if (!Cast<Declaration>(stm)) {
             stm->perform(this);
           }
         }
@@ -140,16 +140,16 @@ namespace Sass {
       Statement_Obj stm = b->at(i);
       bool bPrintExpression = true;
       // Check print conditions
-      if (Declaration_Ptr dec = SASS_MEMORY_CAST(Declaration, stm)) {
-        if (String_Constant_Ptr valConst = SASS_MEMORY_CAST(String_Constant, dec->value())) {
+      if (Declaration_Ptr dec = Cast<Declaration>(stm)) {
+        if (String_Constant_Ptr valConst = Cast<String_Constant>(dec->value())) {
           std::string val(valConst->value());
-          if (String_Quoted_Ptr qstr = SASS_MEMORY_CAST_PTR(String_Quoted, valConst)) {
+          if (String_Quoted_Ptr qstr = Cast<String_Quoted>(valConst)) {
             if (!qstr->quote_mark() && val.empty()) {
               bPrintExpression = false;
             }
           }
         }
-        else if (List_Ptr list = SASS_MEMORY_CAST(List, dec->value())) {
+        else if (List_Ptr list = Cast<List>(dec->value())) {
           bool all_invisible = true;
           for (size_t list_i = 0, list_L = list->length(); list_i < list_L; ++list_i) {
             Expression_Ptr item = list->at(list_i);
@@ -201,7 +201,7 @@ namespace Sass {
     if (!Util::isPrintable(f, output_style())) {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (SASS_MEMORY_CAST(Has_Block, stm)) {
+        if (Cast<Has_Block>(stm)) {
           stm->perform(this);
         }
       }
@@ -237,7 +237,7 @@ namespace Sass {
     if (!Util::isPrintable(m, output_style())) {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (SASS_MEMORY_CAST(Has_Block, stm)) {
+        if (Cast<Has_Block>(stm)) {
           stm->perform(this);
         }
       }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -116,8 +116,8 @@ namespace Sass {
     if (!Util::isPrintable(r, output_style())) {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         const Statement_Obj& stm = b->at(i);
-        if (dynamic_cast<Has_Block_Ptr>(&stm)) {
-          if (!dynamic_cast<Declaration_Ptr>(&stm)) {
+        if (SASS_MEMORY_CAST(Has_Block, stm)) {
+          if (!SASS_MEMORY_CAST(Declaration, stm)) {
             stm->perform(this);
           }
         }
@@ -135,7 +135,7 @@ namespace Sass {
       append_optional_linefeed();
     }
     if (s) s->perform(this);
-    append_scope_opener(&b);
+    append_scope_opener(b);
     for (size_t i = 0, L = b->length(); i < L; ++i) {
       Statement_Obj stm = b->at(i);
       bool bPrintExpression = true;
@@ -152,7 +152,7 @@ namespace Sass {
         else if (List_Ptr list = SASS_MEMORY_CAST(List, dec->value())) {
           bool all_invisible = true;
           for (size_t list_i = 0, list_L = list->length(); list_i < list_L; ++list_i) {
-            Expression_Ptr item = &list->at(list_i);
+            Expression_Ptr item = list->at(list_i);
             if (!item->is_invisible()) all_invisible = false;
           }
           if (all_invisible && !list->is_bracketed()) bPrintExpression = false;
@@ -164,7 +164,7 @@ namespace Sass {
       }
     }
     if (output_style() == NESTED) indentation -= r->tabs();
-    append_scope_closer(&b);
+    append_scope_closer(b);
 
   }
   void Output::operator()(Keyframe_Rule_Ptr r)
@@ -172,7 +172,7 @@ namespace Sass {
     Block_Obj b = r->block();
     Selector_Obj v = r->name();
 
-    if (&v) {
+    if (!v.isNull()) {
       v->perform(this);
     }
 
@@ -201,7 +201,7 @@ namespace Sass {
     if (!Util::isPrintable(f, output_style())) {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (dynamic_cast<Has_Block_Ptr>(&stm)) {
+        if (SASS_MEMORY_CAST(Has_Block, stm)) {
           stm->perform(this);
         }
       }
@@ -237,7 +237,7 @@ namespace Sass {
     if (!Util::isPrintable(m, output_style())) {
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (dynamic_cast<Has_Block_Ptr>(&stm)) {
+        if (SASS_MEMORY_CAST(Has_Block, stm)) {
           stm->perform(this);
         }
       }
@@ -282,7 +282,7 @@ namespace Sass {
     if (v) {
       append_mandatory_space();
       // ruby sass bug? should use options?
-      append_token(v->to_string(/* opt */), &v);
+      append_token(v->to_string(/* opt */), v);
     }
     if (!b) {
       append_delimiter();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -448,7 +448,7 @@ namespace Sass {
       bool is_arglist = false;
       bool is_keyword = false;
       Expression_Obj val = parse_space_list();
-      List_Ptr l = SASS_MEMORY_CAST(List, val);
+      List_Ptr l = Cast<List>(val);
       if (lex_css< exactly< ellipsis > >()) {
         if (val->concrete_type() == Expression::MAP || (
            (l != NULL && l->separator() == SASS_HASH)
@@ -1001,7 +1001,7 @@ namespace Sass {
       }
       else {
         value = parse_list(DELAYED);
-        if (List_Ptr list = SASS_MEMORY_CAST(List, value)) {
+        if (List_Ptr list = Cast<List>(value)) {
           if (!list->is_bracketed() && list->length() == 0 && !peek< exactly <'{'> >()) {
             css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
           }
@@ -1085,7 +1085,7 @@ namespace Sass {
     Expression_Obj list = parse_space_list();
     // if it's a singleton, return it (don't wrap it)
     if (!peek_css< exactly<','> >(position)) {
-      List_Obj l = SASS_MEMORY_CAST(List, list);
+      List_Obj l = Cast<List>(list);
       if (!l || l->is_bracketed() || has_paren) {
         List_Obj bracketed_list = SASS_MEMORY_NEW(List, pstate, 1, SASS_SPACE, false, true);
         bracketed_list->append(list);
@@ -1391,7 +1391,7 @@ namespace Sass {
     }
     else if (lex< identifier_schema >()) {
       String_Obj string = parse_identifier_schema();
-      if (String_Schema_Ptr schema = SASS_MEMORY_CAST(String_Schema, string)) {
+      if (String_Schema_Ptr schema = Cast<String_Schema>(string)) {
         if (lex < exactly < '(' > >()) {
           schema->append(parse_list());
           lex < exactly < ')' > >();
@@ -2220,7 +2220,7 @@ namespace Sass {
     List_Obj value = SASS_MEMORY_NEW(List, feature->pstate(), 1);
 
     if (expression->concrete_type() == Expression::LIST) {
-        value = SASS_MEMORY_CAST(List, expression);
+        value = Cast<List>(expression);
     }
     else value->append(expression);
 
@@ -2670,7 +2670,7 @@ namespace Sass {
 
   Expression_Obj Parser::fold_operands(Expression_Obj base, std::vector<Expression_Obj>& operands, std::vector<Operand>& ops, size_t i)
   {
-    if (String_Schema_Ptr schema = SASS_MEMORY_CAST(String_Schema, base)) {
+    if (String_Schema_Ptr schema = Cast<String_Schema>(base)) {
       // return schema;
       if (schema->has_interpolants()) {
         if (i + 1 < operands.size() && (
@@ -2693,7 +2693,7 @@ namespace Sass {
     }
 
     for (size_t S = operands.size(); i < S; ++i) {
-      if (String_Schema_Ptr schema = SASS_MEMORY_CAST(String_Schema, operands[i])) {
+      if (String_Schema_Ptr schema = Cast<String_Schema>(operands[i])) {
         if (schema->has_interpolants()) {
           if (i + 1 < S) {
             Expression_Obj rhs = fold_operands(operands[i+1], operands, ops, i + 2);
@@ -2716,8 +2716,8 @@ namespace Sass {
     }
     // nested binary expression are never to be delayed
     if (Binary_Expression_Ptr b = dynamic_cast<Binary_Expression_Ptr>(base.ptr())) {
-      if (SASS_MEMORY_CAST(Binary_Expression, b->left())) base->set_delayed(false);
-      if (SASS_MEMORY_CAST(Binary_Expression, b->right())) base->set_delayed(false);
+      if (Cast<Binary_Expression>(b->left())) base->set_delayed(false);
+      if (Cast<Binary_Expression>(b->right())) base->set_delayed(false);
     }
     return base;
   }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -105,7 +105,7 @@ namespace Sass {
     // check seems a bit esoteric but works
     if (ctx.resources.size() == 1) {
       // apply headers only on very first include
-      ctx.apply_custom_headers(&root, path, pstate);
+      ctx.apply_custom_headers(root, path, pstate);
     }
 
     // parse children nodes
@@ -157,7 +157,7 @@ namespace Sass {
 
     block_stack.pop_back();
 
-    return &block;
+    return block;
   }
 
   // convenience function for block parsing
@@ -216,15 +216,15 @@ namespace Sass {
     // also parse block comments
 
     // first parse everything that is allowed in functions
-    if (lex < variable >(true)) { block->append(&parse_assignment()); }
-    else if (lex < kwd_err >(true)) { block->append(&parse_error()); }
-    else if (lex < kwd_dbg >(true)) { block->append(&parse_debug()); }
-    else if (lex < kwd_warn >(true)) { block->append(&parse_warning()); }
-    else if (lex < kwd_if_directive >(true)) { block->append(&parse_if_directive()); }
-    else if (lex < kwd_for_directive >(true)) { block->append(&parse_for_directive()); }
-    else if (lex < kwd_each_directive >(true)) { block->append(&parse_each_directive()); }
-    else if (lex < kwd_while_directive >(true)) { block->append(&parse_while_directive()); }
-    else if (lex < kwd_return_directive >(true)) { block->append(&parse_return_directive()); }
+    if (lex < variable >(true)) { block->append(parse_assignment().ptr()); }
+    else if (lex < kwd_err >(true)) { block->append(parse_error().ptr()); }
+    else if (lex < kwd_dbg >(true)) { block->append(parse_debug().ptr()); }
+    else if (lex < kwd_warn >(true)) { block->append(parse_warning().ptr()); }
+    else if (lex < kwd_if_directive >(true)) { block->append(parse_if_directive().ptr()); }
+    else if (lex < kwd_for_directive >(true)) { block->append(parse_for_directive().ptr()); }
+    else if (lex < kwd_each_directive >(true)) { block->append(parse_each_directive().ptr()); }
+    else if (lex < kwd_while_directive >(true)) { block->append(parse_while_directive().ptr()); }
+    else if (lex < kwd_return_directive >(true)) { block->append(parse_return_directive().ptr()); }
 
     // parse imports to process later
     else if (lex < kwd_import >(true)) {
@@ -238,7 +238,7 @@ namespace Sass {
       // import stub will fetch this in expand
       Import_Obj imp = parse_import();
       // if it is a url, we only add the statement
-      if (!imp->urls().empty()) block->append(&imp);
+      if (!imp->urls().empty()) block->append(imp.ptr());
       // process all resources now (add Import_Stub nodes)
       for (size_t i = 0, S = imp->incs().size(); i < S; ++i) {
         block->append(SASS_MEMORY_NEW(Import_Stub, pstate, imp->incs()[i]));
@@ -249,31 +249,31 @@ namespace Sass {
       Lookahead lookahead = lookahead_for_include(position);
       if (!lookahead.found) css_error("Invalid CSS", " after ", ": expected selector, was ");
       Selector_Obj target;
-      if (lookahead.has_interpolants) target = &parse_selector_schema(lookahead.found, true);
-      else                            target = &parse_selector_list(true);
-      block->append(SASS_MEMORY_NEW(Extension, pstate, &target));
+      if (lookahead.has_interpolants) target = parse_selector_schema(lookahead.found, true).ptr();
+      else                            target = parse_selector_list(true).ptr();
+      block->append(SASS_MEMORY_NEW(Extension, pstate, target));
     }
 
     // selector may contain interpolations which need delayed evaluation
     else if (!(lookahead_result = lookahead_for_selector(position)).error)
-    { block->append(&parse_ruleset(lookahead_result)); }
+    { block->append(parse_ruleset(lookahead_result).ptr()); }
 
     // parse multiple specific keyword directives
-    else if (lex < kwd_media >(true)) { block->append(&parse_media_block()); }
-    else if (lex < kwd_at_root >(true)) { block->append(&parse_at_root_block()); }
-    else if (lex < kwd_include_directive >(true)) { block->append(&parse_include_directive()); }
-    else if (lex < kwd_content_directive >(true)) { block->append(&parse_content_directive()); }
-    else if (lex < kwd_supports_directive >(true)) { block->append(&parse_supports_directive()); }
-    else if (lex < kwd_mixin >(true)) { block->append(&parse_definition(Definition::MIXIN)); }
-    else if (lex < kwd_function >(true)) { block->append(&parse_definition(Definition::FUNCTION)); }
+    else if (lex < kwd_media >(true)) { block->append(parse_media_block().ptr()); }
+    else if (lex < kwd_at_root >(true)) { block->append(parse_at_root_block().ptr()); }
+    else if (lex < kwd_include_directive >(true)) { block->append(parse_include_directive().ptr()); }
+    else if (lex < kwd_content_directive >(true)) { block->append(parse_content_directive().ptr()); }
+    else if (lex < kwd_supports_directive >(true)) { block->append(parse_supports_directive().ptr()); }
+    else if (lex < kwd_mixin >(true)) { block->append(parse_definition(Definition::MIXIN).ptr()); }
+    else if (lex < kwd_function >(true)) { block->append(parse_definition(Definition::FUNCTION).ptr()); }
 
     // ignore the @charset directive for now
     else if (lex< kwd_charset_directive >(true)) { parse_charset_directive(); }
 
     // generic at keyword (keep last)
-    else if (lex< re_special_directive >(true)) { block->append(&parse_special_directive()); }
-    else if (lex< re_prefixed_directive >(true)) { block->append(&parse_prefixed_directive()); }
-    else if (lex< at_keyword >(true)) { block->append(&parse_directive()); }
+    else if (lex< re_special_directive >(true)) { block->append(parse_special_directive().ptr()); }
+    else if (lex< re_prefixed_directive >(true)) { block->append(parse_prefixed_directive().ptr()); }
+    else if (lex< at_keyword >(true)) { block->append(parse_directive().ptr()); }
 
     else if (is_root /* && block->is_root() */) {
       lex< css_whitespace >();
@@ -287,7 +287,7 @@ namespace Sass {
       // maybe we are expected to parse something?
       Declaration_Obj decl = parse_declaration();
       decl->tabs(indentation);
-      block->append(&decl);
+      block->append(decl.ptr());
       // maybe we have a "sub-block"
       if (peek< exactly<'{'> >()) {
         if (decl->is_indented()) ++ indentation;
@@ -316,24 +316,24 @@ namespace Sass {
       }
       else if (lex< uri_prefix >()) {
         Arguments_Obj args = SASS_MEMORY_NEW(Arguments, pstate);
-        Function_Call_Obj result = SASS_MEMORY_NEW(Function_Call, pstate, "url", &args);
+        Function_Call_Obj result = SASS_MEMORY_NEW(Function_Call, pstate, "url", args);
 
         if (lex< quoted_string >()) {
-          Expression_Obj the_url = &parse_string();
-          args->append(SASS_MEMORY_NEW(Argument, the_url->pstate(), &the_url));
+          Expression_Obj the_url = parse_string().ptr();
+          args->append(SASS_MEMORY_NEW(Argument, the_url->pstate(), the_url));
         }
         else if (String_Obj the_url = parse_url_function_argument()) {
-          args->append(SASS_MEMORY_NEW(Argument, the_url->pstate(), &the_url));
+          args->append(SASS_MEMORY_NEW(Argument, the_url->pstate(), the_url.ptr()));
         }
         else if (peek < skip_over_scopes < exactly < '(' >, exactly < ')' > > >(position)) {
           Expression_Obj the_url = parse_list(); // parse_interpolated_chunk(lexed);
-          args->append(SASS_MEMORY_NEW(Argument, the_url->pstate(), &the_url));
+          args->append(SASS_MEMORY_NEW(Argument, the_url->pstate(), the_url));
         }
         else {
           error("malformed URL", pstate);
         }
         if (!lex< exactly<')'> >()) error("URI is missing ')'", pstate);
-        to_import.push_back(std::pair<std::string, Function_Call_Obj>("", &result));
+        to_import.push_back(std::pair<std::string, Function_Call_Obj>("", result));
       }
       else {
         if (first) error("@import directive requires a url or quoted path", pstate);
@@ -349,12 +349,12 @@ namespace Sass {
 
     for(auto location : to_import) {
       if (location.second) {
-        imp->urls().push_back(&location.second);
+        imp->urls().push_back(location.second.ptr());
       }
       // check if custom importers want to take over the handling
-      else if (!ctx.call_importers(unquote(location.first), path, pstate, &imp)) {
+      else if (!ctx.call_importers(unquote(location.first), path, pstate, imp)) {
         // nobody wants it, so we do our import
-        ctx.import_url(&imp, location.first, path);
+        ctx.import_url(imp, location.first, path);
       }
     }
 
@@ -374,7 +374,7 @@ namespace Sass {
     else stack.push_back(Scope::Function);
     Block_Obj body = parse_block();
     stack.pop_back();
-    return SASS_MEMORY_NEW(Definition, source_position_of_def, name, &params, &body, which_type);
+    return SASS_MEMORY_NEW(Definition, source_position_of_def, name, params, body, which_type);
   }
 
   Parameters_Obj Parser::parse_parameters()
@@ -385,7 +385,7 @@ namespace Sass {
     if (lex_css< exactly<'('> >()) {
       // if there's anything there at all
       if (!peek_css< exactly<')'> >()) {
-        do params->append(&parse_parameter());
+        do params->append(parse_parameter());
         while (lex_css< exactly<','> >());
       }
       if (!lex_css< exactly<')'> >()) error("expected a variable name (e.g. $x) or ')' for the parameter list for " + name, position);
@@ -409,7 +409,7 @@ namespace Sass {
     else if (lex< exactly< ellipsis > >()) {
       is_rest = true;
     }
-    return SASS_MEMORY_NEW(Parameter, pos, name, &val, is_rest);
+    return SASS_MEMORY_NEW(Parameter, pos, name, val, is_rest);
   }
 
   Arguments_Obj Parser::parse_arguments()
@@ -420,7 +420,7 @@ namespace Sass {
     if (lex_css< exactly<'('> >()) {
       // if there's anything there at all
       if (!peek_css< exactly<')'> >()) {
-        do args->append(&parse_argument());
+        do args->append(parse_argument());
         while (lex_css< exactly<','> >());
       }
       if (!lex_css< exactly<')'> >()) error("expected a variable name (e.g. $x) or ')' for the parameter list for " + name, position);
@@ -471,7 +471,7 @@ namespace Sass {
     Expression_Obj val;
     Lookahead lookahead = lookahead_for_value(position);
     if (lookahead.has_interpolants && lookahead.found) {
-      val = &parse_value_schema(lookahead.found);
+      val = parse_value_schema(lookahead.found).ptr();
     } else {
       val = parse_list();
     }
@@ -495,8 +495,8 @@ namespace Sass {
     // create the connector object (add parts later)
     Ruleset_Obj ruleset = SASS_MEMORY_NEW(Ruleset, pstate);
     // parse selector static or as schema to be evaluated later
-    if (lookahead.parsable) ruleset->selector(&parse_selector_list(false));
-    else ruleset->selector(&parse_selector_schema(lookahead.found, false));
+    if (lookahead.parsable) ruleset->selector(parse_selector_list(false).ptr());
+    else ruleset->selector(parse_selector_schema(lookahead.found, false).ptr());
     // then parse the inner block
     stack.push_back(Scope::Rules);
     ruleset->block(parse_block());
@@ -535,7 +535,7 @@ namespace Sass {
           String_Constant_Obj str = SASS_MEMORY_NEW(String_Constant, pstate, parsed);
           pstate += Offset(parsed);
           str->update_pstate(pstate);
-          schema->append(&str);
+          schema->append(str.ptr());
         }
 
         // check if the interpolation only contains white-space (error out)
@@ -551,7 +551,7 @@ namespace Sass {
         interpolant->is_interpolant(true);
         // schema->has_interpolants(true);
         // add to the string schema
-        schema->append(&interpolant);
+        schema->append(interpolant);
         // advance parser state
         pstate.add(p+2, j);
         // advance position
@@ -567,7 +567,7 @@ namespace Sass {
           pstate += Offset(parsed);
           str->update_pstate(pstate);
           i = end_of_selector;
-          schema->append(&str);
+          schema->append(str.ptr());
         }
         // exit loop
       }
@@ -773,7 +773,7 @@ namespace Sass {
       // parse functional
       if (match < re_pseudo_selector >())
       {
-        seq->append(&parse_simple_selector());
+        seq->append(parse_simple_selector());
       }
       // parse parent selector
       else if (lex< exactly<'&'> >(false))
@@ -808,7 +808,7 @@ namespace Sass {
       else {
         Simple_Selector_Obj sel = parse_simple_selector();
         if (!sel) return 0;
-        seq->append(&sel);
+        seq->append(sel);
       }
     }
 
@@ -838,16 +838,16 @@ namespace Sass {
       return SASS_MEMORY_NEW(Element_Selector, pstate, lexed);
     }
     else if (peek< pseudo_not >()) {
-      return &parse_negated_selector();
+      return parse_negated_selector().ptr();
     }
     else if (peek< re_pseudo_selector >()) {
-      return &parse_pseudo_selector();
+      return parse_pseudo_selector();
     }
     else if (peek< exactly<':'> >()) {
-      return &parse_pseudo_selector();
+      return parse_pseudo_selector();
     }
     else if (lex < exactly<'['> >()) {
-      return &parse_attribute_selector();
+      return parse_attribute_selector().ptr();
     }
     else if (lex< placeholder >()) {
       Placeholder_Selector_Ptr sel = SASS_MEMORY_NEW(Placeholder_Selector, pstate, lexed);
@@ -868,7 +868,7 @@ namespace Sass {
       error("negated selector is missing ')'", pstate);
     }
     name.erase(name.size() - 1);
-    return SASS_MEMORY_NEW(Wrapped_Selector, nsource_position, name, &negated);
+    return SASS_MEMORY_NEW(Wrapped_Selector, nsource_position, name, negated.ptr());
   }
 
   // a pseudo selector often starts with one or two colons
@@ -909,7 +909,7 @@ namespace Sass {
       }
       else if (Selector_List_Obj wrapped = parse_selector_list(true)) {
         if (wrapped && lex_css< exactly<')'> >()) {
-          return SASS_MEMORY_NEW(Wrapped_Selector, p, name, &wrapped);
+          return SASS_MEMORY_NEW(Wrapped_Selector, p, name, wrapped.ptr());
         }
       }
 
@@ -946,7 +946,7 @@ namespace Sass {
       value = SASS_MEMORY_NEW(String_Constant, p, lexed);
     }
     else if (lex_css< quoted_string >()) {
-      value = &parse_interpolated_chunk(lexed, true); // needed!
+      value = parse_interpolated_chunk(lexed, true); // needed!
     }
     else {
       error("expected a string constant or identifier in attribute selector for " + name, pstate);
@@ -987,20 +987,20 @@ namespace Sass {
     if (peek_css< exactly<';'> >()) error("style declaration must contain a value", pstate);
     if (peek_css< exactly<'{'> >()) is_indented = false; // don't indent if value is empty
     if (peek_css< static_value >()) {
-      return SASS_MEMORY_NEW(Declaration, prop->pstate(), prop, &parse_static_value()/*, lex<kwd_important>()*/);
+      return SASS_MEMORY_NEW(Declaration, prop->pstate(), prop, parse_static_value().ptr()/*, lex<kwd_important>()*/);
     }
     else {
       Expression_Obj value;
       Lookahead lookahead = lookahead_for_value(position);
       if (lookahead.found) {
         if (lookahead.has_interpolants) {
-          value = &parse_value_schema(lookahead.found);
+          value = parse_value_schema(lookahead.found).ptr();
         } else {
-          value = &parse_list(DELAYED);
+          value = parse_list(DELAYED);
         }
       }
       else {
-        value = &parse_list(DELAYED);
+        value = parse_list(DELAYED);
         if (List_Ptr list = SASS_MEMORY_CAST(List, value)) {
           if (!list->is_bracketed() && list->length() == 0 && !peek< exactly <'{'> >()) {
             css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
@@ -1066,7 +1066,7 @@ namespace Sass {
     ps.offset = pstate - ps + pstate.offset;
     map->pstate(ps);
 
-    return &map;
+    return map.ptr();
   }
 
   Expression_Obj Parser::parse_bracket_list()
@@ -1088,11 +1088,11 @@ namespace Sass {
       List_Obj l = SASS_MEMORY_CAST(List, list);
       if (!l || l->is_bracketed() || has_paren) {
         List_Obj bracketed_list = SASS_MEMORY_NEW(List, pstate, 1, SASS_SPACE, false, true);
-        bracketed_list->append(&list);
-        return &bracketed_list;
+        bracketed_list->append(list);
+        return bracketed_list.ptr();
       }
       l->is_bracketed(true);
-      return &l;
+      return l.ptr();
     }
 
     // if we got so far, we actually do have a comma list
@@ -1109,7 +1109,7 @@ namespace Sass {
       bracketed_list->append(parse_space_list());
     }
     // return the list
-    return &bracketed_list;
+    return bracketed_list.ptr();
   }
 
   // parse list returns either a space separated list,
@@ -1155,7 +1155,7 @@ namespace Sass {
       comma_list->append(parse_space_list());
     }
     // return the list
-    return &comma_list;
+    return comma_list.ptr();
   }
   // EO parse_comma_list
 
@@ -1179,7 +1179,7 @@ namespace Sass {
       space_list->append(parse_disjunction());
     }
     // return the list
-    return &space_list;
+    return space_list.ptr();
   }
   // EO parse_space_list
 
@@ -1214,7 +1214,7 @@ namespace Sass {
     // parse multiple right hand sides
     std::vector<Expression_Obj> operands;
     while (lex_css< kwd_and >()) {
-      operands.push_back(&parse_relation());
+      operands.push_back(parse_relation());
     }
     // if it's a singleton, return it directly
     if (operands.size() == 0) return rel;
@@ -1260,7 +1260,7 @@ namespace Sass {
       // is directly adjacent to expression?
       bool right_ws = peek < css_comments >() != NULL;
       operators.push_back({ op, left_ws, right_ws });
-      operands.push_back(&parse_expression());
+      operands.push_back(parse_expression());
       left_ws = peek < css_comments >() != NULL;
     }
     // we are called recursively for list, so we first
@@ -1311,7 +1311,7 @@ namespace Sass {
 
       bool right_ws = peek < css_comments >() != NULL;
       operators.push_back({ lexed.to_string() == "+" ? Sass_OP::ADD : Sass_OP::SUB, left_ws, right_ws });
-      operands.push_back(&parse_operators());
+      operands.push_back(parse_operators());
       left_ws = peek < css_comments >() != NULL;
     }
 
@@ -1364,65 +1364,65 @@ namespace Sass {
       // lex the expected closing parenthesis
       if (!lex_css< exactly<')'> >()) error("unclosed parenthesis", pstate);
       // expression can be evaluated
-      return &value;
+      return value;
     }
     else if (lex_css< exactly<'['> >()) {
       // explicit bracketed
       Expression_Obj value = parse_bracket_list();
       // lex the expected closing square bracket
       if (!lex_css< exactly<']'> >()) error("unclosed squared bracket", pstate);
-      return &value;
+      return value;
     }
     // string may be interpolated
     // if (lex< quoted_string >()) {
     //   return &parse_string();
     // }
     else if (peek< ie_property >()) {
-      return &parse_ie_property();
+      return parse_ie_property().ptr();
     }
     else if (peek< ie_keyword_arg >()) {
-      return &parse_ie_keyword_arg();
+      return parse_ie_keyword_arg().ptr();
     }
     else if (peek< sequence < calc_fn_call, exactly <'('> > >()) {
-      return &parse_calc_function();
+      return parse_calc_function().ptr();
     }
     else if (lex < functional_schema >()) {
-      return &parse_function_call_schema();
+      return parse_function_call_schema().ptr();
     }
     else if (lex< identifier_schema >()) {
       String_Obj string = parse_identifier_schema();
       if (String_Schema_Ptr schema = SASS_MEMORY_CAST(String_Schema, string)) {
         if (lex < exactly < '(' > >()) {
-          schema->append(&parse_list());
+          schema->append(parse_list());
           lex < exactly < ')' > >();
         }
       }
-      return &string;
+      return string.ptr();
     }
     else if (peek< sequence< uri_prefix, W, real_uri_value > >()) {
-      return &parse_url_function_string();
+      return parse_url_function_string().ptr();
     }
     else if (peek< re_functional >()) {
-      return &parse_function_call();
+      return parse_function_call().ptr();
     }
     else if (lex< exactly<'+'> >()) {
-      Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::PLUS, &parse_factor());
+      Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::PLUS, parse_factor());
       if (ex && ex->operand()) ex->is_delayed(ex->operand()->is_delayed());
       return ex;
     }
     else if (lex< exactly<'-'> >()) {
-      Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::MINUS, &parse_factor());
+      Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::MINUS, parse_factor());
       if (ex && ex->operand()) ex->is_delayed(ex->operand()->is_delayed());
       return ex;
     }
     else if (lex< sequence< kwd_not > >()) {
-      Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::NOT, &parse_factor());
+      Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::NOT, parse_factor());
       if (ex && ex->operand()) ex->is_delayed(ex->operand()->is_delayed());
       return ex;
     }
     else if (peek < sequence < one_plus < alternatives < css_whitespace, exactly<'-'>, exactly<'+'> > >, number > >()) {
-      if (parse_number_prefix()) return &parse_value(); // prefix is positive
-      Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::MINUS, &parse_value());
+      if (parse_number_prefix()) return parse_value(); // prefix is positive
+      Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::MINUS, parse_value());
       if (ex->operand()) ex->is_delayed(ex->operand()->is_delayed());
       return ex;
     }
@@ -1451,14 +1451,14 @@ namespace Sass {
 
     // string may be interpolated
     if (lex< sequence < quoted_string, lookahead < exactly <'-'> > > >())
-    { return &parse_string(); }
+    { return parse_string().ptr(); }
 
     if (const char* stop = peek< value_schema >())
-    { return &parse_value_schema(stop); }
+    { return parse_value_schema(stop).ptr(); }
 
     // string may be interpolated
     if (lex< quoted_string >())
-    { return &parse_string(); }
+    { return parse_string().ptr(); }
 
     if (lex< kwd_true >())
     { return SASS_MEMORY_NEW(Boolean, pstate, true); }
@@ -1542,7 +1542,7 @@ namespace Sass {
           // parse the interpolant and accumulate it
           Expression_Obj interp_node = Parser::from_token(Token(p+2, j), ctx, pstate, source).parse_list();
           interp_node->is_interpolant(true);
-          schema->append(&interp_node);
+          schema->append(interp_node);
           i = j;
         }
         else {
@@ -1606,7 +1606,7 @@ namespace Sass {
           // parse the interpolant and accumulate it
           Expression_Obj interp_node = Parser::from_token(Token(p+2, j), ctx, pstate, source).parse_list();
           interp_node->is_interpolant(true);
-          schema->append(&interp_node);
+          schema->append(interp_node);
           i = j;
         }
         else {
@@ -1635,9 +1635,9 @@ namespace Sass {
     }
     lex< exactly<'='> >();
     kwd_arg->append(SASS_MEMORY_NEW(String_Constant, pstate, lexed));
-    if (peek< variable >()) kwd_arg->append(&parse_list());
+    if (peek< variable >()) kwd_arg->append(parse_list());
     else if (lex< number >()) kwd_arg->append(SASS_MEMORY_NEW(Textual, pstate, Textual::NUMBER, Util::normalize_decimals(lexed)));
-    else if (peek < ie_keyword_arg_value >()) { kwd_arg->append(&parse_list()); }
+    else if (peek < ie_keyword_arg_value >()) { kwd_arg->append(parse_list()); }
     return kwd_arg;
   }
 
@@ -1665,7 +1665,7 @@ namespace Sass {
         // schema->append(SASS_MEMORY_NEW(String_Constant, pstate, " "));
       }
       if ((e = peek< re_functional >()) && e < stop) {
-        schema->append(&parse_function_call());
+        schema->append(parse_function_call().ptr());
       }
       // lex an interpolant /#{...}/
       else if (lex< exactly < hash_lbrace > >()) {
@@ -1695,7 +1695,7 @@ namespace Sass {
         // need_space = true;
         // if (schema->length()) schema->append(SASS_MEMORY_NEW(String_Constant, pstate, " "));
         // else need_space = true;
-        schema->append(&parse_string());
+        schema->append(parse_string().ptr());
         if ((*position == '"' || *position == '\'') || peek < alternatives < alpha > >()) {
           // need_space = true;
         }
@@ -1733,7 +1733,7 @@ namespace Sass {
       }
       // lex a value in parentheses
       else if (peek< parenthese_scope >()) {
-        schema->append(&parse_factor());
+        schema->append(parse_factor());
       }
       else {
         break;
@@ -1767,7 +1767,7 @@ namespace Sass {
         if (i < p) {
           // accumulate the preceding segment if it's nonempty
           const char* o = position; position = i;
-          schema->append(&parse_value_schema(p));
+          schema->append(parse_value_schema(p).ptr());
           position = o;
         }
         // we need to skip anything inside strings
@@ -1792,7 +1792,7 @@ namespace Sass {
       else { // no interpolants left; add the last segment if nonempty
         if (i < end) {
           const char* o = position; position = i;
-          schema->append(&parse_value_schema(id.end));
+          schema->append(parse_value_schema(id.end).ptr());
           position = o;
         }
         break;
@@ -1817,9 +1817,9 @@ namespace Sass {
           exactly < ')' >
         > >();
 
-    Argument_Obj arg = SASS_MEMORY_NEW(Argument, arg_pos, &parse_interpolated_chunk(Token(arg_beg, arg_end)));
+    Argument_Obj arg = SASS_MEMORY_NEW(Argument, arg_pos, parse_interpolated_chunk(Token(arg_beg, arg_end)).ptr());
     Arguments_Obj args = SASS_MEMORY_NEW(Arguments, arg_pos);
-    args->append(&arg);
+    args->append(arg);
     return SASS_MEMORY_NEW(Function_Call, call_pos, name, args);
   }
 
@@ -1839,16 +1839,16 @@ namespace Sass {
     }
 
     std::string uri("");
-    if (&url_string) {
+    if (url_string) {
       uri = url_string->to_string({ NESTED, 5 });
     }
 
-    if (String_Schema_Ptr schema = dynamic_cast<String_Schema_Ptr>(&url_string)) {
+    if (String_Schema_Ptr schema = dynamic_cast<String_Schema_Ptr>(url_string.ptr())) {
       String_Schema_Obj res = SASS_MEMORY_NEW(String_Schema, pstate);
       res->append(SASS_MEMORY_NEW(String_Constant, pstate, prefix));
       res->append(schema);
       res->append(SASS_MEMORY_NEW(String_Constant, pstate, suffix));
-      return &res;
+      return res.ptr();
     } else {
       std::string res = prefix + uri + suffix;
       return SASS_MEMORY_NEW(String_Constant, pstate, res);
@@ -1871,7 +1871,7 @@ namespace Sass {
         pp = sequence< interpolant, real_uri_value >(pp);
       }
       position = pp;
-      return &parse_interpolated_chunk(Token(p, position));
+      return parse_interpolated_chunk(Token(p, position));
     }
     else if (uri != "") {
       std::string res = Util::rtrim(uri);
@@ -1918,10 +1918,10 @@ namespace Sass {
     // we want all other comments to be parsed
     if (lex_css< elseif_directive >()) {
       alternative = SASS_MEMORY_NEW(Block, pstate);
-      alternative->append(&parse_if_directive(true));
+      alternative->append(parse_if_directive(true).ptr());
     }
     else if (lex_css< kwd_else_directive >()) {
-      alternative = &parse_block(root);
+      alternative = parse_block(root);
     }
     stack.pop_back();
     return SASS_MEMORY_NEW(If, if_source_position, predicate, block, alternative);
@@ -2018,9 +2018,9 @@ namespace Sass {
     media_block->media_queries(parse_media_queries());
 
     Media_Block_Obj prev_media_block = last_media_block;
-    last_media_block = &media_block;
+    last_media_block = media_block;
     media_block->block(parse_css_block());
-    last_media_block = &prev_media_block;
+    last_media_block = prev_media_block;
     stack.pop_back();
     return media_block.detach();
   }
@@ -2029,8 +2029,8 @@ namespace Sass {
   {
     advanceToNextToken();
     List_Obj queries = SASS_MEMORY_NEW(List, pstate, 0, SASS_COMMA);
-    if (!peek_css < exactly <'{'> >()) queries->append(&parse_media_query());
-    while (lex_css < exactly <','> >()) queries->append(&parse_media_query());
+    if (!peek_css < exactly <'{'> >()) queries->append(parse_media_query().ptr());
+    while (lex_css < exactly <','> >()) queries->append(parse_media_query().ptr());
     queries->update_pstate(pstate);
     return queries.detach();
   }
@@ -2043,19 +2043,19 @@ namespace Sass {
     if (lex < kwd_not >()) { media_query->is_negated(true); lex < css_comments >(false); }
     else if (lex < kwd_only >()) { media_query->is_restricted(true); lex < css_comments >(false); }
 
-    if (lex < identifier_schema >())  media_query->media_type(&parse_identifier_schema());
-    else if (lex < identifier >())    media_query->media_type(&parse_interpolated_chunk(lexed));
-    else                             media_query->append(&parse_media_expression());
+    if (lex < identifier_schema >())  media_query->media_type(parse_identifier_schema());
+    else if (lex < identifier >())    media_query->media_type(parse_interpolated_chunk(lexed));
+    else                             media_query->append(parse_media_expression());
 
-    while (lex_css < kwd_and >()) media_query->append(&parse_media_expression());
+    while (lex_css < kwd_and >()) media_query->append(parse_media_expression());
     if (lex < identifier_schema >()) {
       String_Schema_Ptr schema = SASS_MEMORY_NEW(String_Schema, pstate);
-      schema->append(&media_query->media_type());
+      schema->append(media_query->media_type().ptr());
       schema->append(SASS_MEMORY_NEW(String_Constant, pstate, " "));
-      schema->append(&parse_identifier_schema());
+      schema->append(parse_identifier_schema().ptr());
       media_query->media_type(schema);
     }
-    while (lex_css < kwd_and >()) media_query->append(&parse_media_expression());
+    while (lex_css < kwd_and >()) media_query->append(parse_media_expression());
 
     media_query->update_pstate(pstate);
 
@@ -2066,7 +2066,7 @@ namespace Sass {
   {
     if (lex < identifier_schema >()) {
       String_Obj ss = parse_identifier_schema();
-      return SASS_MEMORY_NEW(Media_Query_Expression, pstate, &ss, 0, true);
+      return SASS_MEMORY_NEW(Media_Query_Expression, pstate, ss.ptr(), 0, true);
     }
     if (!lex_css< exactly<'('> >()) {
       error("media query expression must begin with '('", pstate);
@@ -2075,10 +2075,10 @@ namespace Sass {
     if (peek_css< exactly<')'> >()) {
       error("media feature required in media query expression", pstate);
     }
-    feature = &parse_expression();
+    feature = parse_expression();
     Expression_Obj expression = 0;
     if (lex_css< exactly<':'> >()) {
-      expression = &parse_list(DELAYED);
+      expression = parse_list(DELAYED);
     }
     if (!lex_css< exactly<')'> >()) {
       error("unclosed parenthesis in media query expression", pstate);
@@ -2116,13 +2116,13 @@ namespace Sass {
   {
     if (!lex < kwd_not >()) return 0;
     Supports_Condition_Obj cond = parse_supports_condition_in_parens();
-    return SASS_MEMORY_NEW(Supports_Negation, pstate, &cond);
+    return SASS_MEMORY_NEW(Supports_Negation, pstate, cond);
   }
 
   Supports_Condition_Obj Parser::parse_supports_operator()
   {
     Supports_Condition_Obj cond = parse_supports_condition_in_parens();
-    if (!&cond) return 0;
+    if (cond.isNull()) return 0;
 
     while (true) {
       Supports_Operator::Operand op = Supports_Operator::OR;
@@ -2133,7 +2133,7 @@ namespace Sass {
       Supports_Condition_Obj right = parse_supports_condition_in_parens();
 
       // Supports_Condition_Ptr cc = SASS_MEMORY_NEW(Supports_Condition, *static_cast<Supports_Condition_Ptr>(cond));
-      cond = SASS_MEMORY_NEW(Supports_Operator, pstate, &cond, &right, op);
+      cond = SASS_MEMORY_NEW(Supports_Operator, pstate, cond, right, op);
     }
     return cond;
   }
@@ -2145,7 +2145,7 @@ namespace Sass {
     String_Obj interp = parse_interpolated_chunk(lexed);
     if (!interp) return 0;
 
-    return SASS_MEMORY_NEW(Supports_Interpolation, pstate, &interp);
+    return SASS_MEMORY_NEW(Supports_Interpolation, pstate, interp.ptr());
   }
 
   // TODO: This needs some major work. Although feature conditions
@@ -2158,7 +2158,7 @@ namespace Sass {
     if (!declaration) error("@supports condition expected declaration", pstate);
     cond = SASS_MEMORY_NEW(Supports_Declaration,
                      declaration->pstate(),
-                     &declaration->property(),
+                     declaration->property().ptr(),
                      declaration->value());
     // ToDo: maybe we need an additional error condition?
     return cond;
@@ -2167,13 +2167,13 @@ namespace Sass {
   Supports_Condition_Obj Parser::parse_supports_condition_in_parens()
   {
     Supports_Condition_Obj interp = parse_supports_interpolation();
-    if (&interp != 0) return interp;
+    if (interp != 0) return interp;
 
     if (!lex < exactly <'('> >()) return 0;
     lex < css_whitespace >();
 
     Supports_Condition_Obj cond = parse_supports_condition();
-    if (&cond != 0) {
+    if (cond != 0) {
       if (!lex < exactly <')'> >()) error("unclosed parenthesis in @supports declaration", pstate);
     } else {
       cond = parse_supports_declaration();
@@ -2194,15 +2194,15 @@ namespace Sass {
     }
     if (peek_css < exactly<'{'> >()) {
       lex <optional_spaces>();
-      body = &parse_block(true);
+      body = parse_block(true);
     }
     else if ((lookahead_result = lookahead_for_selector(position)).found) {
       Ruleset_Obj r = parse_ruleset(lookahead_result);
       body = SASS_MEMORY_NEW(Block, r->pstate(), 1, true);
-      body->append(&r);
+      body->append(r.ptr());
     }
     At_Root_Block_Obj at_root = SASS_MEMORY_NEW(At_Root_Block, at_source_position, body);
-    if (&expr) at_root->expression(&expr);
+    if (!expr.isNull()) at_root->expression(expr);
     return at_root;
   }
 
@@ -2227,7 +2227,7 @@ namespace Sass {
     At_Root_Query_Obj cond = SASS_MEMORY_NEW(At_Root_Query,
                                           value->pstate(),
                                           feature,
-                                          &value);
+                                          value.ptr());
     if (!lex_css< exactly<')'> >()) error("unclosed parenthesis in @at-root expression", pstate);
     return cond;
   }
@@ -2241,13 +2241,13 @@ namespace Sass {
     Directive_Ptr at_rule = SASS_MEMORY_NEW(Directive, pstate, kwd);
     Lookahead lookahead = lookahead_for_include(position);
     if (lookahead.found && !lookahead.has_interpolants) {
-      at_rule->selector(&parse_selector_list(false));
+      at_rule->selector(parse_selector_list(false).ptr());
     }
 
     lex < css_comments >(false);
 
     if (lex < static_property >()) {
-      at_rule->value(&parse_interpolated_chunk(Token(lexed)));
+      at_rule->value(parse_interpolated_chunk(Token(lexed)).ptr());
     } else if (!(peek < alternatives < exactly<'{'>, exactly<'}'>, exactly<';'> > >())) {
       at_rule->value(parse_list());
     }
@@ -2270,15 +2270,15 @@ namespace Sass {
     Directive_Obj at_rule = SASS_MEMORY_NEW(Directive, pstate, kwd);
     Lookahead lookahead = lookahead_for_include(position);
     if (lookahead.found && !lookahead.has_interpolants) {
-      at_rule->selector(&parse_selector_list(false));
+      at_rule->selector(parse_selector_list(false).ptr());
     }
 
     lex < css_comments >(false);
 
     if (lex < static_property >()) {
-      at_rule->value(&parse_interpolated_chunk(Token(lexed)));
+      at_rule->value(parse_interpolated_chunk(Token(lexed)).ptr());
     } else if (!(peek < alternatives < exactly<'{'>, exactly<'}'>, exactly<';'> > >())) {
-      at_rule->value(&parse_list());
+      at_rule->value(parse_list());
     }
 
     lex < css_comments >(false);
@@ -2296,7 +2296,7 @@ namespace Sass {
     Directive_Obj directive = SASS_MEMORY_NEW(Directive, pstate, lexed);
     String_Schema_Obj val = parse_almost_any_value();
     // strip left and right if they are of type string
-    directive->value(&val);
+    directive->value(val.ptr());
     if (peek< exactly<'{'> >()) {
       directive->block(parse_block());
     }
@@ -2306,7 +2306,7 @@ namespace Sass {
   Expression_Obj Parser::lex_interpolation()
   {
     if (lex < interpolant >(true) != NULL) {
-      return &parse_interpolated_chunk(lexed, true);
+      return parse_interpolated_chunk(lexed, true).ptr();
     }
     return 0;
   }
@@ -2381,12 +2381,12 @@ namespace Sass {
   {
     Expression_Obj rv = 0;
     if (*position == 0) return 0;
-    if ((rv = &lex_almost_any_value_chars())) return rv;
+    if ((rv = lex_almost_any_value_chars())) return rv;
     // if ((rv = lex_block_comment())) return rv;
     // if ((rv = lex_single_line_comment())) return rv;
-    if ((rv = &lex_interp_string())) return rv;
-    if ((rv = &lex_interp_uri())) return rv;
-    if ((rv = &lex_interpolation())) return rv;
+    if ((rv = lex_interp_string())) return rv;
+    if ((rv = lex_interp_uri())) return rv;
+    if ((rv = lex_interpolation())) return rv;
     return rv;
   }
 
@@ -2404,7 +2404,7 @@ namespace Sass {
       return schema.detach();
     }
 
-    while ((token = &lex_almost_any_value_token())) {
+    while ((token = lex_almost_any_value_token())) {
       schema->append(token);
     }
 
@@ -2456,7 +2456,7 @@ namespace Sass {
     // check that we do not have an empty list (ToDo: check if we got all cases)
     if (peek_css < alternatives < exactly < ';' >, exactly < '}' >, end_of_file > >())
     { css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was "); }
-    return SASS_MEMORY_NEW(Return, pstate, &parse_list());
+    return SASS_MEMORY_NEW(Return, pstate, parse_list());
   }
 
   Lookahead Parser::lookahead_for_selector(const char* start)
@@ -2663,14 +2663,14 @@ namespace Sass {
   Expression_Obj Parser::fold_operands(Expression_Obj base, std::vector<Expression_Obj>& operands, Operand op)
   {
     for (size_t i = 0, S = operands.size(); i < S; ++i) {
-      base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), op, &base, operands[i]);
+      base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), op, base, operands[i]);
     }
     return base;
   }
 
   Expression_Obj Parser::fold_operands(Expression_Obj base, std::vector<Expression_Obj>& operands, std::vector<Operand>& ops, size_t i)
   {
-    if (String_Schema_Ptr schema = dynamic_cast<String_Schema_Ptr>(&base)) {
+    if (String_Schema_Ptr schema = SASS_MEMORY_CAST(String_Schema, base)) {
       // return schema;
       if (schema->has_interpolants()) {
         if (i + 1 < operands.size() && (
@@ -2685,7 +2685,7 @@ namespace Sass {
           || (ops[0].operand == Sass_OP::GTE)
         )) {
           Expression_Obj rhs = fold_operands(operands[i], operands, ops, i + 1);
-          rhs = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[0], schema, &rhs);
+          rhs = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[0], schema, rhs);
           return rhs;
         }
         // return schema;
@@ -2693,29 +2693,29 @@ namespace Sass {
     }
 
     for (size_t S = operands.size(); i < S; ++i) {
-      if (String_Schema_Ptr schema = dynamic_cast<String_Schema_Ptr>(&operands[i])) {
+      if (String_Schema_Ptr schema = SASS_MEMORY_CAST(String_Schema, operands[i])) {
         if (schema->has_interpolants()) {
           if (i + 1 < S) {
             Expression_Obj rhs = fold_operands(operands[i+1], operands, ops, i + 2);
-            rhs = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], schema, &rhs);
-            base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], &base, &rhs);
+            rhs = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], schema, rhs);
+            base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], base, rhs);
             return base;
           }
-          base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], &base, operands[i]);
+          base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], base, operands[i]);
           return base;
         } else {
-          base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], &base, operands[i]);
+          base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], base, operands[i]);
         }
       } else {
-        base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], &base, operands[i]);
+        base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], base, operands[i]);
       }
-      Binary_Expression_Ptr b = static_cast<Binary_Expression_Ptr>(&base);
+      Binary_Expression_Ptr b = static_cast<Binary_Expression_Ptr>(base.ptr());
       if (b && ops[i].operand == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
         base->is_delayed(true);
       }
     }
     // nested binary expression are never to be delayed
-    if (Binary_Expression_Ptr b = dynamic_cast<Binary_Expression_Ptr>(&base)) {
+    if (Binary_Expression_Ptr b = dynamic_cast<Binary_Expression_Ptr>(base.ptr())) {
       if (SASS_MEMORY_CAST(Binary_Expression, b->left())) base->set_delayed(false);
       if (SASS_MEMORY_CAST(Binary_Expression, b->right())) base->set_delayed(false);
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2709,7 +2709,7 @@ namespace Sass {
       } else {
         base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], base, operands[i]);
       }
-      Binary_Expression_Ptr b = static_cast<Binary_Expression_Ptr>(base.ptr());
+      Binary_Expression_Ptr b = Cast<Binary_Expression>(base.ptr());
       if (b && ops[i].operand == Sass_OP::DIV && b->left()->is_delayed() && b->right()->is_delayed()) {
         base->is_delayed(true);
       }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1016,6 +1016,7 @@ namespace Sass {
   }
 
   // parse +/- and return false if negative
+  // this is never hit via spec tests
   bool Parser::parse_number_prefix()
   {
     bool positive = true;
@@ -1420,6 +1421,7 @@ namespace Sass {
       if (ex && ex->operand()) ex->is_delayed(ex->operand()->is_delayed());
       return ex;
     }
+    // this whole branch is never hit via spec tests
     else if (peek < sequence < one_plus < alternatives < css_whitespace, exactly<'-'>, exactly<'+'> > >, number > >()) {
       if (parse_number_prefix()) return parse_value(); // prefix is positive
       Unary_Expression_Ptr ex = SASS_MEMORY_NEW(Unary_Expression, pstate, Unary_Expression::MINUS, parse_value());
@@ -2238,6 +2240,8 @@ namespace Sass {
 
     if (lexed == "@else") error("Invalid CSS: @else must come after @if", pstate);
 
+    // this whole branch is never hit via spec tests
+
     Directive_Ptr at_rule = SASS_MEMORY_NEW(Directive, pstate, kwd);
     Lookahead lookahead = lookahead_for_include(position);
     if (lookahead.found && !lookahead.has_interpolants) {
@@ -2261,6 +2265,7 @@ namespace Sass {
     return at_rule;
   }
 
+  // this whole branch is never hit via spec tests
   Directive_Obj Parser::parse_prefixed_directive()
   {
     std::string kwd(lexed);
@@ -2696,6 +2701,7 @@ namespace Sass {
       if (String_Schema_Ptr schema = Cast<String_Schema>(operands[i])) {
         if (schema->has_interpolants()) {
           if (i + 1 < S) {
+            // this whole branch is never hit via spec tests
             Expression_Obj rhs = fold_operands(operands[i+1], operands, ops, i + 2);
             rhs = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], schema, rhs);
             base = SASS_MEMORY_NEW(Binary_Expression, base->pstate(), ops[i], base, rhs);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -340,15 +340,15 @@ namespace Sass {
         schema->append(SASS_MEMORY_NEW(String_Constant, pstate, lexed));
         if (position[0] == '#' && position[1] == '{') {
           Expression_Obj itpl = lex_interpolation();
-          if (&itpl) schema->append(&itpl);
+          if (!itpl.isNull()) schema->append(itpl);
           while (lex < close >(false)) {
             // std::cerr << "LEX [[" << std::string(lexed) << "]]\n";
             schema->append(SASS_MEMORY_NEW(String_Constant, pstate, lexed));
             if (position[0] == '#' && position[1] == '{') {
               Expression_Obj itpl = lex_interpolation();
-              if (&itpl) schema->append(&itpl);
+              if (!itpl.isNull()) schema->append(itpl);
             } else {
-              return &schema;
+              return schema.ptr();
             }
           }
         } else {

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -348,7 +348,7 @@ namespace Sass {
               Expression_Obj itpl = lex_interpolation();
               if (!itpl.isNull()) schema->append(itpl);
             } else {
-              return schema.ptr();
+              return schema;
             }
           }
         } else {

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -85,7 +85,7 @@ namespace Sass {
 
     size_t length()    const { return end - begin; }
     std::string ws_before() const { return std::string(prefix, begin); }
-    std::string to_string() const { return std::string(begin, end); }
+    const std::string to_string() const { return std::string(begin, end); }
     std::string time_wspace() const {
       std::string str(to_string());
       std::string whitespaces(" \t\f\v\n\r");

--- a/src/remove_placeholders.cpp
+++ b/src/remove_placeholders.cpp
@@ -33,7 +33,7 @@ namespace Sass {
 
     void Remove_Placeholders::operator()(Ruleset_Ptr r) {
         // Create a new selector group without placeholders
-        Selector_List_Obj sl = SASS_MEMORY_CAST(Selector_List, r->selector());
+        Selector_List_Obj sl = Cast<Selector_List>(r->selector());
 
         if (sl) {
           // Set the new placeholder selector list
@@ -43,8 +43,8 @@ namespace Sass {
             while (cs) {
               if (cs->head()) {
                 for (Simple_Selector_Obj& ss : cs->head()->elements()) {
-                  if (Wrapped_Selector_Ptr ws = SASS_MEMORY_CAST(Wrapped_Selector, ss)) {
-                    if (Selector_List_Ptr sl = SASS_MEMORY_CAST(Selector_List, ws->selector())) {
+                  if (Wrapped_Selector_Ptr ws = Cast<Wrapped_Selector>(ss)) {
+                    if (Selector_List_Ptr sl = Cast<Selector_List>(ws->selector())) {
                       Selector_List_Ptr clean = remove_placeholders(sl);
                       // also clean superflous parent selectors
                       // probably not really the correct place

--- a/src/remove_placeholders.cpp
+++ b/src/remove_placeholders.cpp
@@ -11,7 +11,7 @@ namespace Sass {
 
     void Remove_Placeholders::operator()(Block_Ptr b) {
         for (size_t i = 0, L = b->length(); i < L; ++i) {
-            Statement_Ptr st = &b->at(i);
+            Statement_Ptr st = b->at(i);
             st->perform(this);
         }
     }
@@ -37,7 +37,7 @@ namespace Sass {
 
         if (sl) {
           // Set the new placeholder selector list
-          r->selector(remove_placeholders(&sl));
+          r->selector(remove_placeholders(sl));
           // Remove placeholders in wrapped selectors
           for (Complex_Selector_Obj cs : sl->elements()) {
             while (cs) {
@@ -71,10 +71,10 @@ namespace Sass {
     }
 
     void Remove_Placeholders::operator()(Media_Block_Ptr m) {
-        operator()(&m->block());
+        operator()(m->block());
     }
     void Remove_Placeholders::operator()(Supports_Block_Ptr m) {
-        operator()(&m->block());
+        operator()(m->block());
     }
 
     void Remove_Placeholders::operator()(Directive_Ptr a) {

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -472,7 +472,7 @@ extern "C" {
     if (compiler->c_ctx->error_status)
       return compiler->c_ctx->error_status;
     // parse the context we have set up (file or data)
-    compiler->root = &sass_parse_block(compiler);
+    compiler->root = sass_parse_block(compiler);
     // success
     return 0;
   }

--- a/src/sass_functions.cpp
+++ b/src/sass_functions.cpp
@@ -166,21 +166,21 @@ extern "C" {
 
   // Getters and Setters for environments (lexical, local and global)
   union Sass_Value* ADDCALL sass_env_get_lexical (Sass_Env_Frame env, const char* name) {
-    Expression_Ptr ex = SASS_MEMORY_CAST(Expression, (*env->frame)[name]);
+    Expression_Ptr ex = Cast<Expression>((*env->frame)[name]);
     return ex != NULL ? ast_node_to_sass_value(ex) : NULL;
   }
   void ADDCALL sass_env_set_lexical (Sass_Env_Frame env, const char* name, union Sass_Value* val) {
     (*env->frame)[name] = sass_value_to_ast_node(val);
   }
   union Sass_Value* ADDCALL sass_env_get_local (Sass_Env_Frame env, const char* name) {
-    Expression_Ptr ex = SASS_MEMORY_CAST(Expression, env->frame->get_local(name));
+    Expression_Ptr ex = Cast<Expression>(env->frame->get_local(name));
     return ex != NULL ? ast_node_to_sass_value(ex) : NULL;
   }
   void ADDCALL sass_env_set_local (Sass_Env_Frame env, const char* name, union Sass_Value* val) {
     env->frame->set_local(name, sass_value_to_ast_node(val));
   }
   union Sass_Value* ADDCALL sass_env_get_global (Sass_Env_Frame env, const char* name) {
-    Expression_Ptr ex = SASS_MEMORY_CAST(Expression, env->frame->get_global(name));
+    Expression_Ptr ex = Cast<Expression>(env->frame->get_global(name));
     return ex != NULL ? ast_node_to_sass_value(ex) : NULL;
   }
   void ADDCALL sass_env_set_global (Sass_Env_Frame env, const char* name, union Sass_Value* val) {

--- a/src/sass_util.hpp
+++ b/src/sass_util.hpp
@@ -40,7 +40,7 @@ namespace Sass {
     bool operator()(const Node& one, const Node& two, Node& out) const {
       // TODO: Is this the correct C++ interpretation?
       // block ||= proc {|a, b| a == b && a}
-      if (nodesEqual(one, two, true)) {
+      if (one == two) {
         out = one;
         return true;
       }

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -297,14 +297,14 @@ extern "C" {
 
       // see if it's a relational expression
       switch(op) {
-        case Sass_OP::EQ:  return sass_make_boolean(Eval::eq(lhs.ptr(), rhs.ptr()));
-        case Sass_OP::NEQ: return sass_make_boolean(!Eval::eq(lhs.ptr(), rhs.ptr()));
-        case Sass_OP::GT:  return sass_make_boolean(!Eval::lt(lhs.ptr(), rhs.ptr(), "gt") && !Eval::eq(lhs.ptr(), rhs.ptr()));
-        case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(lhs.ptr(), rhs.ptr(), "gte"));
-        case Sass_OP::LT:  return sass_make_boolean(Eval::lt(lhs.ptr(), rhs.ptr(), "lt"));
-        case Sass_OP::LTE: return sass_make_boolean(Eval::lt(lhs.ptr(), rhs.ptr(), "lte") || Eval::eq(lhs.ptr(), rhs.ptr()));
-        case Sass_OP::AND: return ast_node_to_sass_value(lhs->is_false() ? lhs.ptr() : rhs.ptr());
-        case Sass_OP::OR:  return ast_node_to_sass_value(lhs->is_false() ? rhs.ptr() : lhs.ptr());
+        case Sass_OP::EQ:  return sass_make_boolean(Eval::eq(lhs, rhs));
+        case Sass_OP::NEQ: return sass_make_boolean(!Eval::eq(lhs, rhs));
+        case Sass_OP::GT:  return sass_make_boolean(!Eval::lt(lhs, rhs, "gt") && !Eval::eq(lhs, rhs));
+        case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(lhs, rhs, "gte"));
+        case Sass_OP::LT:  return sass_make_boolean(Eval::lt(lhs, rhs, "lt"));
+        case Sass_OP::LTE: return sass_make_boolean(Eval::lt(lhs, rhs, "lte") || Eval::eq(lhs, rhs));
+        case Sass_OP::AND: return ast_node_to_sass_value(lhs->is_false() ? lhs : rhs);
+        case Sass_OP::OR:  return ast_node_to_sass_value(lhs->is_false() ? rhs : lhs);
         default:           break;
       }
 

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -297,14 +297,14 @@ extern "C" {
 
       // see if it's a relational expression
       switch(op) {
-        case Sass_OP::EQ:  return sass_make_boolean(Eval::eq(&lhs, &rhs));
-        case Sass_OP::NEQ: return sass_make_boolean(!Eval::eq(&lhs, &rhs));
-        case Sass_OP::GT:  return sass_make_boolean(!Eval::lt(&lhs, &rhs, "gt") && !Eval::eq(&lhs, &rhs));
-        case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(&lhs, &rhs, "gte"));
-        case Sass_OP::LT:  return sass_make_boolean(Eval::lt(&lhs, &rhs, "lt"));
-        case Sass_OP::LTE: return sass_make_boolean(Eval::lt(&lhs, &rhs, "lte") || Eval::eq(&lhs, &rhs));
-        case Sass_OP::AND: return ast_node_to_sass_value(lhs->is_false() ? &lhs : &rhs);
-        case Sass_OP::OR:  return ast_node_to_sass_value(lhs->is_false() ? &rhs : &lhs);
+        case Sass_OP::EQ:  return sass_make_boolean(Eval::eq(lhs.ptr(), rhs.ptr()));
+        case Sass_OP::NEQ: return sass_make_boolean(!Eval::eq(lhs.ptr(), rhs.ptr()));
+        case Sass_OP::GT:  return sass_make_boolean(!Eval::lt(lhs.ptr(), rhs.ptr(), "gt") && !Eval::eq(lhs.ptr(), rhs.ptr()));
+        case Sass_OP::GTE: return sass_make_boolean(!Eval::lt(lhs.ptr(), rhs.ptr(), "gte"));
+        case Sass_OP::LT:  return sass_make_boolean(Eval::lt(lhs.ptr(), rhs.ptr(), "lt"));
+        case Sass_OP::LTE: return sass_make_boolean(Eval::lt(lhs.ptr(), rhs.ptr(), "lte") || Eval::eq(lhs.ptr(), rhs.ptr()));
+        case Sass_OP::AND: return ast_node_to_sass_value(lhs->is_false() ? lhs.ptr() : rhs.ptr());
+        case Sass_OP::OR:  return ast_node_to_sass_value(lhs->is_false() ? rhs.ptr() : lhs.ptr());
         default:           break;
       }
 

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -309,28 +309,28 @@ extern "C" {
       }
 
       if (sass_value_is_number(a) && sass_value_is_number(b)) {
-        Number_Ptr_Const l_n = SASS_MEMORY_CAST(Number, lhs);
-        Number_Ptr_Const r_n = SASS_MEMORY_CAST(Number, rhs);
+        Number_Ptr_Const l_n = Cast<Number>(lhs);
+        Number_Ptr_Const r_n = Cast<Number>(rhs);
         rv = Eval::op_numbers(op, *l_n, *r_n, options);
       }
       else if (sass_value_is_number(a) && sass_value_is_color(a)) {
-        Number_Ptr_Const l_n = SASS_MEMORY_CAST(Number, lhs);
-        Color_Ptr_Const r_c = SASS_MEMORY_CAST(Color, rhs);
+        Number_Ptr_Const l_n = Cast<Number>(lhs);
+        Color_Ptr_Const r_c = Cast<Color>(rhs);
         rv = Eval::op_number_color(op, *l_n, *r_c, options);
       }
       else if (sass_value_is_color(a) && sass_value_is_number(b)) {
-        Color_Ptr_Const l_c = SASS_MEMORY_CAST(Color, lhs);
-        Number_Ptr_Const r_n = SASS_MEMORY_CAST(Number, rhs);
+        Color_Ptr_Const l_c = Cast<Color>(lhs);
+        Number_Ptr_Const r_n = Cast<Number>(rhs);
         rv = Eval::op_color_number(op, *l_c, *r_n, options);
       }
       else if (sass_value_is_color(a) && sass_value_is_color(b)) {
-        Color_Ptr_Const l_c = SASS_MEMORY_CAST(Color, lhs);
-        Color_Ptr_Const r_c = SASS_MEMORY_CAST(Color, rhs);
+        Color_Ptr_Const l_c = Cast<Color>(lhs);
+        Color_Ptr_Const r_c = Cast<Color>(rhs);
         rv = Eval::op_colors(op, *l_c, *r_c, options);
       }
       else /* convert other stuff to string and apply operation */ {
-        Value_Ptr l_v = SASS_MEMORY_CAST(Value, lhs);
-        Value_Ptr r_v = SASS_MEMORY_CAST(Value, rhs);
+        Value_Ptr l_v = Cast<Value>(lhs);
+        Value_Ptr r_v = Cast<Value>(rhs);
         rv = Eval::op_strings(op, *l_v, *r_v, options);
       }
 

--- a/src/subset_map.cpp
+++ b/src/subset_map.cpp
@@ -4,7 +4,7 @@
 
 namespace Sass {
 
-  void Subset_Map::put(const Compound_Selector_Obj& sel, const Subset_Map_Val& value)
+  void Subset_Map::put(const Compound_Selector_Obj& sel, const SubSetMapPair& value)
   {
     if (sel->empty()) throw std::runtime_error("internal error: subset map keys may not be empty");
     size_t index = values_.size();
@@ -15,11 +15,9 @@ namespace Sass {
     }
   }
 
-  std::vector<Subset_Map_Val> Subset_Map::get_kv(const Compound_Selector_Obj& sel)
+  std::vector<SubSetMapPair> Subset_Map::get_kv(const Compound_Selector_Obj& sel)
   {
-    // std::vector<Subset_Map_Key> s = sel->to_str_vec();
-    // std::set<std::string> dict(s.begin(), s.end());
-    std::unordered_set<Simple_Selector_Obj, HashSimpleSelector, CompareSimpleSelector> dict(sel->begin(), sel->end());
+    SimpleSelectorDict dict(sel->begin(), sel->end()); // XXX Set
     std::vector<size_t> indices;
     for (size_t i = 0, S = sel->length(); i < S; ++i) {
       if (!hash_.count((*sel)[i])) {
@@ -42,14 +40,14 @@ namespace Sass {
     std::vector<size_t>::iterator indices_end = unique(indices.begin(), indices.end());
     indices.resize(distance(indices.begin(), indices_end));
 
-    std::vector<Subset_Map_Val> results;
+    std::vector<SubSetMapPair> results;
     for (size_t i = 0, S = indices.size(); i < S; ++i) {
       results.push_back(values_[indices[i]]);
     }
     return results;
   }
 
-  std::vector<Subset_Map_Val> Subset_Map::get_v(const Compound_Selector_Obj& sel)
+  std::vector<SubSetMapPair> Subset_Map::get_v(const Compound_Selector_Obj& sel)
   {
     return get_kv(sel);
   }

--- a/src/subset_map.cpp
+++ b/src/subset_map.cpp
@@ -11,7 +11,7 @@ namespace Sass {
     values_.push_back(value);
     for (size_t i = 0, S = sel->length(); i < S; ++i)
     {
-      hash_[(*sel)[i]].push_back(std::make_pair(&sel, index));
+      hash_[(*sel)[i]].push_back(std::make_pair(sel, index));
     }
   }
 

--- a/src/subset_map.hpp
+++ b/src/subset_map.hpp
@@ -60,15 +60,15 @@ namespace Sass {
 
   class Subset_Map {
   private:
-    std::vector<Subset_Map_Val> values_;
-    std::map<Simple_Selector_Obj, std::vector<std::pair<Compound_Selector_Obj, size_t> > > hash_;
+    std::vector<SubSetMapPair> values_;
+    std::map<Simple_Selector_Obj, std::vector<std::pair<Compound_Selector_Obj, size_t> >, OrderNodes > hash_;
   public:
-    void put(const Compound_Selector_Obj& sel, const Subset_Map_Val& value);
-    std::vector<Subset_Map_Val> get_kv(const Compound_Selector_Obj& s);
-    std::vector<Subset_Map_Val> get_v(const Compound_Selector_Obj& s);
+    void put(const Compound_Selector_Obj& sel, const SubSetMapPair& value);
+    std::vector<SubSetMapPair> get_kv(const Compound_Selector_Obj& s);
+    std::vector<SubSetMapPair> get_v(const Compound_Selector_Obj& s);
     bool empty() { return values_.empty(); }
     void clear() { values_.clear(); hash_.clear(); }
-    const std::vector<Subset_Map_Val> values(void) { return values_; }
+    const std::vector<SubSetMapPair> values(void) { return values_; }
   };
 
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -460,8 +460,8 @@ namespace Sass {
           return true;
         } else if (Declaration_Ptr d = SASS_MEMORY_CAST(Declaration, stm)) {
           return isPrintable(d, style);
-        } else if (SASS_MEMORY_CAST(Has_Block, stm)) {
-          Block_Obj pChildBlock = ((Has_Block_Ptr)stm.ptr())->block(); // XXX
+        } else if (Has_Block_Ptr p = SASS_MEMORY_CAST(Has_Block, stm)) {
+          Block_Obj pChildBlock = p->block();
           if (isPrintable(pChildBlock, style)) {
             hasPrintableChildBlocks = true;
           }
@@ -518,8 +518,8 @@ namespace Sass {
         if (SASS_MEMORY_CAST(Declaration, stm) || SASS_MEMORY_CAST(Directive, stm)) {
           hasDeclarations = true;
         }
-        else if (SASS_MEMORY_CAST(Has_Block, stm)) {
-          Block_Obj pChildBlock = ((Has_Block_Ptr)stm.ptr())->block(); // XXX
+        else if (Has_Block_Ptr b = SASS_MEMORY_CAST(Has_Block, stm)) {
+          Block_Obj pChildBlock = b->block();
           if (isPrintable(pChildBlock, style)) {
             hasPrintableChildBlocks = true;
           }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -445,7 +445,7 @@ namespace Sass {
 
       Block_Obj b = r->block();
 
-      Selector_List_Ptr sl = SASS_MEMORY_CAST(Selector_List, r->selector());
+      Selector_List_Ptr sl = Cast<Selector_List>(r->selector());
       bool hasSelectors = sl ? sl->length() > 0 : false;
 
       if (!hasSelectors) {
@@ -456,16 +456,16 @@ namespace Sass {
       bool hasPrintableChildBlocks = false;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (SASS_MEMORY_CAST(Directive, stm)) {
+        if (Cast<Directive>(stm)) {
           return true;
-        } else if (Declaration_Ptr d = SASS_MEMORY_CAST(Declaration, stm)) {
+        } else if (Declaration_Ptr d = Cast<Declaration>(stm)) {
           return isPrintable(d, style);
-        } else if (Has_Block_Ptr p = SASS_MEMORY_CAST(Has_Block, stm)) {
+        } else if (Has_Block_Ptr p = Cast<Has_Block>(stm)) {
           Block_Obj pChildBlock = p->block();
           if (isPrintable(pChildBlock, style)) {
             hasPrintableChildBlocks = true;
           }
-        } else if (Comment_Ptr c = SASS_MEMORY_CAST(Comment, stm)) {
+        } else if (Comment_Ptr c = Cast<Comment>(stm)) {
           // keep for uncompressed
           if (style != COMPRESSED) {
             hasDeclarations = true;
@@ -499,8 +499,8 @@ namespace Sass {
     bool isPrintable(Declaration_Ptr d, Sass_Output_Style style)
     {
       Expression_Obj val = d->value();
-      if (String_Quoted_Obj sq = SASS_MEMORY_CAST(String_Quoted, val)) return isPrintable(sq, style);
-      if (String_Constant_Obj sc = SASS_MEMORY_CAST(String_Constant, val)) return isPrintable(sc, style);
+      if (String_Quoted_Obj sq = Cast<String_Quoted>(val)) return isPrintable(sq, style);
+      if (String_Constant_Obj sc = Cast<String_Constant>(val)) return isPrintable(sc, style);
       return true;
     }
 
@@ -515,10 +515,10 @@ namespace Sass {
       bool hasPrintableChildBlocks = false;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (SASS_MEMORY_CAST(Declaration, stm) || SASS_MEMORY_CAST(Directive, stm)) {
+        if (Cast<Declaration>(stm) || Cast<Directive>(stm)) {
           hasDeclarations = true;
         }
-        else if (Has_Block_Ptr b = SASS_MEMORY_CAST(Has_Block, stm)) {
+        else if (Has_Block_Ptr b = Cast<Has_Block>(stm)) {
           Block_Obj pChildBlock = b->block();
           if (isPrintable(pChildBlock, style)) {
             hasPrintableChildBlocks = true;
@@ -540,29 +540,29 @@ namespace Sass {
       if (b == 0) return false;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (SASS_MEMORY_CAST(Directive, stm)) return true;
-        else if (SASS_MEMORY_CAST(Declaration, stm)) return true;
-        else if (Comment_Ptr c = SASS_MEMORY_CAST(Comment, stm)) {
+        if (Cast<Directive>(stm)) return true;
+        else if (Cast<Declaration>(stm)) return true;
+        else if (Comment_Ptr c = Cast<Comment>(stm)) {
           if (isPrintable(c, style)) {
             return true;
           }
         }
-        else if (Ruleset_Ptr r = SASS_MEMORY_CAST(Ruleset, stm)) {
+        else if (Ruleset_Ptr r = Cast<Ruleset>(stm)) {
           if (isPrintable(r, style)) {
             return true;
           }
         }
-        else if (Supports_Block_Ptr f = SASS_MEMORY_CAST(Supports_Block, stm)) {
+        else if (Supports_Block_Ptr f = Cast<Supports_Block>(stm)) {
           if (isPrintable(f, style)) {
             return true;
           }
         }
-        else if (Media_Block_Ptr m = SASS_MEMORY_CAST(Media_Block, stm)) {
+        else if (Media_Block_Ptr m = Cast<Media_Block>(stm)) {
           if (isPrintable(m, style)) {
             return true;
           }
         }
-        else if (Has_Block_Ptr b = SASS_MEMORY_CAST(Has_Block, stm)) {
+        else if (Has_Block_Ptr b = Cast<Has_Block>(stm)) {
           if (isPrintable(b->block(), style)) {
             return true;
           }
@@ -592,30 +592,30 @@ namespace Sass {
 
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (SASS_MEMORY_CAST(Declaration, stm) || SASS_MEMORY_CAST(Directive, stm)) {
+        if (Cast<Declaration>(stm) || Cast<Directive>(stm)) {
           return true;
         }
-        else if (Comment_Ptr c = SASS_MEMORY_CAST(Comment, stm)) {
+        else if (Comment_Ptr c = Cast<Comment>(stm)) {
           if (isPrintable(c, style)) {
             return true;
           }
         }
-        else if (Ruleset_Ptr r = SASS_MEMORY_CAST(Ruleset, stm)) {
+        else if (Ruleset_Ptr r = Cast<Ruleset>(stm)) {
           if (isPrintable(r, style)) {
             return true;
           }
         }
-        else if (Supports_Block_Ptr f = SASS_MEMORY_CAST(Supports_Block, stm)) {
+        else if (Supports_Block_Ptr f = Cast<Supports_Block>(stm)) {
           if (isPrintable(f, style)) {
             return true;
           }
         }
-        else if (Media_Block_Ptr m = SASS_MEMORY_CAST(Media_Block, stm)) {
+        else if (Media_Block_Ptr m = Cast<Media_Block>(stm)) {
           if (isPrintable(m, style)) {
             return true;
           }
         }
-        else if (Has_Block_Ptr b = SASS_MEMORY_CAST(Has_Block, stm)) {
+        else if (Has_Block_Ptr b = Cast<Has_Block>(stm)) {
           if (isPrintable(b->block(), style)) {
             return true;
           }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -456,16 +456,16 @@ namespace Sass {
       bool hasPrintableChildBlocks = false;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (dynamic_cast<Directive_Ptr>(&stm)) {
+        if (SASS_MEMORY_CAST(Directive, stm)) {
           return true;
-        } else if (Declaration_Ptr d = dynamic_cast<Declaration_Ptr>(&stm)) {
+        } else if (Declaration_Ptr d = SASS_MEMORY_CAST(Declaration, stm)) {
           return isPrintable(d, style);
-        } else if (dynamic_cast<Has_Block_Ptr>(&stm)) {
-          Block_Obj pChildBlock = ((Has_Block_Ptr)&stm)->block();
-          if (isPrintable(&pChildBlock, style)) {
+        } else if (SASS_MEMORY_CAST(Has_Block, stm)) {
+          Block_Obj pChildBlock = ((Has_Block_Ptr)stm.ptr())->block(); // XXX
+          if (isPrintable(pChildBlock, style)) {
             hasPrintableChildBlocks = true;
           }
-        } else if (Comment_Ptr c = dynamic_cast<Comment_Ptr>(&stm)) {
+        } else if (Comment_Ptr c = SASS_MEMORY_CAST(Comment, stm)) {
           // keep for uncompressed
           if (style != COMPRESSED) {
             hasDeclarations = true;
@@ -499,8 +499,8 @@ namespace Sass {
     bool isPrintable(Declaration_Ptr d, Sass_Output_Style style)
     {
       Expression_Obj val = d->value();
-      if (String_Quoted_Obj sq = SASS_MEMORY_CAST(String_Quoted, val)) return isPrintable(&sq, style);
-      if (String_Constant_Obj sc = SASS_MEMORY_CAST(String_Constant, val)) return isPrintable(&sc, style);
+      if (String_Quoted_Obj sq = SASS_MEMORY_CAST(String_Quoted, val)) return isPrintable(sq, style);
+      if (String_Constant_Obj sc = SASS_MEMORY_CAST(String_Constant, val)) return isPrintable(sc, style);
       return true;
     }
 
@@ -511,18 +511,16 @@ namespace Sass {
 
       Block_Obj b = f->block();
 
-//      bool hasSelectors = f->selector() && static_cast<Selector_List_Ptr>(f->selector())->length() > 0;
-
       bool hasDeclarations = false;
       bool hasPrintableChildBlocks = false;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (dynamic_cast<Declaration_Ptr>(&stm) || dynamic_cast<Directive_Ptr>(&stm)) {
+        if (SASS_MEMORY_CAST(Declaration, stm) || SASS_MEMORY_CAST(Directive, stm)) {
           hasDeclarations = true;
         }
-        else if (dynamic_cast<Has_Block_Ptr>(&stm)) {
-          Block_Obj pChildBlock = ((Has_Block_Ptr)&stm)->block();
-          if (isPrintable(&pChildBlock, style)) {
+        else if (SASS_MEMORY_CAST(Has_Block, stm)) {
+          Block_Obj pChildBlock = ((Has_Block_Ptr)stm.ptr())->block(); // XXX
+          if (isPrintable(pChildBlock, style)) {
             hasPrintableChildBlocks = true;
           }
         }
@@ -542,34 +540,32 @@ namespace Sass {
       if (b == 0) return false;
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (dynamic_cast<Directive_Ptr>(&stm)) return true;
-        else if (dynamic_cast<Declaration_Ptr>(&stm)) return true;
-        else if (dynamic_cast<Comment_Ptr>(&stm)) {
-          Comment_Ptr c = (Comment_Ptr) &stm;
+        if (SASS_MEMORY_CAST(Directive, stm)) return true;
+        else if (SASS_MEMORY_CAST(Declaration, stm)) return true;
+        else if (Comment_Ptr c = SASS_MEMORY_CAST(Comment, stm)) {
           if (isPrintable(c, style)) {
             return true;
           }
         }
-        else if (dynamic_cast<Ruleset_Ptr>(&stm)) {
-          Ruleset_Ptr r = (Ruleset_Ptr) &stm;
+        else if (Ruleset_Ptr r = SASS_MEMORY_CAST(Ruleset, stm)) {
           if (isPrintable(r, style)) {
             return true;
           }
         }
-        else if (dynamic_cast<Supports_Block_Ptr>(&stm)) {
-          Supports_Block_Ptr f = (Supports_Block_Ptr) &stm;
+        else if (Supports_Block_Ptr f = SASS_MEMORY_CAST(Supports_Block, stm)) {
           if (isPrintable(f, style)) {
             return true;
           }
         }
-        else if (dynamic_cast<Media_Block_Ptr>(&stm)) {
-          Media_Block_Ptr m = (Media_Block_Ptr) &stm;
+        else if (Media_Block_Ptr m = SASS_MEMORY_CAST(Media_Block, stm)) {
           if (isPrintable(m, style)) {
             return true;
           }
         }
-        else if (dynamic_cast<Has_Block_Ptr>(&stm) && isPrintable(((Has_Block_Ptr)&stm)->block(), style)) {
-          return true;
+        else if (Has_Block_Ptr b = SASS_MEMORY_CAST(Has_Block, stm)) {
+          if (isPrintable(b->block(), style)) {
+            return true;
+          }
         }
       }
       return false;
@@ -596,35 +592,33 @@ namespace Sass {
 
       for (size_t i = 0, L = b->length(); i < L; ++i) {
         Statement_Obj stm = b->at(i);
-        if (dynamic_cast<Declaration_Ptr>(&stm) || dynamic_cast<Directive_Ptr>(&stm)) {
+        if (SASS_MEMORY_CAST(Declaration, stm) || SASS_MEMORY_CAST(Directive, stm)) {
           return true;
         }
-        else if (dynamic_cast<Comment_Ptr>(&stm)) {
-          Comment_Ptr c = (Comment_Ptr) &stm;
+        else if (Comment_Ptr c = SASS_MEMORY_CAST(Comment, stm)) {
           if (isPrintable(c, style)) {
             return true;
           }
         }
-        else if (dynamic_cast<Ruleset_Ptr>(&stm)) {
-          Ruleset_Ptr r = (Ruleset_Ptr) &stm;
+        else if (Ruleset_Ptr r = SASS_MEMORY_CAST(Ruleset, stm)) {
           if (isPrintable(r, style)) {
             return true;
           }
         }
-        else if (dynamic_cast<Supports_Block_Ptr>(&stm)) {
-          Supports_Block_Ptr f = (Supports_Block_Ptr) &stm;
+        else if (Supports_Block_Ptr f = SASS_MEMORY_CAST(Supports_Block, stm)) {
           if (isPrintable(f, style)) {
             return true;
           }
         }
-        else if (dynamic_cast<Media_Block_Ptr>(&stm)) {
-          Media_Block_Ptr m = (Media_Block_Ptr) &stm;
+        else if (Media_Block_Ptr m = SASS_MEMORY_CAST(Media_Block, stm)) {
           if (isPrintable(m, style)) {
             return true;
           }
         }
-        else if (dynamic_cast<Has_Block_Ptr>(&stm) && isPrintable(((Has_Block_Ptr)&stm)->block(), style)) {
-          return true;
+        else if (Has_Block_Ptr b = SASS_MEMORY_CAST(Has_Block, stm)) {
+          if (isPrintable(b->block(), style)) {
+            return true;
+          }
         }
       }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -499,8 +499,8 @@ namespace Sass {
     bool isPrintable(Declaration_Ptr d, Sass_Output_Style style)
     {
       Expression_Obj val = d->value();
-      if (String_Quoted_Obj sq = Cast<String_Quoted>(val)) return isPrintable(sq, style);
-      if (String_Constant_Obj sc = Cast<String_Constant>(val)) return isPrintable(sc, style);
+      if (String_Quoted_Obj sq = Cast<String_Quoted>(val)) return isPrintable(sq.ptr(), style);
+      if (String_Constant_Obj sc = Cast<String_Constant>(val)) return isPrintable(sc.ptr(), style);
       return true;
     }
 

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -25,7 +25,7 @@ namespace Sass {
       union Sass_Value* list = sass_make_list(l->size(), l->separator(), l->is_bracketed());
       for (size_t i = 0, L = l->length(); i < L; ++i) {
         Expression_Obj obj = l->at(i);
-        auto val = ast_node_to_sass_value(&obj);
+        auto val = ast_node_to_sass_value(obj);
         sass_list_set_value(list, i, val);
       }
       return list;
@@ -35,8 +35,8 @@ namespace Sass {
       Map_Ptr_Const m = dynamic_cast<Map_Ptr_Const>(val);
       union Sass_Value* map = sass_make_map(m->length());
       size_t i = 0; for (Expression_Obj key : m->keys()) {
-        sass_map_set_key(map, i, ast_node_to_sass_value(&key));
-        sass_map_set_value(map, i, ast_node_to_sass_value(&m->at(key)));
+        sass_map_set_key(map, i, ast_node_to_sass_value(key));
+        sass_map_set_value(map, i, ast_node_to_sass_value(m->at(key)));
         ++ i;
       }
       return map;

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -11,17 +11,17 @@ namespace Sass {
   {
     if (val->concrete_type() == Expression::NUMBER)
     {
-      Number_Ptr_Const res = dynamic_cast<Number_Ptr_Const>(val);
+      Number_Ptr_Const res = Cast<Number>(val);
       return sass_make_number(res->value(), res->unit().c_str());
     }
     else if (val->concrete_type() == Expression::COLOR)
     {
-      Color_Ptr_Const col = dynamic_cast<Color_Ptr_Const>(val);
+      Color_Ptr_Const col = Cast<Color>(val);
       return sass_make_color(col->r(), col->g(), col->b(), col->a());
     }
     else if (val->concrete_type() == Expression::LIST)
     {
-      List_Ptr_Const l = dynamic_cast<List_Ptr_Const>(val);
+      List_Ptr_Const l = Cast<List>(val);
       union Sass_Value* list = sass_make_list(l->size(), l->separator(), l->is_bracketed());
       for (size_t i = 0, L = l->length(); i < L; ++i) {
         Expression_Obj obj = l->at(i);
@@ -32,7 +32,7 @@ namespace Sass {
     }
     else if (val->concrete_type() == Expression::MAP)
     {
-      Map_Ptr_Const m = dynamic_cast<Map_Ptr_Const>(val);
+      Map_Ptr_Const m = Cast<Map>(val);
       union Sass_Value* map = sass_make_map(m->length());
       size_t i = 0; for (Expression_Obj key : m->keys()) {
         sass_map_set_key(map, i, ast_node_to_sass_value(key));
@@ -47,16 +47,16 @@ namespace Sass {
     }
     else if (val->concrete_type() == Expression::BOOLEAN)
     {
-      Boolean_Ptr_Const res = dynamic_cast<Boolean_Ptr_Const>(val);
+      Boolean_Ptr_Const res = Cast<Boolean>(val);
       return sass_make_boolean(res->value());
     }
     else if (val->concrete_type() == Expression::STRING)
     {
-      if (String_Quoted_Ptr_Const qstr = dynamic_cast<String_Quoted_Ptr_Const>(val))
+      if (String_Quoted_Ptr_Const qstr = Cast<String_Quoted>(val))
       {
         return sass_make_qstring(qstr->value().c_str());
       }
-      else if (String_Constant_Ptr_Const cstr = dynamic_cast<String_Constant_Ptr_Const>(val))
+      else if (String_Constant_Ptr_Const cstr = Cast<String_Constant>(val))
       {
         return sass_make_string(cstr->value().c_str());
       }

--- a/win/libsass.targets
+++ b/win/libsass.targets
@@ -69,6 +69,7 @@
   <ItemGroup Label="LibSass Sources">
     <ClCompile Include="$(LIBSASS_SRC_DIR)\ast.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\memory\SharedPtr.cpp" />
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast_fwd_decl.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\base64vlq.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\bind.cpp" />
     <ClCompile Condition="$(VisualStudioVersion) &lt; 14.0" Include="$(LIBSASS_SRC_DIR)\c99func.c" />

--- a/win/libsass.vcxproj.filters
+++ b/win/libsass.vcxproj.filters
@@ -218,6 +218,9 @@
     <ClCompile Include="$(LIBSASS_SRC_DIR)\memory\SharedPtr.cpp">
       <Filter>Sources</Filter>
     </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast_fwd_decl.cpp">
+      <Filter>Sources</Filter>
+    </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\base64vlq.cpp">
       <Filter>Sources</Filter>
     </ClCompile>


### PR DESCRIPTION
This mainly replaces `T* operator&()` with the more explicit `ptr` method. Also adding a `operator T*()`. The former turned out to interfere with std::vector implementations on old gcc versions. Also cleaned up some related stuff on the way and broken them out into their own commits.

Replaces the cast macros with a more sophisticated templated approach. This allowed me to centralize a trick that we used to do faster casts when the class involved is final. This nicely unifies our casting mess.