### PR TITLE
Refactor selector list and schema handling

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -127,7 +127,7 @@ namespace Sass {
     return length() < rhs.length();
   }
 
-  bool Compound_Selector::has_parent_ref()
+  bool Compound_Selector::has_parent_ref() const
   {
     for (Simple_Selector_Obj s : *this) {
       if (s && s->has_parent_ref()) return true;
@@ -135,7 +135,7 @@ namespace Sass {
     return false;
   }
 
-  bool Compound_Selector::has_real_parent_ref()
+  bool Compound_Selector::has_real_parent_ref() const
   {
     for (Simple_Selector_Obj s : *this) {
       if (s && s->has_real_parent_ref()) return true;
@@ -143,13 +143,13 @@ namespace Sass {
     return false;
   }
 
-  bool Complex_Selector::has_parent_ref()
+  bool Complex_Selector::has_parent_ref() const
   {
     return (head() && head()->has_parent_ref()) ||
            (tail() && tail()->has_parent_ref());
   }
 
-  bool Complex_Selector::has_real_parent_ref()
+  bool Complex_Selector::has_real_parent_ref() const
   {
     return (head() && head()->has_real_parent_ref()) ||
            (tail() && tail()->has_real_parent_ref());
@@ -1488,12 +1488,12 @@ namespace Sass {
     }
     return hash_;
   }
-  bool Wrapped_Selector::has_parent_ref() {
+  bool Wrapped_Selector::has_parent_ref() const {
     // if (has_reference()) return true;
     if (!selector()) return false;
     return selector()->has_parent_ref();
   }
-  bool Wrapped_Selector::has_real_parent_ref() {
+  bool Wrapped_Selector::has_real_parent_ref() const {
     // if (has_reference()) return true;
     if (!selector()) return false;
     return selector()->has_real_parent_ref();
@@ -1504,7 +1504,7 @@ namespace Sass {
   }
 
 
-  bool Selector_List::has_parent_ref()
+  bool Selector_List::has_parent_ref() const
   {
     for (Complex_Selector_Obj s : elements()) {
       if (s && s->has_parent_ref()) return true;
@@ -1512,7 +1512,7 @@ namespace Sass {
     return false;
   }
 
-  bool Selector_List::has_real_parent_ref()
+  bool Selector_List::has_real_parent_ref() const
   {
     for (Complex_Selector_Obj s : elements()) {
       if (s && s->has_real_parent_ref()) return true;
@@ -1520,7 +1520,7 @@ namespace Sass {
     return false;
   }
 
-  bool Selector_Schema::has_parent_ref()
+  bool Selector_Schema::has_parent_ref() const
   {
     if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
       return schema->length() > 0 && Cast<Parent_Selector>(schema->at(0)) != NULL;
@@ -1528,7 +1528,7 @@ namespace Sass {
     return false;
   }
 
-  bool Selector_Schema::has_real_parent_ref()
+  bool Selector_Schema::has_real_parent_ref() const
   {
     if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
       Parent_Selector_Obj p = Cast<Parent_Selector>(schema->at(0));

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2,6 +2,7 @@
 #include "ast.hpp"
 #include "context.hpp"
 #include "node.hpp"
+#include "eval.hpp"
 #include "extend.hpp"
 #include "emitter.hpp"
 #include "color_maps.hpp"
@@ -1185,7 +1186,14 @@ namespace Sass {
       }
     }
 
+  }
 
+  Selector_List_Obj Selector_List::eval(Eval& eval)
+  {
+    Selector_List_Obj list = schema() ?
+      eval(schema()) : eval(this);
+    list->schema(schema());
+    return list;
   }
 
   Selector_List_Ptr Selector_List::resolve_parent_refs(Context& ctx, std::vector<Selector_List_Obj>& pstack, bool implicit_parent)
@@ -1471,6 +1479,30 @@ namespace Sass {
       }
     }
   }
+
+  size_t Wrapped_Selector::hash()
+  {
+    if (hash_ == 0) {
+      hash_combine(hash_, Simple_Selector::hash());
+      if (selector_) hash_combine(hash_, selector_->hash());
+    }
+    return hash_;
+  }
+  bool Wrapped_Selector::has_parent_ref() {
+    // if (has_reference()) return true;
+    if (!selector()) return false;
+    return selector()->has_parent_ref();
+  }
+  bool Wrapped_Selector::has_real_parent_ref() {
+    // if (has_reference()) return true;
+    if (!selector()) return false;
+    return selector()->has_real_parent_ref();
+  }
+  unsigned long Wrapped_Selector::specificity() const
+  {
+    return selector_ ? selector_->specificity() : 0;
+  }
+
 
   bool Selector_List::has_parent_ref()
   {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -201,7 +201,7 @@ namespace Sass {
     { }
     virtual operator bool() { return true; }
     virtual ~Expression() { }
-    virtual std::string type() { return ""; /* TODO: raise an error? */ }
+    virtual std::string type() const { return ""; /* TODO: raise an error? */ }
     virtual bool is_invisible() const { return false; }
     static std::string type_name() { return ""; }
     virtual bool is_false() { return false; }
@@ -1073,7 +1073,7 @@ namespace Sass {
       is_bracketed_(ptr->is_bracketed_),
       from_selector_(ptr->from_selector_)
     { concrete_type(LIST); }
-    std::string type() { return is_arglist_ ? "arglist" : "list"; }
+    std::string type() const { return is_arglist_ ? "arglist" : "list"; }
     static std::string type_name() { return "list"; }
     const char* sep_string(bool compressed = false) const {
       return separator() == SASS_SPACE ?
@@ -1122,7 +1122,7 @@ namespace Sass {
     : Value(ptr),
       Hashed(*ptr)
     { concrete_type(MAP); }
-    std::string type() { return "map"; }
+    std::string type() const { return "map"; }
     static std::string type_name() { return "map"; }
     bool is_invisible() const { return empty(); }
     List_Obj to_list(Context& ctx, ParserState& pstate);
@@ -1190,7 +1190,7 @@ namespace Sass {
       hash_(ptr->hash_)
     { }
     const std::string type_name() {
-      switch (type()) {
+      switch (optype()) {
         case AND: return "and"; break;
         case OR: return "or"; break;
         case EQ: return "eq"; break;
@@ -1210,7 +1210,7 @@ namespace Sass {
       }
     }
     const std::string separator() {
-      switch (type()) {
+      switch (optype()) {
         case AND: return "&&"; break;
         case OR: return "||"; break;
         case EQ: return "=="; break;
@@ -1261,13 +1261,13 @@ namespace Sass {
     virtual size_t hash()
     {
       if (hash_ == 0) {
-        hash_ = std::hash<size_t>()(type());
+        hash_ = std::hash<size_t>()(optype());
         hash_combine(hash_, left()->hash());
         hash_combine(hash_, right()->hash());
       }
       return hash_;
     }
-    enum Sass_OP type() const { return op_.operand; }
+    enum Sass_OP optype() const { return op_.operand; }
     ATTACH_AST_OPERATIONS(Binary_Expression)
     ATTACH_OPERATIONS()
   };
@@ -1279,21 +1279,21 @@ namespace Sass {
   public:
     enum Type { PLUS, MINUS, NOT };
   private:
-    HASH_PROPERTY(Type, type)
+    HASH_PROPERTY(Type, optype)
     HASH_PROPERTY(Expression_Obj, operand)
     size_t hash_;
   public:
     Unary_Expression(ParserState pstate, Type t, Expression_Obj o)
-    : Expression(pstate), type_(t), operand_(o), hash_(0)
+    : Expression(pstate), optype_(t), operand_(o), hash_(0)
     { }
     Unary_Expression(const Unary_Expression* ptr)
     : Expression(ptr),
-      type_(ptr->type_),
+      optype_(ptr->optype_),
       operand_(ptr->operand_),
       hash_(ptr->hash_)
     { }
     const std::string type_name() {
-      switch (type_) {
+      switch (optype_) {
         case PLUS: return "plus"; break;
         case MINUS: return "minus"; break;
         case NOT: return "not"; break;
@@ -1318,7 +1318,7 @@ namespace Sass {
     virtual size_t hash()
     {
       if (hash_ == 0) {
-        hash_ = std::hash<size_t>()(type_);
+        hash_ = std::hash<size_t>()(optype_);
         hash_combine(hash_, operand()->hash());
       };
       return hash_;
@@ -1541,17 +1541,17 @@ namespace Sass {
   public:
     enum Type { NUMBER, PERCENTAGE, DIMENSION, HEX };
   private:
-    HASH_PROPERTY(Type, type)
+    HASH_PROPERTY(Type, valtype)
     HASH_CONSTREF(std::string, value)
     size_t hash_;
   public:
     Textual(ParserState pstate, Type t, std::string val)
-    : Expression(pstate, DELAYED), type_(t), value_(val),
+    : Expression(pstate, DELAYED), valtype_(t), value_(val),
       hash_(0)
     { }
     Textual(const Textual* ptr)
     : Expression(ptr),
-      type_(ptr->type_),
+      valtype_(ptr->valtype_),
       value_(ptr->value_),
       hash_(ptr->hash_)
     { }
@@ -1574,7 +1574,7 @@ namespace Sass {
     {
       if (hash_ == 0) {
         hash_ = std::hash<std::string>()(value_);
-        hash_combine(hash_, std::hash<int>()(type_));
+        hash_combine(hash_, std::hash<int>()(valtype_));
       }
       return hash_;
     }
@@ -1609,7 +1609,7 @@ namespace Sass {
     std::vector<std::string>& denominator_units() { return denominator_units_; }
     const std::vector<std::string>& numerator_units() const   { return numerator_units_; }
     const std::vector<std::string>& denominator_units() const { return denominator_units_; }
-    std::string type() { return "number"; }
+    std::string type() const { return "number"; }
     static std::string type_name() { return "number"; }
     std::string unit() const;
 
@@ -1662,7 +1662,7 @@ namespace Sass {
       disp_(ptr->disp_),
       hash_(ptr->hash_)
     { concrete_type(COLOR); }
-    std::string type() { return "color"; }
+    std::string type() const { return "color"; }
     static std::string type_name() { return "color"; }
 
     virtual size_t hash()
@@ -1733,7 +1733,7 @@ namespace Sass {
       hash_(ptr->hash_)
     { concrete_type(BOOLEAN); }
     virtual operator bool() { return value_; }
-    std::string type() { return "bool"; }
+    std::string type() const { return "bool"; }
     static std::string type_name() { return "bool"; }
     virtual bool is_false() { return !value_; }
 
@@ -1792,7 +1792,7 @@ namespace Sass {
       hash_(ptr->hash_)
     { concrete_type(STRING); }
 
-    std::string type() { return "string"; }
+    std::string type() const { return "string"; }
     static std::string type_name() { return "string"; }
 
     bool is_left_interpolant(void) const;
@@ -1853,7 +1853,7 @@ namespace Sass {
     String_Constant(ParserState pstate, const Token& tok)
     : String(pstate), quote_mark_(0), can_compress_whitespace_(false), value_(read_css_string(std::string(tok.begin, tok.end))), hash_(0)
     { }
-    std::string type() { return "string"; }
+    std::string type() const { return "string"; }
     static std::string type_name() { return "string"; }
     virtual bool is_invisible() const;
     virtual void rtrim();
@@ -2142,7 +2142,7 @@ namespace Sass {
   public:
     Null(ParserState pstate) : Value(pstate) { concrete_type(NULL_VAL); }
     Null(const Null* ptr) : Value(ptr) { concrete_type(NULL_VAL); }
-    std::string type() { return "null"; }
+    std::string type() const { return "null"; }
     static std::string type_name() { return "null"; }
     bool is_invisible() const { return true; }
     operator bool() { return false; }
@@ -2296,10 +2296,10 @@ namespace Sass {
     virtual void set_media_block(Media_Block_Ptr mb) {
       media_block(mb);
     }
-    virtual bool has_parent_ref() {
+    virtual bool has_parent_ref() const {
       return false;
     }
-    virtual bool has_real_parent_ref() {
+    virtual bool has_real_parent_ref() const {
       return false;
     }
     // dispatch to correct handlers
@@ -2334,8 +2334,8 @@ namespace Sass {
       connect_parent_(ptr->connect_parent_),
       media_block_(ptr->media_block_)
     { }
-    virtual bool has_parent_ref();
-    virtual bool has_real_parent_ref();
+    virtual bool has_parent_ref() const;
+    virtual bool has_real_parent_ref() const;
     virtual bool operator<(const Selector& rhs) const;
     virtual bool operator==(const Selector& rhs) const;
     // selector schema is not yet a final selector, so we do not
@@ -2429,8 +2429,8 @@ namespace Sass {
 
     virtual ~Simple_Selector() = 0;
     virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr, Context&);
-    virtual bool has_parent_ref() { return false; };
-    virtual bool has_real_parent_ref() { return false; };
+    virtual bool has_parent_ref() const { return false; };
+    virtual bool has_real_parent_ref() const  { return false; };
     virtual bool is_pseudo_element() const { return false; }
 
     virtual bool is_superselector_of(Compound_Selector_Obj sub) { return false; }
@@ -2463,14 +2463,14 @@ namespace Sass {
     Parent_Selector(const Parent_Selector* ptr)
     : Simple_Selector(ptr), real_(ptr->real_)
     { /* has_reference(true); */ }
-    bool is_real_parent_ref() { return real(); };
-    virtual bool has_parent_ref() { return true; };
-    virtual bool has_real_parent_ref() { return is_real_parent_ref(); };
+    bool is_real_parent_ref() const { return real(); };
+    virtual bool has_parent_ref() const { return true; };
+    virtual bool has_real_parent_ref() const { return is_real_parent_ref(); };
     virtual unsigned long specificity() const
     {
       return 0;
     }
-    std::string type() { return "selector"; }
+    std::string type() const { return "selector"; }
     static std::string type_name() { return "selector"; }
     ATTACH_AST_OPERATIONS(Parent_Selector)
     ATTACH_OPERATIONS()
@@ -2676,8 +2676,8 @@ namespace Sass {
     // Selectors inside the negation pseudo-class are counted like any
     // other, but the negation itself does not count as a pseudo-class.
     virtual size_t hash();
-    virtual bool has_parent_ref();
-    virtual bool has_real_parent_ref();
+    virtual bool has_parent_ref() const;
+    virtual bool has_real_parent_ref() const;
     virtual unsigned long specificity() const;
     virtual bool operator==(const Simple_Selector& rhs) const;
     virtual bool operator==(const Wrapped_Selector& rhs) const;
@@ -2733,8 +2733,8 @@ namespace Sass {
     Complex_Selector_Obj to_complex();
     Compound_Selector_Ptr unify_with(Compound_Selector_Ptr rhs, Context& ctx);
     // virtual Placeholder_Selector_Ptr find_placeholder();
-    virtual bool has_parent_ref();
-    virtual bool has_real_parent_ref();
+    virtual bool has_parent_ref() const;
+    virtual bool has_real_parent_ref() const;
     Simple_Selector_Ptr base() const {
       if (length() == 0) return 0;
       // ToDo: why is this needed?
@@ -2827,8 +2827,8 @@ namespace Sass {
       head_(ptr->head_), tail_(ptr->tail_),
       reference_(ptr->reference_)
     {};
-    virtual bool has_parent_ref();
-    virtual bool has_real_parent_ref();
+    virtual bool has_parent_ref() const;
+    virtual bool has_real_parent_ref() const;
 
     Complex_Selector_Obj skip_empty_reference()
     {
@@ -2977,11 +2977,11 @@ namespace Sass {
       schema_(ptr->schema_),
       wspace_(ptr->wspace_)
     { }
-    std::string type() { return "list"; }
+    std::string type() const { return "list"; }
     // remove parent selector references
     // basically unwraps parsed selectors
-    virtual bool has_parent_ref();
-    virtual bool has_real_parent_ref();
+    virtual bool has_parent_ref() const;
+    virtual bool has_real_parent_ref() const;
     void remove_parent_selectors();
     Selector_List_Ptr resolve_parent_refs(Context& ctx, std::vector<Selector_List_Obj>& pstack, bool implicit_parent = true);
     virtual bool is_superselector_of(Compound_Selector_Obj sub, std::string wrapping = "");

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -390,7 +390,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     Content_Ptr block = Cast<Content>(node);
     std::cerr << ind << "Content " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [@media:" << block->media_block().ptr() << "]";
+    std::cerr << " [@media:" << block->media_block() << "]";
     std::cerr << " " << block->tabs() << std::endl;
   } else if (Cast<Import_Stub>(node)) {
     Import_Stub_Ptr block = Cast<Import_Stub>(node);
@@ -611,7 +611,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     Content_Ptr expression = Cast<Content>(node);
     std::cerr << ind << "Content " << expression;
     std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [@media:" << expression->media_block().ptr() << "]";
+    std::cerr << " [@media:" << expression->media_block() << "]";
     std::cerr << " [Statement]" << std::endl;
   } else if (Cast<Boolean>(node)) {
     Boolean_Ptr expression = Cast<Boolean>(node);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -103,6 +103,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << (selector->has_line_break() ? " [line-break]": " -");
     std::cerr << (selector->has_line_feed() ? " [line-feed]": " -");
     std::cerr << std::endl;
+    debug_ast(selector->schema(), "#{} ");
 
     for(const Complex_Selector_Obj& i : selector->elements()) { debug_ast(i, ind + " ", env); }
 
@@ -261,8 +262,6 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")"
       << " [@media:" << selector->media_block() << "]"
       << (selector->connect_parent() ? " [connect-parent]": " -")
-      << (selector->has_line_break() ? " [line-break]": " -")
-      << (selector->has_line_feed() ? " [line-feed]": " -")
     << std::endl;
 
     debug_ast(selector->contents(), ind + " ");

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -539,7 +539,7 @@ namespace Sass {
 
     String_Schema_Obj ret_schema;
     Binary_Expression_Obj b = b_in;
-    enum Sass_OP op_type = b->type();
+    enum Sass_OP op_type = b->optype();
 
     // only the last item will be used to eval the binary expression
     if (String_Schema_Ptr s_l = Cast<String_Schema>(b->left())) {
@@ -788,14 +788,14 @@ namespace Sass {
   Expression_Ptr Eval::operator()(Unary_Expression_Ptr u)
   {
     Expression_Obj operand = u->operand()->perform(this);
-    if (u->type() == Unary_Expression::NOT) {
+    if (u->optype() == Unary_Expression::NOT) {
       Boolean_Ptr result = SASS_MEMORY_NEW(Boolean, u->pstate(), (bool)*operand);
       result->value(!result->value());
       return result;
     }
     else if (Number_Obj nr = Cast<Number>(operand)) {
       // negate value for minus unary expression
-      if (u->type() == Unary_Expression::MINUS) {
+      if (u->optype() == Unary_Expression::MINUS) {
         Number_Obj cpy = SASS_MEMORY_COPY(nr);
         cpy->value( - cpy->value() ); // negate value
         return cpy.detach(); // return the copy
@@ -1047,7 +1047,7 @@ namespace Sass {
     if (unit_pos == std::string::npos) unit_pos = text.length();
     const std::string& num = text.substr(num_pos, unit_pos - num_pos);
 
-    switch (t->type())
+    switch (t->valtype())
     {
       case Textual::NUMBER:
         result = SASS_MEMORY_NEW(Number,

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -475,8 +475,8 @@ namespace Sass {
                                 l->length() / 2);
       for (size_t i = 0, L = l->length(); i < L; i += 2)
       {
-        Expression_Ptr key = (*l)[i+0]->perform(this);
-        Expression_Ptr val = (*l)[i+1]->perform(this);
+        Expression_Obj key = (*l)[i+0]->perform(this);
+        Expression_Obj val = (*l)[i+1]->perform(this);
         // make sure the color key never displays its real name
         key->is_delayed(true); // verified
         *lm << std::make_pair(key, val);

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -467,7 +467,7 @@ namespace Sass {
               expr->is_right_interpolant())
 
     )) append_string(" ");
-    switch (expr->type()) {
+    switch (expr->optype()) {
       case Sass_OP::AND: append_string("&&"); break;
       case Sass_OP::OR:  append_string("||");  break;
       case Sass_OP::EQ:  append_string("==");  break;
@@ -495,8 +495,8 @@ namespace Sass {
 
   void Inspect::operator()(Unary_Expression_Ptr expr)
   {
-    if (expr->type() == Unary_Expression::PLUS) append_string("+");
-    else                                        append_string("-");
+    if (expr->optype() == Unary_Expression::PLUS) append_string("+");
+    else                                          append_string("-");
     expr->operand()->perform(this);
   }
 


### PR DESCRIPTION
On the heels of the recent code cleanups, this one fixes a IMO rather big ambiguity. AST nodes holding selectors referenced the base selector class. This lead to multiple issues which were generally solved by using dynamic casts. This PR changes the implementation that Selector Schemas are always part of a Selector List (more precisely, a Selector List can have a Schema). When expanding/evaluating nodes we act accordingly. This is still not perfect, but allows us to carry a Selector List type around, instead of a base class. Since this class is final we know that it will itself evaluate to a selector list and so on.