### PR TITLE
Ci and clang fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,6 @@
 language: cpp
 sudo: false
 
-os:
-  - linux
-  - osx
-
-compiler:
-  - gcc
-  - clang
 
 # don't create redundant code coverage reports
 # - AUTOTOOLS=yes COVERAGE=yes BUILD=static
@@ -19,25 +12,46 @@ compiler:
 # this will still catch all coding errors!
 # - AUTOTOOLS=yes COVERAGE=no BUILD=static
 
-env:
-  - AUTOTOOLS=no COVERAGE=no BUILD=shared
-  - AUTOTOOLS=no COVERAGE=yes BUILD=static
-  - AUTOTOOLS=yes COVERAGE=no BUILD=shared
-
 # currenty there are various issues when
 # built with coverage, clang and autotools
 # - AUTOTOOLS=yes COVERAGE=yes BUILD=shared
 
 matrix:
-  exclude:
-    - compiler: clang
-      env: AUTOTOOLS=yes COVERAGE=yes BUILD=static
+  include :
     - os: linux
+      compiler: gcc
+      env: AUTOTOOLS=no COVERAGE=yes BUILD=static
+    - os: linux
+      compiler: g++-5
+      env: AUTOTOOLS=yes COVERAGE=no BUILD=shared
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+    - os: linux
+      compiler: clang++-3.7
+      env: AUTOTOOLS=no COVERAGE=yes BUILD=static
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+    - os: linux
+      compiler: clang
+      env: AUTOTOOLS=yes COVERAGE=no BUILD=shared
+    - os: osx
+      compiler: clang
       env: AUTOTOOLS=no COVERAGE=no BUILD=shared
     - os: osx
-      compiler: gcc
+      compiler: clang
+      env: AUTOTOOLS=no COVERAGE=yes BUILD=static
     - os: osx
-      env: AUTOTOOLS=no BUILD=static
+      compiler: clang
+      env: AUTOTOOLS=yes COVERAGE=no BUILD=shared
 
 script:
   - ./script/ci-build-libsass

--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -4,7 +4,7 @@ AM_COPT = -Wall -O2
 AM_COVLDFLAGS =
 
 if ENABLE_COVERAGE
-	AM_COPT = -O0 --coverage
+	AM_COPT = -Wall -O1 -fno-omit-frame-pointer --coverage
 	AM_COVLDFLAGS += -lgcov
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,14 @@ INSTALL  ?= install
 CFLAGS   ?= -Wall
 CXXFLAGS ?= -Wall
 LDFLAGS  ?= -Wall
-ifneq "$(COVERAGE)" "yes"
+ifeq "x$(COVERAGE)" "x"
   CFLAGS   += -O2
   CXXFLAGS += -O2
   LDFLAGS  += -O2
+else
+  CFLAGS   += -O1 -fno-omit-frame-pointer
+  CXXFLAGS += -O1 -fno-omit-frame-pointer
+  LDFLAGS  += -O1 -fno-omit-frame-pointer
 endif
 LDFLAGS  += -Wl,-undefined,error
 CAT      ?= $(if $(filter $(OS),Windows_NT),type,cat)

--- a/configure.ac
+++ b/configure.ac
@@ -121,8 +121,8 @@ if test "x$enable_cov" = "xyes"; then
 
     # Remove all optimization flags from C[XX]FLAGS
     changequote({,})
-    CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9]*//g'`
-    CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-O[0-9]*//g'`
+    CFLAGS=`echo "$CFLAGS -O1 -fno-omit-frame-pointer" | $SED -e 's/-O[0-9]*//g'`
+    CXXFLAGS=`echo "$CXXFLAGS -O1 -fno-omit-frame-pointer" | $SED -e 's/-O[0-9]*//g'`
     changequote([,])
 
     AC_SUBST(GCOV)

--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -18,9 +18,14 @@ if [ "x$TRAVIS_OS_NAME" == "x" ]; then export TRAVIS_OS_NAME=`uname -s | perl -n
 
 if [ "x$COVERAGE" == "xyes" ]; then
   COVERAGE_OPT="--enable-coverage"
-  export EXTRA_CFLAGS="--coverage"
-  export EXTRA_CXXFLAGS="--coverage"
-  export EXTRA_LDFLAGS="--coverage"
+  export EXTRA_CFLAGS="-fprofile-arcs -ftest-coverage"
+  export EXTRA_CXXFLAGS="-fprofile-arcs -ftest-coverage"
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    # osx doesn't seem to know gcov lib?
+    export EXTRA_LDFLAGS="--coverage"
+  else
+    export EXTRA_LDFLAGS="-lgcov --coverage"
+  fi
 else
   COVERAGE_OPT="--disable-coverage"
 fi

--- a/script/ci-build-plugin
+++ b/script/ci-build-plugin
@@ -19,6 +19,19 @@ if [ "x$1" == "x" ] ; then
   exit 1
 fi
 
+if [ "x$COVERAGE" == "0" ] ; then
+  unset COVERAGE
+fi
+
+export EXTRA_CFLAGS=""
+export EXTRA_CXXFLAGS=""
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  # osx doesn't seem to know gcov lib?
+  export EXTRA_LDFLAGS="--coverage"
+else
+  export EXTRA_LDFLAGS="-lgcov --coverage"
+fi
+
 mkdir -p plugins
 if [ ! -d plugins/libsass-${PLUGIN} ] ; then
   git clone https://github.com/mgreter/libsass-${PLUGIN} plugins/libsass-${PLUGIN}
@@ -26,10 +39,13 @@ fi
 if [ ! -d plugins/libsass-${PLUGIN}/build ] ; then
   mkdir plugins/libsass-${PLUGIN}/build
 fi
+RETVAL=$?; if [ "$RETVAL" != "0" ]; then exit $RETVAL; fi
 
 cd plugins/libsass-${PLUGIN}/build
 cmake -G "Unix Makefiles" -D LIBSASS_DIR="../../.." ..
-make -j2
+RETVAL=$?; if [ "$RETVAL" != "0" ]; then exit $RETVAL; fi
+make VERBOSE=1 -j2
+RETVAL=$?; if [ "$RETVAL" != "0" ]; then exit $RETVAL; fi
 cd ../../..
 
 # glob only works on paths relative to imports
@@ -40,5 +56,7 @@ else
   cat ${SASS_SPEC_SPEC_DIR}/basic/input.scss | ${SASSC_BIN} --plugin-path plugins/libsass-${PLUGIN}/build -I ${SASS_SPEC_SPEC_DIR}/basic > ${SASS_SPEC_SPEC_DIR}/basic/result.css
   cat ${SASS_SPEC_SPEC_DIR}/basic/input.scss | ${SASSC_BIN} --plugin-path plugins/libsass-${PLUGIN}/build -I ${SASS_SPEC_SPEC_DIR}/basic --sourcemap > /dev/null
 fi
+RETVAL=$?; if [ "$RETVAL" != "0" ]; then exit $RETVAL; fi
 
 diff ${SASS_SPEC_SPEC_DIR}/basic/expected_output.css ${SASS_SPEC_SPEC_DIR}/basic/result.css
+RETVAL=$?; if [ "$RETVAL" != "0" ]; then exit $RETVAL; fi

--- a/script/ci-report-coverage
+++ b/script/ci-report-coverage
@@ -2,6 +2,12 @@
 
 if [ "x$COVERAGE" = "xyes" ]; then
 
+  # find / -name "gcovr"
+  # find / -name "coveralls"
+  # this is only needed for mac os x builds!
+  PATH=$PATH:/Users/travis/Library/Python/2.7/bin/
+
+
   # exclude some directories from profiling (.libs is from autotools)
   export EXCLUDE_COVERAGE="--exclude plugins
                            --exclude sassc/sassc.c
@@ -21,10 +27,14 @@ if [ "x$COVERAGE" = "xyes" ]; then
                            --exclude src/test
                            --exclude src/posix
                            --exclude src/debugger.hpp"
-  # debug via gcovr
-  gcov -v
+  # debug used gcov version
+  # option not available on mac
+  if [ "$TRAVIS_OS_NAME" != "osx" ]; then
+    gcov -v
+  fi
+  # create summarized report
   gcovr -r .
-  # generate and submit report to coveralls.io
+  # submit report to coveralls.io
   coveralls $EXCLUDE_COVERAGE --gcov-options '\-lp'
 
 else

--- a/src/color_maps.hpp
+++ b/src/color_maps.hpp
@@ -1,3 +1,4 @@
+
 #ifndef SASS_COLOR_MAPS_H
 #define SASS_COLOR_MAPS_H
 
@@ -319,14 +320,11 @@ namespace Sass {
     extern const Color transparent;
   }
 
-  extern const std::map<const int, const char*> colors_to_names;
-  extern const std::map<const char*, Color_Ptr_Const, map_cmp_str> names_to_colors;
-
-  extern Color_Ptr_Const name_to_color(const char*);
-  extern Color_Ptr_Const name_to_color(const std::string&);
-  extern const char* color_to_name(const int);
-  extern const char* color_to_name(const Color&);
-  extern const char* color_to_name(const double);
+  Color_Ptr_Const name_to_color(const char*);
+  Color_Ptr_Const name_to_color(const std::string&);
+  const char* color_to_name(const int);
+  const char* color_to_name(const Color&);
+  const char* color_to_name(const double);
 
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,6 +1,5 @@
 #include "sass.hpp"
 #include <cctype>
-#include <cstddef>
 #include <iostream>
 #include <iomanip>
 #include "lexer.hpp"

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1,6 +1,5 @@
 #include "sass.hpp"
 #include <cctype>
-#include <cstddef>
 #include <iostream>
 #include <iomanip>
 #include "util.hpp"

--- a/src/sass_functions.cpp
+++ b/src/sass_functions.cpp
@@ -18,7 +18,7 @@ extern "C" {
   {
     Sass_Function_Entry cb = (Sass_Function_Entry) calloc(1, sizeof(Sass_Function));
     if (cb == 0) return 0;
-    cb->signature = signature;
+    cb->signature = strdup(signature);
     cb->function = function;
     cb->cookie = cookie;
     return cb;

--- a/src/sass_functions.cpp
+++ b/src/sass_functions.cpp
@@ -26,6 +26,7 @@ extern "C" {
 
   void ADDCALL sass_delete_function(Sass_Function_Entry entry)
   {
+    free(entry->signature);
     free(entry);
   }
 

--- a/src/sass_functions.hpp
+++ b/src/sass_functions.hpp
@@ -7,7 +7,7 @@
 
 // Struct to hold custom function callback
 struct Sass_Function {
-  const char*      signature;
+  char*            signature;
   Sass_Function_Fn function;
   void*            cookie;
 };

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -2,7 +2,6 @@
 #include <string>
 #include <sstream>
 #include <iostream>
-#include <cstddef>
 #include <iomanip>
 
 #include "ast.hpp"


### PR DESCRIPTION
- Use more explicit matrix
- Fix issue with clang 3.5+
- Add more compiler variations
- Speed up coverage builds a bit
- Fix coverage on mac (path issue)
- Disable coverage for clang on linux
- Error out correctly on plugin tests