### PR TITLE
Cleanup context usage and extend code

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -296,14 +296,14 @@ namespace Sass {
     return false;
   }
 
-  Compound_Selector_Ptr Compound_Selector::unify_with(Compound_Selector_Ptr rhs, Context& ctx)
+  Compound_Selector_Ptr Compound_Selector::unify_with(Compound_Selector_Ptr rhs)
   {
     if (empty()) return rhs;
     Compound_Selector_Obj unified = SASS_MEMORY_COPY(rhs);
     for (size_t i = 0, L = length(); i < L; ++i)
     {
       if (unified.isNull()) break;
-      unified = at(i)->unify_with(unified, ctx);
+      unified = at(i)->unify_with(unified);
     }
     return unified.detach();
   }
@@ -472,10 +472,10 @@ namespace Sass {
     return false;
   }
 
-  Compound_Selector_Ptr Simple_Selector::unify_with(Compound_Selector_Ptr rhs, Context& ctx)
+  Compound_Selector_Ptr Simple_Selector::unify_with(Compound_Selector_Ptr rhs)
   {
     for (size_t i = 0, L = rhs->length(); i < L; ++i)
-    { if (to_string(ctx.c_options) == rhs->at(i)->to_string(ctx.c_options)) return rhs; }
+    { if (to_string() == rhs->at(i)->to_string()) return rhs; }
 
     // check for pseudo elements because they are always last
     size_t i, L;
@@ -505,7 +505,7 @@ namespace Sass {
     return rhs;
   }
 
-  Simple_Selector_Ptr Element_Selector::unify_with(Simple_Selector_Ptr rhs, Context& ctx)
+  Simple_Selector_Ptr Element_Selector::unify_with(Simple_Selector_Ptr rhs)
   {
     // check if ns can be extended
     // true for no ns or universal
@@ -536,7 +536,7 @@ namespace Sass {
     return this;
   }
 
-  Compound_Selector_Ptr Element_Selector::unify_with(Compound_Selector_Ptr rhs, Context& ctx)
+  Compound_Selector_Ptr Element_Selector::unify_with(Compound_Selector_Ptr rhs)
   {
     // TODO: handle namespaces
 
@@ -554,7 +554,7 @@ namespace Sass {
       {
         // if rhs is universal, just return this tagname + rhs's qualifiers
         Element_Selector_Ptr ts = Cast<Element_Selector>(rhs_0);
-        rhs->at(0) = this->unify_with(ts, ctx);
+        rhs->at(0) = this->unify_with(ts);
         return rhs;
       }
       else if (Cast<Class_Selector>(rhs_0) || Cast<Id_Selector>(rhs_0)) {
@@ -574,7 +574,7 @@ namespace Sass {
       // if rhs is universal, just return this tagname + rhs's qualifiers
       if (rhs_0->name() != "*" && rhs_0->ns() != "*" && rhs_0->name() != name()) return 0;
       // otherwise create new compound and unify first simple selector
-      rhs->at(0) = this->unify_with(rhs_0, ctx);
+      rhs->at(0) = this->unify_with(rhs_0);
       return rhs;
 
     }
@@ -583,13 +583,13 @@ namespace Sass {
     return rhs;
   }
 
-  Compound_Selector_Ptr Class_Selector::unify_with(Compound_Selector_Ptr rhs, Context& ctx)
+  Compound_Selector_Ptr Class_Selector::unify_with(Compound_Selector_Ptr rhs)
   {
     rhs->has_line_break(has_line_break());
-    return Simple_Selector::unify_with(rhs, ctx);
+    return Simple_Selector::unify_with(rhs);
   }
 
-  Compound_Selector_Ptr Id_Selector::unify_with(Compound_Selector_Ptr rhs, Context& ctx)
+  Compound_Selector_Ptr Id_Selector::unify_with(Compound_Selector_Ptr rhs)
   {
     for (size_t i = 0, L = rhs->length(); i < L; ++i)
     {
@@ -598,10 +598,10 @@ namespace Sass {
       }
     }
     rhs->has_line_break(has_line_break());
-    return Simple_Selector::unify_with(rhs, ctx);
+    return Simple_Selector::unify_with(rhs);
   }
 
-  Compound_Selector_Ptr Pseudo_Selector::unify_with(Compound_Selector_Ptr rhs, Context& ctx)
+  Compound_Selector_Ptr Pseudo_Selector::unify_with(Compound_Selector_Ptr rhs)
   {
     if (is_pseudo_element())
     {
@@ -612,7 +612,7 @@ namespace Sass {
         }
       }
     }
-    return Simple_Selector::unify_with(rhs, ctx);
+    return Simple_Selector::unify_with(rhs);
   }
 
   bool Attribute_Selector::operator< (const Attribute_Selector& rhs) const
@@ -913,7 +913,7 @@ namespace Sass {
                            0);
   }
 
-  Selector_List_Ptr Complex_Selector::unify_with(Complex_Selector_Ptr other, Context& ctx)
+  Selector_List_Ptr Complex_Selector::unify_with(Complex_Selector_Ptr other)
   {
 
     // get last tails (on the right side)
@@ -939,7 +939,7 @@ namespace Sass {
     SASS_ASSERT(r_last_head, "rhs head is null");
 
     // get the unification of the last compound selectors
-    Compound_Selector_Obj unified = r_last_head->unify_with(l_last_head, ctx);
+    Compound_Selector_Obj unified = r_last_head->unify_with(l_last_head);
 
     // abort if we could not unify heads
     if (unified == 0) return 0;
@@ -956,25 +956,25 @@ namespace Sass {
     }
 
     // create nodes from both selectors
-    Node lhsNode = complexSelectorToNode(this, ctx);
-    Node rhsNode = complexSelectorToNode(other, ctx);
+    Node lhsNode = complexSelectorToNode(this);
+    Node rhsNode = complexSelectorToNode(other);
 
     // overwrite universal base
     if (!is_universal)
     {
       // create some temporaries to convert to node
       Complex_Selector_Obj fake = unified->to_complex();
-      Node unified_node = complexSelectorToNode(fake, ctx);
+      Node unified_node = complexSelectorToNode(fake);
       // add to permutate the list?
       rhsNode.plus(unified_node);
     }
 
     // do some magic we inherit from node and extend
-    Node node = Extend::subweave(lhsNode, rhsNode, ctx);
+    Node node = subweave(lhsNode, rhsNode);
     Selector_List_Ptr result = SASS_MEMORY_NEW(Selector_List, pstate());
     NodeDequePtr col = node.collection(); // move from collection to list
     for (NodeDeque::iterator it = col->begin(), end = col->end(); it != end; it++)
-    { result->append(nodeToComplexSelector(Node::naiveTrim(*it, ctx), ctx)); }
+    { result->append(nodeToComplexSelector(Node::naiveTrim(*it))); }
 
     // only return if list has some entries
     return result->length() ? result : 0;
@@ -1110,7 +1110,7 @@ namespace Sass {
   // check if we need to append some headers
   // then we need to check for the combinator
   // only then we can safely set the new tail
-  void Complex_Selector::append(Context& ctx, Complex_Selector_Obj ss)
+  void Complex_Selector::append(Complex_Selector_Obj ss)
   {
 
     Complex_Selector_Obj t = ss->tail();
@@ -1196,21 +1196,21 @@ namespace Sass {
     return list;
   }
 
-  Selector_List_Ptr Selector_List::resolve_parent_refs(Context& ctx, std::vector<Selector_List_Obj>& pstack, bool implicit_parent)
+  Selector_List_Ptr Selector_List::resolve_parent_refs(std::vector<Selector_List_Obj>& pstack, bool implicit_parent)
   {
     if (!this->has_parent_ref()) return this;
     Selector_List_Ptr ss = SASS_MEMORY_NEW(Selector_List, pstate());
     Selector_List_Ptr ps = pstack.back();
     for (size_t pi = 0, pL = ps->length(); pi < pL; ++pi) {
       for (size_t si = 0, sL = this->length(); si < sL; ++si) {
-        Selector_List_Obj rv = at(si)->resolve_parent_refs(ctx, pstack, implicit_parent);
+        Selector_List_Obj rv = at(si)->resolve_parent_refs(pstack, implicit_parent);
         ss->concat(rv);
       }
     }
     return ss;
   }
 
-  Selector_List_Ptr Complex_Selector::resolve_parent_refs(Context& ctx, std::vector<Selector_List_Obj>& pstack, bool implicit_parent)
+  Selector_List_Ptr Complex_Selector::resolve_parent_refs(std::vector<Selector_List_Obj>& pstack, bool implicit_parent)
   {
     Complex_Selector_Obj tail = this->tail();
     Compound_Selector_Obj head = this->head();
@@ -1223,7 +1223,7 @@ namespace Sass {
     }
 
     // first resolve_parent_refs the tail (which may return an expanded list)
-    Selector_List_Obj tails = tail ? tail->resolve_parent_refs(ctx, pstack, implicit_parent) : 0;
+    Selector_List_Obj tails = tail ? tail->resolve_parent_refs(pstack, implicit_parent) : 0;
 
     if (head && head->length() > 0) {
 
@@ -1269,7 +1269,7 @@ namespace Sass {
                 // keep old parser state
                 s->pstate(pstate());
                 // append new tail
-                s->append(ctx, ss);
+                s->append(ss);
                 retval->append(s);
               }
             }
@@ -1307,7 +1307,7 @@ namespace Sass {
               // keep old parser state
               s->pstate(pstate());
               // append new tail
-              s->append(ctx, ss);
+              s->append(ss);
               retval->append(s);
             }
           }
@@ -1338,13 +1338,13 @@ namespace Sass {
       }
       // no parent selector in head
       else {
-        retval = this->tails(ctx, tails);
+        retval = this->tails(tails);
       }
 
       for (Simple_Selector_Obj ss : head->elements()) {
         if (Wrapped_Selector_Ptr ws = Cast<Wrapped_Selector>(ss)) {
           if (Selector_List_Ptr sl = Cast<Selector_List>(ws->selector())) {
-            if (parents) ws->selector(sl->resolve_parent_refs(ctx, pstack, implicit_parent));
+            if (parents) ws->selector(sl->resolve_parent_refs(pstack, implicit_parent));
           }
         }
       }
@@ -1354,14 +1354,14 @@ namespace Sass {
     }
     // has no head
     else {
-      return this->tails(ctx, tails);
+      return this->tails(tails);
     }
 
     // unreachable
     return 0;
   }
 
-  Selector_List_Ptr Complex_Selector::tails(Context& ctx, Selector_List_Ptr tails)
+  Selector_List_Ptr Complex_Selector::tails(Selector_List_Ptr tails)
   {
     Selector_List_Ptr rv = SASS_MEMORY_NEW(Selector_List, pstate_);
     if (tails && tails->length()) {
@@ -1586,7 +1586,7 @@ namespace Sass {
     return false;
   }
 
-  Selector_List_Ptr Selector_List::unify_with(Selector_List_Ptr rhs, Context& ctx) {
+  Selector_List_Ptr Selector_List::unify_with(Selector_List_Ptr rhs) {
     std::vector<Complex_Selector_Obj> unified_complex_selectors;
     // Unify all of children with RHS's children, storing the results in `unified_complex_selectors`
     for (size_t lhs_i = 0, lhs_L = length(); lhs_i < lhs_L; ++lhs_i) {
@@ -1594,7 +1594,7 @@ namespace Sass {
       for(size_t rhs_i = 0, rhs_L = rhs->length(); rhs_i < rhs_L; ++rhs_i) {
         Complex_Selector_Ptr seq2 = rhs->at(rhs_i);
 
-        Selector_List_Obj result = seq1->unify_with(seq2, ctx);
+        Selector_List_Obj result = seq1->unify_with(seq2);
         if( result ) {
           for(size_t i = 0, L = result->length(); i < L; ++i) {
             unified_complex_selectors.push_back( (*result)[i] );
@@ -1611,7 +1611,7 @@ namespace Sass {
     return final_result;
   }
 
-  void Selector_List::populate_extends(Selector_List_Obj extendee, Context& ctx, Subset_Map& extends)
+  void Selector_List::populate_extends(Selector_List_Obj extendee, Subset_Map& extends)
   {
 
     Selector_List_Ptr extender = this;
@@ -1650,7 +1650,7 @@ namespace Sass {
     pstate_.offset += element->pstate().offset;
   }
 
-  Compound_Selector_Ptr Compound_Selector::minus(Compound_Selector_Ptr rhs, Context& ctx)
+  Compound_Selector_Ptr Compound_Selector::minus(Compound_Selector_Ptr rhs)
   {
     Compound_Selector_Ptr result = SASS_MEMORY_NEW(Compound_Selector, pstate());
     // result->has_parent_reference(has_parent_reference());
@@ -1659,10 +1659,10 @@ namespace Sass {
     for (size_t i = 0, L = length(); i < L; ++i)
     {
       bool found = false;
-      std::string thisSelector((*this)[i]->to_string(ctx.c_options));
+      std::string thisSelector((*this)[i]->to_string());
       for (size_t j = 0, M = rhs->length(); j < M; ++j)
       {
-        if (thisSelector == (*rhs)[j]->to_string(ctx.c_options))
+        if (thisSelector == (*rhs)[j]->to_string())
         {
           found = true;
           break;
@@ -1674,7 +1674,7 @@ namespace Sass {
     return result;
   }
 
-  void Compound_Selector::mergeSources(ComplexSelectorSet& sources, Context& ctx)
+  void Compound_Selector::mergeSources(ComplexSelectorSet& sources)
   {
     for (ComplexSelectorSet::iterator iterator = sources.begin(), endIterator = sources.end(); iterator != endIterator; ++iterator) {
       this->sources_.insert(SASS_MEMORY_CLONE(*iterator));
@@ -2343,7 +2343,7 @@ namespace Sass {
   //////////////////////////////////////////////////////////////////////////////////////////
   // Convert map to (key, value) list.
   //////////////////////////////////////////////////////////////////////////////////////////
-  List_Obj Map::to_list(Context& ctx, ParserState& pstate) {
+  List_Obj Map::to_list(ParserState& pstate) {
     List_Obj ret = SASS_MEMORY_NEW(List, pstate, length(), SASS_COMMA);
 
     for (auto key : keys()) {

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1125,7 +1125,7 @@ namespace Sass {
     std::string type() const { return "map"; }
     static std::string type_name() { return "map"; }
     bool is_invisible() const { return empty(); }
-    List_Obj to_list(Context& ctx, ParserState& pstate);
+    List_Obj to_list(ParserState& pstate);
 
     virtual size_t hash()
     {
@@ -2428,7 +2428,7 @@ namespace Sass {
     }
 
     virtual ~Simple_Selector() = 0;
-    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr, Context&);
+    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr);
     virtual bool has_parent_ref() const { return false; };
     virtual bool has_real_parent_ref() const  { return false; };
     virtual bool is_pseudo_element() const { return false; }
@@ -2515,8 +2515,8 @@ namespace Sass {
       if (name() == "*") return 0;
       else               return Constants::Specificity_Element;
     }
-    virtual Simple_Selector_Ptr unify_with(Simple_Selector_Ptr, Context&);
-    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr, Context&);
+    virtual Simple_Selector_Ptr unify_with(Simple_Selector_Ptr);
+    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr);
     ATTACH_AST_OPERATIONS(Element_Selector)
     ATTACH_OPERATIONS()
   };
@@ -2536,7 +2536,7 @@ namespace Sass {
     {
       return Constants::Specificity_Class;
     }
-    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr, Context&);
+    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr);
     ATTACH_AST_OPERATIONS(Class_Selector)
     ATTACH_OPERATIONS()
   };
@@ -2556,7 +2556,7 @@ namespace Sass {
     {
       return Constants::Specificity_ID;
     }
-    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr, Context&);
+    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr);
     ATTACH_AST_OPERATIONS(Id_Selector)
     ATTACH_OPERATIONS()
   };
@@ -2655,7 +2655,7 @@ namespace Sass {
     virtual bool operator==(const Pseudo_Selector& rhs) const;
     virtual bool operator<(const Simple_Selector& rhs) const;
     virtual bool operator<(const Pseudo_Selector& rhs) const;
-    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr, Context&);
+    virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr);
     ATTACH_AST_OPERATIONS(Pseudo_Selector)
     ATTACH_OPERATIONS()
   };
@@ -2731,7 +2731,7 @@ namespace Sass {
     }
 
     Complex_Selector_Obj to_complex();
-    Compound_Selector_Ptr unify_with(Compound_Selector_Ptr rhs, Context& ctx);
+    Compound_Selector_Ptr unify_with(Compound_Selector_Ptr rhs);
     // virtual Placeholder_Selector_Ptr find_placeholder();
     virtual bool has_parent_ref() const;
     virtual bool has_real_parent_ref() const;
@@ -2784,9 +2784,9 @@ namespace Sass {
 
     ComplexSelectorSet& sources() { return sources_; }
     void clearSources() { sources_.clear(); }
-    void mergeSources(ComplexSelectorSet& sources, Context& ctx);
+    void mergeSources(ComplexSelectorSet& sources);
 
-    Compound_Selector_Ptr minus(Compound_Selector_Ptr rhs, Context& ctx);
+    Compound_Selector_Ptr minus(Compound_Selector_Ptr rhs);
     virtual void cloneChildren();
     ATTACH_AST_OPERATIONS(Compound_Selector)
     ATTACH_OPERATIONS()
@@ -2850,7 +2850,7 @@ namespace Sass {
              combinator() == Combinator::ANCESTOR_OF;
     }
 
-    Selector_List_Ptr tails(Context& ctx, Selector_List_Ptr tails);
+    Selector_List_Ptr tails(Selector_List_Ptr tails);
 
     // front returns the first real tail
     // skips over parent and empty ones
@@ -2862,13 +2862,13 @@ namespace Sass {
     Complex_Selector_Obj innermost() { return last(); };
 
     size_t length() const;
-    Selector_List_Ptr resolve_parent_refs(Context& ctx, std::vector<Selector_List_Obj>& pstack, bool implicit_parent = true);
+    Selector_List_Ptr resolve_parent_refs(std::vector<Selector_List_Obj>& pstack, bool implicit_parent = true);
     virtual bool is_superselector_of(Compound_Selector_Obj sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector_Obj sub, std::string wrapping = "");
     virtual bool is_superselector_of(Selector_List_Obj sub, std::string wrapping = "");
-    Selector_List_Ptr unify_with(Complex_Selector_Ptr rhs, Context& ctx);
+    Selector_List_Ptr unify_with(Complex_Selector_Ptr rhs);
     Combinator clear_innermost();
-    void append(Context&, Complex_Selector_Obj);
+    void append(Complex_Selector_Obj);
     void set_innermost(Complex_Selector_Obj, Combinator);
     virtual size_t hash()
     {
@@ -2925,14 +2925,14 @@ namespace Sass {
 
       return srcs;
     }
-    void addSources(ComplexSelectorSet& sources, Context& ctx) {
+    void addSources(ComplexSelectorSet& sources) {
       // members.map! {|m| m.is_a?(SimpleSequence) ? m.with_more_sources(sources) : m}
       Complex_Selector_Ptr pIter = this;
       while (pIter) {
         Compound_Selector_Ptr pHead = pIter->head();
 
         if (pHead) {
-          pHead->mergeSources(sources, ctx);
+          pHead->mergeSources(sources);
         }
 
         pIter = pIter->tail();
@@ -2983,12 +2983,12 @@ namespace Sass {
     virtual bool has_parent_ref() const;
     virtual bool has_real_parent_ref() const;
     void remove_parent_selectors();
-    Selector_List_Ptr resolve_parent_refs(Context& ctx, std::vector<Selector_List_Obj>& pstack, bool implicit_parent = true);
+    Selector_List_Ptr resolve_parent_refs(std::vector<Selector_List_Obj>& pstack, bool implicit_parent = true);
     virtual bool is_superselector_of(Compound_Selector_Obj sub, std::string wrapping = "");
     virtual bool is_superselector_of(Complex_Selector_Obj sub, std::string wrapping = "");
     virtual bool is_superselector_of(Selector_List_Obj sub, std::string wrapping = "");
-    Selector_List_Ptr unify_with(Selector_List_Ptr, Context&);
-    void populate_extends(Selector_List_Obj, Context&, Subset_Map&);
+    Selector_List_Ptr unify_with(Selector_List_Ptr);
+    void populate_extends(Selector_List_Obj, Subset_Map&);
     Selector_List_Obj eval(Eval& eval);
     virtual size_t hash()
     {

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -410,6 +410,7 @@ namespace Sass {
   typedef std::deque<Complex_Selector_Obj> ComplexSelectorDeque;
   typedef std::set<Simple_Selector_Obj, OrderNodes> SimpleSelectorSet;
   typedef std::set<Complex_Selector_Obj, OrderNodes> ComplexSelectorSet;
+  typedef std::set<Compound_Selector_Obj, OrderNodes> CompoundSelectorSet;
   typedef std::unordered_set<Simple_Selector_Obj, HashNodes, CompareNodes> SimpleSelectorDict;
 
   // ###########################################################################

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -661,7 +661,7 @@ namespace Sass {
     // should we extend something?
     if (!subset_map.empty()) {
       // create crtp visitor object
-      Extend extend(*this, subset_map);
+      Extend extend(subset_map);
       // extend tree nodes
       extend(root);
     }

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1727,7 +1727,7 @@ namespace Sass {
   Selector_List_Ptr Eval::operator()(Complex_Selector_Ptr s)
   {
     bool implicit_parent = !exp.old_at_root_without_rule;
-    return s->resolve_parent_refs(ctx, exp.selector_stack, implicit_parent);
+    return s->resolve_parent_refs(exp.selector_stack, implicit_parent);
   }
 
   // XXX: this is never hit via spec tests

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -598,8 +598,8 @@ namespace Sass {
         std::string sel_str(contextualized->to_string(ctx.c_options));
         error("Can't extend " + sel_str + ": can't extend nested selectors", c->pstate(), backtrace());
       }
-      Compound_Selector_Obj placeholder = c->head();
-      if (contextualized->is_optional()) placeholder->is_optional(true);
+      Compound_Selector_Obj target = c->head();
+      if (contextualized->is_optional()) target->is_optional(true);
       for (size_t i = 0, L = extender->length(); i < L; ++i) {
         Complex_Selector_Obj sel = (*extender)[i];
         if (!(sel->head() && sel->head()->length() > 0 &&
@@ -618,7 +618,7 @@ namespace Sass {
           sel = ssel;
         }
         // if (c->has_line_feed()) sel->has_line_feed(true);
-        ctx.subset_map.put(placeholder, std::make_pair(sel, placeholder));
+        ctx.subset_map.put(target, std::make_pair(sel, target));
       }
     }
 

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1513,7 +1513,7 @@ namespace Sass {
       return pSelector;
     }
   };
-  Node Extend::extendCompoundSelector(Compound_Selector_Ptr pSelector, std::set<Compound_Selector>& seen, bool isReplace) {
+  Node Extend::extendCompoundSelector(Compound_Selector_Ptr pSelector, CompoundSelectorSet& seen, bool isReplace) {
 
     DEBUG_EXEC(EXTEND_COMPOUND, printCompoundSelector(pSelector, "EXTEND COMPOUND: "))
     // TODO: Ruby has another loop here to skip certain members?
@@ -1638,13 +1638,13 @@ namespace Sass {
 
 
       // RUBY??: next [] if seen.include?(sels)
-      if (seen.find(*pSels) != seen.end()) {
+      if (seen.find(pSels) != seen.end()) {
         continue;
       }
 
 
-      std::set<Compound_Selector> recurseSeen(seen);
-      recurseSeen.insert(*pSels);
+      CompoundSelectorSet recurseSeen(seen);
+      recurseSeen.insert(pSels);
 
 
       DEBUG_PRINTLN(EXTEND_COMPOUND, "RECURSING DO EXTEND: " << complexSelectorToNode(pNewSelector))
@@ -1673,7 +1673,7 @@ namespace Sass {
 
 
   // check if selector has something to be extended by subset_map
-  bool Extend::complexSelectorHasExtension(Complex_Selector_Ptr pComplexSelector, std::set<Compound_Selector>& seen) {
+  bool Extend::complexSelectorHasExtension(Complex_Selector_Ptr pComplexSelector, CompoundSelectorSet& seen) {
 
     bool hasExtension = false;
 
@@ -1729,7 +1729,7 @@ namespace Sass {
      the combinator and compound selector are one unit
      next [[sseq_or_op]] unless sseq_or_op.is_a?(SimpleSequence)
    */
-  Node Extend::extendComplexSelector(Complex_Selector_Ptr pComplexSelector, std::set<Compound_Selector>& seen, bool isReplace, bool isOriginal) {
+  Node Extend::extendComplexSelector(Complex_Selector_Ptr pComplexSelector, CompoundSelectorSet& seen, bool isReplace, bool isOriginal) {
 
     Node complexSelector = complexSelectorToNode(pComplexSelector);
     DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTEND COMPLEX: " << complexSelector)
@@ -1851,7 +1851,7 @@ namespace Sass {
   */
   // We get a selector list with has something to extend and a subset_map with
   // all extenders. Pick the ones that match our selectors in the list.
-  Selector_List_Ptr Extend::extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen) {
+  Selector_List_Ptr Extend::extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace, bool& extendedSomething, CompoundSelectorSet& seen) {
 
     Selector_List_Obj pNewSelectors = SASS_MEMORY_NEW(Selector_List, pSelectorList->pstate(), pSelectorList->length());
 
@@ -1902,9 +1902,9 @@ namespace Sass {
       // process tails
       while (cur) {
         // process header
-        if (cur->head() && seen.find(*cur->head()) == seen.end()) {
-          std::set<Compound_Selector> recseen(seen);
-          recseen.insert(*cur->head());
+        if (cur->head() && seen.find(cur->head()) == seen.end()) {
+          CompoundSelectorSet recseen(seen);
+          recseen.insert(cur->head());
           // create a copy since we add multiple items if stuff get unwrapped
           Compound_Selector_Obj cpy_head = SASS_MEMORY_NEW(Compound_Selector, cur->pstate());
           for (Simple_Selector_Obj hs : *cur->head()) {
@@ -2016,7 +2016,7 @@ namespace Sass {
 
     bool extendedSomething = false;
 
-    std::set<Compound_Selector> seen;
+    CompoundSelectorSet seen;
     Selector_List_Obj pNewSelectorList = extendSelectorList(pObject->selector(), false, extendedSomething, seen);
 
     if (extendedSomething && pNewSelectorList) {

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -23,20 +23,20 @@ namespace Sass {
   private:
 
     void extendObjectWithSelectorAndBlock(Ruleset_Ptr pObject);
-    Node extendComplexSelector(Complex_Selector_Ptr sel, std::set<Compound_Selector>& seen, bool isReplace, bool isOriginal);
-    Node extendCompoundSelector(Compound_Selector_Ptr sel, std::set<Compound_Selector>& seen, bool isReplace);
-    bool complexSelectorHasExtension(Complex_Selector_Ptr selector, std::set<Compound_Selector>& seen);
+    Node extendComplexSelector(Complex_Selector_Ptr sel, CompoundSelectorSet& seen, bool isReplace, bool isOriginal);
+    Node extendCompoundSelector(Compound_Selector_Ptr sel, CompoundSelectorSet& seen, bool isReplace);
+    bool complexSelectorHasExtension(Complex_Selector_Ptr selector, CompoundSelectorSet& seen);
     Node trim(Node& seqses, bool isReplace);
     Node weave(Node& path);
 
   public:
-    Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
+    Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace, bool& extendedSomething, CompoundSelectorSet& seen);
     Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace = false) {
       bool extendedSomething = false;
-      std::set<Compound_Selector> seen;
+      CompoundSelectorSet seen;
       return extendSelectorList(pSelectorList, isReplace, extendedSomething, seen);
     }
-    Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, std::set<Compound_Selector>& seen) {
+    Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, CompoundSelectorSet& seen) {
       bool isReplace = false;
       bool extendedSomething = false;
       return extendSelectorList(pSelectorList, isReplace, extendedSomething, seen);

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -5,35 +5,43 @@
 #include <set>
 
 #include "ast.hpp"
+#include "node.hpp"
 #include "operation.hpp"
 #include "subset_map.hpp"
+#include "ast_fwd_decl.hpp"
 
 namespace Sass {
 
-  class Context;
-  class Node;
+  Node subweave(Node& one, Node& two);
 
   class Extend : public Operation_CRTP<void, Extend> {
 
-    Context&            ctx;
     Subset_Map& subset_map;
 
     void fallback_impl(AST_Node_Ptr n) { }
 
+  private:
+
+    void extendObjectWithSelectorAndBlock(Ruleset_Ptr pObject);
+    Node extendComplexSelector(Complex_Selector_Ptr sel, std::set<Compound_Selector>& seen, bool isReplace, bool isOriginal);
+    Node extendCompoundSelector(Compound_Selector_Ptr sel, std::set<Compound_Selector>& seen, bool isReplace);
+    bool complexSelectorHasExtension(Complex_Selector_Ptr selector, std::set<Compound_Selector>& seen);
+    Node trim(Node& seqses, bool isReplace);
+    Node weave(Node& path);
+
   public:
-    static Node subweave(Node& one, Node& two, Context& ctx);
-    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, Subset_Map& subset_map, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
-    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, Subset_Map& subset_map, bool isReplace, bool& extendedSomething);
-    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, Subset_Map& subset_map, bool isReplace = false) {
+    Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace, bool& extendedSomething, std::set<Compound_Selector>& seen);
+    Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace = false) {
       bool extendedSomething = false;
-      return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething);
+      std::set<Compound_Selector> seen;
+      return extendSelectorList(pSelectorList, isReplace, extendedSomething, seen);
     }
-    static Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, Context& ctx, Subset_Map& subset_map, std::set<Compound_Selector>& seen) {
+    Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, std::set<Compound_Selector>& seen) {
       bool isReplace = false;
       bool extendedSomething = false;
-      return extendSelectorList(pSelectorList, ctx, subset_map, isReplace, extendedSomething, seen);
+      return extendSelectorList(pSelectorList, isReplace, extendedSomething, seen);
     }
-    Extend(Context&, Subset_Map&);
+    Extend(Subset_Map&);
     ~Extend() { }
 
     void operator()(Block_Ptr);

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1301,7 +1301,7 @@ namespace Sass {
         l->append(ARG("$list", Expression));
       }
       if (m) {
-        l = m->to_list(ctx, pstate);
+        l = m->to_list(pstate);
       }
       if (l->empty()) error("argument `$list` of `" + std::string(sig) + "` must not be empty", pstate);
       double index = std::floor(n->value() < 0 ? l->length() + n->value() : n->value() - 1);
@@ -1324,7 +1324,7 @@ namespace Sass {
         l->append(ARG("$list", Expression));
       }
       if (m) {
-        l = m->to_list(ctx, pstate);
+        l = m->to_list(pstate);
       }
       for (size_t i = 0, L = l->length(); i < L; ++i) {
         if (Eval::eq(l->value_at_index(i), v)) return SASS_MEMORY_NEW(Number, pstate, (double)(i+1));
@@ -1354,11 +1354,11 @@ namespace Sass {
         l2->append(ARG("$list2", Expression));
       }
       if (m1) {
-        l1 = m1->to_list(ctx, pstate);
+        l1 = m1->to_list(pstate);
         sep_val = SASS_COMMA;
       }
       if (m2) {
-        l2 = m2->to_list(ctx, pstate);
+        l2 = m2->to_list(pstate);
       }
       size_t len = l1->length() + l2->length();
       std::string sep_str = unquote(sep->value());
@@ -1392,7 +1392,7 @@ namespace Sass {
         l->append(ARG("$list", Expression));
       }
       if (m) {
-        l = m->to_list(ctx, pstate);
+        l = m->to_list(pstate);
       }
       List_Ptr result = SASS_MEMORY_COPY(l);
       std::string sep_str(unquote(sep->value()));
@@ -1425,7 +1425,7 @@ namespace Sass {
         Map_Obj mith = Cast<Map>(arglist->value_at_index(i));
         if (!ith) {
           if (mith) {
-            ith = mith->to_list(ctx, pstate);
+            ith = mith->to_list(pstate);
           } else {
             ith = SASS_MEMORY_NEW(List, pstate, 1);
             ith->append(arglist->value_at_index(i));
@@ -1793,7 +1793,7 @@ namespace Sass {
         Selector_List_Obj child = *itr;
         std::vector<Complex_Selector_Obj> exploded;
         selector_stack.push_back(result);
-        Selector_List_Obj rv = child->resolve_parent_refs(ctx, selector_stack);
+        Selector_List_Obj rv = child->resolve_parent_refs(selector_stack);
         selector_stack.pop_back();
         for (size_t m = 0, mLen = rv->length(); m < mLen; ++m) {
           exploded.push_back((*rv)[m]);
@@ -1905,7 +1905,7 @@ namespace Sass {
       Selector_List_Obj selector1 = ARGSEL("$selector1", Selector_List_Obj, p_contextualize);
       Selector_List_Obj selector2 = ARGSEL("$selector2", Selector_List_Obj, p_contextualize);
 
-      Selector_List_Obj result = selector1->unify_with(selector2, ctx);
+      Selector_List_Obj result = selector1->unify_with(selector2);
       Listize listize;
       return result->perform(&listize);
     }
@@ -1935,9 +1935,10 @@ namespace Sass {
       Selector_List_Obj  extender = ARGSEL("$extender", Selector_List_Obj, p_contextualize);
 
       Subset_Map subset_map;
-      extender->populate_extends(extendee, ctx, subset_map);
+      extender->populate_extends(extendee, subset_map);
+      Extend extend(subset_map);
 
-      Selector_List_Obj result = Extend::extendSelectorList(selector, ctx, subset_map, false);
+      Selector_List_Obj result = extend.extendSelectorList(selector, false);
 
       Listize listize;
       return result->perform(&listize);
@@ -1950,9 +1951,10 @@ namespace Sass {
       Selector_List_Obj original = ARGSEL("$original", Selector_List_Obj, p_contextualize);
       Selector_List_Obj replacement = ARGSEL("$replacement", Selector_List_Obj, p_contextualize);
       Subset_Map subset_map;
-      replacement->populate_extends(original, ctx, subset_map);
+      replacement->populate_extends(original, subset_map);
+      Extend extend(subset_map);
 
-      Selector_List_Obj result = Extend::extendSelectorList(selector, ctx, subset_map, true);
+      Selector_List_Obj result = extend.extendSelectorList(selector, true);
 
       Listize listize;
       return result->perform(&listize);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -14,7 +14,7 @@ namespace Sass {
   }
 
 
-  Node Node::createSelector(Complex_Selector_Ptr pSelector, Context& ctx) {
+  Node Node::createSelector(Complex_Selector_Ptr pSelector) {
     NodeDequePtr null;
 
     Complex_Selector_Ptr pStripped = SASS_MEMORY_COPY(pSelector);
@@ -50,12 +50,12 @@ namespace Sass {
   { if (pSelector) got_line_feed = pSelector->has_line_feed(); }
 
 
-  Node Node::klone(Context& ctx) const {
+  Node Node::klone() const {
     NodeDequePtr pNewCollection = std::make_shared<NodeDeque>();
     if (mpCollection) {
       for (NodeDeque::iterator iter = mpCollection->begin(), iterEnd = mpCollection->end(); iter != iterEnd; iter++) {
         Node& toClone = *iter;
-        pNewCollection->push_back(toClone.klone(ctx));
+        pNewCollection->push_back(toClone.klone());
       }
     }
 
@@ -65,7 +65,7 @@ namespace Sass {
   }
 
 
-  bool Node::contains(const Node& potentialChild, bool simpleSelectorOrderDependent) const {
+  bool Node::contains(const Node& potentialChild) const {
     bool found = false;
 
     for (NodeDeque::iterator iter = mpCollection->begin(), iterEnd = mpCollection->end(); iter != iterEnd; iter++) {
@@ -172,7 +172,7 @@ namespace Sass {
 #endif
 
 
-  Node complexSelectorToNode(Complex_Selector_Ptr pToConvert, Context& ctx) {
+  Node complexSelectorToNode(Complex_Selector_Ptr pToConvert) {
     if (pToConvert == NULL) {
       return Node::createNil();
     }
@@ -196,7 +196,7 @@ namespace Sass {
 
       // the first Complex_Selector may contain a dummy head pointer, skip it.
       if (pToConvert->head() && !empty_parent_ref) {
-        node.collection()->push_back(Node::createSelector(pToConvert, ctx));
+        node.collection()->push_back(Node::createSelector(pToConvert));
         if (has_lf) node.collection()->back().got_line_feed = has_lf;
         has_lf = false;
       }
@@ -218,7 +218,7 @@ namespace Sass {
   }
 
 
-  Complex_Selector_Ptr nodeToComplexSelector(const Node& toConvert, Context& ctx) {
+  Complex_Selector_Ptr nodeToComplexSelector(const Node& toConvert) {
     if (toConvert.isNil()) {
       return NULL;
     }
@@ -280,7 +280,7 @@ namespace Sass {
 
   // A very naive trim function, which removes duplicates in a node
   // This is only used in Complex_Selector::unify_with for now, may need modifications to fit other needs
-  Node Node::naiveTrim(Node& seqses, Context& ctx) {
+  Node Node::naiveTrim(Node& seqses) {
 
     std::vector<Node*> res;
     std::vector<Complex_Selector_Obj> known;

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -61,15 +61,15 @@ namespace Sass {
     static Node createCombinator(const Complex_Selector::Combinator& combinator);
 
     // This method will klone the selector, stripping off the tail and combinator
-    static Node createSelector(Complex_Selector_Ptr pSelector, Context& ctx);
+    static Node createSelector(Complex_Selector_Ptr pSelector);
 
     static Node createCollection();
     static Node createCollection(const NodeDeque& values);
 
     static Node createNil();
-    static Node naiveTrim(Node& seqses, Context& ctx);
+    static Node naiveTrim(Node& seqses);
 
-    Node klone(Context& ctx) const;
+    Node klone() const;
 
     bool operator==(const Node& rhs) const;
     inline bool operator!=(const Node& rhs) const { return !(*this == rhs); }
@@ -91,7 +91,7 @@ namespace Sass {
     // potentialChild must be a node collection of selectors/combinators. this must be a collection
     // of collections of nodes/combinators. This method checks if potentialChild is a child of this
     // Node.
-    bool contains(const Node& potentialChild, bool simpleSelectorOrderDependent) const;
+    bool contains(const Node& potentialChild) const;
 
   private:
     // Private constructor; Use the static methods (like createCombinator and createSelector)
@@ -110,8 +110,8 @@ namespace Sass {
 #ifdef DEBUG
   std::ostream& operator<<(std::ostream& os, const Node& node);
 #endif
-  Node complexSelectorToNode(Complex_Selector_Ptr pToConvert, Context& ctx);
-  Complex_Selector_Ptr nodeToComplexSelector(const Node& toConvert, Context& ctx);
+  Node complexSelectorToNode(Complex_Selector_Ptr pToConvert);
+  Complex_Selector_Ptr nodeToComplexSelector(const Node& toConvert);
 
 }
 

--- a/src/sass_util.cpp
+++ b/src/sass_util.cpp
@@ -37,7 +37,7 @@ namespace Sass {
       end
     end
   */
-  Node paths(const Node& arrs, Context& ctx) {
+  Node paths(const Node& arrs) {
 
     Node loopStart = Node::createCollection();
     loopStart.collection()->push_back(Node::createCollection());
@@ -108,7 +108,7 @@ namespace Sass {
     return flattened
   end
   */
-  Node flatten(Node& arr, Context& ctx, int n) {
+  Node flatten(Node& arr, int n) {
     if (n != -1 && n == 0) {
       return arr;
     }
@@ -124,7 +124,7 @@ namespace Sass {
       if (e.isCollection()) {
 
       	// e.collection().got_line_feed = e.got_line_feed;
-      	Node recurseFlattened = flatten(e, ctx, n - 1);
+      	Node recurseFlattened = flatten(e, n - 1);
 
       	if(e.got_line_feed) {
       		 flattened.got_line_feed = e.got_line_feed;

--- a/src/sass_util.hpp
+++ b/src/sass_util.hpp
@@ -28,7 +28,7 @@ namespace Sass {
     #     #  [1, 4, 5],
     #     #  [2, 4, 5]]
   */
-  Node paths(const Node& arrs, Context& ctx);
+  Node paths(const Node& arrs);
 
 
   /*
@@ -139,7 +139,7 @@ namespace Sass {
   http://en.wikipedia.org/wiki/Longest_common_subsequence_problem
   */
   template<typename ComparatorType>
-  Node lcs(Node& x, Node& y, const ComparatorType& comparator, Context& ctx) {
+  Node lcs(Node& x, Node& y, const ComparatorType& comparator) {
     DEBUG_PRINTLN(LCS, "LCS: X=" << x << " Y=" << y)
 
     Node newX = Node::createCollection();
@@ -169,7 +169,7 @@ namespace Sass {
   # @param n [int] The number of levels to flatten
   # @return [NodeCollection] The flattened array
   */
-  Node flatten(Node& arr, Context& ctx, int n = -1);
+  Node flatten(Node& arr, int n = -1);
 
 
   /*


### PR DESCRIPTION
Makes the API of extend a bit more sane

I removed `ctx.options` from some `to_string` occurences. The occurences were AFAIR only debug or comparison related (the comparison one should go once we adopt to https://github.com/sass/sass/issues/2229). Also I can't think of any usage of numbers in selectors (maybe attributes?), so this seems legit to use default precision.

Also removes unused `simpleSelectorOrderDependent` from `contains` function.