### PR TITLE
Speed up repeated extends by memoizing calculations

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -275,7 +275,7 @@ namespace Sass {
       else if ((!l_h && !r_h) ||
                (!l_h && r_h->empty()) ||
                (!r_h && l_h->empty()) ||
-               (*l_h == *r_h))
+               (l_h && r_h && *l_h == *r_h))
       {
         // check combinator after heads
         if (l->combinator() != r->combinator())
@@ -314,7 +314,6 @@ namespace Sass {
     if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this == *cs;
     if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this == *ch;
     throw std::runtime_error("invalid selector base classes to compare");
-    return false;
   }
 
 
@@ -334,7 +333,6 @@ namespace Sass {
     if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this == *cs;
     if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this == *ch;
     throw std::runtime_error("invalid selector base classes to compare");
-    return false;
   }
 
   bool Compound_Selector::operator< (const Selector& rhs) const
@@ -344,7 +342,6 @@ namespace Sass {
     if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this < *cs;
     if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this < *ch;
     throw std::runtime_error("invalid selector base classes to compare");
-    return false;
   }
 
   bool Selector_Schema::operator== (const Selector& rhs) const
@@ -354,7 +351,6 @@ namespace Sass {
     if (const Complex_Selector* cs = Cast<Complex_Selector>(&rhs)) return *this == *cs;
     if (const Compound_Selector* ch = Cast<Compound_Selector>(&rhs)) return *this == *ch;
     throw std::runtime_error("invalid selector base classes to compare");
-    return false;
   }
 
   bool Selector_Schema::operator< (const Selector& rhs) const

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -22,6 +22,30 @@ namespace Sass {
 
   private:
 
+    std::unordered_map<
+      Selector_List_Obj, // key
+      Selector_List_Obj, // value
+      HashNodes, // hasher
+      CompareNodes // compare
+    > memoizeList;
+
+    std::unordered_map<
+      Complex_Selector_Obj, // key
+      Node, // value
+      HashNodes, // hasher
+      CompareNodes // compare
+    > memoizeComplex;
+
+    /* this turned out to be too much overhead
+       re-evaluate once we store an ast selector
+    std::unordered_map<
+      Compound_Selector_Obj, // key
+      Node, // value
+      HashNodes, // hasher
+      CompareNodes // compare
+    > memoizeCompound;
+    */
+
     void extendObjectWithSelectorAndBlock(Ruleset_Ptr pObject);
     Node extendComplexSelector(Complex_Selector_Ptr sel, CompoundSelectorSet& seen, bool isReplace, bool isOriginal);
     Node extendCompoundSelector(Compound_Selector_Ptr sel, CompoundSelectorSet& seen, bool isReplace);


### PR DESCRIPTION
The extend code path is probably the most expensive to go down in LibSass. It involves multiple conversions between the regular AST selector node to the internal used format and back again. Storing results from previous runs is rather cheap, due to the new shared object memory storage and since we already have everything to use selectors efficiently as hash map keys.

This might be more benchmark driven than I'd like, but it's the only way I have to asses our bottlenecks. Btw. I mostly do the performance assessments in Visual Studio Community. Problem is coming up with a good and balanced test case. The extend code regularly pops up as one of the hottest code paths in LibSass. But optimizing this is rather tedious. I started to look into the extend logic, but I don't see any horizon when we can get rid of the wastefull AST to Node conversion.

This speed up basically uses some clever memoizing to optimize the case when you extend the same selectors again. Since the subset_map is gathered in the expand phase before, the results should be the same for all calls with the same selector. ~~I was not yet able to get this down to the compound selector level as there seem to be some unexpected side effects.~~ My real world test suite has shown a minor increase of 5-10%. While synthetic bencharks can gain up to 500%.

So this may not be the ultimate performance boost for extend, but it does give a nice improve for scalability. I expect this to be noticable in very big code bases, where the chance of repeated extends gets higher. The memory costs should be rather slim. We just have two maps that hold on to shared objects that should live on anyway (did not check, but should be the case). Chances are that this should even improve memory usage, as we return the same object for every identical extend. Previousely extend would have created a pretty expensive deep clone. This could have side effects. But if it does I would like to know why, because we do want to avoid unnecessary copies when possible.

Conclusion: The extend code really needs a cleanup 🤔  