### PR TITLE
Fix SIGSEGV from bad cast

### DIFF
--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -168,7 +168,7 @@ namespace Sass {
         // normal param and rest arg
         List_Obj arglist = Cast<List>(a->value());
         // empty rest arg - treat all args as default values
-        if (!arglist->length()) {
+        if (!arglist || !arglist->length()) {
           break;
         } else {
           if (arglist->length() > LP - ip && !ps->has_rest_parameter()) {


### PR DESCRIPTION
- [x] don't segfault
- [ ] don't error
- [ ] produce correct output

Fixes #2321
Spec https://github.com/sass/sass-spec/pull/1081