### PR TITLE
Speed up tight for loops

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -178,6 +178,11 @@ namespace Sass {
       WRAPPED_SEL,
     };
   private:
+    // Force copy in eval if needed. This is only recognized by
+    // numbers at the moment. We want to avoid to make a separate
+    // ast node for every iteration. This effectively delayes that
+    // copy to the eval stage (where numbers are normaly static).
+    ADD_PROPERTY(bool, force_copy);
     // expressions in some contexts shouldn't be evaluated
     ADD_PROPERTY(bool, is_delayed)
     ADD_PROPERTY(bool, is_expanded)
@@ -187,6 +192,7 @@ namespace Sass {
     Expression(ParserState pstate,
                bool d = false, bool e = false, bool i = false, Concrete_Type ct = NONE)
     : AST_Node(pstate),
+      force_copy_(false),
       is_delayed_(d),
       is_expanded_(e),
       is_interpolant_(i),
@@ -194,6 +200,7 @@ namespace Sass {
     { }
     Expression(const Expression* ptr)
     : AST_Node(ptr),
+      force_copy_(ptr->force_copy_),
       is_delayed_(ptr->is_delayed_),
       is_expanded_(ptr->is_expanded_),
       is_interpolant_(ptr->is_interpolant_),
@@ -1608,7 +1615,10 @@ namespace Sass {
       numerator_units_(ptr->numerator_units_),
       denominator_units_(ptr->denominator_units_),
       hash_(ptr->hash_)
-    { concrete_type(NUMBER); }
+    {
+      is_expanded(true);
+      concrete_type(NUMBER);
+    }
 
     bool zero() { return zero_; }
     bool is_valid_css_unit() const;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -187,12 +187,14 @@ namespace Sass {
     exp.env_stack.push_back(&env);
     Block_Obj body = f->block();
     Expression_Ptr val = 0;
+    Number_Obj it = SASS_MEMORY_NEW(Number, low->pstate(), start, sass_end->unit());
+    it->force_copy(true); // makes a copy in eval when used inside the block
     if (start < end) {
       if (f->is_inclusive()) ++end;
       for (double i = start;
            i < end;
            ++i) {
-        Number_Obj it = SASS_MEMORY_NEW(Number, low->pstate(), i, sass_end->unit());
+        it->value(i);
         env.set_local(variable, it);
         val = body->perform(this);
         if (val) break;
@@ -202,7 +204,7 @@ namespace Sass {
       for (double i = start;
            i > end;
            --i) {
-        Number_Obj it = SASS_MEMORY_NEW(Number, low->pstate(), i, sass_end->unit());
+        it->value(i);
         env.set_local(variable, it);
         val = body->perform(this);
         if (val) break;
@@ -1107,6 +1109,11 @@ namespace Sass {
 
   Expression_Ptr Eval::operator()(Number_Ptr n)
   {
+    if (n->force_copy()) {
+      n = n->copy();
+      n->force_copy(false);
+      return n;
+    }
     return n;
   }
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -435,12 +435,14 @@ namespace Sass {
     env_stack.push_back(&env);
     call_stack.push_back(f);
     Block_Ptr body = f->block();
+    Number_Obj it = SASS_MEMORY_NEW(Number, low->pstate(), start, sass_end->unit());
+    it->force_copy(true); // makes a copy in eval when used inside the block
     if (start < end) {
       if (f->is_inclusive()) ++end;
       for (double i = start;
            i < end;
            ++i) {
-        Number_Obj it = SASS_MEMORY_NEW(Number, low->pstate(), i, sass_end->unit());
+        it->value(i);
         env.set_local(variable, it);
         append_block(body);
       }
@@ -449,7 +451,7 @@ namespace Sass {
       for (double i = start;
            i > end;
            --i) {
-        Number_Obj it = SASS_MEMORY_NEW(Number, low->pstate(), i, sass_end->unit());
+        it->value(i);
         env.set_local(variable, it);
         append_block(body);
       }


### PR DESCRIPTION
Avoids unnecessary copies of the iteration value
if it is only used in the loop control.