### PR TITLE
Produce a deprecation warning for ID strings that look like colors

### DIFF
--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -180,7 +180,7 @@ namespace Sass {
     std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
   }
 
-  void deprecated(std::string msg, std::string msg2, ParserState pstate)
+  void deprecated(std::string msg, std::string msg2, bool with_column, ParserState pstate)
   {
     std::string cwd(Sass::File::get_cwd());
     std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
@@ -188,9 +188,10 @@ namespace Sass {
     std::string output_path(Sass::File::path_for_console(rel_path, pstate.path, pstate.path));
 
     std::cerr << "DEPRECATION WARNING on line " << pstate.line + 1;
+    if (with_column) std::cerr << ", column " << pstate.column + pstate.offset.column + 1;
     if (output_path.length()) std::cerr << " of " << output_path;
     std::cerr << ":" << std::endl;
-    std::cerr << msg << " and will be an error in future versions of Sass." << std::endl;
+    std::cerr << msg << std::endl;
     if (msg2.length()) std::cerr << msg2 << std::endl;
     std::cerr << std::endl;
   }

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -195,7 +195,7 @@ namespace Sass {
   void warn(std::string msg, ParserState pstate, Backtrace* bt);
 
   void deprecated_function(std::string msg, ParserState pstate);
-  void deprecated(std::string msg, std::string msg2, ParserState pstate);
+  void deprecated(std::string msg, std::string msg2, bool with_column, ParserState pstate);
   void deprecated_bind(std::string msg, ParserState pstate);
   // void deprecated(std::string msg, ParserState pstate, Backtrace* bt);
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -666,9 +666,9 @@ namespace Sass {
       d->name() == "url"
     )) {
       deprecated(
-        "Naming a function \"" + d->name() + "\" is disallowed",
+        "Naming a function \"" + d->name() + "\" is disallowed and will be an error in future versions of Sass.",
         "This name conflicts with an existing CSS function with special parse rules.",
-         d->pstate()
+        false, d->pstate()
       );
     }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1602,6 +1602,19 @@ namespace Sass {
     if (lex< sequence < alternatives< hex, hex0 >, negate < exactly<'-'> > > >())
     { return lexed_hex_color(lexed); }
 
+    if (lex< hexa >())
+    {
+      std::string s = lexed.to_string();
+
+      deprecated(
+        "The value \""+s+"\" is currently parsed as a string, but it will be parsed as a color in",
+        "future versions of Sass. Use \"unquote('"+s+"')\" to continue parsing it as a string.",
+        true, pstate
+      );
+
+      return SASS_MEMORY_NEW(String_Quoted, pstate, lexed);
+    }
+
     if (lex< sequence < exactly <'#'>, identifier > >())
     { return SASS_MEMORY_NEW(String_Quoted, pstate, lexed); }
 

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1036,7 +1036,7 @@ namespace Sass {
     const char* hexa(const char* src) {
       const char* p = sequence< exactly<'#'>, one_plus<xdigit> >(src);
       ptrdiff_t len = p - src;
-      return (len != 4 && len != 7 && len != 9) ? 0 : p;
+      return (len != 5 && len != 9) ? 0 : p;
     }
     const char* hex0(const char* src) {
       const char* p = sequence< exactly<'0'>, exactly<'x'>, one_plus<xdigit> >(src);
@@ -1268,7 +1268,7 @@ namespace Sass {
             optional_css_whitespace,
             exactly<'='>,
             optional_css_whitespace,
-            alternatives< variable, identifier_schema, identifier, quoted_string, number, hexa >,
+            alternatives< variable, identifier_schema, identifier, quoted_string, number, hex, hexa >,
             zero_plus< sequence<
               optional_css_whitespace,
               exactly<','>,
@@ -1278,7 +1278,7 @@ namespace Sass {
                 optional_css_whitespace,
                 exactly<'='>,
                 optional_css_whitespace,
-                alternatives< variable, identifier_schema, identifier, quoted_string, number, hexa >
+                alternatives< variable, identifier_schema, identifier, quoted_string, number, hex, hexa >
               >
             > >
           > >,
@@ -1313,6 +1313,7 @@ namespace Sass {
           identifier,
           quoted_string,
           number,
+          hex,
           hexa,
           sequence <
             exactly < '(' >,


### PR DESCRIPTION
Best to get this out sooner rather than later so people have time
to address the issue before 3.6.

Fixes #2302 
Spec sass/sass-spec#1099