### PR TITLE
Fix segfault with invalid map keys

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1061,6 +1061,11 @@ namespace Sass {
     if (!lex_css< exactly<':'> >())
     { return key; }
 
+    List_Obj l = Cast<List>(key);
+    if (l && l->separator() == SASS_COMMA) {
+      css_error("Invalid CSS", " after ", ": expected \")\", was ");
+    }
+
     Expression_Obj value = parse_space_list();
 
     map->append(key);


### PR DESCRIPTION
Originally reported by @mrtuxracer via HackerOne.

The changed to using even sized lists to represent maps during the
parse stage inadvertently removed certain parser-time error
guarantees. The results being that invalid keys could make their
way into the lists and cause segfaults during eval.

This PR adds parser-time error handling for the most likely error
case.

Spec https://github.com/sass/sass-spec/pull/1104