### PR TITLE
Fix null pointer dereference in css_error

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2893,6 +2893,7 @@ namespace Sass {
     const char* end = this->end;
     while (*end != 0) ++ end;
     const char* pos = peek < optional_spaces >();
+    if (!pos) pos = position;
 
     const char* last_pos(pos);
     if (last_pos > source) {


### PR DESCRIPTION
Originally reported by @mrtuxracer via HackerOne.

Fixes #2369
Spec https://github.com/sass/sass-spec/pull/1105