### PR TITLE
Fix bug when parsing selector schemas

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -514,7 +514,7 @@ namespace Sass {
     if (lookahead.parsable) ruleset->selector(parse_selector_list(false));
     else {
       Selector_List_Obj list = SASS_MEMORY_NEW(Selector_List, pstate);
-      list->schema(parse_selector_schema(lookahead.found, false));
+      list->schema(parse_selector_schema(lookahead.position, false));
       ruleset->selector(list);
     }
     // then parse the inner block


### PR DESCRIPTION
Discovered whilst debugging a different issue. The code below is showing
the wrong error message because a null pointer assignment.

```scss
#{a==b}
```
LibSass
```
Error: Invalid CSS after "#": expected "{", was "#{a==b}"
```
Ruby Sass
```
Error: Invalid CSS after "#{a==b}": expected "{", was ""
```

