### PR TITLE
Implement 3.5 first class functions

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2329,6 +2329,16 @@ namespace Sass {
     return rhs.concrete_type() == NULL_VAL;
   }
 
+  bool Function::operator== (const Expression& rhs) const
+  {
+    if (Function_Ptr_Const r = Cast<Function>(&rhs)) {
+      Definition_Ptr_Const d1 = Cast<Definition>(definition());
+      Definition_Ptr_Const d2 = Cast<Definition>(r->definition());
+      return d1 && d2 && d1 == d2 && is_css() == r->is_css();
+    }
+    return false;
+  }
+
   size_t List::size() const {
     if (!is_arglist_) return length();
     // arglist expects a list of arguments
@@ -2464,6 +2474,7 @@ namespace Sass {
   IMPLEMENT_AST_OPERATORS(Custom_Error);
   IMPLEMENT_AST_OPERATORS(List);
   IMPLEMENT_AST_OPERATORS(Map);
+  IMPLEMENT_AST_OPERATORS(Function);
   IMPLEMENT_AST_OPERATORS(Number);
   IMPLEMENT_AST_OPERATORS(Binary_Expression);
   IMPLEMENT_AST_OPERATORS(String_Schema);
@@ -2514,5 +2525,4 @@ namespace Sass {
   IMPLEMENT_AST_OPERATORS(Placeholder_Selector);
   IMPLEMENT_AST_OPERATORS(Definition);
   IMPLEMENT_AST_OPERATORS(Declaration);
-
 }

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -132,6 +132,9 @@ namespace Sass {
   class Map;
   typedef Map* Map_Ptr;
   typedef Map const* Map_Ptr_Const;
+  class Function;
+  typedef Function* Function_Ptr;
+  typedef Function const* Function_Ptr_Const;
 
   class Mixin_Call;
   typedef Mixin_Call* Mixin_Call_Ptr;
@@ -311,6 +314,7 @@ namespace Sass {
   IMPL_MEM_OBJ(Expression);
   IMPL_MEM_OBJ(List);
   IMPL_MEM_OBJ(Map);
+  IMPL_MEM_OBJ(Function);
   IMPL_MEM_OBJ(Binary_Expression);
   IMPL_MEM_OBJ(Unary_Expression);
   IMPL_MEM_OBJ(Function_Call);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -833,6 +833,7 @@ namespace Sass {
     register_function(ctx, feature_exists_sig, feature_exists, env);
     register_function(ctx, call_sig, call, env);
     register_function(ctx, content_exists_sig, content_exists, env);
+    register_function(ctx, get_function_sig, get_function, env);
     // Boolean Functions
     register_function(ctx, not_sig, sass_not, env);
     register_function(ctx, if_sig, sass_if, env);

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -512,8 +512,17 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     std::cerr << " [" << expression->name() << "]";
     if (expression->is_delayed()) std::cerr << " [delayed]";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
+    if (expression->is_css()) std::cerr << " [css]";
     std::cerr << std::endl;
     debug_ast(expression->arguments(), ind + " args: ", env);
+    debug_ast(expression->func(), ind + " func: ", env);
+  } else if (Cast<Function>(node)) {
+    Function_Ptr expression = Cast<Function>(node);
+    std::cerr << ind << "Function " << expression;
+    std::cerr << " (" << pstate_source_position(node) << ")";
+    if (expression->is_css()) std::cerr << " [css]";
+    std::cerr << std::endl;
+    debug_ast(expression->definition(), ind + " definition: ", env);
   } else if (Cast<Arguments>(node)) {
     Arguments_Ptr expression = Cast<Arguments>(node);
     std::cerr << ind << "Arguments " << expression;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -838,10 +838,10 @@ namespace Sass {
         if (op_type == Sass_OP::SUB) interpolant = false;
         // if (op_type == Sass_OP::DIV) interpolant = true;
         // check for type violations
-        if (l_type == Expression::MAP) {
+        if (l_type == Expression::MAP || l_type == Expression::FUNCTION_VAL) {
           throw Exception::InvalidValue(*v_l);
         }
-        if (r_type == Expression::MAP) {
+        if (r_type == Expression::MAP || l_type == Expression::FUNCTION_VAL) {
           throw Exception::InvalidValue(*v_r);
         }
         Value_Ptr ex = op_strings(b->op(), *v_l, *v_r, ctx.c_options, pstate, !interpolant); // pass true to compress
@@ -976,6 +976,8 @@ namespace Sass {
     }
     Definition_Ptr def = Cast<Definition>((*env)[full_name]);
 
+    if (c->func()) def = c->func()->definition();
+
     if (def->is_overload_stub()) {
       std::stringstream ss;
       size_t L = args->length();
@@ -997,6 +999,8 @@ namespace Sass {
     Block_Obj          body   = def->block();
     Native_Function func   = def->native_function();
     Sass_Function_Entry c_function = def->c_function();
+
+    if (c->is_css()) return result.detach();
 
     Parameters_Obj params = def->parameters();
     Env fn_env(def->environment());

--- a/src/functions.hpp
+++ b/src/functions.hpp
@@ -107,6 +107,7 @@ namespace Sass {
     extern Signature selector_parse_sig;
     extern Signature is_bracketed_sig;
     extern Signature content_exists_sig;
+    extern Signature get_function_sig;
 
     BUILT_IN(rgb);
     BUILT_IN(rgba_4);
@@ -190,6 +191,7 @@ namespace Sass {
     BUILT_IN(selector_parse);
     BUILT_IN(is_bracketed);
     BUILT_IN(content_exists);
+    BUILT_IN(get_function);
   }
 }
 

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -829,6 +829,14 @@ namespace Sass {
     append_string(")");
   }
 
+  void Inspect::operator()(Function_Ptr f)
+  {
+    append_token("get-function", f);
+    append_string("(");
+    append_string(quote(f->name()));
+    append_string(")");
+  }
+
   void Inspect::operator()(Null_Ptr n)
   {
     // output the final token

--- a/src/inspect.hpp
+++ b/src/inspect.hpp
@@ -48,6 +48,7 @@ namespace Sass {
     virtual void operator()(Content_Ptr);
     // expressions
     virtual void operator()(Map_Ptr);
+    virtual void operator()(Function_Ptr);
     virtual void operator()(List_Ptr);
     virtual void operator()(Binary_Expression_Ptr);
     virtual void operator()(Unary_Expression_Ptr);

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -40,6 +40,7 @@ namespace Sass {
     // expressions
     virtual T operator()(List_Ptr x)                   = 0;
     virtual T operator()(Map_Ptr x)                    = 0;
+    virtual T operator()(Function_Ptr x)               = 0;
     virtual T operator()(Binary_Expression_Ptr x)      = 0;
     virtual T operator()(Unary_Expression_Ptr x)       = 0;
     virtual T operator()(Function_Call_Ptr x)          = 0;
@@ -121,6 +122,7 @@ namespace Sass {
     // expressions
     T operator()(List_Ptr x)                   { return static_cast<D*>(this)->fallback(x); }
     T operator()(Map_Ptr x)                    { return static_cast<D*>(this)->fallback(x); }
+    T operator()(Function_Ptr x)               { return static_cast<D*>(this)->fallback(x); }
     T operator()(Binary_Expression_Ptr x)      { return static_cast<D*>(this)->fallback(x); }
     T operator()(Unary_Expression_Ptr x)       { return static_cast<D*>(this)->fallback(x); }
     T operator()(Function_Call_Ptr x)          { return static_cast<D*>(this)->fallback(x); }

--- a/src/to_value.cpp
+++ b/src/to_value.cpp
@@ -79,6 +79,12 @@ namespace Sass {
     return n;
   }
 
+  // Function is a valid value
+  Value_Ptr To_Value::operator()(Function_Ptr n)
+  {
+    return n;
+  }
+
   // Argument returns its value
   Value_Ptr To_Value::operator()(Argument_Ptr arg)
   {

--- a/src/to_value.hpp
+++ b/src/to_value.hpp
@@ -34,6 +34,7 @@ namespace Sass {
     Value_Ptr operator()(List_Ptr);
     Value_Ptr operator()(Map_Ptr);
     Value_Ptr operator()(Null_Ptr);
+    Value_Ptr operator()(Function_Ptr);
 
     // convert to string via `To_String`
     Value_Ptr operator()(Selector_List_Ptr);


### PR DESCRIPTION
Implements `get-function` and a `Function` to represent function references.

Fixes https://github.com/sass/libsass/issues/2277
Spec https://github.com/sass/sass-spec/pull/1108