### PR TITLE
Fix wrong parsing of calc functions as number units (#2382)

### DIFF
--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -437,6 +437,10 @@ namespace Sass {
         optional <
           sequence <
           exactly <'/'>,
+          negate < sequence <
+            exactly < calc_fn_kwd >,
+            exactly < '(' >
+          > >,
           multiple_units
         > >
       >(src);


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/2382