### PR TITLE
Skip comment evaluation for compressed output (#2359)

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -382,6 +382,11 @@ namespace Sass {
 
   Statement_Ptr Expand::operator()(Comment_Ptr c)
   {
+    if (ctx.output_style() == COMPRESSED) {
+      // comments should not be evaluated in compact
+      // https://github.com/sass/libsass/issues/2359
+      if (!c->is_important()) return NULL;
+    }
     eval.is_in_comment = true;
     Comment_Ptr rv = SASS_MEMORY_NEW(Comment, c->pstate(), Cast<String>(c->text()->perform(&eval)), c->is_important());
     eval.is_in_comment = false;


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/2359