### PR TITLE
expose list-delim option for simplifying huge css changes

### DIFF
--- a/include/sass/context.h
+++ b/include/sass/context.h
@@ -79,6 +79,7 @@ ADDAPI bool ADDCALL sass_option_get_omit_source_map_url (struct Sass_Options* op
 ADDAPI bool ADDCALL sass_option_get_is_indented_syntax_src (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_indent (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_linefeed (struct Sass_Options* options);
+ADDAPI char ADDCALL sass_option_get_list_delim (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_input_path (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_output_path (struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_source_map_file (struct Sass_Options* options);
@@ -98,6 +99,7 @@ ADDAPI void ADDCALL sass_option_set_omit_source_map_url (struct Sass_Options* op
 ADDAPI void ADDCALL sass_option_set_is_indented_syntax_src (struct Sass_Options* options, bool is_indented_syntax_src);
 ADDAPI void ADDCALL sass_option_set_indent (struct Sass_Options* options, const char* indent);
 ADDAPI void ADDCALL sass_option_set_linefeed (struct Sass_Options* options, const char* linefeed);
+ADDAPI void ADDCALL sass_option_set_list_delim (struct Sass_Options* options, char list_delim);
 ADDAPI void ADDCALL sass_option_set_input_path (struct Sass_Options* options, const char* input_path);
 ADDAPI void ADDCALL sass_option_set_output_path (struct Sass_Options* options, const char* output_path);
 ADDAPI void ADDCALL sass_option_set_plugin_path (struct Sass_Options* options, const char* plugin_path);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -82,6 +82,7 @@ namespace Sass {
 
     indent                  (safe_str(c_options.indent, "  ")),
     linefeed                (safe_str(c_options.linefeed, "\n")),
+    list_delim              (c_options.list_delim),
 
     input_path              (make_canonical_path(safe_input(c_options.input_path))),
     output_path             (make_canonical_path(safe_output(c_options.output_path, input_path))),

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -82,6 +82,7 @@ namespace Sass {
 
     const std::string indent; // String to be used for indentation
     const std::string linefeed; // String to be used for line feeds
+    char list_delim; // Character used to delimit CSS lists
     const std::string input_path; // for relative paths in src-map
     const std::string output_path; // for relative paths to the output
     const std::string source_map_file; // path to source map file (enables feature)

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -186,7 +186,11 @@ namespace Sass {
   {
     // scheduled_space = 0;
     append_string(",");
-    append_optional_space();
+    if (opt.list_delim == ' ') {
+      append_optional_space();
+    } else if (opt.list_delim == '\n') {
+      append_optional_newline();
+    }
   }
 
   void Emitter::append_colon_separator()
@@ -207,6 +211,16 @@ namespace Sass {
       unsigned char lst = buffer().at(buffer().length() - 1);
       if (!isspace(lst) || scheduled_delimiter) {
         append_mandatory_space();
+      }
+    }
+  }
+
+  void Emitter::append_optional_newline()
+  {
+    if ((output_style() != COMPRESSED) && buffer().size()) {
+      unsigned char lst = buffer().at(buffer().length() - 1);
+      if (!isspace(lst) || scheduled_delimiter) {
+          scheduled_linefeed = 1;
       }
     }
   }

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -75,6 +75,7 @@ namespace Sass {
     public: // syntax sugar
       void append_indentation();
       void append_optional_space(void);
+      void append_optional_newline(void);
       void append_mandatory_space(void);
       void append_special_linefeed(void);
       void append_optional_linefeed(void);

--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -105,6 +105,8 @@ struct Sass_Output_Options : Sass_Inspect_Options {
   const char* indent;
   // String to be used to for line feeds
   const char* linefeed;
+  // String used to separate CSS lists
+  char list_delim;
 
   // Emit comments in the generated CSS indicating
   // the corresponding source line.
@@ -114,9 +116,10 @@ struct Sass_Output_Options : Sass_Inspect_Options {
   Sass_Output_Options(struct Sass_Inspect_Options opt,
                       const char* indent = "  ",
                       const char* linefeed = "\n",
+                      char list_delim = ' ',
                       bool source_comments = false)
   : Sass_Inspect_Options(opt),
-    indent(indent), linefeed(linefeed),
+    indent(indent), linefeed(linefeed), list_delim(list_delim),
     source_comments(source_comments)
   { }
 
@@ -125,9 +128,10 @@ struct Sass_Output_Options : Sass_Inspect_Options {
                       int precision = 5,
                       const char* indent = "  ",
                       const char* linefeed = "\n",
+                      char list_delim = ' ',
                       bool source_comments = false)
   : Sass_Inspect_Options(style, precision),
-    indent(indent), linefeed(linefeed),
+    indent(indent), linefeed(linefeed), list_delim(list_delim),
     source_comments(source_comments)
   { }
 

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -377,6 +377,7 @@ extern "C" {
     options->precision = 5;
     options->indent = "  ";
     options->linefeed = LFEED;
+    options->list_delim = ' ';
   }
 
   Sass_Options* ADDCALL sass_make_options (void)
@@ -702,6 +703,7 @@ extern "C" {
   IMPLEMENT_SASS_OPTION_ACCESSOR(Sass_Importer_List, c_headers);
   IMPLEMENT_SASS_OPTION_ACCESSOR(const char*, indent);
   IMPLEMENT_SASS_OPTION_ACCESSOR(const char*, linefeed);
+  IMPLEMENT_SASS_OPTION_ACCESSOR(char, list_delim);
   IMPLEMENT_SASS_OPTION_STRING_SETTER(const char*, plugin_path, 0);
   IMPLEMENT_SASS_OPTION_STRING_SETTER(const char*, include_path, 0);
   IMPLEMENT_SASS_OPTION_STRING_ACCESSOR(const char*, input_path, 0);


### PR DESCRIPTION
Please read the commit message for more information.

I'll be upfront that, although it builds, I haven't actually tested the code, as there's more to it than just a change in the backend library. In our case I believe we're going to need changes to `gulp-sass` as well.

Is this a change that you'd consider finishing off, provided the use-case?
Some example commits where this would be useful: https://github.com/cuckoosandbox/cuckoo/commit/cb7fda22c38e244e1e6bccc1ee2f9d4e8008c21c https://github.com/cuckoosandbox/cuckoo/commit/cc89f90443a3c3e6337bf8d4043f88456a3b0886 https://github.com/cuckoosandbox/cuckoo/commit/02b95ca2a70ec59a8ecbc2a61123ab85f5aedc4e.