### PR TITLE
Avoid segfault in parser edge case

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -523,7 +523,9 @@ namespace Sass {
                                 m->length());
     for (auto key : m->keys()) {
       Expression_Ptr ex_key = key->perform(this);
-      Expression_Ptr ex_val = m->at(key)->perform(this);
+      Expression_Ptr ex_val = m->at(key);
+      if (ex_val == NULL) continue;
+      ex_val = ex_val->perform(this);
       *mm << std::make_pair(ex_key, ex_val);
     }
 


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/2446
Spec https://github.com/sass/sass-spec/pull/1165

Error differst from ruby sass:
```
Error:  isn't a valid CSS value.
        on line 1 of POC
```

vs

```
Error: Invalid UTF-8 character "\xE5"
        on line 1 of POC
```