### PR TITLE
Use case-insensitive lookup to parse colors.

### DIFF
--- a/src/color_maps.cpp
+++ b/src/color_maps.cpp
@@ -607,16 +607,20 @@ namespace Sass {
 
   Color_Ptr_Const name_to_color(const char* key)
   {
-    auto p = names_to_colors.find(key);
-    if (p != names_to_colors.end()) {
-      return p->second;
-    }
-    return 0;
+    return name_to_color(std::string(key));
   }
 
   Color_Ptr_Const name_to_color(const std::string& key)
   {
-    return name_to_color(key.c_str());
+    // case insensitive lookup.  See #2462
+    std::string lower{key};
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+
+    auto p = names_to_colors.find(lower.c_str());
+    if (p != names_to_colors.end()) {
+      return p->second;
+    }
+    return 0;
   }
 
   const char* color_to_name(const int key)


### PR DESCRIPTION
Fixes #2462
Spec https://github.com/sass/sass-spec/pull/1161