### PR TITLE
Replace the GitHub with a managed heroku proxy

### DIFF
--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -114,7 +114,7 @@ then
   then
     echo "Travis rate limit on github exceeded"
     echo "Retrying via 'special purpose proxy'"
-    JSON=$(curl -L -sS http://libsass.ocbnet.ch/libsass-spec-pr.psgi/$TRAVIS_PULL_REQUEST)
+    JSON=$(curl -L -sS https://github-api-reverse-proxy.herokuapp.com/repos/sass/libsass/pulls/$TRAVIS_PULL_REQUEST)
   fi
 
   RE_SPEC_PR="sass\/sass-spec(#|\/pull\/)([0-9]+)"


### PR DESCRIPTION
We sometimes hit the GitHub API rate limit. To get around this we
have a hosted reverse proxy that has a baked in auth token. We
occasionally have issue with the proxy going down, and can only wait
for it to be bumped.

This PR uses a proxy deployed on heroku with a very restrictive auth
token. This should put an end to the proxy going down, and make it
possible for multiple people to manage the server if needed.