### PR TITLE
added '-p' param to mkdir to handle when directories already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CC       ?= gcc
 CXX      ?= g++
 RM       ?= rm -f
 CP       ?= cp -a
-MKDIR    ?= mkdir
+MKDIR    ?= mkdir -p
 RMDIR    ?= rmdir
 WINDRES  ?= windres
 # Solaris/Illumos flavors


### PR DESCRIPTION
When trying to build and install the library an error occurs when the install directory already exists, I change the Makefile to handle this with the "-p" param.