### PR TITLE
Heavily improve wrapped pseudo selector handling

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -665,6 +665,7 @@ namespace Sass {
     if (!subset_map.empty()) {
       // create crtp visitor object
       Extend extend(subset_map);
+      extend.setEval(expand.eval);
       // extend tree nodes
       extend(root);
     }

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -219,7 +219,7 @@ namespace Sass {
     }
     return get_local(key);
   }
-
+/*
   #ifdef DEBUG
   template <typename T>
   size_t Environment<T>::print(std::string prefix)
@@ -238,7 +238,7 @@ namespace Sass {
     return indent ;
   }
   #endif
-
+*/
   // compile implementation for AST_Node
   template class Environment<AST_Node_Obj>;
 

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1769,7 +1769,25 @@ namespace Sass {
     if (is_in_selector_schema) exp.selector_stack.push_back(0);
     Selector_List_Obj resolved = s->resolve_parent_refs(exp.selector_stack, implicit_parent);
     if (is_in_selector_schema) exp.selector_stack.pop_back();
+    for (size_t i = 0; i < resolved->length(); i++) {
+      Complex_Selector_Ptr is = resolved->at(i)->first();
+      while (is) {
+        if (is->head()) {
+          is->head()->perform(this);
+        }
+        is = is->tail();
+      }
+    }
     return resolved.detach();
+  }
+
+  Compound_Selector_Ptr Eval::operator()(Compound_Selector_Ptr s)
+  {
+    for (size_t i = 0; i < s->length(); i++) {
+      Simple_Selector_Ptr ss = s->at(i);
+      if (ss) ss->perform(this);
+    }
+    return s;
   }
 
   // XXX: this is never hit via spec tests
@@ -1826,5 +1844,40 @@ namespace Sass {
       return SASS_MEMORY_NEW(Null, p->pstate());
     }
   }
+
+  // hotfix to avoid invalid nested `:not` selectors
+  // probably the wrong place, but this should ultimately
+  // be fixed by implement superselector correctly for `:not`
+  // first use of "find" (ATM only implemented for selectors)
+  bool hasNotSelector(AST_Node_Obj obj) {
+    if (Wrapped_Selector_Ptr w = Cast<Wrapped_Selector>(obj)) {
+      return w->name() == ":not";
+    }
+    return false;
+  }
+
+  Wrapped_Selector_Ptr Eval::operator()(Wrapped_Selector_Ptr s)
+  {
+
+    if (s->name() == ":not") {
+      if (exp.selector_stack.back()) {
+        if (s->selector()->find(hasNotSelector)) {
+          s->selector()->clear();
+          s->name(" ");
+        } else if (s->selector()->length() == 1) {
+          Complex_Selector_Ptr cs = s->selector()->at(0);
+          if (cs->tail()) {
+            s->selector()->clear();
+            s->name(" ");
+          }
+        } else if (s->selector()->length() > 1) {
+          s->selector()->clear();
+          s->name(" ");
+        }
+      }
+    }
+
+    return s;
+  };
 
 }

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -75,11 +75,12 @@ namespace Sass {
     // these will return selectors
     Selector_List_Ptr operator()(Selector_List_Ptr);
     Selector_List_Ptr operator()(Complex_Selector_Ptr);
+    Compound_Selector_Ptr operator()(Compound_Selector_Ptr);
     Attribute_Selector_Ptr operator()(Attribute_Selector_Ptr);
     // they don't have any specific implementatio (yet)
     Element_Selector_Ptr operator()(Element_Selector_Ptr s) { return s; };
     Pseudo_Selector_Ptr operator()(Pseudo_Selector_Ptr s) { return s; };
-    Wrapped_Selector_Ptr operator()(Wrapped_Selector_Ptr s) { return s; };
+    Wrapped_Selector_Ptr operator()(Wrapped_Selector_Ptr s);
     Class_Selector_Ptr operator()(Class_Selector_Ptr s) { return s; };
     Id_Selector_Ptr operator()(Id_Selector_Ptr s) { return s; };
     Placeholder_Selector_Ptr operator()(Placeholder_Selector_Ptr s) { return s; };

--- a/src/extend.hpp
+++ b/src/extend.hpp
@@ -6,6 +6,7 @@
 
 #include "ast.hpp"
 #include "node.hpp"
+#include "eval.hpp"
 #include "operation.hpp"
 #include "subset_map.hpp"
 #include "ast_fwd_decl.hpp"
@@ -17,6 +18,7 @@ namespace Sass {
   class Extend : public Operation_CRTP<void, Extend> {
 
     Subset_Map& subset_map;
+    Eval* eval;
 
     void fallback_impl(AST_Node_Ptr n) { }
 
@@ -54,6 +56,7 @@ namespace Sass {
     Node weave(Node& path);
 
   public:
+    void setEval(Eval& eval);
     Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace, bool& extendedSomething, CompoundSelectorSet& seen);
     Selector_List_Ptr extendSelectorList(Selector_List_Obj pSelectorList, bool isReplace = false) {
       bool extendedSomething = false;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1770,8 +1770,8 @@ namespace Sass {
       if (ss) {
         name = Util::normalize_underscores(unquote(ss->value()));
         std::cerr << "DEPRECATION WARNING: ";
-        std::cerr << "Passing a string to call() is deprecated and will be illegal " << std::endl;
-        std::cerr << "in Sass 4.0. Use call(get-function(" + quote(name) + ")) instead. " << std::endl;
+        std::cerr << "Passing a string to call() is deprecated and will be illegal" << std::endl;
+        std::cerr << "in Sass 4.0. Use call(get-function(" + quote(name) + ")) instead." << std::endl;
         std::cerr << std::endl;
       } else if (ff) {
         name = ff->name();

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -969,20 +969,11 @@ namespace Sass {
     }
   }
 
-  // hotfix to avoid invalid nested `:not` selectors
-  // probably the wrong place, but this should ultimatively
-  // be fixed by implement superselector correctly for `:not`
-  // first use of "find" (ATM only implemented for selectors)
-  bool hasNotSelector(AST_Node_Obj obj) {
-    if (Wrapped_Selector_Ptr w = Cast<Wrapped_Selector>(obj)) {
-      return w->name() == ":not";
-    }
-    return false;
-  }
-
   void Inspect::operator()(Wrapped_Selector_Ptr s)
   {
-    if (!s->selector()->find(hasNotSelector)) {
+    if (s->name() == " ") {
+      append_string("");
+    } else {
       bool was = in_wrapped;
       in_wrapped = true;
       append_token(s->name(), s);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -191,13 +191,15 @@ namespace Sass {
 
       bool empty_parent_ref = pToConvert->head() && pToConvert->head()->is_empty_reference();
 
-      if (pToConvert->head() || empty_parent_ref) {
-      }
-
       // the first Complex_Selector may contain a dummy head pointer, skip it.
       if (pToConvert->head() && !empty_parent_ref) {
         node.collection()->push_back(Node::createSelector(*pToConvert));
         if (has_lf) node.collection()->back().got_line_feed = has_lf;
+        if (pToConvert->head() || empty_parent_ref) {
+          if (pToConvert->tail()) {
+            pToConvert->tail()->has_line_feed(pToConvert->has_line_feed());
+          }
+        }
         has_lf = false;
       }
 


### PR DESCRIPTION
Quite a hacky PR, but the logic once more escapes my imagination.
Lets see what CI thinks ... fixes https://github.com/sass/libsass/issues/2464 and fixes https://github.com/sass/libsass/issues/2383

Correctly compiles the following:
```scss
:host(:not(.baz1)) {
  left: 0;
}

:not(:not(.baz2)) {
  left: 0;
}

a {
  :not(:not(.baz3)) {
    left: 0;
  }
}

q {

    .thing {
      color: black;
    }
  
    .a,
    .b,
    .c,
    .d,
    .e {
      &:not(.thing) { @extend .thing; }
    }

  }
  
:host(.abc1) { x: y; }
.a {@extend .abc1}

:not(.abc2) { x: y; }
.a {@extend .abc2}

:not(.thing) {
  color: red;
}
:not(.bar) {
  @extend .thing;
  background: blue;
}

:not(.foo1):not(:not(.ext1)) {
  color: red; }

a {
  :not(.foo2):not(:not(.ext2)) {
  color: red; }
}
```

to
```css
:host(:not(.baz1)) {
  left: 0; }

:not(:not(.baz2)) {
  left: 0; }

a  {
  left: 0; }

q .thing, q .a:not(.thing),
q .b:not(.thing),
q .c:not(.thing),
q .d:not(.thing),
q .e:not(.thing), q :not(.bar) {
  color: black; }

:host(.abc1, .a) {
  x: y; }

:not(.abc2):not(.a) {
  x: y; }

:not(.thing) {
  color: red; }

:not(.bar) {
  background: blue; }

:not(.foo1):not(:not(.ext1)) {
  color: red; }

a :not(.foo2) {
  color: red; }
```