### PR TITLE
Fix memory leak by removing previously unused code

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1767,7 +1767,7 @@ namespace Sass {
       Complex_Selector_Ptr is = resolved->at(i)->first();
       while (is) {
         if (is->head()) {
-          is->head()->perform(this);
+          is->head(operator()(is->head()));
         }
         is = is->tail();
       }
@@ -1779,19 +1779,11 @@ namespace Sass {
   {
     for (size_t i = 0; i < s->length(); i++) {
       Simple_Selector_Ptr ss = s->at(i);
-      if (ss) ss->perform(this);
+      // skip parents here (called via resolve_parent_refs)
+      if (ss == NULL || Cast<Parent_Selector>(ss)) continue;
+      s->at(i) = Cast<Simple_Selector>(ss->perform(this));
     }
     return s;
-  }
-
-  // XXX: this is never hit via spec tests
-  Attribute_Selector_Ptr Eval::operator()(Attribute_Selector_Ptr s)
-  {
-    String_Obj attr = s->value();
-    if (attr) { attr = static_cast<String_Ptr>(attr->perform(this)); }
-    Attribute_Selector_Ptr ss = SASS_MEMORY_COPY(s);
-    ss->value(attr);
-    return ss;
   }
 
   Selector_List_Ptr Eval::operator()(Selector_Schema_Ptr s)
@@ -1841,6 +1833,11 @@ namespace Sass {
     }
   }
 
+  Simple_Selector_Ptr Eval::operator()(Simple_Selector_Ptr s)
+  {
+    return s;
+  }
+
   // hotfix to avoid invalid nested `:not` selectors
   // probably the wrong place, but this should ultimately
   // be fixed by implement superselector correctly for `:not`
@@ -1872,7 +1869,6 @@ namespace Sass {
         }
       }
     }
-
     return s;
   };
 

--- a/src/eval.hpp
+++ b/src/eval.hpp
@@ -76,14 +76,14 @@ namespace Sass {
     Selector_List_Ptr operator()(Selector_List_Ptr);
     Selector_List_Ptr operator()(Complex_Selector_Ptr);
     Compound_Selector_Ptr operator()(Compound_Selector_Ptr);
-    Attribute_Selector_Ptr operator()(Attribute_Selector_Ptr);
-    // they don't have any specific implementatio (yet)
-    Element_Selector_Ptr operator()(Element_Selector_Ptr s) { return s; };
-    Pseudo_Selector_Ptr operator()(Pseudo_Selector_Ptr s) { return s; };
+    Simple_Selector_Ptr operator()(Simple_Selector_Ptr s);
     Wrapped_Selector_Ptr operator()(Wrapped_Selector_Ptr s);
-    Class_Selector_Ptr operator()(Class_Selector_Ptr s) { return s; };
-    Id_Selector_Ptr operator()(Id_Selector_Ptr s) { return s; };
-    Placeholder_Selector_Ptr operator()(Placeholder_Selector_Ptr s) { return s; };
+    // they don't have any specific implementation (yet)
+    // Element_Selector_Ptr operator()(Element_Selector_Ptr s) { return s; };
+    // Pseudo_Selector_Ptr operator()(Pseudo_Selector_Ptr s) { return s; };
+    // Class_Selector_Ptr operator()(Class_Selector_Ptr s) { return s; };
+    // Id_Selector_Ptr operator()(Id_Selector_Ptr s) { return s; };
+    // Placeholder_Selector_Ptr operator()(Placeholder_Selector_Ptr s) { return s; };
     // actual evaluated selectors
     Selector_List_Ptr operator()(Selector_Schema_Ptr);
     Expression_Ptr operator()(Parent_Selector_Ptr);


### PR DESCRIPTION
Ensure to take over returned ast node.
Skip CRTP operator for parent selectors.