### PR TITLE
Emit warning for double parent selectors

### DIFF
--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -165,6 +165,17 @@ namespace Sass {
     std::cerr << "Warning: " << msg<< std::endl;
   }
 
+  void warning(std::string msg, ParserState pstate)
+  {
+    std::string cwd(Sass::File::get_cwd());
+    std::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
+    std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
+    std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
+
+    std::cerr << "WARNING on line " << pstate.line+1 << ", column " << pstate.column+1 << " of " << output_path << std::endl;
+    std::cerr << msg << std::endl << std::endl;
+  }
+
   void warn(std::string msg, ParserState pstate, Backtrace* bt)
   {
     Backtrace top(bt, pstate, "");

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -200,6 +200,7 @@ namespace Sass {
 
   void warn(std::string msg, ParserState pstate);
   void warn(std::string msg, ParserState pstate, Backtrace* bt);
+  void warning(std::string msg, ParserState pstate);
 
   void deprecated_function(std::string msg, ParserState pstate);
   void deprecated(std::string msg, std::string msg2, bool with_column, ParserState pstate);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1611,6 +1611,9 @@ namespace Sass {
     lex< css_comments >(false);
     if (lex< ampersand >())
     {
+      if (match< ampersand >()) {
+        warning("In Sass, \"&&\" means two copies of the parent selector. You probably want to use \"and\" instead.", pstate);
+      }
       return SASS_MEMORY_NEW(Parent_Selector, pstate); }
 
     if (lex< kwd_important >())

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -108,7 +108,7 @@ namespace Sass {
 
     }
 
-    // peek will only skip over space, tabs and line comment
+    // match will not skip over space, tabs and line comment
     // return the position where the lexer match will occur
     template <Prelexer::prelexer mx>
     const char* match(const char* start = 0)


### PR DESCRIPTION
Addresses https://github.com/sass/libsass/issues/2522

Seems this needs to introduce yet another type of warning ...