### PR TITLE
Add support for custom property syntax

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -2394,6 +2394,13 @@ namespace Sass {
     return quote(value_, '*');
   }
 
+  bool Declaration::is_invisible() const
+  {
+    if (is_custom_property()) return false;
+
+    return !(value_ && value_->concrete_type() != Expression::NULL_VAL);
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////
   // Additional method on Lists to retrieve values directly or from an encompassed Argument.
   //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -660,19 +660,22 @@ namespace Sass {
     ADD_PROPERTY(String_Obj, property)
     ADD_PROPERTY(Expression_Obj, value)
     ADD_PROPERTY(bool, is_important)
+    ADD_PROPERTY(bool, is_custom_property)
     ADD_PROPERTY(bool, is_indented)
   public:
     Declaration(ParserState pstate,
-                String_Obj prop, Expression_Obj val, bool i = false, Block_Obj b = 0)
-    : Has_Block(pstate, b), property_(prop), value_(val), is_important_(i), is_indented_(false)
+                String_Obj prop, Expression_Obj val, bool i = false, bool c = false, Block_Obj b = 0)
+    : Has_Block(pstate, b), property_(prop), value_(val), is_important_(i), is_custom_property_(c), is_indented_(false)
     { statement_type(DECLARATION); }
     Declaration(const Declaration* ptr)
     : Has_Block(ptr),
       property_(ptr->property_),
       value_(ptr->value_),
       is_important_(ptr->is_important_),
+      is_custom_property_(ptr->is_custom_property_),
       is_indented_(ptr->is_indented_)
     { statement_type(DECLARATION); }
+    virtual bool is_invisible() const;
     ATTACH_AST_OPERATIONS(Declaration)
     ATTACH_OPERATIONS()
   };

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -80,6 +80,7 @@ namespace Sass {
     extern const char keyframes_kwd[]    = "keyframes";
     extern const char only_kwd[]         = "only";
     extern const char rgb_fn_kwd[]       = "rgb(";
+    extern const char url_fn_kwd[]       = "url(";
     extern const char url_kwd[]          = "url";
     // extern const char url_prefix_fn_kwd[] = "url-prefix(";
     extern const char important_kwd[]    = "important";

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -80,6 +80,7 @@ namespace Sass {
     extern const char keyframes_kwd[];
     extern const char only_kwd[];
     extern const char rgb_fn_kwd[];
+    extern const char url_fn_kwd[];
     extern const char url_kwd[];
     // extern const char url_prefix_fn_kwd[];
     extern const char important_kwd[];

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -54,7 +54,8 @@ namespace Sass {
                                       d->pstate(),
                                       property,
                                       d->value(),
-                                      d->is_important());
+                                      d->is_important(),
+                                      d->is_custom_property());
     dd->is_indented(d->is_indented());
     dd->tabs(d->tabs());
 

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -415,6 +415,7 @@ inline void debug_ast(AST_Node_Ptr node, std::string ind, Env* env)
     Declaration_Ptr block = Cast<Declaration>(node);
     std::cerr << ind << "Declaration " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
+    std::cerr << " [is_custom_property: " << block->is_custom_property() << "] ";
     std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->property(), ind + " prop: ", env);
     debug_ast(block->value(), ind + " value: ", env);

--- a/src/emitter.cpp
+++ b/src/emitter.cpp
@@ -15,6 +15,7 @@ namespace Sass {
     scheduled_linefeed(0),
     scheduled_delimiter(false),
     scheduled_mapping(0),
+    in_custom_property(false),
     in_comment(false),
     in_wrapped(false),
     in_media_block(false),
@@ -209,7 +210,7 @@ namespace Sass {
   {
     scheduled_space = 0;
     append_string(":");
-    append_optional_space();
+    if (!in_custom_property) append_optional_space();
   }
 
   void Emitter::append_mandatory_space()

--- a/src/emitter.hpp
+++ b/src/emitter.hpp
@@ -40,6 +40,8 @@ namespace Sass {
       AST_Node_Ptr scheduled_mapping;
 
     public:
+      // output strings different in custom css properties
+      bool in_custom_property;
       // output strings different in comments
       bool in_comment;
       // selector list does not get linefeeds

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -265,6 +265,7 @@ namespace Sass {
                                         new_p,
                                         value,
                                         d->is_important(),
+                                        d->is_custom_property(),
                                         bb);
     decl->tabs(d->tabs());
     return decl;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -222,7 +222,8 @@ namespace Sass {
       "global-variable-shadowing",
       "extend-selector-pseudoclass",
       "at-error",
-      "units-level-3"
+      "units-level-3",
+      "custom-property"
     };
 
     ////////////////

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -123,6 +123,8 @@ namespace Sass {
     if (dec->value()->concrete_type() == Expression::NULL_VAL) return;
     bool was_decl = in_declaration;
     in_declaration = true;
+    LOCAL_FLAG(in_custom_property, dec->is_custom_property());
+
     if (output_style() == NESTED)
       indentation += dec->tabs();
     append_indentation();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -324,7 +324,7 @@ namespace Sass {
     if (s->can_compress_whitespace() && output_style() == COMPRESSED) {
       value.erase(std::remove_if(value.begin(), value.end(), ::isspace), value.end());
     }
-    if (!in_comment) {
+    if (!in_comment && !in_custom_property) {
       append_token(string_to_output(value), s);
     } else {
       append_token(value, s);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -25,6 +25,7 @@ struct Lookahead {
   const char* position;
   bool parsable;
   bool has_interpolants;
+  bool is_custom_property;
 };
 
 namespace Sass {
@@ -285,6 +286,8 @@ namespace Sass {
     String_Obj parse_interpolated_chunk(Token, bool constant = false);
     String_Obj parse_string();
     String_Constant_Obj parse_static_value();
+    String_Schema_Obj parse_css_variable_value(bool top_level = true);
+    String_Schema_Obj parse_css_variable_value_token(bool top_level = true);
     String_Obj parse_ie_property();
     String_Obj parse_ie_keyword_arg();
     String_Schema_Obj parse_value_schema(const char* stop);

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1461,6 +1461,16 @@ namespace Sass {
     //   >(src);
     // }
 
+    const char* real_uri(const char* src) {
+      return sequence<
+        exactly< url_kwd >,
+        exactly< '(' >,
+        W,
+        real_uri_value,
+        exactly< ')' >
+      >(src);
+    }
+
     const char* real_uri_suffix(const char* src) {
       return sequence< W, exactly< ')' > >(src);
     }
@@ -1511,6 +1521,7 @@ namespace Sass {
                            static_string,
                            percentage,
                            hex,
+                           hexa,
                            exactly<'|'>,
                            // exactly<'+'>,
                            sequence < number, unit_identifier >,
@@ -1576,6 +1587,40 @@ namespace Sass {
                        zero_plus < spaces >,
                        alternatives< exactly<';'>, exactly<'}'> >
                       >(src);
+    }
+
+    extern const char css_variable_url_negates[] = "()[]{}\"'#/";
+    const char* css_variable_value(const char* src) {
+      return sequence<
+        alternatives<
+          sequence<
+            negate< exactly< url_fn_kwd > >,
+            one_plus< neg_class_char< css_variable_url_negates > >
+          >,
+          sequence< exactly<'#'>, negate< exactly<'{'> > >,
+          sequence< exactly<'/'>, negate< exactly<'*'> > >,
+          static_string,
+          real_uri,
+          block_comment
+        >
+      >(src);
+    }
+
+    extern const char css_variable_url_top_level_negates[] = "()[]{}\"'#/;!";
+    const char* css_variable_top_level_value(const char* src) {
+      return sequence<
+        alternatives<
+          sequence<
+            negate< exactly< url_fn_kwd > >,
+            one_plus< neg_class_char< css_variable_url_top_level_negates > >
+          >,
+          sequence< exactly<'#'>, negate< exactly<'{'> > >,
+          sequence< exactly<'/'>, negate< exactly<'*'> > >,
+          static_string,
+          real_uri,
+          block_comment
+        >
+      >(src);
     }
 
     const char* parenthese_scope(const char* src) {

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -365,6 +365,7 @@ namespace Sass {
     const char* UUNICODE(const char* src);
     const char* NONASCII(const char* src);
     const char* ESCAPE(const char* src);
+    const char* real_uri(const char* src);
     const char* real_uri_suffix(const char* src);
     // const char* real_uri_prefix(const char* src);
     const char* real_uri_value(const char* src);
@@ -378,6 +379,9 @@ namespace Sass {
     const char* static_component(const char* src);
     const char* static_property(const char* src);
     const char* static_value(const char* src);
+
+    const char* css_variable_value(const char* src);
+    const char* css_variable_top_level_value(const char* src);
 
     // Utility functions for finding and counting characters in a string.
     template<char c>


### PR DESCRIPTION
I've been working on this on-and-off for the last couple months. 
It's mostly a 1-1 port of the Ruby Sass implementation.

The only thing of interest is that the whitespace after the `:`
need to be captured as written for custom properties.

This PR does not handle some less significant features
- [re-indentation][1]
- [sass syntax][2] (will open a bug downstream in sass2scss)

[1]: https://github.com/sass/sass-spec/tree/master/spec/css/custom_properties/indentation
[2]: https://github.com/sass/sass-spec/tree/master/spec/css/custom_properties/error/no_nesting

Spec sass/sass-spec#1199
Fixes #2076

