### PR TITLE
Tweak warning message format

### DIFF
--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -172,7 +172,7 @@ namespace Sass {
     std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
     std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
 
-    std::cerr << "WARNING on line " << pstate.line+1 << ", column " << pstate.column+1 << " of " << output_path << std::endl;
+    std::cerr << "WARNING on line " << pstate.line+1 << ", column " << pstate.column+1 << " of " << output_path << ":" << std::endl;
     std::cerr << msg << std::endl << std::endl;
   }
 


### PR DESCRIPTION
Added a missing trailing `:` to match specs.

Spec https://github.com/sass/sass-spec/pull/1200