### PR TITLE
Adding the missing scope identifier `std::`

### DIFF
--- a/src/utf8_string.cpp
+++ b/src/utf8_string.cpp
@@ -28,7 +28,7 @@ namespace Sass {
     size_t offset_at_position(const string& str, size_t position) {
       string::const_iterator it = str.begin();
       utf8::advance(it, position, str.end());
-      return distance(str.begin(), it);
+      return utf8::distance(str.begin(), it);
     }
 
     // function that returns number of bytes in a character at offset

--- a/src/utf8_string.cpp
+++ b/src/utf8_string.cpp
@@ -28,7 +28,7 @@ namespace Sass {
     size_t offset_at_position(const string& str, size_t position) {
       string::const_iterator it = str.begin();
       utf8::advance(it, position, str.end());
-      return utf8::distance(str.begin(), it);
+      return std::distance(str.begin(), it);
     }
 
     // function that returns number of bytes in a character at offset


### PR DESCRIPTION
This missing identifier is causing compilation error under certain compiler/config combination.