### PR TITLE
Fix preserving quoted strings on C-API

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1889,7 +1889,7 @@ namespace Sass {
       if (skip_unquoting == false) {
         value_ = unquote(value_, &quote_mark_, keep_utf8_escapes, strict_unquoting);
       }
-      if (q && quote_mark_) quote_mark_ = q;
+      if (q /* && quote_mark_ */) quote_mark_ = q;
     }
     String_Quoted(const String_Quoted* ptr)
     : String_Constant(ptr)

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1695,7 +1695,7 @@ namespace Sass {
       } break;
       case SASS_STRING: {
         if (sass_string_is_quoted(v))
-          e = SASS_MEMORY_NEW(String_Quoted, pstate, sass_string_get_value(v));
+          e = SASS_MEMORY_NEW(String_Quoted, pstate, sass_string_get_value(v), '*');
         else {
           e = SASS_MEMORY_NEW(String_Constant, pstate, sass_string_get_value(v));
         }

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -88,7 +88,8 @@ namespace Sass {
         if (sass_string_is_quoted(val)) {
           return SASS_MEMORY_NEW(String_Quoted,
                                  ParserState("[C-VALUE]"),
-                                 sass_string_get_value(val));
+                                 sass_string_get_value(val),
+                                 '*');
         }
         return SASS_MEMORY_NEW(String_Constant,
                                  ParserState("[C-VALUE]"),


### PR DESCRIPTION
Related to https://github.com/sass/node-sass/issues/2228, since I did not understand how static parsing of strings, string constants and quoted strings do work before.