### PR TITLE
Add special check nesting handling for @else

### DIFF
--- a/src/check_nesting.cpp
+++ b/src/check_nesting.cpp
@@ -103,6 +103,19 @@ namespace Sass {
     return n;
   }
 
+  Statement_Ptr CheckNesting::operator()(If_Ptr i)
+  {
+    this->visit_children(i);
+
+    if (Block_Ptr b = Cast<Block>(i->alternative())) {
+      for (auto n : i->alternative()->elements()) {
+        n->perform(this);
+      }
+    }
+
+    return i;
+  }
+
   Statement_Ptr CheckNesting::fallback_impl(Statement_Ptr s)
   {
     Block_Ptr b1 = Cast<Block>(s);

--- a/src/check_nesting.hpp
+++ b/src/check_nesting.hpp
@@ -22,6 +22,7 @@ namespace Sass {
 
     Statement_Ptr operator()(Block_Ptr);
     Statement_Ptr operator()(Definition_Ptr);
+    Statement_Ptr operator()(If_Ptr);
 
     template <typename U>
     Statement_Ptr fallback(U x) {


### PR DESCRIPTION
We treat `@else` as a block which breaks the check nesting algorithm
ported over from Ruby Sass. With change the intermediate `Block`
to container `@else` children is invisible. This better emulates the
the Ruby Sass algorithm.

Fixes #2569
Spec https://github.com/sass/sass-spec/pull/1218