### PR TITLE
Fix parsing of @supports declarations

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2448,12 +2448,16 @@ namespace Sass {
   {
     Supports_Condition_Ptr cond;
     // parse something declaration like
-    Declaration_Obj declaration = parse_declaration();
-    if (!declaration) error("@supports condition expected declaration", pstate);
+    Expression_Obj feature = parse_expression();
+    Expression_Obj expression = 0;
+    if (lex_css< exactly<':'> >()) {
+      expression = parse_list(DELAYED);
+    }
+    if (!feature || !expression) error("@supports condition expected declaration", pstate);
     cond = SASS_MEMORY_NEW(Supports_Declaration,
-                     declaration->pstate(),
-                     declaration->property(),
-                     declaration->value());
+                     feature->pstate(),
+                     feature,
+                     expression);
     // ToDo: maybe we need an additional error condition?
     return cond;
   }


### PR DESCRIPTION
Emulate the parse behaviour of `@media` query declarations.

Fixes #2452
Spec https://github.com/sass/sass-spec/pull/1219