### PR TITLE
Add sass.cr to implementations list

### DIFF
--- a/docs/implementations.md
+++ b/docs/implementations.md
@@ -3,6 +3,9 @@ There are several implementations of `libsass` for a variety of languages. Here 
 ### C
 * [sassc](https://github.com/hcatlin/sassc)
 
+### Crystal
+* [sass.cr](https://github.com/straight-shoota/sass.cr)
+
 ### Elixir
 * [sass.ex](https://github.com/scottdavis/sass.ex)
 


### PR DESCRIPTION
This adds the [Crystal](https://crystal-lang.org) bindings `sass.cr` to the list of implementations.