### PR TITLE
Implement proper nth pseudo selector parsing

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -85,11 +85,17 @@ namespace Sass {
     // extern const char url_prefix_fn_kwd[] = "url-prefix(";
     extern const char important_kwd[]    = "important";
     extern const char pseudo_not_fn_kwd[] = ":not(";
-    extern const char even_kwd[]         = "even";
-    extern const char odd_kwd[]          = "odd";
     extern const char progid_kwd[]       = "progid";
     extern const char expression_kwd[]   = "expression";
     extern const char calc_fn_kwd[]      = "calc";
+
+    extern const char odd_kwd[]          = "odd";
+    extern const char even_kwd[]         = "even";
+    // some specific pseudo selectors
+    extern const char nth_child_kwd[]    = "nth-child";
+    extern const char nth_of_child_kwd[] = "nth-of-child";
+    extern const char nth_last_child_kwd[]    = "nth-last-child";
+    extern const char nth_last_of_child_kwd[] = "nth-last-of-child";
 
     extern const char almost_any_value_class[] = "\"'#!;{}";
 

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -93,8 +93,10 @@ namespace Sass {
     extern const char even_kwd[]         = "even";
     // some specific pseudo selectors
     extern const char nth_child_kwd[]    = "nth-child";
+    extern const char nth_of_type_kwd[]  = "nth-of-type";
     extern const char nth_of_child_kwd[] = "nth-of-child";
     extern const char nth_last_child_kwd[]    = "nth-last-child";
+    extern const char nth_last_of_type_kwd[]  = "nth-last-of-type";
     extern const char nth_last_of_child_kwd[] = "nth-last-of-child";
 
     extern const char almost_any_value_class[] = "\"'#!;{}";

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -93,8 +93,10 @@ namespace Sass {
     extern const char even_kwd[];
     // some specific pseudo selectors
     extern const char nth_child_kwd[];
+    extern const char nth_of_type_kwd[];
     extern const char nth_of_child_kwd[];
     extern const char nth_last_child_kwd[];
+    extern const char nth_last_of_type_kwd[];
     extern const char nth_last_of_child_kwd[];
 
     // char classes for "regular expressions"

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -85,11 +85,17 @@ namespace Sass {
     // extern const char url_prefix_fn_kwd[];
     extern const char important_kwd[];
     extern const char pseudo_not_fn_kwd[];
-    extern const char even_kwd[];
-    extern const char odd_kwd[];
     extern const char progid_kwd[];
     extern const char expression_kwd[];
     extern const char calc_fn_kwd[];
+
+    extern const char odd_kwd[];
+    extern const char even_kwd[];
+    // some specific pseudo selectors
+    extern const char nth_child_kwd[];
+    extern const char nth_of_child_kwd[];
+    extern const char nth_last_child_kwd[];
+    extern const char nth_last_of_child_kwd[];
 
     // char classes for "regular expressions"
     extern const char almost_any_value_class[];

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -263,6 +263,8 @@ namespace Sass {
     Simple_Selector_Obj parse_simple_selector();
     Wrapped_Selector_Obj parse_negated_selector();
     Simple_Selector_Obj parse_pseudo_selector();
+    Simple_Selector_Obj parse_nth_selector();
+    
     Attribute_Selector_Obj parse_attribute_selector();
     Block_Obj parse_block(bool is_root = false);
     Block_Obj parse_css_block(bool is_root = false);

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -876,12 +876,20 @@ namespace Sass {
       return word<nth_child_kwd>(src);
     }
 
+    const char* kwd_nth_of_type(const char* src) {
+      return word<nth_of_type_kwd>(src);
+    }
+
     const char* kwd_nth_of_child(const char* src) {
       return word<nth_of_child_kwd>(src);
     }
 
     const char* kwd_nth_last_child(const char* src) {
       return word<nth_last_child_kwd>(src);
+    }
+
+    const char* kwd_nth_last_of_type(const char* src) {
+      return word<nth_last_of_type_kwd>(src);
     }
 
     const char* kwd_nth_last_of_child(const char* src) {
@@ -1199,8 +1207,10 @@ namespace Sass {
         exactly <':'>,
         alternatives <
           kwd_nth_child,
+          kwd_nth_of_type,
           kwd_nth_of_child,
           kwd_nth_last_child,
+          kwd_nth_last_of_type,
           kwd_nth_last_of_child
         >
       >(src);

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -261,6 +261,7 @@ namespace Sass {
     const char* kwd_each_directive(const char* src);
     const char* kwd_in(const char* src);
 
+    const char* kwd_nth_child(const char* src);
     const char* kwd_while_directive(const char* src);
 
     const char* re_nothing(const char* src);
@@ -299,6 +300,7 @@ namespace Sass {
     // Match CSS numeric constants.
     const char* op(const char* src);
     const char* sign(const char* src);
+    const char* signint(const char* src);
     const char* unsigned_number(const char* src);
     const char* number(const char* src);
     const char* coefficient(const char* src);
@@ -326,6 +328,11 @@ namespace Sass {
     const char* re_pseudo_selector(const char* src);
     const char* functional_schema(const char* src);
     const char* pseudo_not(const char* src);
+
+    // nth pseudo names (without opening brace)
+    const char* re_nth_pseudo(const char* src);
+    const char* re_nth_argument(const char* src);
+
     // Match CSS 'odd' and 'even' keywords for functional pseudo-classes.
     const char* even(const char* src);
     const char* odd(const char* src);


### PR DESCRIPTION
Still not compressed yet but error on invalid syntax.
Fixes https://github.com/sass/libsass/issues/2175 - Syntax verified with the following tests:

```scss
:nth-child { foo: bar; }
:nth-child(n) { foo: bar; }
:nth-child(+2) { foo: bar; }
:nth-child(-2) { foo: bar; }
:nth-child(odd) { foo: bar; }
:nth-child(even) { foo: bar; }
:nth-child(-n+3) { foo: bar; }
:nth-child(42n+42) { foo: bar; }

:nth-of-child { foo: bar; }
:nth-of-child(n) { foo: bar; }
:nth-of-child(+2) { foo: bar; }
:nth-of-child(-2) { foo: bar; }
:nth-of-child(odd) { foo: bar; }
:nth-of-child(even) { foo: bar; }
:nth-of-child(-n+3) { foo: bar; }
:nth-of-child(42n+42) { foo: bar; }

:nth-last-child { foo: bar; }
:nth-last-child(n) { foo: bar; }
:nth-last-child(+2) { foo: bar; }
:nth-last-child(-2) { foo: bar; }
:nth-last-child(odd) { foo: bar; }
:nth-last-child(even) { foo: bar; }
:nth-last-child(-n+3) { foo: bar; }
:nth-last-child(42n+42) { foo: bar; }

:nth-last-of-child { foo: bar; }
:nth-last-of-child(n) { foo: bar; }
:nth-last-of-child(-2) { foo: bar; }
:nth-last-of-child(+2) { foo: bar; }
:nth-last-of-child(odd) { foo: bar; }
:nth-last-of-child(even) { foo: bar; }
:nth-last-of-child(-n+3) { foo: bar; }
:nth-last-of-child(42n+42) { foo: bar; }
```

Also did a few more esoteric tests related to comments (they are also retained as is).