### PR TITLE
Add a deprecation warning for @import's that resolved .css files

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -373,6 +373,14 @@ namespace Sass {
     // process the resolved entry
     else if (resolved.size() == 1) {
       bool use_cache = c_importers.size() == 0;
+      if (resolved[0].deprecated) {
+        // emit deprecation warning when import resolves to a .css file
+        deprecated(
+          "Including .css files with @import is non-standard behaviour which will be removed in future versions of LibSass.",
+          "Use a custom importer to maintain this behaviour. Check your implementations documentation on how to create a custom importer.",
+          true, pstate
+        );
+      }
       // use cache for the resource loading
       if (use_cache && sheets.count(resolved[0].abs_path)) return resolved[0];
       // try to read the content of the resolved file entry

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -357,13 +357,13 @@ namespace Sass {
       for(auto ext : d_exts) {
         rel_path = join_paths(base, "_" + name + ext);
         abs_path = join_paths(root, rel_path);
-        if (file_exists(abs_path)) includes.push_back({{ rel_path, root }, abs_path });
+        if (file_exists(abs_path)) includes.push_back({{ rel_path, root }, abs_path, true });
       }
       // next test plain name with d_exts
       for(auto ext : d_exts) {
         rel_path = join_paths(base, name + ext);
         abs_path = join_paths(root, rel_path);
-        if (file_exists(abs_path)) includes.push_back({{ rel_path, root }, abs_path });
+        if (file_exists(abs_path)) includes.push_back({{ rel_path, root }, abs_path, true });
       }
       // index files
       if (includes.size() == 0) {

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -89,9 +89,14 @@ namespace Sass {
     public:
       // resolved absolute path
       std::string abs_path;
+      // is a deprecated file type
+      bool deprecated;
     public:
+      Include(const Importer& imp, std::string abs_path, bool deprecated)
+      : Importer(imp), abs_path(abs_path), deprecated(deprecated)
+      { }
       Include(const Importer& imp, std::string abs_path)
-      : Importer(imp), abs_path(abs_path)
+      : Importer(imp), abs_path(abs_path), deprecated(false)
       { }
   };
 


### PR DESCRIPTION
See #2611

This is the first to removing native CSS imports.

Like Ruby Sass, Dart Sass will not implement this behaviour. This is
blocking compatibility between Node Sass and Dart Sass.

This is a non-standard behaviour which is constant source of confusion.

We had originally planned to removed this behaviour when the module
system was ready. However that has feature has been delayed and
people are continuing to be tripped up by this behaviour.

```
DEPRECATION WARNING on line 1, column 8 of /libsass/test.scss:
Including .css files with @import is non-standard behaviour which will be removed in future versions of LibSass.
Use a custom importer to maintain this behaviour. Check your implementations documentation on how to create a custom importer.
```