### PR TITLE
Remove duplicate definition of out_of_memory macro

### DIFF
--- a/src/sass.cpp
+++ b/src/sass.cpp
@@ -34,8 +34,10 @@ extern "C" {
   void* ADDCALL sass_alloc_memory(size_t size)
   {
     void* ptr = malloc(size);
-    if (ptr == NULL)
-      out_of_memory();
+    if (ptr == NULL) {
+      std::cerr << "Out of memory.\n";
+      exit(EXIT_FAILURE);
+    }
     return ptr;
   }
 

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -12,11 +12,6 @@
 
 namespace Sass {
 
-  #define out_of_memory() do {            \
-      std::cerr << "Out of memory.\n";    \
-      exit(EXIT_FAILURE);                 \
-    } while (0)
-
   double round(double val, size_t precision = 0);
   double sass_strtod(const char* str);
   const char* safe_str(const char *, const char* = "");


### PR DESCRIPTION
When combining the project into a single file (as go-libsass does), gcc complains that `out_of_memory` is redefined.

Ref: https://github.com/wellington/go-libsass/issues/57