### PR TITLE
Emit transparent colors as rgba(0, 0, 0, 0)

### DIFF
--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -671,9 +671,6 @@ namespace Sass {
     if (name != "") {
       ss << name;
     }
-    else if (r == 0 && g == 0 && b == 0 && a == 0) {
-      ss << "transparent";
-    }
     else if (a >= 1) {
       if (res_name != "") {
         if (compressed && hexlet.str().size() < res_name.size()) {


### PR DESCRIPTION
This change breaks browser compat for IE < 10 so it is scheduled
for 3.6. It will not be back ported to the 3.5 line.

See sass/sass#1782
Fixes #2298
Spec https://github.com/sass/sass-spec/pull/1242