### PR TITLE
Include <stdexcept> in operation.hpp

### DIFF
--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -4,6 +4,8 @@
 // base classes to implement curiously recurring template pattern (CRTP)
 // https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
 
+#include <stdexcept>
+
 #include "ast_fwd_decl.hpp"
 #include "ast_def_macros.hpp"
 


### PR DESCRIPTION
Because we are throwing `std::runtime_error` on line 192 (since aa7386f2fc5f9c3681fbe861220c40b5a7a910b5) , we need to include `<stdexcept>`.
This was causing building to fail with `runtime_error is not a member of std` (gcc version 4.6.3).