### PR TITLE
Remove legacy workaround for parsing modulo operator

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1723,10 +1723,6 @@ namespace Sass {
     if (lex< variable >())
     { return SASS_MEMORY_NEW(Variable, pstate, Util::normalize_underscores(lexed)); }
 
-    // Special case handling for `%` proceeding an interpolant.
-    if (lex< sequence< exactly<'%'>, optional< percentage > > >())
-    { return SASS_MEMORY_NEW(String_Constant, pstate, lexed); }
-
     css_error("Invalid CSS", " after ", ": expected expression (e.g. 1px, bold), was ");
 
     // unreachable statement


### PR DESCRIPTION
Fixes #2659