### PR TITLE
Undeprecate CSS imports

### DIFF
--- a/include/sass/context.h
+++ b/include/sass/context.h
@@ -149,9 +149,6 @@ ADDAPI size_t ADDCALL sass_compiler_get_callee_stack_size(struct Sass_Compiler* 
 ADDAPI Sass_Callee_Entry ADDCALL sass_compiler_get_last_callee(struct Sass_Compiler* compiler);
 ADDAPI Sass_Callee_Entry ADDCALL sass_compiler_get_callee_entry(struct Sass_Compiler* compiler, size_t idx);
 
-// Push function for import extenions
-ADDAPI void ADDCALL sass_option_push_import_extension (struct Sass_Options* options, const char* ext);
-
 // Push function for paths (no manipulation support for now)
 ADDAPI void ADDCALL sass_option_push_plugin_path (struct Sass_Options* options, const char* path);
 ADDAPI void ADDCALL sass_option_push_include_path (struct Sass_Options* options, const char* path);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -104,8 +104,6 @@ namespace Sass {
     // include_paths.push_back(CWD);
 
     // collect more paths from different options
-    collect_extensions(c_options.extension);
-    collect_extensions(c_options.extensions);
     collect_include_paths(c_options.include_path);
     collect_include_paths(c_options.include_paths);
     collect_plugin_paths(c_options.plugin_path);
@@ -174,37 +172,6 @@ namespace Sass {
 
   File_Context::~File_Context()
   {
-  }
-
-  void Context::collect_extensions(const char* exts_str)
-  {
-    if (exts_str) {
-      const char* beg = exts_str;
-      const char* end = Prelexer::find_first<PATH_SEP>(beg);
-
-      while (end) {
-        std::string ext(beg, end - beg);
-        if (!ext.empty()) {
-          extensions.push_back(ext);
-        }
-        beg = end + 1;
-        end = Prelexer::find_first<PATH_SEP>(beg);
-      }
-
-      std::string ext(beg);
-      if (!ext.empty()) {
-        extensions.push_back(ext);
-      }
-    }
-  }
-
-  void Context::collect_extensions(string_list* paths_array)
-  {
-    while (paths_array)
-    {
-      collect_extensions(paths_array->string);
-      paths_array = paths_array->next;
-    }
   }
 
   void Context::collect_include_paths(const char* paths_str)
@@ -277,20 +244,15 @@ namespace Sass {
   // looks for alternatives and returns a list from one directory
   std::vector<Include> Context::find_includes(const Importer& import)
   {
-    // include configured extensions
-    std::vector<std::string> exts(File::defaultExtensions);
-    if (extensions.size() > 0) {
-      exts.insert(exts.end(), extensions.begin(), extensions.end());
-    }
     // make sure we resolve against an absolute path
     std::string base_path(rel2abs(import.base_path));
     // first try to resolve the load path relative to the base path
-    std::vector<Include> vec(resolve_includes(base_path, import.imp_path, exts));
+    std::vector<Include> vec(resolve_includes(base_path, import.imp_path));
     // then search in every include path (but only if nothing found yet)
     for (size_t i = 0, S = include_paths.size(); vec.size() == 0 && i < S; ++i)
     {
       // call resolve_includes and individual base path and append all results
-      std::vector<Include> resolved(resolve_includes(include_paths[i], import.imp_path, exts));
+      std::vector<Include> resolved(resolve_includes(include_paths[i], import.imp_path));
       if (resolved.size()) vec.insert(vec.end(), resolved.begin(), resolved.end());
     }
     // return vector

--- a/src/context.hpp
+++ b/src/context.hpp
@@ -67,7 +67,6 @@ namespace Sass {
 
     std::vector<std::string> plugin_paths; // relative paths to load plugins
     std::vector<std::string> include_paths; // lookup paths for includes
-    std::vector<std::string> extensions; // lookup extensions for imports`
 
 
 
@@ -110,8 +109,6 @@ namespace Sass {
     void collect_plugin_paths(string_list* paths_array);
     void collect_include_paths(const char* paths_str);
     void collect_include_paths(string_list* paths_array);
-    void collect_extensions(const char* extensions_str);
-    void collect_extensions(string_list* extensions_array);
     std::string format_embedded_source_map();
     std::string format_source_mapping_url(const std::string& out_path);
 

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -121,7 +121,7 @@ namespace Sass {
 
   namespace File {
 
-    static std::vector<std::string> defaultExtensions = { ".scss", ".sass" };
+    static std::vector<std::string> defaultExtensions = { ".scss", ".sass", ".css" };
 
     std::vector<Include> resolve_includes(const std::string& root, const std::string& file,
       const std::vector<std::string>& exts = defaultExtensions);

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -74,14 +74,14 @@ namespace Sass {
         // move line_beg pointer to line start
         while (line_beg && *line_beg && lines != 0) {
           if (*line_beg == '\n') --lines;
-          utf8::unchecked::next(line_beg);
+          utf8::unchecked::next(line_beg); 
         }
         const char* line_end = line_beg;
         // move line_end before next newline character
         while (line_end && *line_end && *line_end != '\n') {
           if (*line_end == '\n') break;
           if (*line_end == '\r') break;
-          utf8::unchecked::next(line_end);
+          utf8::unchecked::next(line_end); 
         }
         if (line_end && *line_end != 0) ++ line_end;
         size_t line_len = line_end - line_beg;
@@ -524,7 +524,6 @@ extern "C" {
     options->c_headers = 0;
     options->plugin_paths = 0;
     options->include_paths = 0;
-    options->extensions = 0;
   }
 
   // helper function, not exported, only accessible locally
@@ -559,18 +558,6 @@ extern "C" {
         cur = next;
       }
     }
-    // Deallocate extension
-    if (options->extensions) {
-      struct string_list* cur;
-      struct string_list* next;
-      cur = options->extensions;
-      while (cur) {
-        next = cur->next;
-        free(cur->string);
-        free(cur);
-        cur = next;
-      }
-    }
     // Free options strings
     free(options->input_path);
     free(options->output_path);
@@ -590,7 +577,6 @@ extern "C" {
     options->c_headers = 0;
     options->plugin_paths = 0;
     options->include_paths = 0;
-    options->extensions = 0;
   }
 
   // helper function, not exported, only accessible locally
@@ -726,22 +712,6 @@ extern "C" {
   IMPLEMENT_SASS_CONTEXT_TAKER(char*, output_string);
   IMPLEMENT_SASS_CONTEXT_TAKER(char*, source_map_string);
   IMPLEMENT_SASS_CONTEXT_TAKER(char**, included_files);
-
-  // Push function for import extenions
-  void ADDCALL sass_option_push_import_extension(struct Sass_Options* options, const char* ext)
-  {
-    struct string_list* extension = (struct string_list*) calloc(1, sizeof(struct string_list));
-    if (extension == 0) return;
-    extension->string = ext ? sass_copy_c_string(ext) : 0;
-    struct string_list* last = options->extensions;
-    if (!options->extensions) {
-      options->extensions = extension;
-    } else {
-      while (last->next)
-        last = last->next;
-      last->next = extension;
-    }
-  }
 
   // Push function for include paths (no manipulation support for now)
   void ADDCALL sass_option_push_include_path(struct Sass_Options* options, const char* path)

--- a/src/sass_context.hpp
+++ b/src/sass_context.hpp
@@ -40,12 +40,9 @@ struct Sass_Options : Sass_Output_Options {
   // Colon-separated list of paths
   // Semicolon-separated on Windows
   // Maybe use array interface instead?
-  char* extension;
   char* include_path;
   char* plugin_path;
 
-  // Extensions (linked string list)
-  struct string_list* extensions;
   // Include paths (linked string list)
   struct string_list* include_paths;
   // Plugin paths (linked string list)


### PR DESCRIPTION
This feature is the gift that keeps on giving.

Reverts https://github.com/sass/libsass/pull/2615
See https://github.com/sass/libsass/pull/2684