### PR TITLE
Support hex colors with alpha channels

### DIFF
--- a/script/ci-build-plugin
+++ b/script/ci-build-plugin
@@ -50,11 +50,11 @@ cd ../../..
 
 # glob only works on paths relative to imports
 if [ "x$PLUGIN" == "xglob" ]; then
-  ${SASSC_BIN} --plugin-path plugins/libsass-${PLUGIN}/build ${SASS_SPEC_SPEC_DIR}/basic/input.scss > ${SASS_SPEC_SPEC_DIR}/basic/result.css
-  ${SASSC_BIN} --plugin-path plugins/libsass-${PLUGIN}/build ${SASS_SPEC_SPEC_DIR}/basic/input.scss --sourcemap > /dev/null
+  ${SASSC_BIN} --precision 5 --plugin-path plugins/libsass-${PLUGIN}/build ${SASS_SPEC_SPEC_DIR}/basic/input.scss > ${SASS_SPEC_SPEC_DIR}/basic/result.css
+  ${SASSC_BIN} --precision 5 --plugin-path plugins/libsass-${PLUGIN}/build ${SASS_SPEC_SPEC_DIR}/basic/input.scss --sourcemap > /dev/null
 else
-  cat ${SASS_SPEC_SPEC_DIR}/basic/input.scss | ${SASSC_BIN} --plugin-path plugins/libsass-${PLUGIN}/build -I ${SASS_SPEC_SPEC_DIR}/basic > ${SASS_SPEC_SPEC_DIR}/basic/result.css
-  cat ${SASS_SPEC_SPEC_DIR}/basic/input.scss | ${SASSC_BIN} --plugin-path plugins/libsass-${PLUGIN}/build -I ${SASS_SPEC_SPEC_DIR}/basic --sourcemap > /dev/null
+  cat ${SASS_SPEC_SPEC_DIR}/basic/input.scss | ${SASSC_BIN} --precision 5 --plugin-path plugins/libsass-${PLUGIN}/build -I ${SASS_SPEC_SPEC_DIR}/basic > ${SASS_SPEC_SPEC_DIR}/basic/result.css
+  cat ${SASS_SPEC_SPEC_DIR}/basic/input.scss | ${SASSC_BIN} --precision 5 --plugin-path plugins/libsass-${PLUGIN}/build -I ${SASS_SPEC_SPEC_DIR}/basic --sourcemap > /dev/null
 fi
 RETVAL=$?; if [ "$RETVAL" != "0" ]; then exit $RETVAL; fi
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1598,6 +1598,19 @@ namespace Sass {
                                1, // alpha channel
                                parsed);
     }
+    else if (parsed.length() == 5) {
+      std::string r(2, parsed[1]);
+      std::string g(2, parsed[2]);
+      std::string b(2, parsed[3]);
+      std::string a(2, parsed[4]);
+      color = SASS_MEMORY_NEW(Color,
+                               pstate,
+                               static_cast<double>(strtol(r.c_str(), NULL, 16)),
+                               static_cast<double>(strtol(g.c_str(), NULL, 16)),
+                               static_cast<double>(strtol(b.c_str(), NULL, 16)),
+                               static_cast<double>(strtol(a.c_str(), NULL, 16)) / 255,
+                               parsed);
+    }
     else if (parsed.length() == 7) {
       std::string r(parsed.substr(1,2));
       std::string g(parsed.substr(3,2));
@@ -1694,17 +1707,7 @@ namespace Sass {
     { return lexed_hex_color(lexed); }
 
     if (lex< hexa >())
-    {
-      std::string s = lexed.to_string();
-
-      deprecated(
-        "The value \""+s+"\" is currently parsed as a string, but it will be parsed as a color in",
-        "future versions of Sass. Use \"unquote('"+s+"')\" to continue parsing it as a string.",
-        true, pstate
-      );
-
-      return SASS_MEMORY_NEW(String_Quoted, pstate, lexed);
-    }
+    { return lexed_hex_color(lexed); }
 
     if (lex< sequence < exactly <'#'>, identifier > >())
     { return SASS_MEMORY_NEW(String_Quoted, pstate, lexed); }


### PR DESCRIPTION
A deprecation for the old behaviour landed in #2302. This PR removes
the deprecation warning for the old behaviour, and starts parsing
4 and 8 digit hex values as Colors.

Looks like we had support for 8 digit hex colors for a while but
somehow 4 digit support was missed.

Spec https://github.com/sass/sass-spec/pull/1273

Fixes #2674