### PR TITLE
Fix --no-undefined in Makefile on non-Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,7 @@ else
   CXXFLAGS += -O1 -fno-omit-frame-pointer
   LDFLAGS  += -O1 -fno-omit-frame-pointer
 endif
-LDFLAGS  += -Wl,-undefined,error
-CAT      ?= $(if $(filter $(OS),Windows_NT),type,cat)
+CAT ?= $(if $(filter $(OS),Windows_NT),type,cat)
 
 ifneq (,$(findstring /cygdrive/,$(PATH)))
 	UNAME := Cygwin


### PR DESCRIPTION
As far as I can tell, `-undefined error` was introduced mistakenly to replace `--no-undefined`, which doesn't work Apple's cctools' ld. The problem is, `-undefined error` _only_ works on cctools' ld. This is much less noticeable than the original problem, because GCC's ld won't complain, it just won't do the right thing. The Solaris linker, on the other hand, _will_ complain:

    ld: fatal: file error: open failed: No such file or directory

This is a misleading error message, but what it is actually telling us is that it can't open a file named "error", which it tries to do because it doesn't recognise "-undefined" as an option that can take an argument.

We can demonstrate that this doesn't have the desired effect in GCC too. Consider this a C source file, main.c, containing the following:

```c
extern void hello(void);

int main(void) {
    hello();
}
````

If we compile this using the command `gcc -fPIC -shared main.c`, we will get no indication that the `hello` function we are trying to call has never been defined. This is for, as the GCC documentation puts it, "historial reasons".

If we don't want this, we can pass `--no-undefined` to the linker, like this:

    gcc -fPIC -shared -Wl,--no-undefined main.c

This is what the Makefile used to do, before being changed. Running this command will produce an error informing us of our mistake:

>     /tmp/ccGRJkJ8.o: In function `main':
>     main.c:(.text+0xc): undefined reference to `hello'
>     collect2: error: ld returned 1 exit status

However, trying to use the cctools' ld's equivalent reveals that GCC's ld definitely does not interpret it the same way. This command will succeed, just the same as the one where we specified no explicit linker options at all. I don't want to speculate on what effect, if any, `-undefined error` has on GCC's ld, but it definitely isn't the right one.

The fix, then, is to use cctools's ld's `-undefined error` on Darwin, and GCC's ld's `--no-undefined` on everything else. Checking operating system isn't bulletproof — it is completely possible to use GCC's ld on Darwin, but it is nevertheless better than the status quo. GCC ld users will get the desired errors, and linking will no longer outright fail on Solaris. I'm not sure what effect this would have on BSD systems, having never used one, but it's conceivable to me that they use a similar linker to Darwin. If this turns out to be the case, the fix is to change the operating system check to use the cctools variant on BSD as well as Darwin.