### PR TITLE
Makefile: Compiler-specific LDFLAGS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ GNUmakefile
 /script/install-sh
 /script/ltmain.sh
 /script/missing
+/script/print-compiler-family
 /script/test-driver
 /src/stamp-h1
 /src/Makefile.in

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,14 @@ else
   CXXFLAGS += -O1 -fno-omit-frame-pointer
   LDFLAGS  += -O1 -fno-omit-frame-pointer
 endif
-LDFLAGS  += -Wl,-undefined,error
+
+COMPILER_FAMILY := $(shell $(CC) script/print-compiler-family.c -o script/print-compiler-family && script/print-compiler-family)
+ifeq (clang, $(COMPILER_FAMILY))
+	LDFLAGS += -Wl,-undefined,error
+else ifeq (gcc, $(COMPILER_FAMILY))
+	LDFLAGS += -Wl,--no-undefined
+endif
+
 CAT      ?= $(if $(filter $(OS),Windows_NT),type,cat)
 
 ifneq (,$(findstring /cygdrive/,$(PATH)))

--- a/script/print-compiler-family.c
+++ b/script/print-compiler-family.c
@@ -1,0 +1,21 @@
+// Print the compiler family, used by ../Makefile.
+#include <stdio.h>
+
+int main()
+{
+  int code = printf(
+#if defined(__clang__)
+      "clang"
+#elif defined(__GNUC__) || defined(__GNUG__)
+      "gcc"
+#else
+      "other"
+#endif
+      "\n");
+  if (code < 0)
+  {
+    fprintf(stderr, "error: printf returned %d\n", code);
+    return 1;
+  }
+  return 0;
+}

--- a/script/print-compiler-family.c
+++ b/script/print-compiler-family.c
@@ -12,8 +12,7 @@ int main()
       "other"
 #endif
       "\n");
-  if (code < 0)
-  {
+  if (code < 0) {
     fprintf(stderr, "error: printf returned %d\n", code);
     return 1;
   }


### PR DESCRIPTION
Detects compiler family by compiling and running a tiny C file on every invocation of make (30ms on my machine).

Alternative to #2720