### PR TITLE
Set default precision to 10 in Sass_Output_Options

### DIFF
--- a/src/sass.hpp
+++ b/src/sass.hpp
@@ -128,7 +128,7 @@ struct Sass_Output_Options : Sass_Inspect_Options {
 
   // initialization list (constructor with defaults)
   Sass_Output_Options(Sass_Output_Style style = Sass::NESTED,
-                      int precision = 5,
+                      int precision = 10,
                       const char* indent = "  ",
                       const char* linefeed = "\n",
                       bool source_comments = false)


### PR DESCRIPTION
Follow-up to #2730 (missed one). Refs #2716