### PR TITLE
SharedPtr: Remove explicit `detached` bool

### DIFF
--- a/src/memory/SharedPtr.cpp
+++ b/src/memory/SharedPtr.cpp
@@ -32,12 +32,11 @@ namespace Sass {
   bool SharedObj::taint = false;
 
   SharedObj::SharedObj()
-  : detached(false)
+  : refcounter(0)
     #ifdef DEBUG_SHARED_PTR
     , dbg(false)
     #endif
   {
-    refcounter = 0;
     #ifdef DEBUG_SHARED_PTR
       if (taint) all.push_back(this);
     #endif
@@ -63,9 +62,7 @@ namespace Sass {
           // AST_Node_Ptr ast = dynamic_cast<AST_Node*>(node);
           if (node->dbg) std::cerr << "DELETE NODE " << node << "\n";
         #endif
-        if (!node->detached) {
-          delete(node);
-        }
+        delete(node);
       }
     }
   }
@@ -73,7 +70,6 @@ namespace Sass {
   void SharedPtr::incRefCount() {
     if (node) {
       ++ node->refcounter;
-      node->detached = false;
       #ifdef DEBUG_SHARED_PTR
         if (node->dbg) {
           std::cerr << "+ " << node << " X " << node->refcounter << " (" << this << ") " << "\n";

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -49,8 +49,6 @@ namespace Sass {
     #endif
     static bool taint;
     long refcounter;
-    // long refcount;
-    bool detached;
     #ifdef DEBUG_SHARED_PTR
       bool dbg;
     #endif
@@ -82,7 +80,7 @@ namespace Sass {
     virtual const std::string to_string() const = 0;
 
     virtual ~SharedObj();
-    long getRefCount() {
+    long getRefCount() const {
       return refcounter;
     }
   };
@@ -123,11 +121,10 @@ namespace Sass {
     bool isNull () const {
       return node == NULL;
     };
-    SharedObj* detach() const {
-      if (node) {
-        node->detached = true;
-      }
-      return node;
+    SharedObj* detach() {
+      SharedObj* result = node;
+      node = NULL;
+      return result;
     };
     operator bool() const {
       return node != NULL;
@@ -197,8 +194,7 @@ namespace Sass {
     T* ptr () const {
       return static_cast<T*>(this->obj());
     };
-    T* detach() const {
-      if (this->obj() == NULL) return NULL;
+    T* detach() {
       return static_cast<T*>(SharedPtr::detach());
     }
     bool isNull() const {


### PR DESCRIPTION
`detach()` now fully releases the object (sets `node` to `NULL`), resulting in memory savings (1 less bool per object, as we no longer need the `detached` bool) and performance improvements (thanks to cheaper inc/dec ref counts, profile below).

Profile before (compiling bootstrap 4):

```
      flat  flat%   sum%        cum   cum%
  24651348  6.97%  6.97%   24651348  6.97%  [[kernel.kallsyms]]
  20746241  5.87% 12.84%   20746241  5.87%  Sass::SharedPtr::decRefCount
  18401663  5.20% 18.04%   20420896  5.78%  __libc_malloc
  15205959  4.30% 22.34%   15205959  4.30%  [libc-2.27.so]
  12974307  3.67% 26.01%   14070189  3.98%  _int_malloc
  10958857  3.10% 29.11%   10958857  3.10%  Sass::SharedPtr::incRefCount
   9837672  2.78% 31.89%   18433250  5.21%  cfree
   8770779  2.48% 34.37%    8770779  2.48%  Sass::Inspect::operator()
```

Profile after:

```
      flat  flat%   sum%        cum   cum%
  28346546  7.94%  7.94%   28346546  7.94%  [[kernel.kallsyms]]
  20920665  5.86% 13.80%   20920665  5.86%  [libc-2.27.so]
  13540151  3.79% 17.60%   14637507  4.10%  __libc_malloc
  13091487  3.67% 21.26%   13091487  3.67%  Sass::SharedPtr::incRefCount
   9864675  2.76% 24.03%    9864675  2.76%  Sass::SharedPtr::decRefCount
   8763387  2.46% 26.48%    8763387  2.46%  _int_malloc
   7676121  2.15% 28.63%    7676121  2.15%  std::vector::_M_realloc_insert
   6578211  1.84% 30.48%    6578211  1.84%  __dynamic_cast
```