### PR TITLE
SharedPtr: More cleanup

### DIFF
--- a/src/memory/SharedPtr.cpp
+++ b/src/memory/SharedPtr.cpp
@@ -62,7 +62,8 @@ namespace Sass {
           // AST_Node_Ptr ast = dynamic_cast<AST_Node*>(node);
           if (node->dbg) std::cerr << "DELETE NODE " << node << "\n";
         #endif
-        delete(node);
+        delete node;
+        node = NULL;
       }
     }
   }

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -48,7 +48,7 @@ namespace Sass {
       size_t line;
     #endif
     static bool taint;
-    long refcounter;
+    size_t refcounter;
     #ifdef DEBUG_SHARED_PTR
       bool dbg;
     #endif
@@ -72,6 +72,9 @@ namespace Sass {
       void setDbg(bool dbg) {
         this->dbg = dbg;
       }
+      size_t getRefCount() const {
+        return refcounter;
+      }
     #endif
     static void setTaint(bool val) {
       taint = val;
@@ -80,9 +83,6 @@ namespace Sass {
     virtual const std::string to_string() const = 0;
 
     virtual ~SharedObj();
-    long getRefCount() const {
-      return refcounter;
-    }
   };
 
 
@@ -114,9 +114,6 @@ namespace Sass {
     };
     SharedObj* operator-> () const {
       return node;
-    };
-    bool isNull () {
-      return node == NULL;
     };
     bool isNull () const {
       return node == NULL;
@@ -179,6 +176,8 @@ namespace Sass {
 
     ~SharedImpl() {};
   public:
+    using SharedPtr::isNull;
+    using SharedPtr::operator bool;
     operator T*() const {
       return static_cast<T*>(this->obj());
     }
@@ -197,15 +196,6 @@ namespace Sass {
     T* detach() {
       return static_cast<T*>(SharedPtr::detach());
     }
-    bool isNull() const {
-      return this->obj() == NULL;
-    }
-    bool operator<(const T& rhs) const {
-      return *this->ptr() < rhs;
-    };
-    operator bool() const {
-      return this->obj() != NULL;
-    };
   };
 
 }


### PR DESCRIPTION
1. Use `size_t` instead of `long` for `refcounter`.
2. Use parent impls for `SharedImpl` where possible.
3. Remove some unused methods.
4. Set `node` to `NULL` after calling `delete`.