### PR TITLE
Use -std=c++11

### DIFF
--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -18,11 +18,9 @@ AM_LDFLAGS  = $(AM_COPT) $(AM_COVLDFLAGS)
 AM_CPPFLAGS += -I$(top_srcdir)
 
 RESOURCES =
+AM_CXXFLAGS += -std=c++11
 if COMPILER_IS_MINGW32
   RESOURCES += res/libsass.rc
-  AM_CXXFLAGS += -std=gnu++0x
-else
-  AM_CXXFLAGS += -std=c++0x
 endif
 
 TEST_EXTENSIONS = .rb

--- a/Makefile
+++ b/Makefile
@@ -51,21 +51,19 @@ ifdef LIBSASS_VERSION
 	CXXFLAGS += -DLIBSASS_VERSION="\"$(LIBSASS_VERSION)\""
 endif
 
-# enable mandatory flag
+CXXFLAGS += -std=c++11
+LDFLAGS  += -std=c++11
+
 ifeq (Windows,$(UNAME))
 	ifneq ($(BUILD),shared)
 		STATIC_ALL     ?= 1
 	endif
 	STATIC_LIBGCC    ?= 1
 	STATIC_LIBSTDCPP ?= 1
-	CXXFLAGS += -std=gnu++0x
-	LDFLAGS  += -std=gnu++0x
 else
 	STATIC_ALL       ?= 0
 	STATIC_LIBGCC    ?= 0
 	STATIC_LIBSTDCPP ?= 0
-	CXXFLAGS += -std=c++0x
-	LDFLAGS  += -std=c++0x
 endif
 
 ifndef SASS_LIBSASS_PATH

--- a/src/GNUmakefile.am
+++ b/src/GNUmakefile.am
@@ -13,11 +13,7 @@ AM_CFLAGS   = $(AM_COPT)
 AM_CXXFLAGS = $(AM_COPT)
 AM_LDFLAGS  = $(AM_COPT) $(AM_COVLDFLAGS)
 
-if COMPILER_IS_MINGW32
-  AM_CXXFLAGS += -std=gnu++0x
-else
-  AM_CXXFLAGS += -std=c++0x
-endif
+AM_CXXFLAGS += -std=c++11
 
 EXTRA_DIST = \
 	COPYING \


### PR DESCRIPTION
C++0x (`-std=c++0x` / `-std=gnu++0x`) was the working name of what is nowadays known as C++11.

Use the standard name to avoid accidentally depending on GCC-specific
extensions and other quirks.