### PR TITLE
Revert recent SharedPtr changes

### DIFF
--- a/src/memory/SharedPtr.cpp
+++ b/src/memory/SharedPtr.cpp
@@ -62,8 +62,7 @@ namespace Sass {
           // AST_Node_Ptr ast = dynamic_cast<AST_Node*>(node);
           if (node->dbg) std::cerr << "DELETE NODE " << node << "\n";
         #endif
-        delete node;
-        node = NULL;
+        delete(node);
       }
     }
   }

--- a/src/memory/SharedPtr.cpp
+++ b/src/memory/SharedPtr.cpp
@@ -32,11 +32,12 @@ namespace Sass {
   bool SharedObj::taint = false;
 
   SharedObj::SharedObj()
-  : refcounter(0)
+  : detached(false)
     #ifdef DEBUG_SHARED_PTR
     , dbg(false)
     #endif
   {
+    refcounter = 0;
     #ifdef DEBUG_SHARED_PTR
       if (taint) all.push_back(this);
     #endif
@@ -62,7 +63,9 @@ namespace Sass {
           // AST_Node_Ptr ast = dynamic_cast<AST_Node*>(node);
           if (node->dbg) std::cerr << "DELETE NODE " << node << "\n";
         #endif
-        delete(node);
+        if (!node->detached) {
+          delete(node);
+        }
       }
     }
   }
@@ -70,6 +73,7 @@ namespace Sass {
   void SharedPtr::incRefCount() {
     if (node) {
       ++ node->refcounter;
+      node->detached = false;
       #ifdef DEBUG_SHARED_PTR
         if (node->dbg) {
           std::cerr << "+ " << node << " X " << node->refcounter << " (" << this << ") " << "\n";

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -48,7 +48,7 @@ namespace Sass {
       size_t line;
     #endif
     static bool taint;
-    size_t refcounter;
+    long refcounter;
     #ifdef DEBUG_SHARED_PTR
       bool dbg;
     #endif
@@ -72,9 +72,6 @@ namespace Sass {
       void setDbg(bool dbg) {
         this->dbg = dbg;
       }
-      size_t getRefCount() const {
-        return refcounter;
-      }
     #endif
     static void setTaint(bool val) {
       taint = val;
@@ -83,6 +80,9 @@ namespace Sass {
     virtual const std::string to_string() const = 0;
 
     virtual ~SharedObj();
+    long getRefCount() const {
+      return refcounter;
+    }
   };
 
 
@@ -114,6 +114,9 @@ namespace Sass {
     };
     SharedObj* operator-> () const {
       return node;
+    };
+    bool isNull () {
+      return node == NULL;
     };
     bool isNull () const {
       return node == NULL;
@@ -176,8 +179,6 @@ namespace Sass {
 
     ~SharedImpl() {};
   public:
-    using SharedPtr::isNull;
-    using SharedPtr::operator bool;
     operator T*() const {
       return static_cast<T*>(this->obj());
     }
@@ -196,6 +197,15 @@ namespace Sass {
     T* detach() {
       return static_cast<T*>(SharedPtr::detach());
     }
+    bool isNull() const {
+      return this->obj() == NULL;
+    }
+    bool operator<(const T& rhs) const {
+      return *this->ptr() < rhs;
+    };
+    operator bool() const {
+      return this->obj() != NULL;
+    };
   };
 
 }

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -49,6 +49,8 @@ namespace Sass {
     #endif
     static bool taint;
     long refcounter;
+    // long refcount;
+    bool detached;
     #ifdef DEBUG_SHARED_PTR
       bool dbg;
     #endif
@@ -80,7 +82,7 @@ namespace Sass {
     virtual const std::string to_string() const = 0;
 
     virtual ~SharedObj();
-    long getRefCount() const {
+    long getRefCount() {
       return refcounter;
     }
   };
@@ -121,10 +123,11 @@ namespace Sass {
     bool isNull () const {
       return node == NULL;
     };
-    SharedObj* detach() {
-      SharedObj* result = node;
-      node = NULL;
-      return result;
+    SharedObj* detach() const {
+      if (node) {
+        node->detached = true;
+      }
+      return node;
     };
     operator bool() const {
       return node != NULL;
@@ -194,7 +197,8 @@ namespace Sass {
     T* ptr () const {
       return static_cast<T*>(this->obj());
     };
-    T* detach() {
+    T* detach() const {
+      if (this->obj() == NULL) return NULL;
       return static_cast<T*>(SharedPtr::detach());
     }
     bool isNull() const {


### PR DESCRIPTION
Based on the number of ASAN errors with various combinations of commits, my recent SharedPtr changes are problematic. Revert for now.

ASAN errors: 29.