### PR TITLE
Fix memory leak introduced in March

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -960,8 +960,8 @@ namespace Sass {
     }
 
     if (Cast<String_Schema>(c->sname())) {
-      Expression_Ptr evaluated_name = c->sname()->perform(this);
-      Expression_Ptr evaluated_args = c->arguments()->perform(this);
+      Expression_Obj evaluated_name = c->sname()->perform(this);
+      Expression_Obj evaluated_args = c->arguments()->perform(this);
       std::string str(evaluated_name->to_string());
       str += evaluated_args->to_string();
       return SASS_MEMORY_NEW(String_Constant, c->pstate(), str);


### PR DESCRIPTION
This memory leak was introduced in https://github.com/sass/libsass/commit/205dc65d0f1af1f5f715080432192195d64256be.

This results in exactly the same number of ASAN errors as completely reverting that commit.

ASAN errors: 16 with #2744.