### PR TITLE
Fix memory leak in resolve_parent_refs

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1243,7 +1243,8 @@ namespace Sass {
     if (!this->has_parent_ref()) return this;
     Selector_List_Ptr ss = SASS_MEMORY_NEW(Selector_List, pstate());
     for (size_t si = 0, sL = this->length(); si < sL; ++si) {
-      ss->concat(at(si)->resolve_parent_refs(pstack, traces, implicit_parent));
+      Selector_List_Obj rv = at(si)->resolve_parent_refs(pstack, traces, implicit_parent);
+      ss->concat(rv);
     }
     return ss;
   }


### PR DESCRIPTION
Fixes a memory leak introduced in https://github.com/sass/libsass/commit/4254054dec66bb715d3a16ce3a9cf40501522773.

I do not understand why it leaks without this change but it does seem like a bug in `SharedPtr`.

Fixes #2746

With #2744, #2745, and this, no more memory leaks are reported by ASAN.