### PR TITLE
.travis.yml: `sudo: required` for ptrace support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: cpp
-sudo: false
 
+# ASan needs ptrace support which currently requires `sudo: required`.
+# See https://github.com/travis-ci/travis-ci/issues/9033.
+sudo: required
 
 # don't create redundant code coverage reports
 # - AUTOTOOLS=yes COVERAGE=yes BUILD=static


### PR DESCRIPTION
See travis-ci/travis-ci#9033

This makes the clang+ASan build run. Still fails but only because now it exposes other issues.