### PR TITLE
Do not use `0` for initializing SharedImpl

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -807,7 +807,7 @@ namespace Sass {
     return ns() < rhs.ns();
   }
 
-  bool Wrapped_Selector::is_superselector_of(Wrapped_Selector_Obj sub) const
+  bool Wrapped_Selector::is_superselector_of(Wrapped_Selector_Ptr_Const sub) const
   {
     if (this->name() != sub->name()) return false;
     if (this->name() == ":current") return false;
@@ -820,7 +820,7 @@ namespace Sass {
     return false;
   }
 
-  bool Compound_Selector::is_superselector_of(Selector_List_Obj rhs, std::string wrapped) const
+  bool Compound_Selector::is_superselector_of(Selector_List_Ptr_Const rhs, std::string wrapped) const
   {
     for (Complex_Selector_Obj item : rhs->elements()) {
       if (is_superselector_of(item, wrapped)) return true;
@@ -828,13 +828,13 @@ namespace Sass {
     return false;
   }
 
-  bool Compound_Selector::is_superselector_of(Complex_Selector_Obj rhs, std::string wrapped) const
+  bool Compound_Selector::is_superselector_of(Complex_Selector_Ptr_Const rhs, std::string wrapped) const
   {
     if (rhs->head()) return is_superselector_of(rhs->head(), wrapped);
     return false;
   }
 
-  bool Compound_Selector::is_superselector_of(Compound_Selector_Obj rhs, std::string wrapping) const
+  bool Compound_Selector::is_superselector_of(Compound_Selector_Ptr_Const rhs, std::string wrapping) const
   {
     Compound_Selector_Ptr_Const lhs = this;
     Simple_Selector_Ptr lbase = lhs->base();
@@ -895,7 +895,7 @@ namespace Sass {
         if (wrapped->name() == ":matches" || wrapped->name() == ":-moz-any") {
           wlhs = wrapped->selector();
           if (Selector_List_Obj list = Cast<Selector_List>(wrapped->selector())) {
-            if (Compound_Selector_Obj comp = Cast<Compound_Selector>(rhs)) {
+            if (Compound_Selector_Ptr_Const comp = Cast<Compound_Selector>(rhs)) {
               if (!wrapping.empty() && wrapping != wrapped->name()) return false;
               if (wrapping.empty() || wrapping != wrapped->name()) {;
                 if (list->is_superselector_of(comp, wrapped->name())) return true;
@@ -956,7 +956,7 @@ namespace Sass {
                            pstate(),
                            Complex_Selector::ANCESTOR_OF,
                            this,
-                           0);
+                           {});
   }
 
   Selector_List_Ptr Complex_Selector::unify_with(Complex_Selector_Ptr other)
@@ -997,7 +997,7 @@ namespace Sass {
     if (is_universal)
     {
       // move the head
-      l_last->head(0);
+      l_last->head({});
       r_last->head(unified);
     }
 
@@ -1059,12 +1059,12 @@ namespace Sass {
     // there is no break?!
   }
 
-  bool Complex_Selector::is_superselector_of(Compound_Selector_Obj rhs, std::string wrapping) const
+  bool Complex_Selector::is_superselector_of(Compound_Selector_Ptr_Const rhs, std::string wrapping) const
   {
     return last()->head() && last()->head()->is_superselector_of(rhs, wrapping);
   }
 
-  bool Complex_Selector::is_superselector_of(Complex_Selector_Obj rhs, std::string wrapping) const
+  bool Complex_Selector::is_superselector_of(Complex_Selector_Ptr_Const rhs, std::string wrapping) const
   {
     Complex_Selector_Ptr_Const lhs = this;
     // check for selectors with leading or trailing combinators
@@ -1098,7 +1098,7 @@ namespace Sass {
     }
 
     bool found = false;
-    Complex_Selector_Obj marker = rhs;
+    Complex_Selector_Ptr_Const marker = rhs;
     for (size_t i = 0, L = rhs->length(); i < L; ++i) {
       if (i == L-1)
       { return false; }
@@ -1297,7 +1297,7 @@ namespace Sass {
                   h->erase(h->begin());
                   ss->head(h);
                 } else {
-                  ss->head(NULL);
+                  ss->head({});
                 }
                 // adjust for parent selector (1 char)
                 // if (h->length()) {
@@ -1334,7 +1334,7 @@ namespace Sass {
                 h->erase(h->begin());
                 ss->head(h);
               } else {
-                ss->head(NULL);
+                ss->head({});
               }
               // \/ IMO ruby sass bug \/
               ss->has_line_feed(false);
@@ -1362,7 +1362,7 @@ namespace Sass {
               cpy->head(SASS_MEMORY_NEW(Compound_Selector, head->pstate()));
               for (size_t i = 1, L = this->head()->length(); i < L; ++i)
                 cpy->head()->append((*this->head())[i]);
-              if (!cpy->head()->length()) cpy->head(0);
+              if (!cpy->head()->length()) cpy->head({});
               retval->append(cpy->skip_empty_reference());
             }
           }
@@ -1372,7 +1372,7 @@ namespace Sass {
             cpy->head(SASS_MEMORY_NEW(Compound_Selector, head->pstate()));
             for (size_t i = 1, L = this->head()->length(); i < L; ++i)
               cpy->head()->append((*this->head())[i]);
-            if (!cpy->head()->length()) cpy->head(0);
+            if (!cpy->head()->length()) cpy->head({});
             retval->append(cpy->skip_empty_reference());
           }
         }
@@ -1461,8 +1461,8 @@ namespace Sass {
   Complex_Selector::Combinator Complex_Selector::clear_innermost()
   {
     Combinator c;
-    if (!tail() || tail()->tail() == 0)
-    { c = combinator(); combinator(ANCESTOR_OF); tail(0); }
+    if (!tail() || tail()->tail() == nullptr)
+    { c = combinator(); combinator(ANCESTOR_OF); tail({}); }
     else
     { c = tail_->clear_innermost(); }
     return c;
@@ -1590,7 +1590,7 @@ namespace Sass {
 
   // it's a superselector if every selector of the right side
   // list is a superselector of the given left side selector
-  bool Complex_Selector::is_superselector_of(Selector_List_Obj sub, std::string wrapping) const
+  bool Complex_Selector::is_superselector_of(Selector_List_Ptr_Const sub, std::string wrapping) const
   {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = sub->length(); i < L; ++i) {
@@ -1601,7 +1601,7 @@ namespace Sass {
 
   // it's a superselector if every selector of the right side
   // list is a superselector of the given left side selector
-  bool Selector_List::is_superselector_of(Selector_List_Obj sub, std::string wrapping) const
+  bool Selector_List::is_superselector_of(Selector_List_Ptr_Const sub, std::string wrapping) const
   {
     // Check every rhs selector against left hand list
     for(size_t i = 0, L = sub->length(); i < L; ++i) {
@@ -1612,7 +1612,7 @@ namespace Sass {
 
   // it's a superselector if every selector on the right side
   // is a superselector of any one of the left side selectors
-  bool Selector_List::is_superselector_of(Compound_Selector_Obj sub, std::string wrapping) const
+  bool Selector_List::is_superselector_of(Compound_Selector_Ptr_Const sub, std::string wrapping) const
   {
     // Check every lhs selector against right hand
     for(size_t i = 0, L = length(); i < L; ++i) {
@@ -1623,7 +1623,7 @@ namespace Sass {
 
   // it's a superselector if every selector on the right side
   // is a superselector of any one of the left side selectors
-  bool Selector_List::is_superselector_of(Complex_Selector_Obj sub, std::string wrapping) const
+  bool Selector_List::is_superselector_of(Complex_Selector_Ptr_Const sub, std::string wrapping) const
   {
     // Check every lhs selector against right hand
     for(size_t i = 0, L = length(); i < L; ++i) {
@@ -1736,7 +1736,7 @@ namespace Sass {
         }
       }
     }
-    return NULL;
+    return {};
   }
 
   Argument_Obj Arguments::get_keyword_argument()
@@ -1748,7 +1748,7 @@ namespace Sass {
         }
       }
     }
-    return NULL;
+    return {};
   }
 
   void Arguments::adjust_after_pushing(Argument_Obj a)
@@ -2034,7 +2034,7 @@ namespace Sass {
   {
     if (elements_.count(k))
     { return elements_.at(k); }
-    else { return NULL; }
+    else { return {}; }
   }
 
   bool Binary_Expression::is_left_interpolant(void) const
@@ -2096,7 +2096,7 @@ namespace Sass {
   }
 
   Function_Call::Function_Call(ParserState pstate, std::string n, Arguments_Obj args, void* cookie)
-  : PreValue(pstate), sname_(SASS_MEMORY_NEW(String_Constant, pstate, n)), arguments_(args), func_(0), via_call_(false), cookie_(cookie), hash_(0)
+  : PreValue(pstate), sname_(SASS_MEMORY_NEW(String_Constant, pstate, n)), arguments_(args), func_(), via_call_(false), cookie_(cookie), hash_(0)
   { concrete_type(FUNCTION); }
   Function_Call::Function_Call(ParserState pstate, std::string n, Arguments_Obj args, Function_Obj func)
   : PreValue(pstate), sname_(SASS_MEMORY_NEW(String_Constant, pstate, n)), arguments_(args), func_(func), via_call_(false), cookie_(0), hash_(0)

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -329,13 +329,13 @@ namespace Sass {
     mutable size_t hash_;
     Expression_Obj duplicate_key_;
     void reset_hash() { hash_ = 0; }
-    void reset_duplicate_key() { duplicate_key_ = 0; }
+    void reset_duplicate_key() { duplicate_key_ = {}; }
     virtual void adjust_after_pushing(std::pair<Expression_Obj, Expression_Obj> p) { }
   public:
     Hashed(size_t s = 0)
     : elements_(ExpressionMap(s)),
       list_(std::vector<Expression_Obj>()),
-      hash_(0), duplicate_key_(NULL)
+      hash_(0), duplicate_key_({})
     { elements_.reserve(s); list_.reserve(s); }
     virtual ~Hashed();
     size_t length() const                  { return list_.size(); }
@@ -501,7 +501,7 @@ namespace Sass {
     ADD_PROPERTY(Selector_List_Obj, selector)
     ADD_PROPERTY(bool, is_root);
   public:
-    Ruleset(ParserState pstate, Selector_List_Obj s = 0, Block_Obj b = 0)
+    Ruleset(ParserState pstate, Selector_List_Obj s = {}, Block_Obj b = {})
     : Has_Block(pstate, b), selector_(s), is_root_(false)
     { statement_type(RULESET); }
     Ruleset(const Ruleset* ptr)
@@ -521,7 +521,7 @@ namespace Sass {
     ADD_PROPERTY(Statement_Obj, node)
     ADD_PROPERTY(bool, group_end)
   public:
-    Bubble(ParserState pstate, Statement_Obj n, Statement_Obj g = 0, size_t t = 0)
+    Bubble(ParserState pstate, Statement_Obj n, Statement_Obj g = {}, size_t t = 0)
     : Statement(pstate, Statement::BUBBLE, t), node_(n), group_end_(g == 0)
     { }
     Bubble(const Bubble* ptr)
@@ -541,7 +541,7 @@ namespace Sass {
     ADD_CONSTREF(char, type)
     ADD_CONSTREF(std::string, name)
   public:
-    Trace(ParserState pstate, std::string n, Block_Obj b = 0, char type = 'm')
+    Trace(ParserState pstate, std::string n, Block_Obj b = {}, char type = 'm')
     : Has_Block(pstate, b), type_(type), name_(n)
     { }
     Trace(const Trace* ptr)
@@ -580,7 +580,7 @@ namespace Sass {
     ADD_PROPERTY(Selector_List_Obj, selector)
     ADD_PROPERTY(Expression_Obj, value)
   public:
-    Directive(ParserState pstate, std::string kwd, Selector_List_Obj sel = 0, Block_Obj b = 0, Expression_Obj val = 0)
+    Directive(ParserState pstate, std::string kwd, Selector_List_Obj sel = {}, Block_Obj b = {}, Expression_Obj val = {})
     : Has_Block(pstate, b), keyword_(kwd), selector_(sel), value_(val) // set value manually if needed
     { statement_type(DIRECTIVE); }
     Directive(const Directive* ptr)
@@ -635,7 +635,7 @@ namespace Sass {
     ADD_PROPERTY(bool, is_indented)
   public:
     Declaration(ParserState pstate,
-                String_Obj prop, Expression_Obj val, bool i = false, bool c = false, Block_Obj b = 0)
+                String_Obj prop, Expression_Obj val, bool i = false, bool c = false, Block_Obj b = {})
     : Has_Block(pstate, b), property_(prop), value_(val), is_important_(i), is_custom_property_(c), is_indented_(false)
     { statement_type(DECLARATION); }
     Declaration(const Declaration* ptr)
@@ -799,7 +799,7 @@ namespace Sass {
     ADD_PROPERTY(Expression_Obj, predicate)
     ADD_PROPERTY(Block_Obj, alternative)
   public:
-    If(ParserState pstate, Expression_Obj pred, Block_Obj con, Block_Obj alt = 0)
+    If(ParserState pstate, Expression_Obj pred, Block_Obj con, Block_Obj alt = {})
     : Has_Block(pstate, con), predicate_(pred), alternative_(alt)
     { statement_type(IF); }
     If(const If* ptr)
@@ -957,7 +957,7 @@ namespace Sass {
                Parameters_Obj params,
                Native_Function func_ptr,
                bool overload_stub = false)
-    : Has_Block(pstate, 0),
+    : Has_Block(pstate, {}),
       name_(n),
       parameters_(params),
       environment_(0),
@@ -973,7 +973,7 @@ namespace Sass {
                std::string n,
                Parameters_Obj params,
                Sass_Function_Entry c_func)
-    : Has_Block(pstate, 0),
+    : Has_Block(pstate, {}),
       name_(n),
       parameters_(params),
       environment_(0),
@@ -995,7 +995,7 @@ namespace Sass {
     ADD_CONSTREF(std::string, name)
     ADD_PROPERTY(Arguments_Obj, arguments)
   public:
-    Mixin_Call(ParserState pstate, std::string n, Arguments_Obj args, Block_Obj b = 0)
+    Mixin_Call(ParserState pstate, std::string n, Arguments_Obj args, Block_Obj b = {})
     : Has_Block(pstate, b), name_(n), arguments_(args)
     { }
     Mixin_Call(const Mixin_Call* ptr)
@@ -1433,7 +1433,7 @@ namespace Sass {
     Function_Call(ParserState pstate, std::string n, Arguments_Obj args);
 
     Function_Call(ParserState pstate, String_Obj n, Arguments_Obj args, void* cookie)
-    : PreValue(pstate), sname_(n), arguments_(args), func_(0), via_call_(false), cookie_(cookie), hash_(0)
+    : PreValue(pstate), sname_(n), arguments_(args), func_(), via_call_(false), cookie_(cookie), hash_(0)
     { concrete_type(FUNCTION); }
     Function_Call(ParserState pstate, String_Obj n, Arguments_Obj args, Function_Obj func)
     : PreValue(pstate), sname_(n), arguments_(args), func_(func), via_call_(false), cookie_(0), hash_(0)
@@ -1821,7 +1821,7 @@ namespace Sass {
     ADD_PROPERTY(bool, is_restricted)
   public:
     Media_Query(ParserState pstate,
-                String_Obj t = 0, size_t s = 0, bool n = false, bool r = false)
+                String_Obj t = {}, size_t s = 0, bool n = false, bool r = false)
     : Expression(pstate), Vectorized<Media_Query_Expression_Obj>(s),
       media_type_(t), is_negated_(n), is_restricted_(r)
     { }
@@ -1864,7 +1864,7 @@ namespace Sass {
   class Supports_Block final : public Has_Block {
     ADD_PROPERTY(Supports_Condition_Obj, condition)
   public:
-    Supports_Block(ParserState pstate, Supports_Condition_Obj condition, Block_Obj block = 0)
+    Supports_Block(ParserState pstate, Supports_Condition_Obj condition, Block_Obj block = {})
     : Has_Block(pstate, block), condition_(condition)
     { statement_type(SUPPORTS); }
     Supports_Block(const Supports_Block* ptr)
@@ -1982,7 +1982,7 @@ namespace Sass {
     ADD_PROPERTY(Expression_Obj, feature)
     ADD_PROPERTY(Expression_Obj, value)
   public:
-    At_Root_Query(ParserState pstate, Expression_Obj f = 0, Expression_Obj v = 0, bool i = false)
+    At_Root_Query(ParserState pstate, Expression_Obj f = {}, Expression_Obj v = {}, bool i = false)
     : Expression(pstate), feature_(f), value_(v)
     { }
     At_Root_Query(const At_Root_Query* ptr)
@@ -2001,7 +2001,7 @@ namespace Sass {
   class At_Root_Block final : public Has_Block {
     ADD_PROPERTY(At_Root_Query_Obj, expression)
   public:
-    At_Root_Block(ParserState pstate, Block_Obj b = 0, At_Root_Query_Obj e = 0)
+    At_Root_Block(ParserState pstate, Block_Obj b = {}, At_Root_Query_Obj e = {})
     : Has_Block(pstate, b), expression_(e)
     { statement_type(ATROOT); }
     At_Root_Block(const At_Root_Block* ptr)
@@ -2078,7 +2078,7 @@ namespace Sass {
     ADD_PROPERTY(bool, is_rest_parameter)
   public:
     Parameter(ParserState pstate,
-              std::string n, Expression_Obj def = 0, bool rest = false)
+              std::string n, Expression_Obj def = {}, bool rest = false)
     : AST_Node(pstate), name_(n), default_value_(def), is_rest_parameter_(rest)
     {
       // tried to come up with a spec test for this, but it does no longer
@@ -2332,7 +2332,7 @@ namespace Sass {
     virtual Compound_Selector_Ptr unify_with(Compound_Selector_Ptr);
     virtual bool is_pseudo_element() const { return false; }
 
-    virtual bool is_superselector_of(Compound_Selector_Obj sub) const { return false; }
+    virtual bool is_superselector_of(Compound_Selector_Ptr_Const sub) const { return false; }
 
     bool operator==(const Selector& rhs) const final override;
     virtual bool operator==(const Simple_Selector& rhs) const;
@@ -2564,7 +2564,7 @@ namespace Sass {
   class Pseudo_Selector final : public Simple_Selector {
     ADD_PROPERTY(String_Obj, expression)
   public:
-    Pseudo_Selector(ParserState pstate, std::string n, String_Obj expr = 0)
+    Pseudo_Selector(ParserState pstate, std::string n, String_Obj expr = {})
     : Simple_Selector(pstate, n), expression_(expr)
     { simple_type(PSEUDO_SEL); }
     Pseudo_Selector(const Pseudo_Selector* ptr)
@@ -2626,7 +2626,7 @@ namespace Sass {
     : Simple_Selector(ptr), selector_(ptr->selector_)
     { simple_type(WRAPPED_SEL); }
     using Simple_Selector::is_superselector_of;
-    bool is_superselector_of(Wrapped_Selector_Obj sub) const;
+    bool is_superselector_of(Wrapped_Selector_Ptr_Const sub) const;
     // Selectors inside the negation pseudo-class are counted like any
     // other, but the negation itself does not count as a pseudo-class.
     size_t hash() const override;
@@ -2701,9 +2701,9 @@ namespace Sass {
         return (*this)[0];
       return 0;
     }
-    bool is_superselector_of(Compound_Selector_Obj sub, std::string wrapped = "") const;
-    bool is_superselector_of(Complex_Selector_Obj sub, std::string wrapped = "") const;
-    bool is_superselector_of(Selector_List_Obj sub, std::string wrapped = "") const;
+    bool is_superselector_of(Compound_Selector_Ptr_Const sub, std::string wrapped = "") const;
+    bool is_superselector_of(Complex_Selector_Ptr_Const sub, std::string wrapped = "") const;
+    bool is_superselector_of(Selector_List_Ptr_Const sub, std::string wrapped = "") const;
     size_t hash() const override
     {
       if (Selector::hash_ == 0) {
@@ -2777,9 +2777,9 @@ namespace Sass {
     };
     Complex_Selector(ParserState pstate,
                      Combinator c = ANCESTOR_OF,
-                     Compound_Selector_Obj h = 0,
-                     Complex_Selector_Obj t = 0,
-                     String_Obj r = 0)
+                     Compound_Selector_Obj h = {},
+                     Complex_Selector_Obj t = {},
+                     String_Obj r = {})
     : Selector(pstate),
       combinator_(c),
       head_(h), tail_(t),
@@ -2799,7 +2799,7 @@ namespace Sass {
       if ((!head_ || !head_->length() || head_->is_empty_reference()) &&
           combinator() == Combinator::ANCESTOR_OF)
       {
-        if (!tail_) return 0;
+        if (!tail_) return {};
         tail_->has_line_feed_ = this->has_line_feed_;
         // tail_->has_line_break_ = this->has_line_break_;
         return tail_->skip_empty_reference();
@@ -2827,9 +2827,9 @@ namespace Sass {
 
     size_t length() const;
     Selector_List_Ptr resolve_parent_refs(SelectorStack& pstack, Backtraces& traces, bool implicit_parent = true);
-    bool is_superselector_of(Compound_Selector_Obj sub, std::string wrapping = "") const;
-    bool is_superselector_of(Complex_Selector_Obj sub, std::string wrapping = "") const;
-    bool is_superselector_of(Selector_List_Obj sub, std::string wrapping = "") const;
+    bool is_superselector_of(Compound_Selector_Ptr_Const sub, std::string wrapping = "") const;
+    bool is_superselector_of(Complex_Selector_Ptr_Const sub, std::string wrapping = "") const;
+    bool is_superselector_of(Selector_List_Ptr_Const sub, std::string wrapping = "") const;
     Selector_List_Ptr unify_with(Complex_Selector_Ptr rhs);
     Combinator clear_innermost();
     void append(Complex_Selector_Obj, Backtraces& traces);
@@ -2937,7 +2937,7 @@ namespace Sass {
     Selector_List(ParserState pstate, size_t s = 0)
     : Selector(pstate),
       Vectorized<Complex_Selector_Obj>(s),
-      schema_(NULL),
+      schema_({}),
       wspace_(0)
     { }
     Selector_List(const Selector_List* ptr)
@@ -2953,9 +2953,9 @@ namespace Sass {
     bool has_real_parent_ref() const override;
     void remove_parent_selectors();
     Selector_List_Ptr resolve_parent_refs(SelectorStack& pstack, Backtraces& traces, bool implicit_parent = true);
-    bool is_superselector_of(Compound_Selector_Obj sub, std::string wrapping = "") const;
-    bool is_superselector_of(Complex_Selector_Obj sub, std::string wrapping = "") const;
-    bool is_superselector_of(Selector_List_Obj sub, std::string wrapping = "") const;
+    bool is_superselector_of(Compound_Selector_Ptr_Const sub, std::string wrapping = "") const;
+    bool is_superselector_of(Complex_Selector_Ptr_Const sub, std::string wrapping = "") const;
+    bool is_superselector_of(Selector_List_Ptr_Const sub, std::string wrapping = "") const;
     Selector_List_Ptr unify_with(Selector_List_Ptr);
     void populate_extends(Selector_List_Obj, Subset_Map&);
     Selector_List_Obj eval(Eval& eval);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -413,7 +413,7 @@ namespace Sass {
       Argument_Obj loc_arg = SASS_MEMORY_NEW(Argument, pstate, loc);
       Arguments_Obj loc_args = SASS_MEMORY_NEW(Arguments, pstate);
       loc_args->append(loc_arg);
-      Function_Call_Ptr new_url = SASS_MEMORY_NEW(Function_Call, pstate, "url", loc_args);
+      Function_Call_Ptr new_url = SASS_MEMORY_NEW(Function_Call, pstate, std::string("url"), loc_args);
       imp->urls().push_back(new_url);
     }
     else {
@@ -564,7 +564,7 @@ namespace Sass {
   {
 
     // check if entry file is given
-    if (input_path.empty()) return 0;
+    if (input_path.empty()) return {};
 
     // create absolute path from input filename
     // ToDo: this should be resolved via custom importers
@@ -610,7 +610,7 @@ namespace Sass {
   {
 
     // check if source string is given
-    if (!source_c_str) return 0;
+    if (!source_c_str) return {};
 
     // convert indented sass syntax
     if(c_options.is_indented_syntax_src) {
@@ -653,11 +653,11 @@ namespace Sass {
   Block_Obj Context::compile()
   {
     // abort if there is no data
-    if (resources.size() == 0) return 0;
+    if (resources.size() == 0) return {};
     // get root block from the first style sheet
     Block_Obj root = sheets.at(entry_path).root;
     // abort on invalid root
-    if (root.isNull()) return 0;
+    if (root.isNull()) return {};
     Env global; // create root environment
     // register built-in functions on env
     register_built_in_functions(*this, &global);
@@ -760,7 +760,7 @@ namespace Sass {
                                        ParserState("[built-in function]"),
                                        0,
                                        name,
-                                       0,
+                                       {},
                                        0,
                                        true);
     (*env)[name + "[f]"] = stub;

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -421,7 +421,7 @@ namespace Sass {
 
   Block_Ptr Cssize::debubble(Block_Ptr children, Statement_Ptr parent)
   {
-    Has_Block_Obj previous_parent = 0;
+    Has_Block_Obj previous_parent;
     std::vector<std::pair<bool, Block_Obj>> baz = slice_by_bubble(children);
     Block_Obj result = SASS_MEMORY_NEW(Block, children->pstate());
 
@@ -497,7 +497,7 @@ namespace Sass {
         wrapper_block->append(wrapper);
 
         if (wrapper->length()) {
-          previous_parent = NULL;
+          previous_parent = {};
         }
 
         if (wrapper_block) {
@@ -584,7 +584,7 @@ namespace Sass {
 
     Media_Query_Ptr mm = SASS_MEMORY_NEW(Media_Query,
                                          mq1->pstate(),
-                                         0,
+                                         {},
                                          mq1->length() + mq2->length(),
                                          mod == "not",
                                          mod == "only");

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -163,7 +163,7 @@ namespace Sass {
 
   Expression_Ptr Eval::operator()(If_Ptr i)
   {
-    Expression_Obj rv = 0;
+    Expression_Obj rv;
     Env env(environment());
     env_stack().push_back(&env);
     Expression_Obj cond = i->predicate()->perform(this);
@@ -242,8 +242,8 @@ namespace Sass {
     Expression_Obj expr = e->list()->perform(this);
     Env env(environment(), true);
     env_stack().push_back(&env);
-    List_Obj list = 0;
-    Map_Ptr map = 0;
+    List_Obj list;
+    Map_Ptr map = nullptr;
     if (expr->concrete_type() == Expression::MAP) {
       map = Cast<Map>(expr);
     }
@@ -261,7 +261,7 @@ namespace Sass {
     }
 
     Block_Obj body = e->block();
-    Expression_Obj val = 0;
+    Expression_Obj val;
 
     if (map) {
       for (Expression_Obj key : map->keys()) {
@@ -1129,7 +1129,7 @@ namespace Sass {
 
   Expression_Ptr Eval::operator()(Variable_Ptr v)
   {
-    Expression_Obj value = 0;
+    Expression_Obj value;
     Env* env = environment();
     const std::string& name(v->name());
     EnvResult rv(env->find(name));
@@ -1529,7 +1529,7 @@ namespace Sass {
   Selector_List_Ptr Eval::operator()(Complex_Selector_Ptr s)
   {
     bool implicit_parent = !exp.old_at_root_without_rule;
-    if (is_in_selector_schema) exp.selector_stack.push_back(0);
+    if (is_in_selector_schema) exp.selector_stack.push_back({});
     Selector_List_Obj resolved = s->resolve_parent_refs(exp.selector_stack, traces, implicit_parent);
     if (is_in_selector_schema) exp.selector_stack.pop_back();
     for (size_t i = 0; i < resolved->length(); i++) {

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -30,13 +30,13 @@ namespace Sass {
     selector_stack(SelectorStack()),
     media_stack(MediaStack())
   {
-    env_stack.push_back(0);
+    env_stack.push_back(nullptr);
     env_stack.push_back(env);
-    block_stack.push_back(0);
-    call_stack.push_back(0);
-    if (stack == NULL) { selector_stack.push_back(0); }
+    block_stack.push_back(nullptr);
+    call_stack.push_back({});
+    if (stack == NULL) { selector_stack.push_back({}); }
     else { selector_stack.insert(selector_stack.end(), stack->begin(), stack->end()); }
-    media_stack.push_back(0);
+    media_stack.push_back(nullptr);
   }
 
   Env* Expand::environment()
@@ -50,7 +50,7 @@ namespace Sass {
   {
     if (selector_stack.size() > 0)
       return selector_stack.back();
-    return 0;
+    return {};
   }
 
   // blocks create new variable scopes
@@ -86,7 +86,7 @@ namespace Sass {
       Keyframe_Rule_Obj k = SASS_MEMORY_NEW(Keyframe_Rule, r->pstate(), bb);
       if (r->selector()) {
         if (Selector_List_Ptr s = r->selector()) {
-          selector_stack.push_back(0);
+          selector_stack.push_back({});
           k->name(s->eval(eval));
           selector_stack.pop_back();
         }
@@ -140,7 +140,7 @@ namespace Sass {
       env_stack.push_back(&env);
     }
     sel->set_media_block(media_stack.back());
-    Block_Obj blk = 0;
+    Block_Obj blk;
     if (r->block()) blk = operator()(r->block());
     Ruleset_Ptr rr = SASS_MEMORY_NEW(Ruleset,
                                   r->pstate(),
@@ -175,7 +175,7 @@ namespace Sass {
     // Looks like we are able to reset block reference for copy
     // Good as it will ensure a low memory overhead for this fix
     // So this is a cheap solution with a minimal price
-    ctx.ast_gc.push_back(cpy); cpy->block(0);
+    ctx.ast_gc.push_back(cpy); cpy->block({});
     Expression_Obj mq = eval(m->media_queries());
     std::string str_mq(mq->to_string(ctx.c_options));
     char* str = sass_copy_c_string(str_mq.c_str());
@@ -221,7 +221,7 @@ namespace Sass {
     Block_Ptr ab = a->block();
     Selector_List_Ptr as = a->selector();
     Expression_Ptr av = a->value();
-    selector_stack.push_back(0);
+    selector_stack.push_back({});
     if (av) av = av->perform(&eval);
     if (as) as = eval(as);
     selector_stack.pop_back();
@@ -483,7 +483,7 @@ namespace Sass {
   {
     std::vector<std::string> variables(e->variables());
     Expression_Obj expr = e->list()->perform(&eval);
-    List_Obj list = 0;
+    List_Obj list;
     Map_Obj map;
     if (expr->concrete_type() == Expression::MAP) {
       map = Cast<Map>(expr);
@@ -652,7 +652,7 @@ namespace Sass {
           sl = eval(sl->schema());
           block_stack.pop_back();
         } else {
-          selector_stack.push_back(0);
+          selector_stack.push_back({});
           sl = eval(sl->schema());
           selector_stack.pop_back();
         }
@@ -662,7 +662,7 @@ namespace Sass {
           cs->head()->media_block(media_stack.back());
         }
       }
-      selector_stack.push_back(0);
+      selector_stack.push_back({});
       expand_selector_list(sl, extender);
       selector_stack.pop_back();
     }
@@ -776,7 +776,7 @@ namespace Sass {
     if (!env->has("@content[m]")) return 0;
 
     if (block_stack.back()->is_root()) {
-      selector_stack.push_back(0);
+      selector_stack.push_back({});
     }
 
     Mixin_Call_Obj call = SASS_MEMORY_NEW(Mixin_Call,

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -286,7 +286,7 @@ namespace Sass {
     Element_Selector_Obj fakeParent = SASS_MEMORY_NEW(Element_Selector, ParserState("[FAKE]"), "temp");
     Compound_Selector_Obj fakeHead = SASS_MEMORY_NEW(Compound_Selector, ParserState("[FAKE]"), 1 /*size*/);
     fakeHead->elements().push_back(fakeParent);
-    Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, fakeHead /*head*/, NULL /*tail*/);
+    Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, fakeHead /*head*/, {} /*tail*/);
 
     pOne->set_innermost(fakeParentContainer, Complex_Selector::ANCESTOR_OF);
     pTwo->set_innermost(fakeParentContainer, Complex_Selector::ANCESTOR_OF);
@@ -440,8 +440,8 @@ namespace Sass {
     //DEBUG_PRINTLN(LCS, "LCS: X=" << x << " Y=" << y)
     // TODO: make printComplexSelectorDeque and use DEBUG_EXEC AND DEBUG_PRINTLN HERE to get equivalent output
 
-    x.push_front(NULL);
-    y.push_front(NULL);
+    x.push_front({});
+    y.push_front({});
 
     LCSTable table;
     lcs_table(x, y, comparator, table);
@@ -646,7 +646,7 @@ namespace Sass {
     Element_Selector_Obj fakeParent = SASS_MEMORY_NEW(Element_Selector, ParserState("[FAKE]"), "temp");
     Compound_Selector_Obj fakeHead = SASS_MEMORY_NEW(Compound_Selector, ParserState("[FAKE]"), 1 /*size*/);
     fakeHead->elements().push_back(fakeParent);
-    Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, fakeHead /*head*/, NULL /*tail*/);
+    Complex_Selector_Obj fakeParentContainer = SASS_MEMORY_NEW(Complex_Selector, ParserState("[FAKE]"), Complex_Selector::ANCESTOR_OF, fakeHead /*head*/, {} /*tail*/);
 
     Complex_Selector_Obj pOneWithFakeParent = nodeToComplexSelector(one);
     pOneWithFakeParent->set_innermost(fakeParentContainer, Complex_Selector::ANCESTOR_OF);
@@ -1595,7 +1595,7 @@ namespace Sass {
       // out and aren't operated on.
       Complex_Selector_Obj pNewSelector = SASS_MEMORY_CLONE(pExtComplexSelector); // ->first();
 
-      Complex_Selector_Obj pNewInnerMost = SASS_MEMORY_NEW(Complex_Selector, pSelector->pstate(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, NULL);
+      Complex_Selector_Obj pNewInnerMost = SASS_MEMORY_NEW(Complex_Selector, pSelector->pstate(), Complex_Selector::ANCESTOR_OF, pUnifiedSelector, {});
 
       Complex_Selector::Combinator combinator = pNewSelector->clear_innermost();
       pNewSelector->set_innermost(pNewInnerMost, combinator);
@@ -1956,7 +1956,7 @@ namespace Sass {
                       Wrapped_Selector_Obj cpy_ws = SASS_MEMORY_COPY(ws);
                       Selector_List_Obj cpy_ws_sl = SASS_MEMORY_NEW(Selector_List, sl->pstate());
                       // remove parent selectors from inner selector
-                      Compound_Selector_Obj ext_head = NULL;
+                      Compound_Selector_Obj ext_head;
                       if (ext_cs->first()) ext_head = ext_cs->first()->head();
                       if (ext_head && ext_head && ext_head->length() > 0) {
                         cpy_ws_sl->append(ext_cs->mutable_first());

--- a/src/fn_numbers.cpp
+++ b/src/fn_numbers.cpp
@@ -102,7 +102,7 @@ namespace Sass {
     BUILT_IN(min)
     {
       List_Ptr arglist = ARG("$numbers", List);
-      Number_Obj least = NULL;
+      Number_Obj least;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression_Obj val = arglist->value_at_index(i);
         Number_Obj xi = Cast<Number>(val);
@@ -120,7 +120,7 @@ namespace Sass {
     BUILT_IN(max)
     {
       List_Ptr arglist = ARG("$numbers", List);
-      Number_Obj greatest = NULL;
+      Number_Obj greatest;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression_Obj val = arglist->value_at_index(i);
         Number_Obj xi = Cast<Number>(val);

--- a/src/fn_utils.cpp
+++ b/src/fn_utils.cpp
@@ -142,7 +142,7 @@ namespace Sass {
       }
       std::string exp_src = exp->to_string(ctx.c_options);
       Selector_List_Obj sel_list = Parser::parse_selector(exp_src.c_str(), ctx, traces);
-      if (sel_list->length() == 0) return NULL;
+      if (sel_list->length() == 0) return {};
       Complex_Selector_Obj first = sel_list->first();
       if (!first->tail()) return first->head();
       return first->tail()->head();

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -18,7 +18,7 @@ namespace Sass {
     NodeDequePtr null;
 
     Complex_Selector_Ptr pStripped = SASS_MEMORY_COPY(&pSelector);
-    pStripped->tail(NULL);
+    pStripped->tail({});
     pStripped->combinator(Complex_Selector::ANCESTOR_OF);
 
     Node n(SELECTOR, Complex_Selector::ANCESTOR_OF, pStripped, null /*pCollection*/);
@@ -234,7 +234,7 @@ namespace Sass {
     NodeDeque& childNodes = *toConvert.collection();
 
     std::string noPath("");
-    Complex_Selector_Obj pFirst = SASS_MEMORY_NEW(Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL);
+    Complex_Selector_Obj pFirst = SASS_MEMORY_NEW(Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, {}, {});
 
     Complex_Selector_Obj pCurrent = pFirst;
 
@@ -259,7 +259,7 @@ namespace Sass {
         if (childIter+1 != childIterEnd) {
           Node& nextNode = *(childIter+1);
           if (nextNode.isCombinator()) {
-            pCurrent->tail(SASS_MEMORY_NEW(Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, NULL, NULL));
+            pCurrent->tail(SASS_MEMORY_NEW(Complex_Selector, ParserState("[NODE]"), Complex_Selector::ANCESTOR_OF, {}, {}));
             if (nextNode.got_line_feed) pCurrent->tail()->has_line_feed(nextNode.got_line_feed);
             pCurrent = pCurrent->tail();
           }

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -55,7 +55,7 @@ namespace Sass {
     : ParserState(pstate), ctx(ctx), block_stack(), stack(0), last_media_block(),
       source(0), position(0), end(0), before_token(pstate), after_token(pstate),
       pstate(pstate), traces(traces), indentation(0), nestings(0)
-    { 
+    {
       stack.push_back(Scope::Root);
     }
 
@@ -375,7 +375,7 @@ namespace Sass {
           return SASS_MEMORY_NEW(String_Constant, pstate, lexed);
         }
       }
-      return 0;
+      return {};
     }
 
   public:

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -74,14 +74,14 @@ namespace Sass {
         // move line_beg pointer to line start
         while (line_beg && *line_beg && lines != 0) {
           if (*line_beg == '\n') --lines;
-          utf8::unchecked::next(line_beg); 
+          utf8::unchecked::next(line_beg);
         }
         const char* line_end = line_beg;
         // move line_end before next newline character
         while (line_end && *line_end && *line_end != '\n') {
           if (*line_end == '\n') break;
           if (*line_end == '\r') break;
-          utf8::unchecked::next(line_end); 
+          utf8::unchecked::next(line_end);
         }
         if (line_end && *line_end != 0) ++ line_end;
         size_t line_len = line_end - line_beg;
@@ -212,7 +212,7 @@ namespace Sass {
   {
 
     // assert valid pointer
-    if (compiler == 0) return 0;
+    if (compiler == 0) return {};
     // The cpp context must be set by now
     Context* cpp_ctx = compiler->cpp_ctx;
     Sass_Context* c_ctx = compiler->c_ctx;
@@ -233,7 +233,7 @@ namespace Sass {
       // dispatch parse call
       Block_Obj root(cpp_ctx->parse());
       // abort on errors
-      if (!root) return 0;
+      if (!root) return {};
 
       // skip all prefixed files? (ToDo: check srcmap)
       // IMO source-maps should point to headers already
@@ -253,7 +253,7 @@ namespace Sass {
     catch (...) { handle_errors(c_ctx); }
 
     // error
-    return 0;
+    return {};
 
   }
 
@@ -617,7 +617,7 @@ extern "C" {
     if (cpp_ctx) delete(cpp_ctx);
     compiler->cpp_ctx = NULL;
     compiler->c_ctx = NULL;
-    compiler->root = NULL;
+    compiler->root = {};
     free(compiler);
   }
 


### PR DESCRIPTION
This is more readable and avoids creating a temporary `SharedImpl(nullptr)`

Later on this will allow us to initialized `SharedImpl` directly from `T*`, avoiding a redundant temporary `SharedImpl` construction and counter increment+decrement.

Also changes `is_superselector_of` signature to accept a const pointer, avoiding an unnecessary `SharedImpl` there.

ASAN passes locally.