### PR TITLE
Fixes another memory leak and improves travis config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 /sassc
 /sass-spec
+/plugins/
 
 VERSION
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,10 @@ matrix:
           packages:
             - g++-5
     - os: linux
-      compiler: clang++-3.7
-      env: AUTOTOOLS=no COVERAGE=no BUILD=static
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.7
-          packages:
-            - clang-3.7
+      compiler: clang
+      # This build runs with ASan and we set `detect_odr_violation=0`
+      # to work around https://bugs.llvm.org/show_bug.cgi?id=37545.
+      env: AUTOTOOLS=no COVERAGE=no BUILD=static ASAN_OPTIONS=detect_odr_violation=0
     - os: linux
       compiler: clang
       env: AUTOTOOLS=yes COVERAGE=no BUILD=shared

--- a/src/fn_colors.cpp
+++ b/src/fn_colors.cpp
@@ -102,10 +102,10 @@ namespace Sass {
         return SASS_MEMORY_NEW(String_Constant, pstate, strm.str());
       }
 
-      Color_Ptr new_c = SASS_MEMORY_COPY(c_arg);
+      Color_Obj new_c = SASS_MEMORY_COPY(c_arg);
       new_c->a(ALPHA_NUM("$alpha"));
       new_c->disp("");
-      return new_c;
+      return new_c.detach();
     }
 
     ////////////////


### PR DESCRIPTION
1. Fixes another memory leak.
2. Uses the default clang for ASan on Travis (v5.0) and adds an `ASAN_OPTIONS` work-around for ODR violation red herring caused by https://bugs.llvm.org/show_bug.cgi?id=37545.

This still doesn't completely fix the Travis ASan build but it brings us much closer.