### PR TITLE
Fixes for: heap-use-after-free in parser error handling; out-of-range in `special_number`

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1561,7 +1561,7 @@ namespace Sass {
   {
     if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
       if (schema->length() == 0) return false;
-      return Cast<Parent_Reference>(schema->at(0));
+      return Cast<Parent_Reference>(schema->at(0)) != nullptr;
     }
     return false;
   }

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -15,8 +15,8 @@ namespace Sass {
       prefix("Error"), pstate(pstate), traces(traces)
     { }
 
-    InvalidSass::InvalidSass(ParserState pstate, Backtraces traces, std::string msg)
-    : Base(pstate, msg, traces)
+    InvalidSass::InvalidSass(ParserState pstate, Backtraces traces, std::string msg, char* owned_src)
+    : Base(pstate, msg, traces), owned_src(owned_src)
     { }
 
 

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -37,8 +37,9 @@ namespace Sass {
 
     class InvalidSass : public Base {
       public:
-        InvalidSass(ParserState pstate, Backtraces traces, std::string msg);
-        virtual ~InvalidSass() throw() {};
+        InvalidSass(ParserState pstate, Backtraces traces, std::string msg, char* owned_src = nullptr);
+        virtual ~InvalidSass() throw() { sass_free_memory(owned_src); };
+        char *owned_src;
     };
 
     class InvalidParent : public Base {

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -37,6 +37,17 @@ namespace Sass {
 
     class InvalidSass : public Base {
       public:
+        InvalidSass(InvalidSass& other) : Base(other), owned_src(other.owned_src) {
+          // Assumes that `this` will outlive `other`.
+          other.owned_src = nullptr;
+        }
+
+        // Required because the copy constructor's argument is not const.
+        // Can't use `std::move` here because we build on Visual Studio 2013.
+        InvalidSass(InvalidSass &&other) : Base(other), owned_src(other.owned_src) {
+          other.owned_src = nullptr;
+        }
+
         InvalidSass(ParserState pstate, Backtraces traces, std::string msg, char* owned_src = nullptr);
         virtual ~InvalidSass() throw() { sass_free_memory(owned_src); };
         char *owned_src;

--- a/src/fn_colors.cpp
+++ b/src/fn_colors.cpp
@@ -10,11 +10,11 @@ namespace Sass {
 
     bool special_number(String_Constant_Ptr s) {
       if (s) {
-        std::string calc("calc(");
-        std::string var("var(");
-        std::string ss(s->value());
-        return std::equal(calc.begin(), calc.end(), ss.begin()) ||
-               std::equal(var.begin(), var.end(), ss.begin());
+        static const char* const calc = "calc(";
+        static const char* const var = "var(";
+        const std::string& str = s->value();
+        return str.compare(0, strlen(calc), calc) == 0 ||
+               str.compare(0, strlen(var), var) == 0;
       }
       return false;
     }

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -200,7 +200,7 @@ namespace Sass {
     {
       std::string msg(typeid(*this).name());
       msg += ": CRTP not implemented for ";
-      throw std::runtime_error(msg + typeid(*x).name());
+      throw std::runtime_error(msg + typeid(x).name());
     }
 
   };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3054,8 +3054,11 @@ namespace Sass {
   {
     Position p(pos.line ? pos : before_token);
     ParserState pstate(path, source, p, Offset(0, 0));
+    // `pstate.src` may not outlive stack unwind so we must copy it.
+    char *src_copy = sass_copy_c_string(pstate.src);
+    pstate.src = src_copy;
     traces.push_back(Backtrace(pstate));
-    throw Exception::InvalidSass(pstate, traces, msg);
+    throw Exception::InvalidSass(pstate, traces, msg, src_copy);
   }
 
   void Parser::error(std::string msg)

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -67,23 +67,23 @@ namespace Sass {
       }
 
       // now create the code trace (ToDo: maybe have util functions?)
-      if (e.pstate.line != std::string::npos && e.pstate.column != std::string::npos) {
+      if (e.pstate.line != std::string::npos &&
+          e.pstate.column != std::string::npos &&
+          e.pstate.src != nullptr) {
         size_t lines = e.pstate.line;
-        const char* line_beg = e.pstate.src;
         // scan through src until target line
         // move line_beg pointer to line start
-        while (line_beg && *line_beg && lines != 0) {
+        const char* line_beg;
+        for (line_beg = e.pstate.src; *line_beg != '\0'; ++line_beg) {
+          if (lines == 0) break;
           if (*line_beg == '\n') --lines;
-          utf8::unchecked::next(line_beg);
         }
-        const char* line_end = line_beg;
         // move line_end before next newline character
-        while (line_end && *line_end && *line_end != '\n') {
-          if (*line_end == '\n') break;
-          if (*line_end == '\r') break;
-          utf8::unchecked::next(line_end);
+        const char* line_end;
+        for (line_end = line_beg; *line_end != '\0'; ++line_end) {
+          if (*line_end == '\n' || *line_end == '\r') break;
         }
-        if (line_end && *line_end != 0) ++ line_end;
+        if (*line_end != '\0') ++line_end;
         size_t line_len = line_end - line_beg;
         size_t move_in = 0; size_t shorten = 0;
         size_t left_chars = 42; size_t max_chars = 76;


### PR DESCRIPTION
Fixes #2643: `pstate.src` may not outlive stack unwind so we must copy it.

Also optimizes line_begin/end search in `handle_error`. There is no need to advance by UTF-8 code points when searching for an ASCII character, because UTF-8 is a prefix-free encoding.