### PR TITLE
Update AppVeyor CI to Visual Studio 2015

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-os: Visual Studio 2013
+os: Visual Studio 2015
 
 environment:
   CTEST_OUTPUT_ON_FAILURE: 1

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -9,22 +9,11 @@
 
 #include <cmath>
 #include <stdint.h>
-#if defined(_MSC_VER) && _MSC_VER >= 1800 && _MSC_VER < 1900 && defined(_M_X64)
-#include <mutex>
-#endif
 
 namespace Sass {
 
   double round(double val, size_t precision)
   {
-    // Disable FMA3-optimized implementation when compiling with VS2013 for x64 targets
-    // See https://github.com/sass/node-sass/issues/1854 for details
-    // FIXME: Remove this workaround when we switch to VS2015+
-    #if defined(_MSC_VER) && _MSC_VER >= 1800 && _MSC_VER < 1900 && defined(_M_X64)
-      static std::once_flag flag;
-      std::call_once(flag, []() { _set_FMA3_enable(0); });
-    #endif
-
     // https://github.com/sass/sass/commit/4e3e1d5684cc29073a507578fc977434ff488c93
     if (fmod(val, 1) - 0.5 > - std::pow(0.1, precision + 1)) return std::ceil(val);
     else if (fmod(val, 1) - 0.5 > std::pow(0.1, precision)) return std::floor(val);


### PR DESCRIPTION
Fixes #2757 

Looks like sassc has been using VS2015 since the beginning.