### PR TITLE
Disallow parent selectors in `selector-append`

### DIFF
--- a/src/fn_selectors.cpp
+++ b/src/fn_selectors.cpp
@@ -83,7 +83,10 @@ namespace Sass {
           str->quote_mark(0);
         }
         std::string exp_src = exp->to_string();
-        Selector_List_Obj sel = Parser::parse_selector(exp_src.c_str(), ctx, traces);
+        Selector_List_Obj sel = Parser::parse_selector(exp_src.c_str(), ctx, traces,
+                                                       exp->pstate(), pstate.src,
+                                                       /*allow_parent=*/false);
+
         parsedSelectors.push_back(sel);
       }
 

--- a/src/fn_utils.cpp
+++ b/src/fn_utils.cpp
@@ -121,13 +121,13 @@ namespace Sass {
         std::stringstream msg;
         msg << argname << ": null is not a valid selector: it must be a string,\n";
         msg << "a list of strings, or a list of lists of strings for `" << function_name(sig) << "'";
-        error(msg.str(), pstate, traces);
+        error(msg.str(), exp->pstate(), traces);
       }
       if (String_Constant_Ptr str = Cast<String_Constant>(exp)) {
         str->quote_mark(0);
       }
       std::string exp_src = exp->to_string(ctx.c_options);
-      return Parser::parse_selector(exp_src.c_str(), ctx, traces);
+      return Parser::parse_selector(exp_src.c_str(), ctx, traces, exp->pstate(), pstate.src);
     }
 
     Compound_Selector_Obj get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces, Context& ctx) {
@@ -135,13 +135,13 @@ namespace Sass {
       if (exp->concrete_type() == Expression::NULL_VAL) {
         std::stringstream msg;
         msg << argname << ": null is not a string for `" << function_name(sig) << "'";
-        error(msg.str(), pstate, traces);
+        error(msg.str(), exp->pstate(), traces);
       }
       if (String_Constant_Ptr str = Cast<String_Constant>(exp)) {
         str->quote_mark(0);
       }
       std::string exp_src = exp->to_string(ctx.c_options);
-      Selector_List_Obj sel_list = Parser::parse_selector(exp_src.c_str(), ctx, traces);
+      Selector_List_Obj sel_list = Parser::parse_selector(exp_src.c_str(), ctx, traces, exp->pstate(), pstate.src);
       if (sel_list->length() == 0) return {};
       Complex_Selector_Obj first = sel_list->first();
       if (!first->tail()) return first->head();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -48,23 +48,24 @@ namespace Sass {
     Backtraces traces;
     size_t indentation;
     size_t nestings;
+    bool allow_parent;
 
     Token lexed;
 
-    Parser(Context& ctx, const ParserState& pstate, Backtraces traces)
+    Parser(Context& ctx, const ParserState& pstate, Backtraces traces, bool allow_parent = true)
     : ParserState(pstate), ctx(ctx), block_stack(), stack(0), last_media_block(),
       source(0), position(0), end(0), before_token(pstate), after_token(pstate),
-      pstate(pstate), traces(traces), indentation(0), nestings(0)
+      pstate(pstate), traces(traces), indentation(0), nestings(0), allow_parent(allow_parent)
     {
       stack.push_back(Scope::Root);
     }
 
     // static Parser from_string(const std::string& src, Context& ctx, ParserState pstate = ParserState("[STRING]"));
-    static Parser from_c_str(const char* src, Context& ctx, Backtraces, ParserState pstate = ParserState("[CSTRING]"), const char* source = 0);
-    static Parser from_c_str(const char* beg, const char* end, Context& ctx, Backtraces, ParserState pstate = ParserState("[CSTRING]"), const char* source = 0);
-    static Parser from_token(Token t, Context& ctx, Backtraces, ParserState pstate = ParserState("[TOKEN]"), const char* source = 0);
+    static Parser from_c_str(const char* src, Context& ctx, Backtraces, ParserState pstate = ParserState("[CSTRING]"), const char* source = nullptr, bool allow_parent = true);
+    static Parser from_c_str(const char* beg, const char* end, Context& ctx, Backtraces, ParserState pstate = ParserState("[CSTRING]"), const char* source = nullptr, bool allow_parent = true);
+    static Parser from_token(Token t, Context& ctx, Backtraces, ParserState pstate = ParserState("[TOKEN]"), const char* source = nullptr);
     // special static parsers to convert strings into certain selectors
-    static Selector_List_Obj parse_selector(const char* src, Context& ctx, Backtraces, ParserState pstate = ParserState("[SELECTOR]"), const char* source = 0);
+    static Selector_List_Obj parse_selector(const char* src, Context& ctx, Backtraces, ParserState pstate = ParserState("[SELECTOR]"), const char* source = nullptr, bool allow_parent = true);
 
 #ifdef __clang__
 


### PR DESCRIPTION
Now correctly errors on inputs such as this one instead of crashing (see #2663):

```scss
div {
  a: selector-append('.menu', 'li', '&');
}
```

```
Error: Parent selectors aren't allowed here.
        on line 3:37 of ../../../tmp/test.scss, in function `selector-append`
        from line 3:6 of ../../../tmp/test.scss
>>   e: selector-append('.menu', 'li', '&');

   ------------------------------------^
```

