### PR TITLE
Fix crash in `selector-append('.x~~', 'a')`

### DIFF
--- a/src/fn_selectors.cpp
+++ b/src/fn_selectors.cpp
@@ -140,11 +140,13 @@ namespace Sass {
 
             // TODO: Add check for namespace stuff
 
-            // append any selectors in childSeq's head
-            parentSeqClone->mutable_last()->head()->concat(base->head());
-
-            // Set parentSeqClone new tail
-            parentSeqClone->mutable_last()->tail( base->tail() );
+            Complex_Selector_Ptr lastComponent = parentSeqClone->mutable_last();
+            if (lastComponent->head() == nullptr) {
+              std::string msg = "Parent \"" + parentSeqClone->to_string() + "\" is incompatible with \"" + base->to_string() + "\"";
+              error(msg, pstate, traces);
+            }
+            lastComponent->head()->concat(base->head());
+            lastComponent->tail(base->tail());
 
             newElements.push_back(parentSeqClone);
           }


### PR DESCRIPTION
Test case:

```scss
div {
  a: selector-append('.x~~', 'a')
}
```

Before: segfault
After: 

```
Error: Parent ".x ~ ~" is incompatible with "a"
        on line 2:6 of ../../../tmp/test2.scss, in function `selector-append`
        from line 2:6 of ../../../tmp/test2.scss
>>   a: selector-append('.x~~', 'a')

   -----^
```

Fixes #2663