### PR TITLE
appveyor CI: Reduce parallelism to 2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,9 +41,9 @@ install:
 build_script:
   - ps: |
       if ($env:Compiler -eq "mingw") {
-        mingw32-make -j4 sassc
+        mingw32-make -j2 sassc
       } else {
-        msbuild /m:4 /p:"Configuration=$env:Config;Platform=$env:Platform" sassc\win\sassc.sln
+        msbuild /m:2 /p:"Configuration=$env:Config;Platform=$env:Platform" sassc\win\sassc.sln
       }
 
       # print the branding art


### PR DESCRIPTION
Should make appveyor builds faster
Pretty sure appveyor OSS doesn't have more than 2 cores (maybe it's just
one), and ~~looks like it doesn't have enough RAM to build in parallel~~.