### PR TITLE
Re-implement selector unification

### DIFF
--- a/include/sass/base.h
+++ b/include/sass/base.h
@@ -1,6 +1,7 @@
 #ifndef SASS_BASE_H
 #define SASS_BASE_H
 
+// #define DEBUG
 // #define DEBUG_SHARED_PTR
 
 #ifdef _MSC_VER

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -319,6 +319,12 @@ namespace Sass {
       return hash_;
     }
 
+    template <typename P, typename V>
+    typename std::vector<T>::iterator insert(P position, const V& val) {
+      reset_hash();
+      return elements_.insert(position, val);
+    }
+
     typename std::vector<T>::iterator end() { return elements_.end(); }
     typename std::vector<T>::iterator begin() { return elements_.begin(); }
     typename std::vector<T>::const_iterator end() const { return elements_.end(); }

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -431,7 +431,6 @@ namespace Sass {
   typedef std::pair<Complex_Selector_Obj, SubSetMapPairs> SubSetMapResult;
   typedef std::vector<SubSetMapResult> SubSetMapResults;
 
-  #define OrderSelectors OrderFunction<Selector_Obj>
   typedef std::set<Selector_Obj, OrderNodes> SelectorSet;
 
   typedef std::deque<Complex_Selector_Obj> ComplexSelectorDeque;

--- a/src/ast_sel_cmp.cpp
+++ b/src/ast_sel_cmp.cpp
@@ -467,10 +467,7 @@ namespace Sass {
 
   bool Simple_Selector::operator== (const Selector_List& rhs) const
   {
-    size_t len = rhs.length();
-    if (len > 1) return false;
-    if (len == 0) return empty();
-    return *this == *rhs.at(0);
+    return rhs.length() == 1 && *this == *rhs.at(0);
   }
 
   bool Simple_Selector::operator< (const Selector_List& rhs) const
@@ -483,9 +480,9 @@ namespace Sass {
 
   bool Simple_Selector::operator== (const Complex_Selector& rhs) const
   {
-    if (rhs.tail()) return false;
-    if (!rhs.head()) return empty();
-    return *this == *rhs.head();
+    return !rhs.tail() && rhs.head() &&
+           rhs.combinator() == Complex_Selector::ANCESTOR_OF &&
+           *this == *rhs.head();
   }
 
   bool Simple_Selector::operator< (const Complex_Selector& rhs) const
@@ -497,10 +494,7 @@ namespace Sass {
 
   bool Simple_Selector::operator== (const Compound_Selector& rhs) const
   {
-    size_t len = rhs.length();
-    if (len > 1) return false;
-    if (len == 0) return empty();
-    return *this == *rhs.at(0);
+    return rhs.length() == 1 && *this == *rhs.at(0);
   }
 
   bool Simple_Selector::operator< (const Compound_Selector& rhs) const
@@ -832,15 +826,11 @@ namespace Sass {
 
   bool Type_Selector::operator< (const Type_Selector& rhs) const
   {
-    if (is_ns_eq(rhs))
-    { 
-      if (rhs.has_ns_ && has_ns_)
-        return name() < rhs.name();
-      if (!rhs.has_ns_ && !has_ns_)
-        return name() < rhs.name();
-      return true;
-    }
-    return ns() < rhs.ns();
+    return has_ns_ == rhs.has_ns_
+      ? (ns_ == rhs.ns_
+         ? name_ < rhs.name_
+         : ns_ < rhs.ns_)
+      : has_ns_ < rhs.has_ns_;
   }
 
   bool Class_Selector::operator< (const Class_Selector& rhs) const

--- a/src/ast_selectors.hpp
+++ b/src/ast_selectors.hpp
@@ -109,10 +109,10 @@ namespace Sass {
       PLACEHOLDER_SEL,
     };
   public:
-    ADD_CONSTREF(std::string, ns)
-    ADD_CONSTREF(std::string, name)
+    HASH_CONSTREF(std::string, ns)
+    HASH_CONSTREF(std::string, name)
     ADD_PROPERTY(Simple_Type, simple_type)
-    ADD_PROPERTY(bool, has_ns)
+    HASH_PROPERTY(bool, has_ns)
   public:
     Simple_Selector(ParserState pstate, std::string n = "");
     Simple_Selector(const Simple_Selector* ptr);
@@ -123,7 +123,6 @@ namespace Sass {
     bool is_ns_eq(const Simple_Selector& r) const;
     // namespace query functions
     bool is_universal_ns() const;
-    bool has_universal_ns() const;
     bool is_empty_ns() const;
     bool has_empty_ns() const;
     bool has_qualified_ns() const;

--- a/src/extend.cpp
+++ b/src/extend.cpp
@@ -1851,8 +1851,7 @@ namespace Sass {
     // Ruby Equivalent: flatten
     Node flattened(flatten(trimmed, 1));
 
-    DEBUG_PRINTLN(EXTEND_COMPLEX, ">>>>> EXTENDED: " << extendedSelectors)
-    DEBUG_PRINTLN(EXTEND_COMPLEX, "EXTEND COMPLEX END: " << complexSelector)
+    DEBUG_PRINTLN(EXTEND_COMPLEX, "FLATTENED: " << flattened)
 
     // memory results in a map table - since extending is very expensive
     memoizeComplex.insert(std::pair<Complex_Selector_Obj, Node>(selector, flattened));

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -648,7 +648,7 @@ namespace Sass {
     // parse mandatory arguments
     call->arguments(parse_arguments());
     // parse using and optional block parameters
-    bool has_parameters = lex< kwd_using >();
+    bool has_parameters = lex< kwd_using >() != nullptr;
 
     if (has_parameters) {
       if (!peek< exactly<'('> >()) css_error("Invalid CSS", " after ", ": expected \"(\", was ");

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -35,6 +35,15 @@ namespace Sass {
 
   bool peek_linefeed(const char* start);
 
+  // Returns true iff `elements` ⊆ `container`.
+  template <typename C, typename T>
+  bool contains_all(C container, T elements) {
+    for (const auto &el : elements) {
+      if (container.find(el) == container.end()) return false;
+    }
+    return true;
+  }
+
   // C++20 `starts_with` equivalent.
   // See https://en.cppreference.com/w/cpp/string/basic_string/starts_with
   inline bool starts_with(const std::string& str, const char* prefix, size_t prefix_len) {


### PR DESCRIPTION
This new implementation is similar to the one in dart-sass.

Also fixes a few bugs in hash calculation (`==` objects having different hashes) and comparison (`a < b` and `b < a` being true at the same time; this fixes #2776).

Also cleans up and optimizes `Compound_Selector::is_superselector_of(Compound_Selector_Ptr_Const, std::string)`.

The following tests are fixed by this change:

```
/spec/selector-functions/unify/universal_simple
/spec/extend-tests/237_extend_with_universal_selector_different_namespace
/spec/extend-tests/040_test_universal_unification_with_namespaced_element_target
/spec/extend-tests/053_test_element_unification_with_namespaced_universal_target
/spec/extend-tests/236_extend_with_universal_selector_empty_namespace
/spec/extend-tests/096_test_long_extender_runs_unification
/spec/extend-tests/060_test_element_unification_with_namespaceless_element_target
/spec/extend-tests/051_test_element_unification_with_namespaceless_universal_target
/spec/extend-tests/038_test_universal_unification_with_namespaceless_element_target
/spec/extend-tests/029_test_universal_unification_with_namespaceless_universal_target
/spec/extend-tests/031_test_universal_unification_with_namespaced_universal_target
/spec/extend-tests/062_test_element_unification_with_namespaced_element_target
```

sass-spec `output_styles` update + marking newly passing tests: https://github.com/sass/sass-spec/pull/1319