### PR TITLE
Fix #2782: heap-use-after-free in expand.cpp

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -640,7 +640,7 @@ namespace Sass {
 
   Statement* Expand::operator()(Extension_Ptr e)
   {
-    if (Selector_List_Ptr extender = selector()) {
+    if (Selector_List_Obj extender = selector()) {
       Selector_List_Ptr sl = e->selector();
       // abort on invalid selector
       if (sl == NULL) return NULL;


### PR DESCRIPTION
Selector stack got popped during eval, resulting in `extender` deletion.