### PR TITLE
Catch exceptions by reference

### DIFF
--- a/src/fn_strings.cpp
+++ b/src/fn_strings.cpp
@@ -14,15 +14,15 @@ namespace Sass {
       try {
        throw;
       }
-      catch (utf8::invalid_code_point) {
+      catch (utf8::invalid_code_point&) {
         std::string msg("utf8::invalid_code_point");
         error(msg, pstate, traces);
       }
-      catch (utf8::not_enough_room) {
+      catch (utf8::not_enough_room&) {
         std::string msg("utf8::not_enough_room");
         error(msg, pstate, traces);
       }
-      catch (utf8::invalid_utf8) {
+      catch (utf8::invalid_utf8&) {
         std::string msg("utf8::invalid_utf8");
         error(msg, pstate, traces);
       }

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -402,7 +402,7 @@ char *json_encode_string(const char *str)
   try {
     emit_string(&sb, str);
   }
-  catch (std::exception) {
+  catch (std::exception&) {
     sb_free(&sb);
     throw;
   }
@@ -421,7 +421,7 @@ char *json_stringify(const JsonNode *node, const char *space)
     else
       emit_value(&sb, node);
   }
-  catch (std::exception) {
+  catch (std::exception&) {
     sb_free(&sb);
     throw;
   }


### PR DESCRIPTION
Fixes `-Wcatch-value` warnings reported by gcc 8.2.0

The warnings looked like this:

```
src/fn_strings.cpp: In function ‘void Sass::Functions::handle_utf8_error(const Sass::ParserState&, Sass::Backtraces)’:
src/fn_strings.cpp:17:20: warning: catching polymorphic type ‘class utf8::invalid_code_point’ by value [-Wcatch-value=]
       catch (utf8::invalid_code_point) {
                    ^~~~~~~~~~~~~~~~~~
src/fn_strings.cpp:21:20: warning: catching polymorphic type ‘class utf8::not_enough_room’ by value [-Wcatch-value=]
       catch (utf8::not_enough_room) {
                    ^~~~~~~~~~~~~~~
src/fn_strings.cpp:25:20: warning: catching polymorphic type ‘class utf8::invalid_utf8’ by value [-Wcatch-value=]
       catch (utf8::invalid_utf8) {
                    ^~~~~~~~~~~~
```