### PR TITLE
Fix VS2013 warning C4800 in src/ast_selectors.cpp

### DIFF
--- a/src/ast_selectors.cpp
+++ b/src/ast_selectors.cpp
@@ -88,7 +88,7 @@ namespace Sass {
   bool Selector_Schema::has_parent_ref() const
   {
     if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
-      return schema->length() > 0 && Cast<Parent_Selector>(schema->at(0)) != NULL;
+      return !schema->empty() && typeid(*schema->at(0)) == typeid(Parent_Selector);
     }
     return false;
   }
@@ -96,8 +96,7 @@ namespace Sass {
   bool Selector_Schema::has_real_parent_ref() const
   {
     if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
-      if (schema->length() == 0) return false;
-      return Cast<Parent_Reference>(schema->at(0));
+      return !schema->empty() && typeid(*schema->at(0)) == typeid(Parent_Reference);
     }
     return false;
   }


### PR DESCRIPTION
Fixes the following warning when compiling with VS2013:

> ..\..\src\ast_selectors.cpp(100): warning C4800: 'Sass::Parent_Reference *' : forcing value to bool 'true' or 'false' (performance warning)

This warning is visible in AppVeyor: https://ci.appveyor.com/project/sass/libsass/builds/21035726/job/dyi132vi6qnqy0ir

Also adjusts `has_parent_ref` for consistency.