### PR TITLE
`const Expression_Ptr` -> `Expression_Ptr`

### DIFF
--- a/src/values.cpp
+++ b/src/values.cpp
@@ -7,7 +7,7 @@
 namespace Sass {
 
   // convert value from C++ side to C-API
-  union Sass_Value* ast_node_to_sass_value (const Expression_Ptr val)
+  union Sass_Value* ast_node_to_sass_value (Expression_Ptr val)
   {
     if (val->concrete_type() == Expression::NUMBER)
     {


### PR DESCRIPTION
The `const` there was useless, as it didn't mean the constness of Expression but merely that `val` pointer could not be reassigned within the function (due to how pointer typedefs and consts interact).

Assignee: @mgreter

If we actually want the Expression to be const there, we'll need to add const conversion functions to Color.