### PR TITLE
Avoid modifying Expression in ast_node_to_sass_value

### DIFF
--- a/src/ast2c.cpp
+++ b/src/ast2c.cpp
@@ -20,7 +20,10 @@ namespace Sass {
   { return sass_make_color(c->r(), c->g(), c->b(), c->a()); }
 
   union Sass_Value* AST2C::operator()(Color_HSLA_Ptr c)
-  { return operator()(c->toRGBA()); }
+  {
+    Color_RGBA_Obj rgba = c->copyAsRGBA();
+    return operator()(rgba.ptr());
+  }
 
   union Sass_Value* AST2C::operator()(String_Constant_Ptr s)
   {

--- a/src/ast_values.cpp
+++ b/src/ast_values.cpp
@@ -551,7 +551,7 @@ namespace Sass {
     return hash_;
   }
 
-  Color_HSLA_Ptr Color_RGBA::toHSLA(bool copy)
+  Color_HSLA_Ptr Color_RGBA::copyAsHSLA() const
   {
 
     // Algorithm from http://en.wikipedia.org/wiki/wHSL_and_HSV#Conversion_from_RGB_to_HSL_or_HSV
@@ -589,9 +589,9 @@ namespace Sass {
     );
   }
 
-  Color_RGBA_Ptr Color_RGBA::toRGBA(bool copy)
+  Color_RGBA_Ptr Color_RGBA::copyAsRGBA() const
   {
-    return copy ? SASS_MEMORY_COPY(this) : this;
+    return SASS_MEMORY_COPY(this);
   }
 
   /////////////////////////////////////////////////////////////////////////
@@ -646,7 +646,7 @@ namespace Sass {
     return m1;
   }
 
-  Color_RGBA_Ptr Color_HSLA::toRGBA(bool copy)
+  Color_RGBA_Ptr Color_HSLA::copyAsRGBA() const
   {
 
     double h = absmod(h_ / 360.0, 1.0);
@@ -668,9 +668,9 @@ namespace Sass {
     );
   }
 
-  Color_HSLA_Ptr Color_HSLA::toHSLA(bool copy)
+  Color_HSLA_Ptr Color_HSLA::copyAsHSLA() const
   {
-    return copy ? SASS_MEMORY_COPY(this) : this;
+    return SASS_MEMORY_COPY(this);
   }
 
   /////////////////////////////////////////////////////////////////////////

--- a/src/ast_values.hpp
+++ b/src/ast_values.hpp
@@ -250,8 +250,11 @@ namespace Sass {
 
     bool operator== (const Expression& rhs) const override;
 
-    virtual Color_RGBA_Ptr toRGBA(bool copy = false) = 0;
-    virtual Color_HSLA_Ptr toHSLA(bool copy = false) = 0;
+    virtual Color_RGBA_Ptr copyAsRGBA() const = 0;
+    virtual Color_RGBA_Ptr toRGBA() = 0;
+
+    virtual Color_HSLA_Ptr copyAsHSLA() const = 0;
+    virtual Color_HSLA_Ptr toHSLA() = 0;
 
     ATTACH_VIRTUAL_AST_OPERATIONS(Color)
   };
@@ -270,8 +273,12 @@ namespace Sass {
     static std::string type_name() { return "color"; }
 
     size_t hash() const override;
-    Color_RGBA_Ptr toRGBA(bool copy = false) override;
-    Color_HSLA_Ptr toHSLA(bool copy = false) override;
+
+    Color_RGBA_Ptr copyAsRGBA() const override;
+    Color_RGBA_Ptr toRGBA() override { return this; }
+
+    Color_HSLA_Ptr copyAsHSLA() const override;
+    Color_HSLA_Ptr toHSLA() override { return copyAsHSLA(); }
 
     bool operator== (const Expression& rhs) const override;
 
@@ -294,8 +301,12 @@ namespace Sass {
     static std::string type_name() { return "color"; }
 
     size_t hash() const override;
-    Color_RGBA_Ptr toRGBA(bool copy = false) override;
-    Color_HSLA_Ptr toHSLA(bool copy = false) override;
+
+    Color_RGBA_Ptr copyAsRGBA() const override;
+    Color_RGBA_Ptr toRGBA() override { return copyAsRGBA(); }
+
+    Color_HSLA_Ptr copyAsHSLA() const override;
+    Color_HSLA_Ptr toHSLA() override { return this; }
 
     bool operator== (const Expression& rhs) const override;
 

--- a/src/fn_colors.cpp
+++ b/src/fn_colors.cpp
@@ -122,7 +122,7 @@ namespace Sass {
 
     Signature red_sig = "red($color)";
     BUILT_IN(red)
-    { 
+    {
       Color_RGBA_Obj color = ARG("$color", Color)->toRGBA();
       return SASS_MEMORY_NEW(Number, pstate, color->r());
     }
@@ -273,7 +273,7 @@ namespace Sass {
     {
       Color_Ptr col = ARG("$color", Color);
       double degrees = ARGVAL("$degrees");
-      Color_HSLA_Obj copy = col->toHSLA(true);
+      Color_HSLA_Obj copy = col->copyAsHSLA();
       copy->h(absmod(copy->h() + degrees, 360.0));
       return copy.detach();
     }
@@ -283,7 +283,7 @@ namespace Sass {
     {
       Color_Ptr col = ARG("$color", Color);
       double amount = DARG_U_PRCT("$amount");
-      Color_HSLA_Obj copy = col->toHSLA(true);
+      Color_HSLA_Obj copy = col->copyAsHSLA();
       copy->l(clip(copy->l() + amount, 0.0, 100.0));
       return copy.detach();
 
@@ -294,7 +294,7 @@ namespace Sass {
     {
       Color_Ptr col = ARG("$color", Color);
       double amount = DARG_U_PRCT("$amount");
-      Color_HSLA_Obj copy = col->toHSLA(true);
+      Color_HSLA_Obj copy = col->copyAsHSLA();
       copy->l(clip(copy->l() - amount, 0.0, 100.0));
       return copy.detach();
     }
@@ -309,7 +309,7 @@ namespace Sass {
 
       Color_Ptr col = ARG("$color", Color);
       double amount = DARG_U_PRCT("$amount");
-      Color_HSLA_Obj copy = col->toHSLA(true);
+      Color_HSLA_Obj copy = col->copyAsHSLA();
       copy->s(clip(copy->s() + amount, 0.0, 100.0));
       return copy.detach();
     }
@@ -319,7 +319,7 @@ namespace Sass {
     {
       Color_Ptr col = ARG("$color", Color);
       double amount = DARG_U_PRCT("$amount");
-      Color_HSLA_Obj copy = col->toHSLA(true);
+      Color_HSLA_Obj copy = col->copyAsHSLA();
       copy->s(clip(copy->s() - amount, 0.0, 100.0));
       return copy.detach();
     }
@@ -334,7 +334,7 @@ namespace Sass {
       }
 
       Color_Ptr col = ARG("$color", Color);
-      Color_HSLA_Obj copy = col->toHSLA(true);
+      Color_HSLA_Obj copy = col->copyAsHSLA();
       copy->s(0.0); // just reset saturation
       return copy.detach();
     }
@@ -347,7 +347,7 @@ namespace Sass {
     BUILT_IN(complement)
     {
       Color_Ptr col = ARG("$color", Color);
-      Color_HSLA_Obj copy = col->toHSLA(true);
+      Color_HSLA_Obj copy = col->copyAsHSLA();
       copy->h(absmod(copy->h() - 180.0, 360.0));
       return copy.detach();
     }
@@ -363,7 +363,7 @@ namespace Sass {
 
       Color_Ptr col = ARG("$color", Color);
       double weight = DARG_U_PRCT("$weight");
-      Color_RGBA_Obj inv = col->toRGBA(true);
+      Color_RGBA_Obj inv = col->copyAsRGBA();
       inv->r(clip(255.0 - inv->r(), 0.0, 255.0));
       inv->g(clip(255.0 - inv->g(), 0.0, 255.0));
       inv->b(clip(255.0 - inv->b(), 0.0, 255.0));
@@ -437,7 +437,7 @@ namespace Sass {
         error("Cannot specify HSL and RGB values for a color at the same time for `adjust-color'", pstate, traces);
       }
       else if (rgb) {
-        Color_RGBA_Obj c = col->toRGBA(true);
+        Color_RGBA_Obj c = col->copyAsRGBA();
         if (r) c->r(c->r() + DARG_R_BYTE("$red"));
         if (g) c->g(c->g() + DARG_R_BYTE("$green"));
         if (b) c->b(c->b() + DARG_R_BYTE("$blue"));
@@ -445,7 +445,7 @@ namespace Sass {
         return c.detach();
       }
       else if (hsl) {
-        Color_HSLA_Obj c = col->toHSLA(true);
+        Color_HSLA_Obj c = col->copyAsHSLA();
         if (h) c->h(c->h() + absmod(h->value(), 360.0));
         if (s) c->s(c->s() + DARG_R_PRCT("$saturation"));
         if (l) c->l(c->l() + DARG_R_PRCT("$lightness"));
@@ -482,7 +482,7 @@ namespace Sass {
         error("Cannot specify HSL and RGB values for a color at the same time for `scale-color'", pstate, traces);
       }
       else if (rgb) {
-        Color_RGBA_Obj c = col->toRGBA(true);
+        Color_RGBA_Obj c = col->copyAsRGBA();
         double rscale = (r ? DARG_R_PRCT("$red") : 0.0) / 100.0;
         double gscale = (g ? DARG_R_PRCT("$green") : 0.0) / 100.0;
         double bscale = (b ? DARG_R_PRCT("$blue") : 0.0) / 100.0;
@@ -494,7 +494,7 @@ namespace Sass {
         return c.detach();
       }
       else if (hsl) {
-        Color_HSLA_Obj c = col->toHSLA(true);
+        Color_HSLA_Obj c = col->copyAsHSLA();
         double hscale = (h ? DARG_R_PRCT("$hue") : 0.0) / 100.0;
         double sscale = (s ? DARG_R_PRCT("$saturation") : 0.0) / 100.0;
         double lscale = (l ? DARG_R_PRCT("$lightness") : 0.0) / 100.0;
@@ -536,7 +536,7 @@ namespace Sass {
         error("Cannot specify HSL and RGB values for a color at the same time for `change-color'", pstate, traces);
       }
       else if (rgb) {
-        Color_RGBA_Obj c = col->toRGBA(true);
+        Color_RGBA_Obj c = col->copyAsRGBA();
         if (r) c->r(DARG_U_BYTE("$red"));
         if (g) c->g(DARG_U_BYTE("$green"));
         if (b) c->b(DARG_U_BYTE("$blue"));
@@ -544,7 +544,7 @@ namespace Sass {
         return c.detach();
       }
       else if (hsl) {
-        Color_HSLA_Obj c = col->toHSLA(true);
+        Color_HSLA_Obj c = col->copyAsHSLA();
         if (h) c->h(absmod(h->value(), 360.0));
         if (s) c->s(DARG_U_PRCT("$saturation"));
         if (l) c->l(DARG_U_PRCT("$lightness"));

--- a/src/values.cpp
+++ b/src/values.cpp
@@ -7,7 +7,7 @@
 namespace Sass {
 
   // convert value from C++ side to C-API
-  union Sass_Value* ast_node_to_sass_value (const Expression_Ptr val)
+  union Sass_Value* ast_node_to_sass_value (Expression_Ptr_Const val)
   {
     if (val->concrete_type() == Expression::NUMBER)
     {
@@ -16,9 +16,13 @@ namespace Sass {
     }
     else if (val->concrete_type() == Expression::COLOR)
     {
-      // ToDo: allow to also use HSLA colors!!
-      Color_RGBA_Obj col = Cast<Color>(val)->toRGBA();
-      return sass_make_color(col->r(), col->g(), col->b(), col->a());
+      if (Color_RGBA_Ptr_Const rgba = Cast<Color_RGBA>(val)) {
+        return sass_make_color(rgba->r(), rgba->g(), rgba->b(), rgba->a());
+      } else {
+        // ToDo: allow to also use HSLA colors!!
+        Color_RGBA_Obj col = Cast<Color>(val)->copyAsRGBA();
+        return sass_make_color(col->r(), col->g(), col->b(), col->a());
+      }
     }
     else if (val->concrete_type() == Expression::LIST)
     {

--- a/src/values.hpp
+++ b/src/values.hpp
@@ -5,7 +5,7 @@
 
 namespace Sass {
 
-  union Sass_Value* ast_node_to_sass_value (const Expression_Ptr val);
+  union Sass_Value* ast_node_to_sass_value (Expression_Ptr_Const val);
   Value_Ptr sass_value_to_ast_node (const union Sass_Value* val);
 
 }


### PR DESCRIPTION
Previously, the argument to `ast_node_to_sass_value` was a `const Expression_Ptr`.

The `const` there was useless, as it didn't mean the constness of Expression but merely that `val` pointer could not be reassigned within the function (due to how pointer `typedef` and `const` interacts).

Assuming the intended argument type was `const Expression_Ptr *`, I've changed it to `Expression_Ptr_Const`.

This required splitting `to{RGBA,HSLA}(bool)` into separate functions, so that the one that always copies could be marked as `const`.

@mgreter 