### PR TITLE
[WIP] Enable LTO: 500 KiB smaller binary, 15% faster build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: cpp
 
 # ASan needs ptrace support which currently requires `sudo: required`.
@@ -24,14 +25,8 @@ matrix:
       compiler: gcc
       env: AUTOTOOLS=no COVERAGE=yes BUILD=static
     - os: linux
-      compiler: g++-5
+      compiler: gcc
       env: AUTOTOOLS=yes COVERAGE=no BUILD=shared
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
     - os: linux
       compiler: clang
       # This build runs with ASan and we set `detect_odr_violation=0`

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,22 @@ matrix:
       # This build runs with ASan and we set `detect_odr_violation=0`
       # to work around https://bugs.llvm.org/show_bug.cgi?id=37545.
       env: AUTOTOOLS=no COVERAGE=no BUILD=static ASAN_OPTIONS=detect_odr_violation=0
+      addons:
+        # https://bugs.launchpad.net/ubuntu/+source/llvm-toolchain-snapshot/+bug/1254970
+        apt:
+          sources:
+          - llvm-toolchain-xenial-7
+          packages:
+          - llvm-7-dev
     - os: linux
       compiler: clang
       env: AUTOTOOLS=yes COVERAGE=no BUILD=shared
+      addons:
+        apt:
+          sources:
+          - llvm-toolchain-xenial-7
+          packages:
+          - llvm-7-dev
     - os: osx
       compiler: clang
       env: AUTOTOOLS=no COVERAGE=no BUILD=shared

--- a/GNUmakefile.am
+++ b/GNUmakefile.am
@@ -3,9 +3,13 @@ ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4 -I script
 AM_COPT = -Wall -O2
 AM_COVLDFLAGS =
 
+if ENABLE_LTO
+AM_COPT += -flto
+endif
+
 if ENABLE_COVERAGE
-	AM_COPT = -Wall -O1 -fno-omit-frame-pointer --coverage
-	AM_COVLDFLAGS += -lgcov
+AM_COPT = -Wall -O1 -fno-omit-frame-pointer --coverage
+AM_COVLDFLAGS += -lgcov
 endif
 
 AM_CPPFLAGS = -I$(top_srcdir)/include

--- a/Makefile
+++ b/Makefile
@@ -29,22 +29,22 @@ else
 	UNAME := $(shell uname -s)
 endif
 
+
 ifneq "$(COVERAGE)" "yes"
-	CFLAGS   += -O2
-	CXXFLAGS += -O2
-	LDFLAGS  += -O2
-	# MinGW on Windows needs a plugin for LTO that isn't there by default.
-	ifneq (Windows,$(UNAME))
-		ifndef NO_LTO
-			CFLAGS   += -flto
-			CXXFLAGS += -flto
-			LDFLAGS  += -flto
-		endif
-	endif
+  CFLAGS   += -O2
+  CXXFLAGS += -O2
+  LDFLAGS  += -O2
 else
-	CFLAGS   += -O1 -fno-omit-frame-pointer
-	CXXFLAGS += -O1 -fno-omit-frame-pointer
-	LDFLAGS  += -O1 -fno-omit-frame-pointer
+  CFLAGS   += -O1 -fno-omit-frame-pointer
+  CXXFLAGS += -O1 -fno-omit-frame-pointer
+  LDFLAGS  += -O1 -fno-omit-frame-pointer
+endif
+
+$(foreach assignment,$(shell sh script/lto-env.sh $(CC)),$(eval $(assignment)))
+ifeq ($(ENABLE_LTO),yes)
+  CFLAGS   += -flto
+  CXXFLAGS += -flto
+  LDFLAGS  += -flto
 endif
 
 ifndef LIBSASS_VERSION
@@ -266,6 +266,8 @@ install-shared: $(DESTDIR)$(PREFIX)/lib/libsass.so \
                 install-headers
 
 $(SASSC_BIN): $(BUILD)
+	export AR=$(AR)
+	export RANLIB=$(RANLIB)
 	$(MAKE) -C $(SASS_SASSC_PATH) build-$(BUILD)-dev
 
 sassc: $(SASSC_BIN)

--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,11 @@ ifneq "$(COVERAGE)" "yes"
 	LDFLAGS  += -O2
 	# MinGW on Windows needs a plugin for LTO that isn't there by default.
 	ifneq (Windows,$(UNAME))
-		CFLAGS   += -flto
-		CXXFLAGS += -flto
-		LDFLAGS  += -flto
+		ifndef NO_LTO
+			CFLAGS   += -flto
+			CXXFLAGS += -flto
+			LDFLAGS  += -flto
+		endif
 	endif
 else
 	CFLAGS   += -O1 -fno-omit-frame-pointer

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,6 @@ INSTALL  ?= install
 CFLAGS   ?= -Wall
 CXXFLAGS ?= -Wall
 LDFLAGS  ?= -Wall
-ifndef COVERAGE
-  CFLAGS   += -O2
-  CXXFLAGS += -O2
-  LDFLAGS  += -O2
-else
-  CFLAGS   += -O1 -fno-omit-frame-pointer
-  CXXFLAGS += -O1 -fno-omit-frame-pointer
-  LDFLAGS  += -O1 -fno-omit-frame-pointer
-endif
 CAT ?= $(if $(filter $(OS),Windows_NT),type,cat)
 
 ifneq (,$(findstring /cygdrive/,$(PATH)))
@@ -36,6 +27,22 @@ else ifneq (,$(findstring MINGW32,$(shell uname -s)))
 	UNAME := Windows
 else
 	UNAME := $(shell uname -s)
+endif
+
+ifneq "$(COVERAGE)" "yes"
+	CFLAGS   += -O2
+	CXXFLAGS += -O2
+	LDFLAGS  += -O2
+	# MinGW on Windows needs a plugin for LTO that isn't there by default.
+	ifneq (Windows,$(UNAME))
+		CFLAGS   += -flto
+		CXXFLAGS += -flto
+		LDFLAGS  += -flto
+	endif
+else
+	CFLAGS   += -O1 -fno-omit-frame-pointer
+	CXXFLAGS += -O1 -fno-omit-frame-pointer
+	LDFLAGS  += -O1 -fno-omit-frame-pointer
 endif
 
 ifndef LIBSASS_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,10 @@ AC_ARG_ENABLE(tests, AS_HELP_STRING([--enable-tests], [enable testing the build]
 AS_CASE([$host], [*-*-mingw*], [is_mingw32=yes], [is_mingw32=no])
 AM_CONDITIONAL(COMPILER_IS_MINGW32, test "x$is_mingw32" = "xyes")
 
+# LTO is enabled by default, except for mingw32 which doesn't have the necessary
+# linker plugin installed by default.
+AM_CONDITIONAL([ENABLE_LTO], [test "$is_mingw32" = no -a -z "$NO_LTO"])
+
 dnl The dlopen() function is in the C library for *BSD and in
 dnl libdl on GLIBC-based systems
 if test "x$is_mingw32" != "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -47,9 +47,13 @@ AC_ARG_ENABLE(tests, AS_HELP_STRING([--enable-tests], [enable testing the build]
 AS_CASE([$host], [*-*-mingw*], [is_mingw32=yes], [is_mingw32=no])
 AM_CONDITIONAL(COMPILER_IS_MINGW32, test "x$is_mingw32" = "xyes")
 
-# LTO is enabled by default, except for mingw32 which doesn't have the necessary
-# linker plugin installed by default.
-AM_CONDITIONAL([ENABLE_LTO], [test "$is_mingw32" = no -a -z "$NO_LTO"])
+source script/lto-env.sh "$CC"
+if test "$enable_lto" = yes; then
+  echo >&2 "LTO enabled"
+  AC_SUBST([AR])
+  AC_SUBST([RANLIB])
+fi
+AM_CONDITIONAL([ENABLE_LTO], [test "$enable_lto" = yes])
 
 dnl The dlopen() function is in the C library for *BSD and in
 dnl libdl on GLIBC-based systems

--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -53,15 +53,16 @@ if [ "x$PREFIX" == "x" ]; then
   fi
 fi
 
-# enable address sanitation
-# https://en.wikipedia.org/wiki/AddressSanitizer
-if [ "x$CC" == "xclang" ]; then
-  if [ "x$COVERAGE" != "xyes" ]; then
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      export EXTRA_CFLAGS="$EXTRA_CFLAGS -fsanitize=address"
-      export EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -fsanitize=address"
-      export EXTRA_LDFLAGS="$EXTRA_LDFLAGS -fsanitize=address"
-    fi
+# -flto doesn't work on travis due to missing linker plugins.
+export NO_LTO=1
+
+if [[ $CC == clang ]]; then
+  # enable address sanitation
+  # https://en.wikipedia.org/wiki/AddressSanitizer
+  if [[ $COVERAGE != yes && $TRAVIS_OS_NAME == linux ]]; then
+    export EXTRA_CFLAGS="$EXTRA_CFLAGS -fsanitize=address"
+    export EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -fsanitize=address"
+    export EXTRA_LDFLAGS="$EXTRA_LDFLAGS -fsanitize=address"
   fi
 fi
 

--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -54,7 +54,7 @@ if [ "x$PREFIX" == "x" ]; then
 fi
 
 # -flto doesn't work on travis due to missing linker plugins.
-export NO_LTO=1
+# export NO_LTO=1
 
 if [[ $CC == clang ]]; then
   # enable address sanitation

--- a/script/ci-install-deps
+++ b/script/ci-install-deps
@@ -6,15 +6,4 @@ else
   echo "no dependencies to install"
 fi
 
-if [ "x$AUTOTOOLS" == "xyes" ]; then
-  AUTOTOOLS=yes
-
-  if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-    sudo add-apt-repository -y ppa:rbose-debianizer/automake &> /dev/null
-    sudo apt-get -qq update
-    sudo apt-get -qq install automake
-  fi
-
-fi
-
 exit 0

--- a/script/lto-env.sh
+++ b/script/lto-env.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+cc=$1
+if test -z "$cc" || test "$cc" = dummy; then
+  cc=cc
+fi
+
+cc_version="$("$cc" -v 2>&1 | grep ' version')"
+compiler_family="$(echo "$cc_version" | grep -o '[a-z]* version' | grep -o '^[^ ]*' | sed s/LLVM/clang/)"
+enable_lto=no
+if test -z "$NO_LTO" && test "$COVERAGE" != yes; then
+  if test "$compiler_family" = clang; then
+    enable_lto=yes AR=llvm-ar RANLIB=llvm-ranlib
+  elif test "$compiler_family" = gcc; then
+    enable_lto=yes AR=gcc-ar RANLIB=gcc-ranlib
+  fi
+fi
+
+echo >&2 "ENABLE_LTO=$enable_lto
+  cc -v | grep ' version': $cc_version
+  Detected compiler family: $compiler_family
+  ld -v: $(ld -v)"
+
+if test "$enable_lto" = yes; then
+  echo "ENABLE_LTO=yes AR=$AR RANLIB=$RANLIB"
+else
+  echo "ENABLE_LTO=no"
+fi

--- a/src/GNUmakefile.am
+++ b/src/GNUmakefile.am
@@ -1,6 +1,6 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4 -I script
 
-AM_COPT = -Wall -O2
+AM_COPT = -Wall -O2 -flto
 AM_COVLDFLAGS =
 
 if ENABLE_COVERAGE

--- a/src/GNUmakefile.am
+++ b/src/GNUmakefile.am
@@ -1,11 +1,15 @@
 ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4 -I script
 
-AM_COPT = -Wall -O2 -flto
+AM_COPT = -Wall -O2
 AM_COVLDFLAGS =
 
+if ENABLE_LTO
+AM_COPT += -flto
+endif
+
 if ENABLE_COVERAGE
-	AM_COPT = -O0 --coverage
-	AM_COVLDFLAGS += -lgcov
+AM_COPT = -Wall -O1 -fno-omit-frame-pointer --coverage
+AM_COVLDFLAGS += -lgcov
 endif
 
 AM_CPPFLAGS = -I$(top_srcdir)/include


### PR DESCRIPTION
Metrics:

* `time make -j1 sassc`: 65s -> 56s
* `libsass.a` size: 6.7 MiB ⭢ 24 MiB
* `libsass.so` size: 3.2 MiB ⭢ 2.7 MiB
* sassc binary size: 2.7 MiB ⭢ 2.2 MiB
* Compiling 10 copies of bootstrap 4: 0.45s ⭢ 0.40s

LTO requires a "recent" (2010+) version of `ar` and `ranlib` (to have LTO support by default). Alternatively, one can use `gcc-ar` / `llvm-ar`. In make and automake we try to detect the compiler and set `AR` and `RANLIB`.

LTO can be disabled by setting `NO_LTO=1`.

I still haven't figured out some builds.