### PR TITLE
travis: Disable coverage for static OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       env: AUTOTOOLS=no COVERAGE=no BUILD=shared
     - os: osx
       compiler: clang
-      env: AUTOTOOLS=no COVERAGE=yes BUILD=static
+      env: AUTOTOOLS=no COVERAGE=no BUILD=static
     - os: osx
       compiler: clang
       env: AUTOTOOLS=yes COVERAGE=no BUILD=shared


### PR DESCRIPTION
There is no need to run this coverage build as we don't have any OSX-specific code.

This build is very slow, and disabling it reduces our overall travis build time by ~10 minutes.