### PR TITLE
Avoid clang warning: expression with side effects will be evaluated despite being used as an operand to 'typeid'

### DIFF
--- a/src/ast_selectors.cpp
+++ b/src/ast_selectors.cpp
@@ -88,7 +88,9 @@ namespace Sass {
   bool Selector_Schema::has_parent_ref() const
   {
     if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
-      return !schema->empty() && typeid(*schema->at(0)) == typeid(Parent_Selector);
+      if (schema->empty()) return false;
+      const auto& first = *schema->at(0);
+      return typeid(first) == typeid(Parent_Selector);
     }
     return false;
   }
@@ -96,7 +98,9 @@ namespace Sass {
   bool Selector_Schema::has_real_parent_ref() const
   {
     if (String_Schema_Obj schema = Cast<String_Schema>(contents())) {
-      return !schema->empty() && typeid(*schema->at(0)) == typeid(Parent_Reference);
+      if (schema->empty()) return false;
+      const auto& first = *schema->at(0);
+      return typeid(first) == typeid(Parent_Reference);
     }
     return false;
   }


### PR DESCRIPTION
This is not a useful warning here but simply extracting `*schema->at(0)` to a variable avoids it.

Warning example: https://travis-ci.org/sass/libsass/jobs/471245025
Refs #1523