### PR TITLE
Fix get-function doesn't see functions defined in inner scopes

### DIFF
--- a/src/fn_miscs.cpp
+++ b/src/fn_miscs.cpp
@@ -237,7 +237,7 @@ namespace Sass {
       }
 
 
-      if (!d_env.has_global(full_name)) {
+      if (!d_env.has(full_name)) {
         error("Function not found: " + name, pstate, traces);
       }
 


### PR DESCRIPTION
This fixes the error reported in #2830 but it appears there is a
general issue using `call` with the result of `get-function`.