### PR TITLE
If OpenBSD, print message showing how to use clang instead of gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 OS       ?= $(shell uname -s)
 CC       ?= cc
 CXX      ?= c++
+ifeq ($(OS),OpenBSD)
+@echo '*** HINT ***: You need to use clang instead of gcc. Please refer to https://github.com/sass/libsass/blob/master/docs/build.md#compiling-with-clang-instead-of-gcc. On some architecturess you'll need to install the clang package first.'
+@echo 'After that, manually write the specification and you should be good to go: https://guides.rubygems.org/command-reference/#extension-install-failures'
+endif
 RM       ?= rm -f
 CP       ?= cp -a
 MKDIR    ?= mkdir


### PR DESCRIPTION
Took me a while to realize this. Printing a message should make it easier for others following in my footsteps.

```
g++ -Wall -O2 -std=c++0x -I /home/dev/.gem/ruby/2.5.1/gems/sassc-2.0.1/ext/libsass/include -fPIC -fPIC -c -o src/ast.o src/ast.cpp
cc1plus: error: unrecognized command line option "-std=c++0x"
gmake: *** [Makefile:249: src/ast.o] Error 1
```