### PR TITLE
If OpenBSD, print message showing how to use `clang` instead of `gcc`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ endif
 CXXFLAGS += -std=c++11
 LDFLAGS  += -std=c++11
 
+ifeq ($(OS),OpenBSD)
+    @echo '*** HINT ***: OpenBSD uses `clang` instead of `gcc`, to fix this please visit: https://github.com/sass/libsass/blob/master/docs/build.md#compiling-with-clang-instead-of-gcc'
+endif
+
 ifeq (Windows,$(UNAME))
 	ifneq ($(BUILD),shared)
 		STATIC_ALL     ?= 1


### PR DESCRIPTION
Kinda hard for ordinary users to figure this out by themselves.