### PR TITLE
Make Makefile compatible with GNU Make >= 3.79.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,20 @@ CAT ?= $(if $(filter $(OS),Windows_NT),type,cat)
 
 ifneq (,$(findstring /cygdrive/,$(PATH)))
 	UNAME := Cygwin
-else ifneq (,$(findstring Windows_NT,$(OS)))
+else
+ifneq (,$(findstring Windows_NT,$(OS)))
 	UNAME := Windows
-else ifneq (,$(findstring mingw32,$(MAKE)))
+else
+ifneq (,$(findstring mingw32,$(MAKE)))
 	UNAME := Windows
-else ifneq (,$(findstring MINGW32,$(shell uname -s)))
+else
+ifneq (,$(findstring MINGW32,$(shell uname -s)))
 	UNAME := Windows
 else
 	UNAME := $(shell uname -s)
+endif
+endif
+endif
 endif
 
 ifndef LIBSASS_VERSION
@@ -153,10 +159,12 @@ ifeq (Windows,$(UNAME))
 		CXXFLAGS  += -D ADD_EXPORTS
 		LIB_SHARED  = $(SASS_LIBSASS_PATH)/lib/libsass.dll
 	endif
-else ifneq (Cygwin,$(UNAME))
+else
+ifneq (Cygwin,$(UNAME))
 	CFLAGS   += -fPIC
 	CXXFLAGS += -fPIC
 	LDFLAGS  += -fPIC
+endif
 endif
 
 include Makefile.conf


### PR DESCRIPTION
This is a small change to the Makefile that makes it syntactically compatible with GNU `make` as far back as at least 3.79.1 while remaining forward compatible.

I'm interested in this change because some coworkers of mine are working on an [R package wrapper](https://github.com/rstudio/sass), and some of the build tools available in the R package compilation environment &mdash; particularly `make` &mdash; are *really* dated. They aren't able to include libsass sources directly in the package (as is required of such things in the R world) without patching it first.

I figured it might be useful for other people to build with really old versions of `make`, and it would be nice not to patch it locally. So, I put together this PR.

## Technical context

The particular reason for this change is that `make` (since 3.8 I think?) [supports two kinds](https://www.gnu.org/software/make/manual/html_node/Conditional-Syntax.html) of "complex conditionals", or conditional statements with `else` clauses:

```make
conditional-directive
text-if-true
else
text-if-false
endif
```
and
```make
conditional-directive-one
text-if-one-is-true
else conditional-directive-two
text-if-two-is-true
else
text-if-one-and-two-are-false
endif
```
The latter syntax is the one used in libsass's Makefile, but `make` 3.79.1 [only supports the former](https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_7.html#SEC73).

This PR translates instances of of the "new" syntax into the old so that `make` 3.79.1 can process the Makefile without any syntax errors.

## Upside

With the old syntax, libsass is likely to build on a wider variety of old platforms.

## Downside

The old syntax is slightly more verbose.

Thanks in advance for considering this change!
