### PR TITLE
Copy Unicode PWD tests from sass-spec

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,9 +80,9 @@ test_script:
         echo "spec runner not found (compile error?)"
         exit 1
       }
-      Write-Host "Explicitly testing the case when cwd has Cyrillic characters: " -nonewline
+      Write-Host "Explicitly testing the case when cwd has Unicode characters: " -nonewline
       # See comments in gh-1774 for details.
-      cd sass-spec/spec/libsass/Sáss-UŢF8/
+      cd test/e2e/unicode-pwd/Sáss-UŢF8/
       &$env:TargetPath ./input.scss 2>&1>$null
       if(-not($?)) {
         echo "Failed!"

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,4 +21,4 @@ build/test_util_string: test_util_string.cpp ../src/util_string.cpp | build
 clean: | build
 	rm -rf build
 
-.PHONY: test test_shared_ptr clean
+.PHONY: test test_shared_ptr test_util_string clean

--- a/test/e2e/unicode-pwd/Sáss-UŢF8/input.scss
+++ b/test/e2e/unicode-pwd/Sáss-UŢF8/input.scss
@@ -1,0 +1,3 @@
+span.utf8-in-path {
+  margin: auto;
+}

--- a/test/e2e/unicode-pwd/Sáss-UŢF8/output.css
+++ b/test/e2e/unicode-pwd/Sáss-UŢF8/output.css
@@ -1,0 +1,3 @@
+span.utf8-in-path {
+  margin: auto;
+}

--- a/test/e2e/unicode-pwd/Sáss-UŢF8/input.scss
+++ b/test/e2e/unicode-pwd/Sáss-UŢF8/input.scss
@@ -1,0 +1,3 @@
+span.utf8-in-path {
+  margin: auto;
+}

--- a/test/e2e/unicode-pwd/Sáss-UŢF8/output.css
+++ b/test/e2e/unicode-pwd/Sáss-UŢF8/output.css
@@ -1,0 +1,3 @@
+span.utf8-in-path {
+  margin: auto;
+}


### PR DESCRIPTION
As sass-spec is migrating to HRX, we need to copy this test here so we
can run it directly via `sassc` instead of the sass-spec runner.

Refs #2854
Refs https://github.com/sass/sass-spec/pull/1365