### PR TITLE
Fix incorrect call to `std::isxdigit`

### DIFF
--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -1400,7 +1400,7 @@ namespace Sass {
     }*/
 
     const char* H(const char* src) {
-      return std::isxdigit(*src) ? src+1 : 0;
+      return std::isxdigit(static_cast<unsigned char>(*src)) ? src+1 : 0;
     }
 
     const char* W(const char* src) {


### PR DESCRIPTION
This caused the Win32 Debug build to crash.

See https://en.cppreference.com/w/cpp/string/byte/isxdigit for more
information.

Fixes #2867