### PR TITLE
Fix spec testing on mac with shared build

### DIFF
--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -128,10 +128,10 @@ then
     echo "Fetching Sass Spec PR $SPEC_PR"
     git -C sass-spec fetch -u origin pull/$SPEC_PR/head:ci-spec-pr-$SPEC_PR
     git -C sass-spec checkout --force ci-spec-pr-$SPEC_PR
-    LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_probe
+    make LD_LIBRARY_PATH="$PREFIX/lib/" DYLD_LIBRARY_PATH="$PREFIX/lib/" $MAKE_OPTS test_probe
   else
-    LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_probe
+    make LD_LIBRARY_PATH="$PREFIX/lib/" DYLD_LIBRARY_PATH="$PREFIX/lib/" $MAKE_OPTS test_probe
   fi
 else
-  LD_LIBRARY_PATH="$PREFIX/lib/" make $MAKE_OPTS test_probe
+  make LD_LIBRARY_PATH="$PREFIX/lib/" DYLD_LIBRARY_PATH="$PREFIX/lib/" $MAKE_OPTS test_probe
 fi


### PR DESCRIPTION
Since spec test runner now executes the tests in the
directory of the spec test, the default library path
resolution does no longer work with relative paths.