### PR TITLE
Remove the link to `ast_factory.hpp` from Visual C++ project files

### DIFF
--- a/win/libsass.targets
+++ b/win/libsass.targets
@@ -16,7 +16,6 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_supports.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_def_macros.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\memory\SharedPtr.hpp" />
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_factory.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_fwd_decl.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\backtrace.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\base64vlq.hpp" />

--- a/win/libsass.vcxproj.filters
+++ b/win/libsass.vcxproj.filters
@@ -63,9 +63,6 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_def_macros.hpp">
       <Filter>Headers</Filter>
     </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_factory.hpp">
-      <Filter>Headers</Filter>
-    </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_fwd_decl.hpp">
       <Filter>Headers</Filter>
     </ClInclude>


### PR DESCRIPTION
The `ast_factory.hpp` file does not exist, so need to remove links to it from the `libsass.targets` and `libsass.vcxproj.filters` files.