### PR TITLE
Remove abspath from native Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ else
 endif
 
 ifndef SASS_LIBSASS_PATH
-	SASS_LIBSASS_PATH = $(abspath $(CURDIR))
+	SASS_LIBSASS_PATH = $(CURDIR)
 endif
 ifdef SASS_LIBSASS_PATH
 	CFLAGS   += -I $(SASS_LIBSASS_PATH)/include


### PR DESCRIPTION
It does not seem extremely portable, since it has some
issues at least on windows gmake. It does not recognize
windows absolute path with drive letters (e.g. D:\foo).

https://stackoverflow.com/questions/21288101

IMO this was mainly added for cosmetics and "just in case", but I
don't think it is actually needed (relative should be good enough)