### PR TITLE
Makefile: Fix STATIC_LIBSTDCPP support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,9 @@ LDFLAGS  += $(EXTRA_LDFLAGS)
 
 LDLIBS = -lm
 ifneq ($(BUILD),shared)
-	LDLIBS += -lstdc++
+	ifneq ($(STATIC_LIBSTDCPP),1)
+		LDLIBS += -lstdc++
+	endif
 endif
 
 # link statically into lib


### PR DESCRIPTION
Previously, `STATIC_LIBSTDC++` was not respected because `-lstdc++` was
present at the same time.