### PR TITLE
Add and use our own ASCII case-conversion routines

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -3,8 +3,6 @@
 #include "sass.hpp"
 
 #include "ast.hpp"
-#include <cctype>
-#include <locale>
 
 namespace Sass {
 

--- a/src/ast_selectors.cpp
+++ b/src/ast_selectors.cpp
@@ -652,15 +652,17 @@ namespace Sass {
   CssMediaQuery_Obj CssMediaQuery::merge(CssMediaQuery_Obj& other)
   {
 
-    std::string ourType(this->type());
-    std::string theirType(other->type());
-    std::string ourModifier(this->modifier());
-    std::string theirModifier(other->modifier());
+    std::string ourType = this->type();
+    Util::ascii_str_tolower(&ourType);
 
-    std::transform(ourType.begin(), ourType.end(), ourType.begin(), ::tolower);
-    std::transform(theirType.begin(), theirType.end(), theirType.begin(), ::tolower);
-    std::transform(ourModifier.begin(), ourModifier.end(), ourModifier.begin(), ::tolower);
-    std::transform(theirModifier.begin(), theirModifier.end(), theirModifier.begin(), ::tolower);
+    std::string theirType = other->type();
+    Util::ascii_str_tolower(&theirType);
+
+    std::string ourModifier = this->modifier();
+    Util::ascii_str_tolower(&ourModifier);
+
+    std::string theirModifier = other->modifier();
+    Util::ascii_str_tolower(&theirModifier);
 
     std::string type;
     std::string modifier;

--- a/src/color_maps.cpp
+++ b/src/color_maps.cpp
@@ -4,6 +4,7 @@
 
 #include "ast.hpp"
 #include "color_maps.hpp"
+#include "util_string.hpp"
 
 namespace Sass {
 
@@ -616,8 +617,8 @@ namespace Sass {
   const Color_RGBA* name_to_color(const std::string& key)
   {
     // case insensitive lookup.  See #2462
-    std::string lower{key};
-    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    std::string lower = key;
+    Util::ascii_str_tolower(&lower);
 
     auto p = names_to_colors.find(lower.c_str());
     if (p != names_to_colors.end()) {

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -13,7 +13,6 @@
 #else
 # include <unistd.h>
 #endif
-#include <cctype>
 #include <cstdio>
 #include <vector>
 #include <algorithm>
@@ -25,6 +24,7 @@
 #include "sass_functions.hpp"
 #include "error_handling.hpp"
 #include "util.hpp"
+#include "util_string.hpp"
 #include "sass2scss.h"
 
 #ifdef _WIN32
@@ -106,13 +106,13 @@ namespace Sass {
     bool is_absolute_path(const std::string& path)
     {
       #ifdef _WIN32
-        if (path.length() >= 2 && isalpha(path[0]) && path[1] == ':') return true;
+        if (path.length() >= 2 && Util::ascii_isalpha(path[0]) && path[1] == ':') return true;
       #endif
       size_t i = 0;
       // check if we have a protocol
-      if (path[i] && Prelexer::is_alpha(path[i])) {
+      if (path[i] && Util::ascii_isalpha(static_cast<unsigned char>(path[i]))) {
         // skip over all alphanumeric characters
-        while (path[i] && Prelexer::is_alnum(path[i])) ++i;
+        while (path[i] && Util::ascii_isalnum(static_cast<unsigned char>(path[i]))) ++i;
         i = i && path[i] == ':' ? i + 1 : 0;
       }
       return path[i] == '/';
@@ -179,9 +179,9 @@ namespace Sass {
 
       size_t proto = 0;
       // check if we have a protocol
-      if (path[proto] && Prelexer::is_alpha(path[proto])) {
+      if (path[proto] && Util::ascii_isalpha(static_cast<unsigned char>(path[proto]))) {
         // skip over all alphanumeric characters
-        while (path[proto] && Prelexer::is_alnum(path[proto++])) {}
+        while (path[proto] && Util::ascii_isalnum(static_cast<unsigned char>(path[proto++]))) {}
         // then skip over the mandatory colon
         if (proto && path[proto] == ':') ++ proto;
       }
@@ -260,9 +260,9 @@ namespace Sass {
 
       size_t proto = 0;
       // check if we have a protocol
-      if (path[proto] && Prelexer::is_alpha(path[proto])) {
+      if (path[proto] && Util::ascii_isalpha(static_cast<unsigned char>(path[proto]))) {
         // skip over all alphanumeric characters
-        while (path[proto] && Prelexer::is_alnum(path[proto++])) {}
+        while (path[proto] && Util::ascii_isalnum(static_cast<unsigned char>(path[proto++]))) {}
         // then skip over the mandatory colon
         if (proto && path[proto] == ':') ++ proto;
       }
@@ -288,7 +288,8 @@ namespace Sass {
         #else
           // compare the charactes in a case insensitive manner
           // windows fs is only case insensitive in ascii ranges
-          if (tolower(abs_path[i]) != tolower(abs_base[i])) break;
+          if (Util::ascii_tolower(static_cast<unsigned char>(abs_path[i])) !=
+              Util::ascii_tolower(static_cast<unsigned char>(abs_base[i]))) break;
         #endif
         if (abs_path[i] == '/') index = i + 1;
       }
@@ -487,8 +488,7 @@ namespace Sass {
       if (path.length() > 5) {
         extension = path.substr(path.length() - 5, 5);
       }
-      for(size_t i=0; i<extension.size();++i)
-        extension[i] = tolower(extension[i]);
+      Util::ascii_str_tolower(&extension);
       if (extension == ".sass" && contents != 0) {
         char * converted = sass2scss(contents, SASS2SCSS_PRETTIFY_1 | SASS2SCSS_KEEP_COMMENT);
         free(contents); // free the indented contents

--- a/src/fn_colors.cpp
+++ b/src/fn_colors.cpp
@@ -2,12 +2,12 @@
 // __EXTENSIONS__ fix on Solaris.
 #include "sass.hpp"
 
-#include <cctype>
 #include <iomanip>
 #include "ast.hpp"
 #include "fn_utils.hpp"
 #include "fn_colors.hpp"
 #include "util.hpp"
+#include "util_string.hpp"
 
 namespace Sass {
 
@@ -582,10 +582,8 @@ namespace Sass {
       ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(g, ctx.c_options.precision));
       ss << std::hex << std::setw(2) << static_cast<unsigned long>(Sass::round(b, ctx.c_options.precision));
 
-      std::string result(ss.str());
-      for (size_t i = 0, L = result.length(); i < L; ++i) {
-        result[i] = std::toupper(result[i]);
-      }
+      std::string result = ss.str();
+      Util::ascii_str_toupper(&result);
       return SASS_MEMORY_NEW(String_Quoted, pstate, result);
     }
 

--- a/src/fn_numbers.cpp
+++ b/src/fn_numbers.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cmath>
-#include <cctype>
 #include <random>
 #include <sstream>
 #include <iomanip>

--- a/src/fn_strings.cpp
+++ b/src/fn_strings.cpp
@@ -2,11 +2,11 @@
 // __EXTENSIONS__ fix on Solaris.
 #include "sass.hpp"
 
-#include <cctype>
 #include "utf8.h"
 #include "ast.hpp"
 #include "fn_utils.hpp"
 #include "fn_strings.hpp"
+#include "util_string.hpp"
 
 namespace Sass {
 
@@ -212,12 +212,7 @@ namespace Sass {
     {
       String_Constant* s = ARG("$string", String_Constant);
       std::string str = s->value();
-
-      for (size_t i = 0, L = str.length(); i < L; ++i) {
-        if (Sass::Util::isAscii(str[i])) {
-          str[i] = std::toupper(str[i]);
-        }
-      }
+      Util::ascii_str_toupper(&str);
 
       if (String_Quoted* ss = Cast<String_Quoted>(s)) {
         String_Quoted* cpy = SASS_MEMORY_COPY(ss);
@@ -233,12 +228,7 @@ namespace Sass {
     {
       String_Constant* s = ARG("$string", String_Constant);
       std::string str = s->value();
-
-      for (size_t i = 0, L = str.length(); i < L; ++i) {
-        if (Sass::Util::isAscii(str[i])) {
-          str[i] = std::tolower(str[i]);
-        }
-      }
+      Util::ascii_str_tolower(&str);
 
       if (String_Quoted* ss = Cast<String_Quoted>(s)) {
         String_Quoted* cpy = SASS_MEMORY_COPY(ss);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -6,6 +6,7 @@
 #include <iomanip>
 #include "lexer.hpp"
 #include "constants.hpp"
+#include "util_string.hpp"
 
 
 namespace Sass {
@@ -27,77 +28,14 @@ namespace Sass {
     const char* kwd_minus(const char* src) { return exactly<'-'>(src); };
     const char* kwd_slash(const char* src) { return exactly<'/'>(src); };
 
-    //####################################
-    // implement some function that do exist in the standard
-    // but those are locale aware which brought some trouble
-    // this even seems to improve performance by quite a bit
-    //####################################
-
-    bool is_alpha(const char& chr)
-    {
-      return unsigned(chr - 'A') <= 'Z' - 'A' ||
-             unsigned(chr - 'a') <= 'z' - 'a';
-    }
-
-    bool is_space(const char& chr)
-    {
-      // adapted the technique from is_alpha
-      return chr == ' ' || unsigned(chr - '\t') <= '\r' - '\t';
-    }
-
-    bool is_digit(const char& chr)
-    {
-      // adapted the technique from is_alpha
-      return unsigned(chr - '0') <= '9' - '0';
-    }
-
-    bool is_number(const char& chr)
-    {
-      // adapted the technique from is_alpha
-      return is_digit(chr) || chr == '-' || chr == '+';
-    }
-
-    bool is_xdigit(const char& chr)
-    {
-      // adapted the technique from is_alpha
-      return unsigned(chr - '0') <= '9' - '0' ||
-             unsigned(chr - 'a') <= 'f' - 'a' ||
-             unsigned(chr - 'A') <= 'F' - 'A';
-    }
-
-    bool is_punct(const char& chr)
-    {
-      // locale independent
-      return chr == '.';
-    }
-
-    bool is_alnum(const char& chr)
-    {
-      return is_alpha(chr) || is_digit(chr);
-    }
-
-    // check if char is outside ascii range
-    bool is_unicode(const char& chr)
-    {
-      // check for unicode range
-      return unsigned(chr) > 127;
-    }
-
-    // check if char is outside ascii range
-    // but with specific ranges (copied from Ruby Sass)
-    bool is_nonascii(const char& chr)
-    {
-      unsigned int cmp = unsigned(chr);
-      return (
-        (cmp >= 128 && cmp <= 15572911) ||
-        (cmp >= 15630464 && cmp <= 15712189) ||
-        (cmp >= 4036001920)
-      );
+    bool is_number(char chr) {
+      return Util::ascii_isdigit(static_cast<unsigned char>(chr)) ||
+        chr == '-' || chr == '+';
     }
 
     // check if char is within a reduced ascii range
     // valid in a uri (copied from Ruby Sass)
-    bool is_uri_character(const char& chr)
+    bool is_uri_character(char chr)
     {
       unsigned int cmp = unsigned(chr);
       return (cmp > 41 && cmp < 127) ||
@@ -106,17 +44,19 @@ namespace Sass {
 
     // check if char is within a reduced ascii range
     // valid for escaping (copied from Ruby Sass)
-    bool is_escapable_character(const char& chr)
+    bool is_escapable_character(char chr)
     {
       unsigned int cmp = unsigned(chr);
       return cmp > 31 && cmp < 127;
     }
 
     // Match word character (look ahead)
-    bool is_character(const char& chr)
+    bool is_character(char chr)
     {
       // valid alpha, numeric or unicode char (plus hyphen)
-      return is_alnum(chr) || is_unicode(chr) || chr == '-';
+      return Util::ascii_isalnum(static_cast<unsigned char>(chr)) ||
+        !Util::ascii_isascii(static_cast<unsigned char>(chr)) ||
+        chr == '-';
     }
 
     //####################################
@@ -124,16 +64,13 @@ namespace Sass {
     //####################################
 
     // create matchers that advance the position
-    const char* space(const char* src) { return is_space(*src) ? src + 1 : 0; }
-    const char* alpha(const char* src) { return is_alpha(*src) ? src + 1 : 0; }
-    const char* unicode(const char* src) { return is_unicode(*src) ? src + 1 : 0; }
-    const char* nonascii(const char* src) { return is_nonascii(*src) ? src + 1 : 0; }
-    const char* digit(const char* src) { return is_digit(*src) ? src + 1 : 0; }
-    const char* xdigit(const char* src) { return is_xdigit(*src) ? src + 1 : 0; }
-    const char* alnum(const char* src) { return is_alnum(*src) ? src + 1 : 0; }
-    const char* punct(const char* src) { return is_punct(*src) ? src + 1 : 0; }
-    const char* hyphen(const char* src) { return *src && *src == '-' ? src + 1 : 0; }
-    const char* character(const char* src) { return is_character(*src) ? src + 1 : 0; }
+    const char* space(const char* src) { return Util::ascii_isspace(static_cast<unsigned char>(*src)) ? src + 1 : nullptr; }
+    const char* alpha(const char* src) { return Util::ascii_isalpha(static_cast<unsigned char>(*src)) ? src + 1 : nullptr; }
+    const char* nonascii(const char* src) { return Util::ascii_isascii(static_cast<unsigned char>(*src)) ? nullptr : src + 1; }
+    const char* digit(const char* src) { return Util::ascii_isdigit(static_cast<unsigned char>(*src)) ? src + 1 : nullptr; }
+    const char* xdigit(const char* src) { return Util::ascii_isxdigit(static_cast<unsigned char>(*src)) ? src + 1 : nullptr; }
+    const char* alnum(const char* src) { return Util::ascii_isalnum(static_cast<unsigned char>(*src)) ? src + 1 : nullptr; }
+    const char* hyphen(const char* src) { return *src == '-' ? src + 1 : 0; }
     const char* uri_character(const char* src) { return is_uri_character(*src) ? src + 1 : 0; }
     const char* escapable_character(const char* src) { return is_escapable_character(*src) ? src + 1 : 0; }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -2,7 +2,6 @@
 // __EXTENSIONS__ fix on Solaris.
 #include "sass.hpp"
 
-#include <cctype>
 #include <iostream>
 #include <iomanip>
 #include "lexer.hpp"

--- a/src/lexer.hpp
+++ b/src/lexer.hpp
@@ -24,19 +24,11 @@ namespace Sass {
     // BASIC CLASS MATCHERS
     //####################################
 
-    // These are locale independant
-    bool is_space(const char& src);
-    bool is_alpha(const char& src);
-    bool is_punct(const char& src);
-    bool is_digit(const char& src);
-    bool is_number(const char& src);
-    bool is_alnum(const char& src);
-    bool is_xdigit(const char& src);
-    bool is_unicode(const char& src);
-    bool is_nonascii(const char& src);
-    bool is_character(const char& src);
-    bool is_uri_character(const char& src);
-    bool escapable_character(const char& src);
+    // Matches ASCII digits, +, and -.
+    bool is_number(char src);
+
+    bool is_uri_character(char src);
+    bool escapable_character(char src);
 
     // Match a single ctype predicate.
     const char* space(const char* src);
@@ -44,11 +36,8 @@ namespace Sass {
     const char* digit(const char* src);
     const char* xdigit(const char* src);
     const char* alnum(const char* src);
-    const char* punct(const char* src);
     const char* hyphen(const char* src);
-    const char* unicode(const char* src);
     const char* nonascii(const char* src);
-    const char* character(const char* src);
     const char* uri_character(const char* src);
     const char* escapable_character(const char* src);
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -672,7 +672,7 @@ namespace Sass {
   }
   // EO parse_include_directive
 
-  
+
   SimpleSelectorObj Parser::parse_simple_selector()
   {
     lex < css_comments >(false);
@@ -2171,7 +2171,7 @@ namespace Sass {
         }
 
       }
-      
+
     }
 
     std::vector<std::string> queries;
@@ -2907,7 +2907,7 @@ namespace Sass {
     }
     // backup position to last significant char
     while (trim && last_pos > source && last_pos < end) {
-      if (!Prelexer::is_space(*last_pos)) break;
+      if (!Util::ascii_isspace(static_cast<unsigned char>(*last_pos))) break;
       utf8::prior(last_pos, source);
     }
 

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -336,7 +336,7 @@ namespace Sass {
       return alternatives<
                unicode_seq,
                alpha,
-               unicode,
+               nonascii,
                exactly<'-'>,
                exactly<'_'>,
                NONASCII,
@@ -351,7 +351,7 @@ namespace Sass {
       return alternatives<
                unicode_seq,
                alnum,
-               unicode,
+               nonascii,
                exactly<'-'>,
                exactly<'_'>,
                NONASCII,
@@ -385,7 +385,7 @@ namespace Sass {
     {
       return alternatives <
                alpha,
-               unicode,
+               nonascii,
                escape_seq,
                exactly<'_'>
              >(src);
@@ -395,7 +395,7 @@ namespace Sass {
     {
       return alternatives <
                alnum,
-               unicode,
+               nonascii,
                escape_seq,
                exactly<'_'>
              >(src);

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -2,10 +2,10 @@
 // __EXTENSIONS__ fix on Solaris.
 #include "sass.hpp"
 
-#include <cctype>
 #include <iostream>
 #include <iomanip>
 #include "util.hpp"
+#include "util_string.hpp"
 #include "position.hpp"
 #include "prelexer.hpp"
 #include "constants.hpp"
@@ -1400,7 +1400,7 @@ namespace Sass {
     }*/
 
     const char* H(const char* src) {
-      return std::isxdigit(static_cast<unsigned char>(*src)) ? src+1 : 0;
+      return Util::ascii_isxdigit(static_cast<unsigned char>(*src)) ? src+1 : 0;
     }
 
     const char* W(const char* src) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,6 +2,7 @@
 #include "sass.h"
 #include "ast.hpp"
 #include "util.hpp"
+#include "util_string.hpp"
 #include "lexer.hpp"
 #include "prelexer.hpp"
 #include "constants.hpp"
@@ -289,7 +290,7 @@ namespace Sass {
 
         // parse as many sequence chars as possible
         // ToDo: Check if ruby aborts after possible max
-        while (i + len < L && s[i + len] && isxdigit(s[i + len])) ++ len;
+        while (i + len < L && s[i + len] && Util::ascii_isxdigit(static_cast<unsigned char>(s[i + len]))) ++ len;
 
         if (len > 1) {
 
@@ -375,7 +376,7 @@ namespace Sass {
 
         // parse as many sequence chars as possible
         // ToDo: Check if ruby aborts after possible max
-        while (i + len < L && s[i + len] && isxdigit(s[i + len])) ++ len;
+        while (i + len < L && s[i + len] && Util::ascii_isxdigit(static_cast<unsigned char>(s[i + len]))) ++ len;
 
         // hex string?
         if (keep_utf8_sequences) {
@@ -716,10 +717,6 @@ namespace Sass {
       }
 
       return false;
-    }
-
-    bool isAscii(const char chr) {
-      return unsigned(chr) < 128;
     }
 
   }

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -100,7 +100,6 @@ namespace Sass {
     bool isPrintable(String_Constant* s, Sass_Output_Style style = NESTED);
     bool isPrintable(String_Quoted* s, Sass_Output_Style style = NESTED);
     bool isPrintable(Declaration* d, Sass_Output_Style style = NESTED);
-    bool isAscii(const char chr);
 
   }
 }

--- a/src/util_string.cpp
+++ b/src/util_string.cpp
@@ -26,7 +26,24 @@ namespace Sass {
       // If not test was too long
       return *lit == 0;
     }
-    // EO equalsLiteral
+
+    void ascii_str_tolower(std::string* s) {
+      for (auto& ch : *s) {
+        ch = ascii_tolower(static_cast<unsigned char>(ch));
+      }
+    }
+
+    void ascii_str_toupper(std::string* s) {
+      for (auto& ch : *s) {
+        ch = ascii_toupper(static_cast<unsigned char>(ch));
+      }
+    }
+
+    std::string rtrim(std::string str) {
+      auto it = std::find_if_not(str.rbegin(), str.rend(), ascii_isspace);
+      str.erase(str.rend() - it);
+      return str;
+    }
 
     // ###########################################################################
     // Returns [name] without a vendor prefix.

--- a/src/util_string.hpp
+++ b/src/util_string.hpp
@@ -29,9 +29,44 @@ namespace Sass {
     char opening_bracket_for(char closing_bracket);
     char closing_bracket_for(char opening_bracket);
 
-  }
-  // namespace Util
-}  
-// namespace Sass
+    // Locale-independent ASCII character routines.
 
+    inline bool ascii_isalpha(unsigned char c) {
+      return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+    }
+
+    inline bool ascii_isdigit(unsigned char c) {
+      return (c >= '0' && c <= '9');
+    }
+
+    inline bool ascii_isalnum(unsigned char c) {
+      return ascii_isalpha(c) || ascii_isdigit(c);
+    }
+
+    inline bool ascii_isascii(unsigned char c) { return c < 128; }
+
+    inline bool ascii_isxdigit(unsigned char c) {
+      return ascii_isdigit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+    }
+
+    inline bool ascii_isspace(unsigned char c) {
+      return c == ' ' || c == '\t' || c == '\v' || c == '\f' || c == '\r' || c == '\n';
+    }
+
+    inline char ascii_tolower(unsigned char c) {
+      if (c >= 'A' && c <= 'Z') return c + 32;
+      return c;
+    }
+
+    void ascii_str_tolower(std::string* s);
+
+    inline char ascii_toupper(unsigned char c) {
+      if (c >= 'a' && c <= 'z') return c - 32;
+      return c;
+    }
+
+    void ascii_str_toupper(std::string* s);
+
+  }  // namespace Sass
+}  // namespace Util
 #endif  // SASS_UTIL_STRING_H

--- a/test/test_util_string.cpp
+++ b/test/test_util_string.cpp
@@ -142,6 +142,45 @@ bool TestUnvendor() {
   return true;
 }
 
+bool Test_ascii_str_to_lower() {
+  std::string str = "A B";
+  Sass::Util::ascii_str_tolower(&str);
+  ASSERT_STR_EQ("a b", str);
+  return true;
+}
+
+bool Test_ascii_str_to_upper() {
+  std::string str = "a b";
+  Sass::Util::ascii_str_toupper(&str);
+  ASSERT_STR_EQ("A B", str);
+  return true;
+}
+
+bool Test_ascii_isalpha() {
+  ASSERT_TRUE(Sass::Util::ascii_isalpha('a'));
+  ASSERT_FALSE(Sass::Util::ascii_isalpha('3'));
+  return true;
+}
+
+bool Test_ascii_isxdigit() {
+  ASSERT_TRUE(Sass::Util::ascii_isxdigit('a'));
+  ASSERT_TRUE(Sass::Util::ascii_isxdigit('F'));
+  ASSERT_TRUE(Sass::Util::ascii_isxdigit('3'));
+  ASSERT_FALSE(Sass::Util::ascii_isxdigit('G'));
+  return true;
+}
+
+bool Test_ascii_isspace() {
+  ASSERT_TRUE(Sass::Util::ascii_isspace(' '));
+  ASSERT_TRUE(Sass::Util::ascii_isspace('\t'));
+  ASSERT_TRUE(Sass::Util::ascii_isspace('\v'));
+  ASSERT_TRUE(Sass::Util::ascii_isspace('\f'));
+  ASSERT_TRUE(Sass::Util::ascii_isspace('\r'));
+  ASSERT_TRUE(Sass::Util::ascii_isspace('\n'));
+  ASSERT_FALSE(Sass::Util::ascii_isspace('G'));
+  return true;
+}
+
 }  // namespace
 
 #define TEST(fn) \
@@ -166,6 +205,11 @@ int main(int argc, char **argv) {
   TEST(TestNormalizeDecimalsNoLeadingZero);
   TEST(testEqualsLiteral);
   TEST(TestUnvendor);
+  TEST(Test_ascii_str_to_lower);
+  TEST(Test_ascii_str_to_upper);
+  TEST(Test_ascii_isalpha);
+  TEST(Test_ascii_isxdigit);
+  TEST(Test_ascii_isspace);
   std::cerr << argv[0] << ": Passed: " << passed.size()
             << ", failed: " << failed.size()
             << "." << std::endl;


### PR DESCRIPTION
`std::tolower` and `std::toupper` are locale-dependent and should not be used anywhere we currently use them.

Adds and switches to our own implementations for these and other locale-dependent functions.