### PR TITLE
Fix overloaded color functions

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -455,6 +455,7 @@ namespace Sass {
     c_function_(ptr->c_function_),
     cookie_(ptr->cookie_),
     is_overload_stub_(ptr->is_overload_stub_),
+    defaultParams_(ptr->defaultParams_),
     signature_(ptr->signature_)
   { }
 
@@ -472,6 +473,7 @@ namespace Sass {
     c_function_(0),
     cookie_(0),
     is_overload_stub_(false),
+    defaultParams_(0),
     signature_(0)
   { }
 
@@ -490,6 +492,7 @@ namespace Sass {
     c_function_(0),
     cookie_(0),
     is_overload_stub_(overload_stub),
+    defaultParams_(0),
     signature_(sig)
   { }
 
@@ -507,6 +510,7 @@ namespace Sass {
     c_function_(c_func),
     cookie_(sass_function_get_cookie(c_func)),
     is_overload_stub_(false),
+    defaultParams_(0),
     signature_(sig)
   { }
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -776,6 +776,7 @@ namespace Sass {
     ADD_PROPERTY(Sass_Function_Entry, c_function)
     ADD_PROPERTY(void*, cookie)
     ADD_PROPERTY(bool, is_overload_stub)
+    ADD_PROPERTY(size_t, defaultParams)
     ADD_PROPERTY(Signature, signature)
   public:
     Definition(ParserState pstate,

--- a/src/ast_values.cpp
+++ b/src/ast_values.cpp
@@ -117,6 +117,19 @@ namespace Sass {
     return length();
   }
 
+  std::map<std::string, ExpressionObj> List::getNormalizedArgMap()
+  {
+    std::map<std::string, ExpressionObj> map;
+    if (is_arglist_) {
+      for (Expression* item : elements()) {
+        if (Argument * arg = Cast<Argument>(item)) {
+          if (arg->name().empty()) continue;
+          map[arg->name()] = arg->value();
+        }
+      }
+    }
+    return map;
+  }
 
   Expression_Obj List::value_at_index(size_t i) {
     Expression_Obj obj = this->at(i);

--- a/src/ast_values.hpp
+++ b/src/ast_values.hpp
@@ -68,6 +68,7 @@ namespace Sass {
     virtual size_t hash() const override;
     virtual size_t size() const;
     virtual void set_delayed(bool delayed) override;
+    std::map<std::string, ExpressionObj> getNormalizedArgMap();
 
     virtual bool operator< (const Expression& rhs) const override;
     virtual bool operator== (const Expression& rhs) const override;

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -53,8 +53,11 @@ namespace Sass {
           }
         }
         std::stringstream msg;
-        msg << "wrong number of arguments (" << LA << " for " << LP << ")";
-        msg << " for `" << name << "'";
+        msg << "Only " << LP << " ";
+        msg << (LP == 1 ? "argument" : "arguments");
+        msg << " allowed, but " << LA << " ";
+        msg << (LA == 1 ? "was" : "were");
+        msg << " passed.";
         return error(msg.str(), as->pstate(), traces);
       }
       Parameter_Obj p = ps->at(ip);
@@ -230,7 +233,7 @@ namespace Sass {
 
           if (!param_map.count(param)) {
             std::stringstream msg;
-            msg << callee << " has no parameter named " << param;
+            msg << "No argument named " << param << ".";
             error(msg.str(), a->pstate(), traces);
           }
           env->local_frame()[param] = argmap->at(key);
@@ -259,7 +262,7 @@ namespace Sass {
             varargs->append(a);
           } else {
             std::stringstream msg;
-            msg << callee << " has no parameter named " << a->name();
+            msg << "No argument named " << a->name() << ".";
             error(msg.str(), a->pstate(), traces);
           }
         }

--- a/src/color_maps.cpp
+++ b/src/color_maps.cpp
@@ -631,6 +631,10 @@ namespace Sass {
   {
     auto p = colors_to_names->find(key);
     if (p != colors_to_names->end()) {
+      std::string rv = p->second;
+      // Match dart-sass output
+      if (rv == "magenta") { return "fuchsia"; }
+      if (rv == "cyan") { return "aqua"; }
       return p->second;
     }
     return nullptr;

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -743,25 +743,25 @@ namespace Sass {
   void register_built_in_functions(Context& ctx, Env* env)
   {
     using namespace Functions;
-    register_overload_stub(ctx, "rgb", env, 3);
+    register_overload_stub(ctx, "rgb", env, 1);
     register_function(ctx, rgb_4_sig, rgb_4, 4, env);
     register_function(ctx, rgb_3_sig, rgb_3, 3, env);
     register_function(ctx, rgb_2_sig, rgb_2, 2, env);
     register_function(ctx, rgb_1_sig, rgb_1, 1, env);
 
-    register_overload_stub(ctx, "rgba", env, 4);
+    register_overload_stub(ctx, "rgba", env, 1);
     register_function(ctx, rgba_4_sig, rgba_4, 4, env);
     register_function(ctx, rgba_3_sig, rgba_3, 3, env);
     register_function(ctx, rgba_2_sig, rgba_2, 2, env);
     register_function(ctx, rgba_1_sig, rgba_1, 1, env);
 
-    register_overload_stub(ctx, "hsl", env, 3);
+    register_overload_stub(ctx, "hsl", env, 1);
     register_function(ctx, hsl_4_sig, hsl_4, 4, env);
     register_function(ctx, hsl_3_sig, hsl_3, 3, env);
     register_function(ctx, hsl_2_sig, hsl_2, 2, env);
     register_function(ctx, hsl_1_sig, hsl_1, 1, env);
 
-    register_overload_stub(ctx, "hsla", env, 4);
+    register_overload_stub(ctx, "hsla", env, 1);
     register_function(ctx, hsla_4_sig, hsla_4, 4, env);
     register_function(ctx, hsla_3_sig, hsla_3, 3, env);
     register_function(ctx, hsla_2_sig, hsla_2, 2, env);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -484,7 +484,7 @@ namespace Sass {
 
   void register_function(Context&, Signature sig, Native_Function f, Env* env);
   void register_function(Context&, Signature sig, Native_Function f, size_t arity, Env* env);
-  void register_overload_stub(Context&, std::string name, Env* env);
+  void register_overload_stub(Context&, std::string name, Env* env, size_t defaultParams);
   void register_built_in_functions(Context&, Env* env);
   void register_c_functions(Context&, Env* env, Sass_Function_List);
   void register_c_function(Context&, Env* env, Sass_Function_Entry);
@@ -726,7 +726,7 @@ namespace Sass {
     (*env)[ss.str()] = def;
   }
 
-  void register_overload_stub(Context& ctx, std::string name, Env* env)
+  void register_overload_stub(Context& ctx, std::string name, Env* env, size_t defaultParams)
   {
     Definition* stub = SASS_MEMORY_NEW(Definition,
                                        ParserState("[built-in function]"),
@@ -735,6 +735,7 @@ namespace Sass {
                                        {},
                                        0,
                                        true);
+    stub->defaultParams(defaultParams);
     (*env)[name + "[f]"] = stub;
   }
 
@@ -742,30 +743,58 @@ namespace Sass {
   void register_built_in_functions(Context& ctx, Env* env)
   {
     using namespace Functions;
-    // RGB Functions
-    register_function(ctx, rgb_sig, rgb, env);
-    register_overload_stub(ctx, "rgba", env);
+    register_overload_stub(ctx, "rgb", env, 3);
+    register_function(ctx, rgb_4_sig, rgb_4, 4, env);
+    register_function(ctx, rgb_3_sig, rgb_3, 3, env);
+    register_function(ctx, rgb_2_sig, rgb_2, 2, env);
+    register_function(ctx, rgb_1_sig, rgb_1, 1, env);
+
+    register_overload_stub(ctx, "rgba", env, 4);
     register_function(ctx, rgba_4_sig, rgba_4, 4, env);
+    register_function(ctx, rgba_3_sig, rgba_3, 3, env);
     register_function(ctx, rgba_2_sig, rgba_2, 2, env);
+    register_function(ctx, rgba_1_sig, rgba_1, 1, env);
+
+    register_overload_stub(ctx, "hsl", env, 3);
+    register_function(ctx, hsl_4_sig, hsl_4, 4, env);
+    register_function(ctx, hsl_3_sig, hsl_3, 3, env);
+    register_function(ctx, hsl_2_sig, hsl_2, 2, env);
+    register_function(ctx, hsl_1_sig, hsl_1, 1, env);
+
+    register_overload_stub(ctx, "hsla", env, 4);
+    register_function(ctx, hsla_4_sig, hsla_4, 4, env);
+    register_function(ctx, hsla_3_sig, hsla_3, 3, env);
+    register_function(ctx, hsla_2_sig, hsla_2, 2, env);
+    register_function(ctx, hsla_1_sig, hsla_1, 1, env);
+
+    register_overload_stub(ctx, "saturate", env, 2);
+    register_function(ctx, saturate_1_sig, saturate_1, 1, env);
+    register_function(ctx, saturate_2_sig, saturate_2, 2, env);
+
+    // RGB Functions
     register_function(ctx, red_sig, red, env);
     register_function(ctx, green_sig, green, env);
     register_function(ctx, blue_sig, blue, env);
     register_function(ctx, mix_sig, mix, env);
     // HSL Functions
-    register_function(ctx, hsl_sig, hsl, env);
-    register_function(ctx, hsla_sig, hsla, env);
     register_function(ctx, hue_sig, hue, env);
     register_function(ctx, saturation_sig, saturation, env);
     register_function(ctx, lightness_sig, lightness, env);
     register_function(ctx, adjust_hue_sig, adjust_hue, env);
     register_function(ctx, lighten_sig, lighten, env);
     register_function(ctx, darken_sig, darken, env);
-    register_function(ctx, saturate_sig, saturate, env);
     register_function(ctx, desaturate_sig, desaturate, env);
     register_function(ctx, grayscale_sig, grayscale, env);
     register_function(ctx, complement_sig, complement, env);
     register_function(ctx, invert_sig, invert, env);
     // Opacity Functions
+    // register_overload_stub(ctx, "alpha", env);
+    // register_function(ctx, alpha_sig, alpha, 1, env);
+    // register_function(ctx, alpha_ie_sig, alpha_ie, std::string::npos, env);
+    // register_overload_stub(ctx, "opacity", env);
+    // register_function(ctx, opacity_sig, alpha, 1, env);
+
+
     register_function(ctx, alpha_sig, alpha, env);
     register_function(ctx, opacity_sig, alpha, env);
     register_function(ctx, opacify_sig, opacify, env);

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -41,15 +41,15 @@ namespace Sass {
     InvalidArgumentType::InvalidArgumentType(ParserState pstate, Backtraces traces, std::string fn, std::string arg, std::string type, const Value* value)
     : Base(pstate, def_msg, traces), fn(fn), arg(arg), type(type), value(value)
     {
-      msg = arg + ": \"";
+      msg = arg + ": ";
       if (value) msg += value->to_string(Sass_Inspect_Options());
-      msg += "\" is not a " + type + " for `" + fn + "'";
+      msg += " is not a " + type + ".";
     }
 
     MissingArgument::MissingArgument(ParserState pstate, Backtraces traces, std::string fn, std::string arg, std::string fntype)
     : Base(pstate, def_msg, traces), fn(fn), arg(arg), fntype(fntype)
     {
-      msg = fntype + " " + fn + " is missing argument " + arg + ".";
+      msg = "Missing argument " + arg + ".";
     }
 
     InvalidSyntax::InvalidSyntax(ParserState pstate, Backtraces traces, std::string msg)

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1013,9 +1013,19 @@ namespace Sass {
         if (rest) L += rest->length() - 1;
       }
       ss << full_name << L;
-      full_name = ss.str();
-      std::string resolved_name(full_name);
-      if (!env->has(resolved_name)) error("overloaded function `" + std::string(c->name()) + "` given wrong number of arguments", c->pstate(), traces);
+      std::string resolved_name(ss.str());
+      if (!env->has(resolved_name)) resolved_name = full_name + "*";
+      // std::cerr << "CALLING " << resolved_name << "\n";
+      if (!env->has(resolved_name)) {
+        size_t LP = def->defaultParams();
+        std::stringstream msg;
+        msg << "Only " << LP << " ";
+        msg << (LP == 1 ? "argument" : "arguments");
+        msg << " allowed, but " << L << " ";
+        msg << (L == 1 ? "was" : "were");
+        msg << " passed.";
+        error(msg.str(), c->pstate(), traces);
+      }
       def = Cast<Definition>((*env)[resolved_name]);
     }
 

--- a/src/fn_colors.hpp
+++ b/src/fn_colors.hpp
@@ -8,33 +8,46 @@ namespace Sass {
   namespace Functions {
 
     // macros for common ranges (u mean unsigned or upper, r for full range)
-    #define DARG_U_FACT(argname) get_arg_r(argname, env, sig, pstate, traces, - 0.0, 1.0) // double
+    #define DARG_U_FACT(argname) get_arg_r(argname, env, sig, pstate, traces,   0.0, 1.0) // double
     #define DARG_R_FACT(argname) get_arg_r(argname, env, sig, pstate, traces, - 1.0, 1.0) // double
-    #define DARG_U_BYTE(argname) get_arg_r(argname, env, sig, pstate, traces, - 0.0, 255.0) // double
+    #define DARG_U_BYTE(argname) get_arg_r(argname, env, sig, pstate, traces,   0.0, 255.0) // double
     #define DARG_R_BYTE(argname) get_arg_r(argname, env, sig, pstate, traces, - 255.0, 255.0) // double
-    #define DARG_U_PRCT(argname) get_arg_r(argname, env, sig, pstate, traces, - 0.0, 100.0) // double
-    #define DARG_R_PRCT(argname) get_arg_r(argname, env, sig, pstate, traces, - 100.0, 100.0) // double
+    #define DARG_U_PRCT(argname) get_arg_r(argname, env, sig, pstate, traces,   0.0, 100.0) // double
+    #define DARG_R_PRCT(argname) get_arg_r(argname, env, sig, pstate, traces, - 100.0, 100.0, "%") // double
+    #define DARG_R_CENT(argname) get_arg_r(argname, env, sig, pstate, traces, - 100.0, 100.0) // double
 
     // macros for color related inputs (rbg and alpha/opacity values)
     #define COLOR_NUM(argname) color_num(argname, env, sig, pstate, traces) // double
     #define ALPHA_NUM(argname) alpha_num(argname, env, sig, pstate, traces) // double
 
-    extern Signature rgb_sig;
+    extern Signature rgb_4_sig;
+    extern Signature rgb_3_sig;
+    extern Signature rgb_2_sig;
+    extern Signature rgb_1_sig;
+    extern Signature hsl_1_sig;
+    extern Signature hsl_2_sig;
+    extern Signature hsl_3_sig;
+    extern Signature hsl_4_sig;
     extern Signature rgba_4_sig;
+    extern Signature rgba_3_sig;
     extern Signature rgba_2_sig;
+    extern Signature rgba_1_sig;
+    extern Signature hsla_4_sig;
+    extern Signature hsla_3_sig;
+    extern Signature hsla_2_sig;
+    extern Signature hsla_1_sig;
     extern Signature red_sig;
     extern Signature green_sig;
     extern Signature blue_sig;
     extern Signature mix_sig;
-    extern Signature hsl_sig;
-    extern Signature hsla_sig;
     extern Signature hue_sig;
     extern Signature saturation_sig;
     extern Signature lightness_sig;
     extern Signature adjust_hue_sig;
     extern Signature lighten_sig;
     extern Signature darken_sig;
-    extern Signature saturate_sig;
+    extern Signature saturate_1_sig;
+    extern Signature saturate_2_sig;
     extern Signature desaturate_sig;
     extern Signature grayscale_sig;
     extern Signature complement_sig;
@@ -50,27 +63,41 @@ namespace Sass {
     extern Signature change_color_sig;
     extern Signature ie_hex_str_sig;
 
-    BUILT_IN(rgb);
+    BUILT_IN(rgb_1);
+    BUILT_IN(rgb_2);
+    BUILT_IN(rgb_3);
+    BUILT_IN(rgb_4);
+    BUILT_IN(hsl_1);
+    BUILT_IN(hsl_2);
+    BUILT_IN(hsl_3);
+    BUILT_IN(hsl_4);
     BUILT_IN(rgba_4);
+    BUILT_IN(rgba_3);
     BUILT_IN(rgba_2);
+    BUILT_IN(rgba_1);
+    BUILT_IN(hsla_1);
+    BUILT_IN(hsla_2);
+    BUILT_IN(hsla_3);
+    BUILT_IN(hsla_4);
+
     BUILT_IN(red);
     BUILT_IN(green);
     BUILT_IN(blue);
     BUILT_IN(mix);
-    BUILT_IN(hsl);
-    BUILT_IN(hsla);
     BUILT_IN(hue);
     BUILT_IN(saturation);
     BUILT_IN(lightness);
     BUILT_IN(adjust_hue);
     BUILT_IN(lighten);
     BUILT_IN(darken);
-    BUILT_IN(saturate);
+    BUILT_IN(saturate_1);
+    BUILT_IN(saturate_2);
     BUILT_IN(desaturate);
     BUILT_IN(grayscale);
     BUILT_IN(complement);
     BUILT_IN(invert);
     BUILT_IN(alpha);
+    BUILT_IN(alpha_ie);
     BUILT_IN(opacify);
     BUILT_IN(transparentize);
     BUILT_IN(adjust_color);

--- a/src/fn_lists.cpp
+++ b/src/fn_lists.cpp
@@ -18,7 +18,7 @@ namespace Sass {
     Signature keywords_sig = "keywords($args)";
     BUILT_IN(keywords)
     {
-      List_Obj arglist = SASS_MEMORY_COPY(ARG("$args", List)); // copy
+      List_Obj arglist = SASS_MEMORY_COPY(ARG("$args", List, "a list")); // copy
       Map_Obj result = SASS_MEMORY_NEW(Map, pstate, 1);
       for (size_t i = arglist->size(), L = arglist->length(); i < L; ++i) {
         Expression_Obj obj = arglist->at(i);
@@ -38,7 +38,7 @@ namespace Sass {
       if (SelectorList * sl = Cast<SelectorList>(env["$list"])) {
         return SASS_MEMORY_NEW(Number, pstate, (double) sl->length());
       }
-      Expression* v = ARG("$list", Expression);
+      Expression* v = ARG("$list", Expression, "an expression");
       if (v->concrete_type() == Expression::MAP) {
         Map* map = Cast<Map>(env["$list"]);
         return SASS_MEMORY_NEW(Number, pstate, (double)(map ? map->length() : 1));
@@ -77,7 +77,7 @@ namespace Sass {
       // if the argument isn't a list, then wrap it in a singleton list
       if (!m && !l) {
         l = SASS_MEMORY_NEW(List, pstate, 1);
-        l->append(ARG("$list", Expression));
+        l->append(ARG("$list", Expression, "an expression"));
       }
       size_t len = m ? m->length() : l->length();
       bool empty = m ? m->empty() : l->empty();
@@ -103,11 +103,11 @@ namespace Sass {
     {
       Map_Obj m = Cast<Map>(env["$list"]);
       List_Obj l = Cast<List>(env["$list"]);
-      Number_Obj n = ARG("$n", Number);
-      Expression_Obj v = ARG("$value", Expression);
+      Number_Obj n = ARGNUM("$n");
+      Expression_Obj v = ARG("$value", Expression, "an expression");
       if (!l) {
         l = SASS_MEMORY_NEW(List, pstate, 1);
-        l->append(ARG("$list", Expression));
+        l->append(ARG("$list", Expression, "an expression"));
       }
       if (m) {
         l = m->to_list(pstate);
@@ -127,10 +127,10 @@ namespace Sass {
     {
       Map_Obj m = Cast<Map>(env["$list"]);
       List_Obj l = Cast<List>(env["$list"]);
-      Expression_Obj v = ARG("$value", Expression);
+      Expression_Obj v = ARG("$value", Expression, "an expression");
       if (!l) {
         l = SASS_MEMORY_NEW(List, pstate, 1);
-        l->append(ARG("$list", Expression));
+        l->append(ARG("$list", Expression, "an expression"));
       }
       if (m) {
         l = m->to_list(pstate);
@@ -148,19 +148,19 @@ namespace Sass {
       Map_Obj m2 = Cast<Map>(env["$list2"]);
       List_Obj l1 = Cast<List>(env["$list1"]);
       List_Obj l2 = Cast<List>(env["$list2"]);
-      String_Constant_Obj sep = ARG("$separator", String_Constant);
+      String_Constant_Obj sep = ARG("$separator", String_Constant, "a string");
       enum Sass_Separator sep_val = (l1 ? l1->separator() : SASS_SPACE);
-      Value* bracketed = ARG("$bracketed", Value);
+      Value* bracketed = ARG("$bracketed", Value, "a value");
       bool is_bracketed = (l1 ? l1->is_bracketed() : false);
       if (!l1) {
         l1 = SASS_MEMORY_NEW(List, pstate, 1);
-        l1->append(ARG("$list1", Expression));
+        l1->append(ARG("$list1", Expression, "an expression"));
         sep_val = (l2 ? l2->separator() : SASS_SPACE);
         is_bracketed = (l2 ? l2->is_bracketed() : false);
       }
       if (!l2) {
         l2 = SASS_MEMORY_NEW(List, pstate, 1);
-        l2->append(ARG("$list2", Expression));
+        l2->append(ARG("$list2", Expression, "an expression"));
       }
       if (m1) {
         l1 = m1->to_list(pstate);
@@ -190,14 +190,14 @@ namespace Sass {
     {
       Map_Obj m = Cast<Map>(env["$list"]);
       List_Obj l = Cast<List>(env["$list"]);
-      Expression_Obj v = ARG("$val", Expression);
+      Expression_Obj v = ARG("$val", Expression, "an expression");
       if (SelectorList * sl = Cast<SelectorList>(env["$list"])) {
         l = Cast<List>(Listize::perform(sl));
       }
-      String_Constant_Obj sep = ARG("$separator", String_Constant);
+      String_Constant_Obj sep = ARG("$separator", String_Constant, "a string");
       if (!l) {
         l = SASS_MEMORY_NEW(List, pstate, 1);
-        l->append(ARG("$list", Expression));
+        l->append(ARG("$list", Expression, "an expression"));
       }
       if (m) {
         l = m->to_list(pstate);
@@ -226,7 +226,7 @@ namespace Sass {
     Signature zip_sig = "zip($lists...)";
     BUILT_IN(zip)
     {
-      List_Obj arglist = SASS_MEMORY_COPY(ARG("$lists", List));
+      List_Obj arglist = SASS_MEMORY_COPY(ARG("$lists", List, "a list"));
       size_t shortest = 0;
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         List_Obj ith = Cast<List>(arglist->value_at_index(i));
@@ -265,7 +265,7 @@ namespace Sass {
       List_Obj l = Cast<List>(env["$list"]);
       if (!l) {
         l = SASS_MEMORY_NEW(List, pstate, 1);
-        l->append(ARG("$list", Expression));
+        l->append(ARG("$list", Expression, "an expression"));
       }
       return SASS_MEMORY_NEW(String_Quoted,
                                pstate,
@@ -275,7 +275,7 @@ namespace Sass {
     Signature is_bracketed_sig = "is-bracketed($list)";
     BUILT_IN(is_bracketed)
     {
-      Value_Obj value = ARG("$list", Value);
+      Value_Obj value = ARG("$list", Value, "a value");
       List_Obj list = Cast<List>(value);
       return SASS_MEMORY_NEW(Boolean, pstate, list && list->is_bracketed());
     }

--- a/src/fn_lists.cpp
+++ b/src/fn_lists.cpp
@@ -112,6 +112,7 @@ namespace Sass {
       }
       else {
         Value_Obj rv = l->value_at_index(static_cast<int>(index));
+        rv = SASS_MEMORY_COPY(rv);
         rv->set_delayed(false);
         return rv.detach();
       }

--- a/src/fn_maps.cpp
+++ b/src/fn_maps.cpp
@@ -77,7 +77,7 @@ namespace Sass {
     {
       bool remove;
       Map_Obj m = ARGM("$map", Map);
-      List_Obj arglist = ARG("$keys", List, "a list");
+      List_Obj arglist = ARGLIST("$keys");
       Map* result = SASS_MEMORY_NEW(Map, pstate, 1);
       for (auto key : m->keys()) {
         remove = false;

--- a/src/fn_maps.cpp
+++ b/src/fn_maps.cpp
@@ -16,7 +16,7 @@ namespace Sass {
       // leaks for "map-get((), foo)" if not Obj
       // investigate why this is (unexpected)
       Map_Obj m = ARGM("$map", Map);
-      Expression_Obj v = ARG("$key", Expression);
+      Expression_Obj v = ARG("$key", Expression, "an expression");
       try {
         Value_Obj val = m->at(v);
         if (!val) return SASS_MEMORY_NEW(Null, pstate);
@@ -32,7 +32,7 @@ namespace Sass {
     BUILT_IN(map_has_key)
     {
       Map_Obj m = ARGM("$map", Map);
-      Expression_Obj v = ARG("$key", Expression);
+      Expression_Obj v = ARG("$key", Expression, "an expression");
       return SASS_MEMORY_NEW(Boolean, pstate, m->has(v));
     }
 
@@ -77,7 +77,7 @@ namespace Sass {
     {
       bool remove;
       Map_Obj m = ARGM("$map", Map);
-      List_Obj arglist = ARG("$keys", List);
+      List_Obj arglist = ARG("$keys", List, "a list");
       Map* result = SASS_MEMORY_NEW(Map, pstate, 1);
       for (auto key : m->keys()) {
         remove = false;

--- a/src/fn_miscs.cpp
+++ b/src/fn_miscs.cpp
@@ -50,7 +50,7 @@ namespace Sass {
     {
       String_Constant* ss = Cast<String_Constant>(env["$name"]);
       if (!ss) {
-        error("$name: " + (env["$name"]->to_string()) + " is not a string for `function-exists'", pstate, traces);
+        error("$name: " + (env["$name"]->to_string()) + " is not a string.", pstate, traces);
       }
 
       std::string name = Util::normalize_underscores(unquote(ss->value()));

--- a/src/fn_miscs.cpp
+++ b/src/fn_miscs.cpp
@@ -108,7 +108,7 @@ namespace Sass {
         function = ff->name();
       }
 
-      List_Obj arglist = SASS_MEMORY_COPY(ARG("$args", List, "a list"));
+      List_Obj arglist = SASS_MEMORY_COPY(ARG("$args", List, "an argument list"));
 
       Arguments_Obj args = SASS_MEMORY_NEW(Arguments, pstate);
       // std::string full_name(name + "[f]");
@@ -178,8 +178,7 @@ namespace Sass {
         return SASS_MEMORY_NEW(String_Constant, pstate, "null");
       } else if (v->concrete_type() == Expression::BOOLEAN && v->is_false()) {
         return SASS_MEMORY_NEW(String_Constant, pstate, "false");
-      } else if (v->concrete_type() == Expression::STRING) {
-        String_Constant *s = Cast<String_Constant>(v);
+      } else if (String_Constant* s = Cast<String_Constant>(v)) {
         if (s->quote_mark()) {
           return SASS_MEMORY_NEW(String_Constant, pstate, quote(s->value(), s->quote_mark()));
         } else {
@@ -203,7 +202,7 @@ namespace Sass {
     BUILT_IN(content_exists)
     {
       if (!d_env.has_global("is_in_mixin")) {
-        error("Cannot call content-exists() except within a mixin.", pstate, traces);
+        error("content-exists() may only be called within a mixin.", pstate, traces);
       }
       return SASS_MEMORY_NEW(Boolean, pstate, d_env.has_lexical("@content[m]"));
     }
@@ -213,7 +212,7 @@ namespace Sass {
     {
       String_Constant* ss = Cast<String_Constant>(env["$name"]);
       if (!ss) {
-        error("$name: " + (env["$name"]->to_string()) + " is not a string for `get-function'", pstate, traces);
+        error("$name: " + (env["$name"]->to_string()) + " is not a string.", pstate, traces);
       }
 
       std::string name = Util::normalize_underscores(unquote(ss->value()));
@@ -231,7 +230,7 @@ namespace Sass {
       }
 
 
-      if (!d_env.has_global(full_name)) {
+      if (!d_env.has(full_name)) {
         error("Function not found: " + name, pstate, traces);
       }
 

--- a/src/fn_miscs.cpp
+++ b/src/fn_miscs.cpp
@@ -15,14 +15,14 @@ namespace Sass {
     Signature type_of_sig = "type-of($value)";
     BUILT_IN(type_of)
     {
-      Expression* v = ARG("$value", Expression);
+      Expression* v = ARG("$value", Expression, "an expression");
       return SASS_MEMORY_NEW(String_Quoted, pstate, v->type());
     }
 
     Signature variable_exists_sig = "variable-exists($name)";
     BUILT_IN(variable_exists)
     {
-      std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
+      std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant, "a string")->value()));
 
       if(d_env.has("$"+s)) {
         return SASS_MEMORY_NEW(Boolean, pstate, true);
@@ -35,7 +35,7 @@ namespace Sass {
     Signature global_variable_exists_sig = "global-variable-exists($name)";
     BUILT_IN(global_variable_exists)
     {
-      std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
+      std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant, "a string")->value()));
 
       if(d_env.has_global("$"+s)) {
         return SASS_MEMORY_NEW(Boolean, pstate, true);
@@ -66,7 +66,7 @@ namespace Sass {
     Signature mixin_exists_sig = "mixin-exists($name)";
     BUILT_IN(mixin_exists)
     {
-      std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant)->value()));
+      std::string s = Util::normalize_underscores(unquote(ARG("$name", String_Constant, "a string")->value()));
 
       if(d_env.has(s+"[m]")) {
         return SASS_MEMORY_NEW(Boolean, pstate, true);
@@ -79,7 +79,7 @@ namespace Sass {
     Signature feature_exists_sig = "feature-exists($feature)";
     BUILT_IN(feature_exists)
     {
-      std::string s = unquote(ARG("$feature", String_Constant)->value());
+      std::string s = unquote(ARG("$feature", String_Constant, "a string")->value());
 
       static const auto *const features = new std::unordered_set<std::string> {
         "global-variable-shadowing",
@@ -108,7 +108,7 @@ namespace Sass {
         function = ff->name();
       }
 
-      List_Obj arglist = SASS_MEMORY_COPY(ARG("$args", List));
+      List_Obj arglist = SASS_MEMORY_COPY(ARG("$args", List, "a list"));
 
       Arguments_Obj args = SASS_MEMORY_NEW(Arguments, pstate);
       // std::string full_name(name + "[f]");
@@ -150,16 +150,16 @@ namespace Sass {
     Signature not_sig = "not($value)";
     BUILT_IN(sass_not)
     {
-      return SASS_MEMORY_NEW(Boolean, pstate, ARG("$value", Expression)->is_false());
+      return SASS_MEMORY_NEW(Boolean, pstate, ARG("$value", Expression, "an expression")->is_false());
     }
 
     Signature if_sig = "if($condition, $if-true, $if-false)";
     BUILT_IN(sass_if)
     {
       Expand expand(ctx, &d_env, &selector_stack, &original_stack);
-      Expression_Obj cond = ARG("$condition", Expression)->perform(&expand.eval);
+      Expression_Obj cond = ARG("$condition", Expression, "an expression")->perform(&expand.eval);
       bool is_true = !cond->is_false();
-      Expression_Obj res = ARG(is_true ? "$if-true" : "$if-false", Expression);
+      Expression_Obj res = ARG(is_true ? "$if-true" : "$if-false", Expression, "an expression");
       Value_Obj qwe = Cast<Value>(res->perform(&expand.eval));
       // res = res->perform(&expand.eval.val_eval);
       qwe->set_delayed(false); // clone?
@@ -173,7 +173,7 @@ namespace Sass {
     Signature inspect_sig = "inspect($value)";
     BUILT_IN(inspect)
     {
-      Expression* v = ARG("$value", Expression);
+      Expression* v = ARG("$value", Expression, "an expression");
       if (v->concrete_type() == Expression::NULL_VAL) {
         return SASS_MEMORY_NEW(String_Constant, pstate, "null");
       } else if (v->concrete_type() == Expression::BOOLEAN && v->is_false()) {
@@ -219,7 +219,7 @@ namespace Sass {
       std::string name = Util::normalize_underscores(unquote(ss->value()));
       std::string full_name = name + "[f]";
 
-      Boolean_Obj css = ARG("$css", Boolean);
+      Boolean_Obj css = ARG("$css", Boolean, "a boolean");
       if (!css->is_false()) {
         Definition* def = SASS_MEMORY_NEW(Definition,
                                          pstate,

--- a/src/fn_numbers.cpp
+++ b/src/fn_numbers.cpp
@@ -103,7 +103,7 @@ namespace Sass {
     Signature min_sig = "min($numbers...)";
     BUILT_IN(min)
     {
-      List* arglist = ARG("$numbers", List);
+      List* arglist = ARG("$numbers", List, "a list");
       Number_Obj least;
       size_t L = arglist->length();
       if (L == 0) {
@@ -125,7 +125,7 @@ namespace Sass {
     Signature max_sig = "max($numbers...)";
     BUILT_IN(max)
     {
-      List* arglist = ARG("$numbers", List);
+      List* arglist = ARG("$numbers", List, "a list");
       Number_Obj greatest;
       size_t L = arglist->length();
       if (L == 0) {

--- a/src/fn_selectors.cpp
+++ b/src/fn_selectors.cpp
@@ -13,7 +13,7 @@ namespace Sass {
     Signature selector_nest_sig = "selector-nest($selectors...)";
     BUILT_IN(selector_nest)
     {
-      List* arglist = ARG("$selectors", List, "a list");
+      List* arglist = ARGLIST("$selectors");
 
       // Not enough parameters
       if (arglist->length() == 0) {
@@ -27,8 +27,8 @@ namespace Sass {
       for (size_t i = 0, L = arglist->length(); i < L; ++i) {
         Expression_Obj exp = Cast<Expression>(arglist->value_at_index(i));
         if (exp->concrete_type() == Expression::NULL_VAL) {
-          error(
-            "$selectors: null is not a valid selector: it must be a string,\n"
+          error( // "$selectors: "
+            "null is not a valid selector: it must be a string,\n"
             "a list of strings, or a list of lists of strings for 'selector-nest'",
             pstate, traces);
         }
@@ -65,13 +65,12 @@ namespace Sass {
     Signature selector_append_sig = "selector-append($selectors...)";
     BUILT_IN(selector_append)
     {
-      List* arglist = ARG("$selectors", List, "a list");
+      List* arglist = ARGLIST("$selectors");
 
       // Not enough parameters
       if (arglist->empty()) {
         error(
-          "$selectors: At least one selector must be "
-          "passed for `selector-append'",
+          "$selectors: At least one selector must be passed.",
           pstate, traces);
       }
 

--- a/src/fn_selectors.cpp
+++ b/src/fn_selectors.cpp
@@ -13,7 +13,7 @@ namespace Sass {
     Signature selector_nest_sig = "selector-nest($selectors...)";
     BUILT_IN(selector_nest)
     {
-      List* arglist = ARG("$selectors", List);
+      List* arglist = ARG("$selectors", List, "a list");
 
       // Not enough parameters
       if (arglist->length() == 0) {
@@ -65,7 +65,7 @@ namespace Sass {
     Signature selector_append_sig = "selector-append($selectors...)";
     BUILT_IN(selector_append)
     {
-      List* arglist = ARG("$selectors", List);
+      List* arglist = ARG("$selectors", List, "a list");
 
       // Not enough parameters
       if (arglist->empty()) {

--- a/src/fn_strings.cpp
+++ b/src/fn_strings.cpp
@@ -65,7 +65,7 @@ namespace Sass {
     Signature quote_sig = "quote($string)";
     BUILT_IN(sass_quote)
     {
-      const String_Constant* s = ARG("$string", String_Constant);
+      const String_Constant* s = ARG("$string", String_Constant, "a string");
       String_Quoted *result = SASS_MEMORY_NEW(
           String_Quoted, pstate, s->value(),
           /*q=*/'\0', /*keep_utf8_escapes=*/false, /*skip_unquoting=*/true);
@@ -78,7 +78,7 @@ namespace Sass {
     {
       size_t len = std::string::npos;
       try {
-        String_Constant* s = ARG("$string", String_Constant);
+        String_Constant* s = ARG("$string", String_Constant, "a string");
         len = UTF_8::code_point_count(s->value(), 0, s->value().size());
 
       }
@@ -94,9 +94,9 @@ namespace Sass {
     {
       std::string str;
       try {
-        String_Constant* s = ARG("$string", String_Constant);
+        String_Constant* s = ARG("$string", String_Constant, "a string");
         str = s->value();
-        String_Constant* i = ARG("$insert", String_Constant);
+        String_Constant* i = ARG("$insert", String_Constant, "a string");
         std::string ins = i->value();
         double index = ARGVAL("$index");
         size_t len = UTF_8::code_point_count(str, 0, str.size());
@@ -137,8 +137,8 @@ namespace Sass {
     {
       size_t index = std::string::npos;
       try {
-        String_Constant* s = ARG("$string", String_Constant);
-        String_Constant* t = ARG("$substring", String_Constant);
+        String_Constant* s = ARG("$string", String_Constant, "a string");
+        String_Constant* t = ARG("$substring", String_Constant, "a string");
         std::string str = s->value();
         std::string substr = t->value();
 
@@ -160,7 +160,7 @@ namespace Sass {
     {
       std::string newstr;
       try {
-        String_Constant* s = ARG("$string", String_Constant);
+        String_Constant* s = ARG("$string", String_Constant, "a string");
         double start_at = ARGVAL("$start-at");
         double end_at = ARGVAL("$end-at");
         String_Quoted* ss = Cast<String_Quoted>(s);
@@ -210,7 +210,7 @@ namespace Sass {
     Signature to_upper_case_sig = "to-upper-case($string)";
     BUILT_IN(to_upper_case)
     {
-      String_Constant* s = ARG("$string", String_Constant);
+      String_Constant* s = ARG("$string", String_Constant, "a string");
       std::string str = s->value();
       Util::ascii_str_toupper(&str);
 
@@ -226,7 +226,7 @@ namespace Sass {
     Signature to_lower_case_sig = "to-lower-case($string)";
     BUILT_IN(to_lower_case)
     {
-      String_Constant* s = ARG("$string", String_Constant);
+      String_Constant* s = ARG("$string", String_Constant, "a string");
       std::string str = s->value();
       Util::ascii_str_tolower(&str);
 

--- a/src/fn_utils.hpp
+++ b/src/fn_utils.hpp
@@ -27,7 +27,11 @@ namespace Sass {
   typedef PreValue* (*Native_Function)(FN_PROTOTYPE);
   #define BUILT_IN(name) PreValue* name(FN_PROTOTYPE)
 
-  #define ARG(argname, argtype) get_arg<argtype>(argname, env, sig, pstate, traces)
+  #define ARG(argname, argtype, type) get_arg<argtype>(argname, env, sig, pstate, traces, type)
+  #define ARGCOL(argname) get_arg<Color>(argname, env, sig, pstate, traces, "a color")
+  #define ARGNUM(argname) get_arg<Number>(argname, env, sig, pstate, traces, "a number")
+  #define ARGLIST(argname) get_arg<List>(argname, env, sig, pstate, traces, "a list")
+  #define ARGSTRC(argname) get_arg<String_Constant>(argname, env, sig, pstate, traces, "a string")
   // special function for weird hsla percent (10px == 10% == 10 != 0.1)
   #define ARGVAL(argname) get_arg_val(argname, env, sig, pstate, traces) // double
 
@@ -36,12 +40,15 @@ namespace Sass {
 
   namespace Functions {
 
+    std::string envValueToString(Env& env, const std::string& name);
+
     template <typename T>
-    T* get_arg(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces)
+    T* get_arg(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces, std::string type)
     {
-      T* val = Cast<T>(env[argname]);
-      if (!val) {
-        error("argument `" + argname + "` of `" + sig + "` must be a " + T::type_name(), pstate, traces);
+      AST_Node* node = env.get_local(argname);
+      T* val = Cast<T>(node);
+      if (node && !val) {
+        error(argname + ": " + envValueToString(env, argname) + " is not " + type + ".", pstate, traces);
       }
       return val;
     }
@@ -50,10 +57,12 @@ namespace Sass {
     Number* get_arg_n(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces); // numbers only
     double alpha_num(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces); // colors only
     double color_num(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces); // colors only
-    double get_arg_r(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces, double lo, double hi); // colors only
+    double get_arg_r(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces, double lo, double hi, std::string unit = ""); // colors only
     double get_arg_val(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces); // shared
     SelectorListObj get_arg_sels(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces, Context& ctx); // selectors only
     CompoundSelectorObj get_arg_sel(const std::string& argname, Env& env, Signature sig, ParserState pstate, Backtraces traces, Context& ctx); // selectors only
+
+    int assertInt(const std::string& name, double nr, ParserState pstate, Backtraces traces);
 
   }
 

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -384,6 +384,13 @@ namespace Sass {
     return u;
   }
 
+  bool Units::hasUnit(std::string unit)
+  {
+    return numerators.size() == 1 &&
+      denominators.empty() &&
+      numerators[0] == unit;
+  }
+
   bool Units::is_unitless() const
   {
     return numerators.empty() &&

--- a/src/units.hpp
+++ b/src/units.hpp
@@ -72,6 +72,10 @@ namespace Sass {
     std::string unit() const;
     // get if units are empty
     bool is_unitless() const;
+
+    bool hasUnits() const {
+      return !is_unitless();
+    }
     // return if valid for css
     bool is_valid_css_unit() const;
     // reduce units for output
@@ -86,6 +90,8 @@ namespace Sass {
     bool operator!= (const Units& rhs) const;
     // factor to convert into given units
     double convert_factor(const Units&) const;
+    // Check if number has the given unit
+    bool hasUnit(std::string numerator);
   };
 
   extern const double size_conversion_factors[6][6];

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -62,6 +62,10 @@ namespace Sass {
     return true;
   }
 
+  inline bool string_constains(const std::string& str, const char chr) {
+    return str.find(chr) != std::string::npos;
+  }
+
   // C++20 `starts_with` equivalent.
   // See https://en.cppreference.com/w/cpp/string/basic_string/starts_with
   inline bool starts_with(const std::string& str, const char* prefix, size_t prefix_len) {


### PR DESCRIPTION
This is backported from ongoing parser backport.
It should allow to enable quite a few todo specs.