### PR TITLE
Improve Mac OSX shared native makefile build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,10 @@ STATICLIB = lib/libsass.a
 SHAREDLIB = lib/libsass.so
 LIB_STATIC = $(SASS_LIBSASS_PATH)/lib/libsass.a
 LIB_SHARED = $(SASS_LIBSASS_PATH)/lib/libsass.so
-
+ifeq ($(UNAME),Darwin)
+	SHAREDLIB = lib/libsass.dylib
+	LIB_SHARED = $(SASS_LIBSASS_PATH)/lib/libsass.dylib
+endif
 ifeq (Windows,$(UNAME))
 	SASSC_BIN = $(SASS_SASSC_PATH)/bin/sassc.exe
 	RESOURCES += res/resource.rc
@@ -206,8 +209,13 @@ lib/libsass.a: $(COBJECTS) $(OBJECTS) | lib
 lib/libsass.so: $(COBJECTS) $(OBJECTS) | lib
 	$(CXX) -shared $(LDFLAGS) -o $@ $(COBJECTS) $(OBJECTS) $(LDLIBS)
 
+lib/libsass.dylib: $(COBJECTS) $(OBJECTS) | lib
+	$(CXX) -shared $(LDFLAGS) -o $@ $(COBJECTS) $(OBJECTS) $(LDLIBS) \
+	-install_name @rpath/libsass.dylib
+
 lib/libsass.dll: $(COBJECTS) $(OBJECTS) $(RCOBJECTS) | lib
-	$(CXX) -shared $(LDFLAGS) -o $@ $(COBJECTS) $(OBJECTS) $(RCOBJECTS) $(LDLIBS) -s -Wl,--subsystem,windows,--out-implib,lib/libsass.a
+	$(CXX) -shared $(LDFLAGS) -o $@ $(COBJECTS) $(OBJECTS) $(RCOBJECTS) $(LDLIBS) \
+	-s -Wl,--subsystem,windows,--out-implib,lib/libsass.a
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -o $@ $<
@@ -262,13 +270,17 @@ $(DESTDIR)$(PREFIX)/lib/%.dll: lib/%.dll \
                                | $(DESTDIR)$(PREFIX)/lib
 	@$(INSTALL) -v -m0755 "$<" "$@"
 
+$(DESTDIR)$(PREFIX)/lib/%.dylib: lib/%.dylib \
+                               | $(DESTDIR)$(PREFIX)/lib
+	@$(INSTALL) -v -m0755 "$<" "$@"
+
 install-static: $(DESTDIR)$(PREFIX)/lib/libsass.a
 
-install-shared: $(DESTDIR)$(PREFIX)/lib/libsass.so \
+install-shared: $(DESTDIR)$(PREFIX)/$(SHAREDLIB) \
                 install-headers
 
 $(SASSC_BIN): $(BUILD)
-	$(MAKE) -C $(SASS_SASSC_PATH) build-$(BUILD)-dev
+	$(MAKE) -C $(SASS_SASSC_PATH) build-$(BUILD)
 
 sassc: $(SASSC_BIN)
 	$(SASSC_BIN) -v
@@ -279,19 +291,27 @@ version: $(SASSC_BIN)
 test: test_build
 
 test_build: $(SASSC_BIN)
-	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) --impl libsass $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
+	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) --impl libsass \
+	--cmd-args "-I $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)" \
+	$(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
 
 test_full: $(SASSC_BIN)
-	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) --impl libsass --run-todo $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
+	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) --impl libsass \
+	--cmd-args "-I $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)" \
+	--run-todo $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
 
 test_probe: $(SASSC_BIN)
-	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) --impl libsass --probe-todo $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
+	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) --impl libsass \
+	--cmd-args "-I $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)" \
+	--probe-todo $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
 
 test_interactive: $(SASSC_BIN)
-	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) --impl libsass --interactive $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
+	$(RUBY_BIN) $(SASS_SPEC_PATH)/sass-spec.rb -c $(SASSC_BIN) --impl libsass \
+	--cmd-args "-I $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)" \
+	--interactive $(LOG_FLAGS) $(SASS_SPEC_PATH)/$(SASS_SPEC_SPEC_DIR)
 
 clean-objects: | lib
-	-$(RM) lib/*.a lib/*.so lib/*.dll lib/*.la
+	-$(RM) lib/*.a lib/*.so lib/*.dll lib/*.dylib lib/*.la
 	-$(RMDIR) lib
 clean: clean-objects
 	$(RM) $(CLEANUPS)

--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -85,9 +85,6 @@ if [ "x$AUTOTOOLS" == "xyes" ]; then
 
   make $MAKE_OPTS clean
 
-  # install to prefix directory
-  PREFIX="$PREFIX" make $MAKE_OPTS install
-
 else
 
   make $MAKE_OPTS clean
@@ -95,6 +92,7 @@ else
   # Run C++ unit tests
   make -C test clean
   make -C test test
+
 fi
 
 # install to prefix directory
@@ -128,10 +126,10 @@ then
     echo "Fetching Sass Spec PR $SPEC_PR"
     git -C sass-spec fetch -u origin pull/$SPEC_PR/head:ci-spec-pr-$SPEC_PR
     git -C sass-spec checkout --force ci-spec-pr-$SPEC_PR
-    make LD_LIBRARY_PATH="$PREFIX/lib/" DYLD_LIBRARY_PATH="$PREFIX/lib/" $MAKE_OPTS test_probe
+    make $MAKE_OPTS test_probe
   else
-    make LD_LIBRARY_PATH="$PREFIX/lib/" DYLD_LIBRARY_PATH="$PREFIX/lib/" $MAKE_OPTS test_probe
+    make $MAKE_OPTS test_probe
   fi
 else
-  make LD_LIBRARY_PATH="$PREFIX/lib/" DYLD_LIBRARY_PATH="$PREFIX/lib/" $MAKE_OPTS test_probe
+  make $MAKE_OPTS test_probe
 fi


### PR DESCRIPTION
Needs https://github.com/sass/sassc/pull/256

- Use dylib instead of so on Mac OSX
- Remove unnessecary MSVC project file