### PR TITLE
Use deprecated rather than roll your own.

### DIFF
--- a/src/fn_miscs.cpp
+++ b/src/fn_miscs.cpp
@@ -100,10 +100,10 @@ namespace Sass {
 
       if (ss) {
         function = Util::normalize_underscores(unquote(ss->value()));
-        std::cerr << "DEPRECATION WARNING: ";
-        std::cerr << "Passing a string to call() is deprecated and will be illegal" << std::endl;
-        std::cerr << "in Sass 4.0. Use call(get-function(" + quote(function) + ")) instead." << std::endl;
-        std::cerr << std::endl;
+        std::string lineOne("Passing a string to call() is deprecated and will be illegal in Sass 4.0.");
+        std::ostringstream lineTwo;
+        lineTwo << "Use call(get-function(" << quote(function) << ")) instead.";
+        deprecated(lineOne, lineTwo.str(), true , pstate);
       } else if (ff) {
         function = ff->name();
       }


### PR DESCRIPTION
This is one of the places (outside of debug and error_handling) where cerr is directly used. As error_handling has a deprecated function, it seems sensible to use it.