### PR TITLE
std::clog instead of std::cerr for non-critical.

### DIFF
--- a/src/ast_sel_cmp.cpp
+++ b/src/ast_sel_cmp.cpp
@@ -204,7 +204,7 @@ namespace Sass {
 
   bool CompoundSelector::operator== (const CompoundSelector& rhs) const
   {
-    // std::cerr << "comp vs comp\n";
+    // std::clog << "comp vs comp" << std::endl;
     if (&rhs == this) return true;
     if (rhs.length() != length()) return false;
     std::unordered_set<const SimpleSelector*, PtrObjHash, PtrObjEquality> lhs_set;

--- a/src/ast_sel_super.cpp
+++ b/src/ast_sel_super.cpp
@@ -9,7 +9,7 @@ namespace Sass {
 
   // ##########################################################################
   // To compare/debug against libsass you can use debugger.hpp:
-  // c++: std::cerr << "result " << debug_vec(compound) << "\n";
+  // c++: std::clog << "result " << debug_vec(compound) << std::endl;
   // dart: stderr.writeln("result " + compound.toString());
   // ##########################################################################
 
@@ -450,6 +450,7 @@ namespace Sass {
       }
     }
 
+    // Unreachable.
     return false;
 
   }

--- a/src/ast_sel_unify.cpp
+++ b/src/ast_sel_unify.cpp
@@ -160,7 +160,7 @@ namespace Sass {
   {
 
     if (compound->length() == 1 && compound->first()->is_universal()) {
-      // std::cerr << "implement universal pseudo\n";
+      // std::clog << "implement universal pseudo" << std::endl;
     }
 
     for (const SimpleSelectorObj& sel : compound->elements()) {

--- a/src/debug.hpp
+++ b/src/debug.hpp
@@ -28,8 +28,8 @@ const uint32_t debug_lvl = UINT32_MAX;
 const uint32_t debug_lvl = (DEBUG_LVL);
 #endif // DEBUG_LVL
 
-#define DEBUG_PRINT(lvl, x) if((lvl) & debug_lvl) { std::cerr << x; }
-#define DEBUG_PRINTLN(lvl, x) if((lvl) & debug_lvl) { std::cerr << x << std::endl; }
+#define DEBUG_PRINT(lvl, x) if((lvl) & debug_lvl) { std::clog << x; }
+#define DEBUG_PRINTLN(lvl, x) if((lvl) & debug_lvl) { std::clog << x << std::endl; }
 #define DEBUG_EXEC(lvl, x) if((lvl) & debug_lvl) { x; }
 
 #else // DEBUG

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -326,44 +326,44 @@ inline std::string pstate_source_position(AST_Node* node)
 inline void debug_ast(AST_Node* node, std::string ind, Env* env)
 {
   if (node == 0) return;
-  if (ind == "") std::cerr << "####################################################################\n";
+  if (ind == "") std::clog << "####################################################################" << std::endl;
   if (Cast<Bubble>(node)) {
     Bubble* bubble = Cast<Bubble>(node);
-    std::cerr << ind << "Bubble " << bubble;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << bubble->tabs();
-    std::cerr << std::endl;
+    std::clog << ind << "Bubble " << bubble;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << bubble->tabs();
+    std::clog << std::endl;
     debug_ast(bubble->node(), ind + " ", env);
   } else if (Cast<Trace>(node)) {
     Trace* trace = Cast<Trace>(node);
-    std::cerr << ind << "Trace " << trace;
-    std::cerr << " (" << pstate_source_position(node) << ")"
+    std::clog << ind << "Trace " << trace;
+    std::clog << " (" << pstate_source_position(node) << ")"
     << " [name:" << trace->name() << ", type: " << trace->type() << "]"
     << std::endl;
     debug_ast(trace->block(), ind + " ", env);
   } else if (Cast<At_Root_Block>(node)) {
     At_Root_Block* root_block = Cast<At_Root_Block>(node);
-    std::cerr << ind << "At_Root_Block " << root_block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << root_block->tabs();
-    std::cerr << std::endl;
+    std::clog << ind << "At_Root_Block " << root_block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << root_block->tabs();
+    std::clog << std::endl;
     debug_ast(root_block->expression(), ind + ":", env);
     debug_ast(root_block->block(), ind + " ", env);
   } else if (Cast<SelectorList>(node)) {
     SelectorList* selector = Cast<SelectorList>(node);
-    std::cerr << ind << "SelectorList " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << selector->hash() << ">";
-    std::cerr << (selector->is_invisible() ? " [is_invisible]" : " -");
-    std::cerr << (selector->isInvisible() ? " [isInvisible]" : " -");
-    std::cerr << (selector->has_real_parent_ref() ? " [real-parent]": " -");
-    std::cerr << std::endl;
+    std::clog << ind << "SelectorList " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <" << selector->hash() << ">";
+    std::clog << (selector->is_invisible() ? " [is_invisible]" : " -");
+    std::clog << (selector->isInvisible() ? " [isInvisible]" : " -");
+    std::clog << (selector->has_real_parent_ref() ? " [real-parent]": " -");
+    std::clog << std::endl;
 
     for(const ComplexSelector_Obj& i : selector->elements()) { debug_ast(i, ind + " ", env); }
 
   } else if (Cast<ComplexSelector>(node)) {
     ComplexSelector* selector = Cast<ComplexSelector>(node);
-    std::cerr << ind << "ComplexSelector " << selector
+    std::clog << ind << "ComplexSelector " << selector
       << " (" << pstate_source_position(node) << ")"
       << " <" << selector->hash() << ">"
       << " [" << (selector->chroots() ? "CHROOT" : "CONNECT") << "]"
@@ -385,7 +385,7 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
 
   } else if (Cast<SelectorCombinator>(node)) {
     SelectorCombinator* selector = Cast<SelectorCombinator>(node);
-    std::cerr << ind << "SelectorCombinator " << selector
+    std::clog << ind << "SelectorCombinator " << selector
       << " (" << pstate_source_position(node) << ")"
       << " <" << selector->hash() << ">"
       << " [weight:" << longToHex(selector->specificity()) << "]"
@@ -399,87 +399,87 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
         case SelectorCombinator::ADJACENT: del = "+"; break;
       }
 
-      std::cerr << "[" << del << "]" << "\n";
+      std::clog << "[" << del << "]" << std::endl;
 
   } else if (Cast<CompoundSelector>(node)) {
     CompoundSelector* selector = Cast<CompoundSelector>(node);
-    std::cerr << ind << "CompoundSelector " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << selector->hash() << ">";
-    std::cerr << (selector->hasRealParent() ? " [REAL PARENT]" : "") << ">";
-    std::cerr << " [weight:" << longToHex(selector->specificity()) << "]";
-    std::cerr << (selector->hasPostLineBreak() ? " [hasPostLineBreak]" : " -");
-    std::cerr << (selector->is_invisible() ? " [is_invisible]" : " -");
-    std::cerr << (selector->isInvisible() ? " [isInvisible]" : " -");
-    std::cerr << "\n";
+    std::clog << ind << "CompoundSelector " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <" << selector->hash() << ">";
+    std::clog << (selector->hasRealParent() ? " [REAL PARENT]" : "") << ">";
+    std::clog << " [weight:" << longToHex(selector->specificity()) << "]";
+    std::clog << (selector->hasPostLineBreak() ? " [hasPostLineBreak]" : " -");
+    std::clog << (selector->is_invisible() ? " [is_invisible]" : " -");
+    std::clog << (selector->isInvisible() ? " [isInvisible]" : " -");
+    std::clog << std::endl;
     for(const SimpleSelector_Obj& i : selector->elements()) { debug_ast(i, ind + " ", env); }
 
   } else if (Cast<Parent_Reference>(node)) {
     Parent_Reference* selector = Cast<Parent_Reference>(node);
-    std::cerr << ind << "Parent_Reference " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
+    std::clog << ind << "Parent_Reference " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <" << selector->hash() << ">";
+    std::clog << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
 
   } else if (Cast<Pseudo_Selector>(node)) {
     Pseudo_Selector* selector = Cast<Pseudo_Selector>(node);
-    std::cerr << ind << "Pseudo_Selector " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>";
-    std::cerr << (selector->isClass() ? " [isClass]": " -");
-    std::cerr << (selector->isSyntacticClass() ? " [isSyntacticClass]": " -");
-    std::cerr << std::endl;
+    std::clog << ind << "Pseudo_Selector " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <" << selector->hash() << ">";
+    std::clog << " <<" << selector->ns_name() << ">>";
+    std::clog << (selector->isClass() ? " [isClass]": " -");
+    std::clog << (selector->isSyntacticClass() ? " [isSyntacticClass]": " -");
+    std::clog << std::endl;
     debug_ast(selector->argument(), ind + " <= ", env);
     debug_ast(selector->selector(), ind + " || ", env);
   } else if (Cast<Attribute_Selector>(node)) {
     Attribute_Selector* selector = Cast<Attribute_Selector>(node);
-    std::cerr << ind << "Attribute_Selector " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>";
-    std::cerr << std::endl;
+    std::clog << ind << "Attribute_Selector " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <" << selector->hash() << ">";
+    std::clog << " <<" << selector->ns_name() << ">>";
+    std::clog << std::endl;
     debug_ast(selector->value(), ind + "[" + selector->matcher() + "] ", env);
   } else if (Cast<Class_Selector>(node)) {
     Class_Selector* selector = Cast<Class_Selector>(node);
-    std::cerr << ind << "Class_Selector " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>";
-    std::cerr << std::endl;
+    std::clog << ind << "Class_Selector " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <" << selector->hash() << ">";
+    std::clog << " <<" << selector->ns_name() << ">>";
+    std::clog << std::endl;
   } else if (Cast<Id_Selector>(node)) {
     Id_Selector* selector = Cast<Id_Selector>(node);
-    std::cerr << ind << "Id_Selector " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>";
-    std::cerr << std::endl;
+    std::clog << ind << "Id_Selector " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <" << selector->hash() << ">";
+    std::clog << " <<" << selector->ns_name() << ">>";
+    std::clog << std::endl;
   } else if (Cast<Type_Selector>(node)) {
     Type_Selector* selector = Cast<Type_Selector>(node);
-    std::cerr << ind << "Type_Selector " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <<" << selector->ns_name() << ">>";
-    std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">";
-    std::cerr << std::endl;
+    std::clog << ind << "Type_Selector " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <" << selector->hash() << ">";
+    std::clog << " <<" << selector->ns_name() << ">>";
+    std::clog << " <" << prettyprint(selector->pstate().token.ws_before()) << ">";
+    std::clog << std::endl;
   } else if (Cast<Placeholder_Selector>(node)) {
 
     Placeholder_Selector* selector = Cast<Placeholder_Selector>(node);
-    std::cerr << ind << "Placeholder_Selector [" << selector->ns_name() << "] " << selector;
-    std::cerr << " (" << pstate_source_position(selector) << ")"
+    std::clog << ind << "Placeholder_Selector [" << selector->ns_name() << "] " << selector;
+    std::clog << " (" << pstate_source_position(selector) << ")"
       << " <" << selector->hash() << ">"
       << (selector->isInvisible() ? " [isInvisible]" : " -")
     << std::endl;
 
   } else if (Cast<SimpleSelector>(node)) {
     SimpleSelector* selector = Cast<SimpleSelector>(node);
-    std::cerr << ind << "SimpleSelector " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")";
+    std::clog << ind << "SimpleSelector " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")";
 
   } else if (Cast<Selector_Schema>(node)) {
     Selector_Schema* selector = Cast<Selector_Schema>(node);
-    std::cerr << ind << "Selector_Schema " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")"
+    std::clog << ind << "Selector_Schema " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")"
       << (selector->connect_parent() ? " [connect-parent]": " -")
     << std::endl;
 
@@ -488,24 +488,24 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
 
   } else if (Cast<Selector>(node)) {
     Selector* selector = Cast<Selector>(node);
-    std::cerr << ind << "Selector " << selector;
-    std::cerr << " (" << pstate_source_position(node) << ")"
+    std::clog << ind << "Selector " << selector;
+    std::clog << " (" << pstate_source_position(node) << ")"
     << std::endl;
 
   } else if (Cast<Media_Query_Expression>(node)) {
     Media_Query_Expression* block = Cast<Media_Query_Expression>(node);
-    std::cerr << ind << "Media_Query_Expression " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << (block->is_interpolated() ? " [is_interpolated]": " -")
+    std::clog << ind << "Media_Query_Expression " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << (block->is_interpolated() ? " [is_interpolated]": " -")
     << std::endl;
     debug_ast(block->feature(), ind + " feature) ");
     debug_ast(block->value(), ind + " value) ");
 
   } else if (Cast<Media_Query>(node)) {
     Media_Query* block = Cast<Media_Query>(node);
-    std::cerr << ind << "Media_Query " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << (block->is_negated() ? " [is_negated]": " -")
+    std::clog << ind << "Media_Query " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << (block->is_negated() ? " [is_negated]": " -")
       << (block->is_restricted() ? " [is_restricted]": " -")
     << std::endl;
     debug_ast(block->media_type(), ind + " ");
@@ -513,17 +513,17 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   }
   else if (Cast<MediaRule>(node)) {
     MediaRule* rule = Cast<MediaRule>(node);
-    std::cerr << ind << "MediaRule " << rule;
-    std::cerr << " (" << pstate_source_position(rule) << ")";
-    std::cerr << " " << rule->tabs() << std::endl;
+    std::clog << ind << "MediaRule " << rule;
+    std::clog << " (" << pstate_source_position(rule) << ")";
+    std::clog << " " << rule->tabs() << std::endl;
     debug_ast(rule->schema(), ind + " =@ ");
     debug_ast(rule->block(), ind + " ");
   }
   else if (Cast<CssMediaRule>(node)) {
     CssMediaRule* rule = Cast<CssMediaRule>(node);
-    std::cerr << ind << "CssMediaRule " << rule;
-    std::cerr << " (" << pstate_source_position(rule) << ")";
-    std::cerr << " " << rule->tabs() << std::endl;
+    std::clog << ind << "CssMediaRule " << rule;
+    std::clog << " (" << pstate_source_position(rule) << ")";
+    std::clog << " " << rule->tabs() << std::endl;
     for (auto item : rule->elements()) {
       debug_ast(item, ind + " == ");
     }
@@ -531,300 +531,300 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
   }
   else if (Cast<CssMediaQuery>(node)) {
     CssMediaQuery* query = Cast<CssMediaQuery>(node);
-    std::cerr << ind << "CssMediaQuery " << query;
-    std::cerr << " (" << pstate_source_position(query) << ")";
-    std::cerr << " [" << (query->modifier()) << "] ";
-    std::cerr << " [" << (query->type()) << "] ";
-    std::cerr << " " << debug_vec(query->features());
-    std::cerr << std::endl;
+    std::clog << ind << "CssMediaQuery " << query;
+    std::clog << " (" << pstate_source_position(query) << ")";
+    std::clog << " [" << (query->modifier()) << "] ";
+    std::clog << " [" << (query->type()) << "] ";
+    std::clog << " " << debug_vec(query->features());
+    std::clog << std::endl;
   } else if (Cast<Supports_Block>(node)) {
     Supports_Block* block = Cast<Supports_Block>(node);
-    std::cerr << ind << "Supports_Block " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Supports_Block " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     debug_ast(block->condition(), ind + " =@ ");
     debug_ast(block->block(), ind + " <>");
   } else if (Cast<Supports_Operator>(node)) {
     Supports_Operator* block = Cast<Supports_Operator>(node);
-    std::cerr << ind << "Supports_Operator " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")"
+    std::clog << ind << "Supports_Operator " << block;
+    std::clog << " (" << pstate_source_position(node) << ")"
     << std::endl;
     debug_ast(block->left(), ind + " left) ");
     debug_ast(block->right(), ind + " right) ");
   } else if (Cast<Supports_Negation>(node)) {
     Supports_Negation* block = Cast<Supports_Negation>(node);
-    std::cerr << ind << "Supports_Negation " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")"
+    std::clog << ind << "Supports_Negation " << block;
+    std::clog << " (" << pstate_source_position(node) << ")"
     << std::endl;
     debug_ast(block->condition(), ind + " condition) ");
   } else if (Cast<At_Root_Query>(node)) {
     At_Root_Query* block = Cast<At_Root_Query>(node);
-    std::cerr << ind << "At_Root_Query " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")"
+    std::clog << ind << "At_Root_Query " << block;
+    std::clog << " (" << pstate_source_position(node) << ")"
     << std::endl;
     debug_ast(block->feature(), ind + " feature) ");
     debug_ast(block->value(), ind + " value) ");
   } else if (Cast<Supports_Declaration>(node)) {
     Supports_Declaration* block = Cast<Supports_Declaration>(node);
-    std::cerr << ind << "Supports_Declaration " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")"
+    std::clog << ind << "Supports_Declaration " << block;
+    std::clog << " (" << pstate_source_position(node) << ")"
     << std::endl;
     debug_ast(block->feature(), ind + " feature) ");
     debug_ast(block->value(), ind + " value) ");
   } else if (Cast<Block>(node)) {
     Block* root_block = Cast<Block>(node);
-    std::cerr << ind << "Block " << root_block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    if (root_block->is_root()) std::cerr << " [root]";
-    if (root_block->isInvisible()) std::cerr << " [isInvisible]";
-    std::cerr << " " << root_block->tabs() << std::endl;
+    std::clog << ind << "Block " << root_block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    if (root_block->is_root()) std::clog << " [root]";
+    if (root_block->isInvisible()) std::clog << " [isInvisible]";
+    std::clog << " " << root_block->tabs() << std::endl;
     for(const Statement_Obj& i : root_block->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Warning>(node)) {
     Warning* block = Cast<Warning>(node);
-    std::cerr << ind << "Warning " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Warning " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     debug_ast(block->message(), ind + " : ");
   } else if (Cast<Error>(node)) {
     Error* block = Cast<Error>(node);
-    std::cerr << ind << "Error " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Error " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
   } else if (Cast<Debug>(node)) {
     Debug* block = Cast<Debug>(node);
-    std::cerr << ind << "Debug " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Debug " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     debug_ast(block->value(), ind + " ");
   } else if (Cast<Comment>(node)) {
     Comment* block = Cast<Comment>(node);
-    std::cerr << ind << "Comment " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() <<
+    std::clog << ind << "Comment " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() <<
       " <" << prettyprint(block->pstate().token.ws_before()) << ">" << std::endl;
     debug_ast(block->text(), ind + "// ", env);
   } else if (Cast<If>(node)) {
     If* block = Cast<If>(node);
-    std::cerr << ind << "If " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "If " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     debug_ast(block->predicate(), ind + " = ");
     debug_ast(block->block(), ind + " <>");
     debug_ast(block->alternative(), ind + " ><");
   } else if (Cast<Return>(node)) {
     Return* block = Cast<Return>(node);
-    std::cerr << ind << "Return " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs();
-    std::cerr << " [" << block->value()->to_string() << "]" << std::endl;
+    std::clog << ind << "Return " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs();
+    std::clog << " [" << block->value()->to_string() << "]" << std::endl;
   } else if (Cast<ExtendRule>(node)) {
     ExtendRule* block = Cast<ExtendRule>(node);
-    std::cerr << ind << "ExtendRule " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "ExtendRule " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     debug_ast(block->selector(), ind + "-> ", env);
   } else if (Cast<Content>(node)) {
     Content* block = Cast<Content>(node);
-    std::cerr << ind << "Content " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Content " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     debug_ast(block->arguments(), ind + " args: ", env);
   } else if (Cast<Import_Stub>(node)) {
     Import_Stub* block = Cast<Import_Stub>(node);
-    std::cerr << ind << "Import_Stub " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << block->imp_path() << "] ";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Import_Stub " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << block->imp_path() << "] ";
+    std::clog << " " << block->tabs() << std::endl;
   } else if (Cast<Import>(node)) {
     Import* block = Cast<Import>(node);
-    std::cerr << ind << "Import " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Import " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     // std::vector<std::string>         files_;
     for (auto imp : block->urls()) debug_ast(imp, ind + "@: ", env);
     debug_ast(block->import_queries(), ind + "@@ ");
   } else if (Cast<Assignment>(node)) {
     Assignment* block = Cast<Assignment>(node);
-    std::cerr << ind << "Assignment " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " <<" << block->variable() << ">> " << block->tabs() << std::endl;
+    std::clog << ind << "Assignment " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " <<" << block->variable() << ">> " << block->tabs() << std::endl;
     debug_ast(block->value(), ind + "=", env);
   } else if (Cast<Declaration>(node)) {
     Declaration* block = Cast<Declaration>(node);
-    std::cerr << ind << "Declaration " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [is_custom_property: " << block->is_custom_property() << "] ";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Declaration " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [is_custom_property: " << block->is_custom_property() << "] ";
+    std::clog << " " << block->tabs() << std::endl;
     debug_ast(block->property(), ind + " prop: ", env);
     debug_ast(block->value(), ind + " value: ", env);
     debug_ast(block->block(), ind + " ", env);
   } else if (Cast<Keyframe_Rule>(node)) {
     Keyframe_Rule* has_block = Cast<Keyframe_Rule>(node);
-    std::cerr << ind << "Keyframe_Rule " << has_block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << has_block->tabs() << std::endl;
+    std::clog << ind << "Keyframe_Rule " << has_block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << has_block->tabs() << std::endl;
     if (has_block->name()) debug_ast(has_block->name(), ind + "@");
     if (has_block->block()) for(const Statement_Obj& i : has_block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Directive>(node)) {
     Directive* block = Cast<Directive>(node);
-    std::cerr << ind << "Directive " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << block->keyword() << "] " << block->tabs() << std::endl;
+    std::clog << ind << "Directive " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << block->keyword() << "] " << block->tabs() << std::endl;
     debug_ast(block->selector(), ind + "~", env);
     debug_ast(block->value(), ind + "+", env);
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Each>(node)) {
     Each* block = Cast<Each>(node);
-    std::cerr << ind << "Each " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "Each " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<For>(node)) {
     For* block = Cast<For>(node);
-    std::cerr << ind << "For " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "For " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<While>(node)) {
     While* block = Cast<While>(node);
-    std::cerr << ind << "While " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() << std::endl;
+    std::clog << ind << "While " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << block->tabs() << std::endl;
     if (block->block()) for(const Statement_Obj& i : block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Definition>(node)) {
     Definition* block = Cast<Definition>(node);
-    std::cerr << ind << "Definition " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [name: " << block->name() << "] ";
-    std::cerr << " [type: " << (block->type() == Sass::Definition::Type::MIXIN ? "Mixin " : "Function ") << "] ";
+    std::clog << ind << "Definition " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [name: " << block->name() << "] ";
+    std::clog << " [type: " << (block->type() == Sass::Definition::Type::MIXIN ? "Mixin " : "Function ") << "] ";
     // this seems to lead to segfaults some times?
-    // std::cerr << " [signature: " << block->signature() << "] ";
-    std::cerr << " [native: " << block->native_function() << "] ";
-    std::cerr << " " << block->tabs() << std::endl;
+    // std::clog << " [signature: " << block->signature() << "] ";
+    std::clog << " [native: " << block->native_function() << "] ";
+    std::clog << " " << block->tabs() << std::endl;
     debug_ast(block->parameters(), ind + " params: ", env);
     if (block->block()) debug_ast(block->block(), ind + " ", env);
   } else if (Cast<Mixin_Call>(node)) {
     Mixin_Call* block = Cast<Mixin_Call>(node);
-    std::cerr << ind << "Mixin_Call " << block << " " << block->tabs();
-    std::cerr << " (" << pstate_source_position(block) << ")";
-    std::cerr << " [" <<  block->name() << "]";
-    std::cerr << " [has_content: " << block->has_content() << "] " << std::endl;
+    std::clog << ind << "Mixin_Call " << block << " " << block->tabs();
+    std::clog << " (" << pstate_source_position(block) << ")";
+    std::clog << " [" <<  block->name() << "]";
+    std::clog << " [has_content: " << block->has_content() << "] " << std::endl;
     debug_ast(block->arguments(), ind + " args: ", env);
     debug_ast(block->block_parameters(), ind + " block_params: ", env);
     if (block->block()) debug_ast(block->block(), ind + " ", env);
   } else if (Ruleset* ruleset = Cast<Ruleset>(node)) {
-    std::cerr << ind << "Ruleset " << ruleset;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [indent: " << ruleset->tabs() << "]";
-    std::cerr << (ruleset->is_invisible() ? " [INVISIBLE]" : "");
-    std::cerr << (ruleset->is_root() ? " [root]" : "");
-    std::cerr << std::endl;
+    std::clog << ind << "Ruleset " << ruleset;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [indent: " << ruleset->tabs() << "]";
+    std::clog << (ruleset->is_invisible() ? " [INVISIBLE]" : "");
+    std::clog << (ruleset->is_root() ? " [root]" : "");
+    std::clog << std::endl;
     debug_ast(ruleset->selector(), ind + ">");
     debug_ast(ruleset->block(), ind + " ");
   } else if (Cast<Block>(node)) {
     Block* block = Cast<Block>(node);
-    std::cerr << ind << "Block " << block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << (block->is_invisible() ? " [INVISIBLE]" : "");
-    std::cerr << " [indent: " << block->tabs() << "]" << std::endl;
+    std::clog << ind << "Block " << block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << (block->is_invisible() ? " [INVISIBLE]" : "");
+    std::clog << " [indent: " << block->tabs() << "]" << std::endl;
     for(const Statement_Obj& i : block->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Variable>(node)) {
     Variable* expression = Cast<Variable>(node);
-    std::cerr << ind << "Variable " << expression;
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << expression->name() << "]" << std::endl;
+    std::clog << ind << "Variable " << expression;
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] ";
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << expression->name() << "]" << std::endl;
     std::string name(expression->name());
     if (env && env->has(name)) debug_ast(Cast<Expression>((*env)[name]), ind + " -> ", env);
   } else if (Cast<Function_Call>(node)) {
     Function_Call* expression = Cast<Function_Call>(node);
-    std::cerr << ind << "Function_Call " << expression;
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << expression->name() << "]";
-    if (expression->is_delayed()) std::cerr << " [delayed]";
-    if (expression->is_interpolant()) std::cerr << " [interpolant]";
-    if (expression->is_css()) std::cerr << " [css]";
-    std::cerr << std::endl;
+    std::clog << ind << "Function_Call " << expression;
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] ";
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << expression->name() << "]";
+    if (expression->is_delayed()) std::clog << " [delayed]";
+    if (expression->is_interpolant()) std::clog << " [interpolant]";
+    if (expression->is_css()) std::clog << " [css]";
+    std::clog << std::endl;
     debug_ast(expression->arguments(), ind + " args: ", env);
     debug_ast(expression->func(), ind + " func: ", env);
   } else if (Cast<Function>(node)) {
     Function* expression = Cast<Function>(node);
-    std::cerr << ind << "Function " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    if (expression->is_css()) std::cerr << " [css]";
-    std::cerr << std::endl;
+    std::clog << ind << "Function " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    if (expression->is_css()) std::clog << " [css]";
+    std::clog << std::endl;
     debug_ast(expression->definition(), ind + " definition: ", env);
   } else if (Cast<Arguments>(node)) {
     Arguments* expression = Cast<Arguments>(node);
-    std::cerr << ind << "Arguments " << expression;
-    if (expression->is_delayed()) std::cerr << " [delayed]";
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    if (expression->has_named_arguments()) std::cerr << " [has_named_arguments]";
-    if (expression->has_rest_argument()) std::cerr << " [has_rest_argument]";
-    if (expression->has_keyword_argument()) std::cerr << " [has_keyword_argument]";
-    std::cerr << std::endl;
+    std::clog << ind << "Arguments " << expression;
+    if (expression->is_delayed()) std::clog << " [delayed]";
+    std::clog << " (" << pstate_source_position(node) << ")";
+    if (expression->has_named_arguments()) std::clog << " [has_named_arguments]";
+    if (expression->has_rest_argument()) std::clog << " [has_rest_argument]";
+    if (expression->has_keyword_argument()) std::clog << " [has_keyword_argument]";
+    std::clog << std::endl;
     for(const Argument_Obj& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Argument>(node)) {
     Argument* expression = Cast<Argument>(node);
-    std::cerr << ind << "Argument " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << expression->value().ptr() << "]";
-    std::cerr << " [name: " << expression->name() << "] ";
-    std::cerr << " [rest: " << expression->is_rest_argument() << "] ";
-    std::cerr << " [keyword: " << expression->is_keyword_argument() << "] " << std::endl;
+    std::clog << ind << "Argument " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << expression->value().ptr() << "]";
+    std::clog << " [name: " << expression->name() << "] ";
+    std::clog << " [rest: " << expression->is_rest_argument() << "] ";
+    std::clog << " [keyword: " << expression->is_keyword_argument() << "] " << std::endl;
     debug_ast(expression->value(), ind + " value: ", env);
   } else if (Cast<Parameters>(node)) {
     Parameters* expression = Cast<Parameters>(node);
-    std::cerr << ind << "Parameters " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [has_optional: " << expression->has_optional_parameters() << "] ";
-    std::cerr << " [has_rest: " << expression->has_rest_parameter() << "] ";
-    std::cerr << std::endl;
+    std::clog << ind << "Parameters " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [has_optional: " << expression->has_optional_parameters() << "] ";
+    std::clog << " [has_rest: " << expression->has_rest_parameter() << "] ";
+    std::clog << std::endl;
     for(const Parameter_Obj& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Parameter>(node)) {
     Parameter* expression = Cast<Parameter>(node);
-    std::cerr << ind << "Parameter " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [name: " << expression->name() << "] ";
-    std::cerr << " [default: " << expression->default_value().ptr() << "] ";
-    std::cerr << " [rest: " << expression->is_rest_parameter() << "] " << std::endl;
+    std::clog << ind << "Parameter " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [name: " << expression->name() << "] ";
+    std::clog << " [default: " << expression->default_value().ptr() << "] ";
+    std::clog << " [rest: " << expression->is_rest_parameter() << "] " << std::endl;
   } else if (Cast<Unary_Expression>(node)) {
     Unary_Expression* expression = Cast<Unary_Expression>(node);
-    std::cerr << ind << "Unary_Expression " << expression;
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
-    std::cerr << " [delayed: " << expression->is_delayed() << "] ";
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << expression->type() << "]" << std::endl;
+    std::clog << ind << "Unary_Expression " << expression;
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] ";
+    std::clog << " [delayed: " << expression->is_delayed() << "] ";
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << expression->type() << "]" << std::endl;
     debug_ast(expression->operand(), ind + " operand: ", env);
   } else if (Cast<Binary_Expression>(node)) {
     Binary_Expression* expression = Cast<Binary_Expression>(node);
-    std::cerr << ind << "Binary_Expression " << expression;
-    if (expression->is_interpolant()) std::cerr << " [is interpolant] ";
-    if (expression->is_left_interpolant()) std::cerr << " [left interpolant] ";
-    if (expression->is_right_interpolant()) std::cerr << " [right interpolant] ";
-    std::cerr << " [delayed: " << expression->is_delayed() << "] ";
-    std::cerr << " [ws_before: " << expression->op().ws_before << "] ";
-    std::cerr << " [ws_after: " << expression->op().ws_after << "] ";
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << expression->type_name() << "]" << std::endl;
+    std::clog << ind << "Binary_Expression " << expression;
+    if (expression->is_interpolant()) std::clog << " [is interpolant] ";
+    if (expression->is_left_interpolant()) std::clog << " [left interpolant] ";
+    if (expression->is_right_interpolant()) std::clog << " [right interpolant] ";
+    std::clog << " [delayed: " << expression->is_delayed() << "] ";
+    std::clog << " [ws_before: " << expression->op().ws_before << "] ";
+    std::clog << " [ws_after: " << expression->op().ws_after << "] ";
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << expression->type_name() << "]" << std::endl;
     debug_ast(expression->left(), ind + " left:  ", env);
     debug_ast(expression->right(), ind + " right: ", env);
   } else if (Cast<Map>(node)) {
     Map* expression = Cast<Map>(node);
-    std::cerr << ind << "Map " << expression;
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [Hashed]" << std::endl;
+    std::clog << ind << "Map " << expression;
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] ";
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [Hashed]" << std::endl;
     for (const auto& i : expression->elements()) {
       debug_ast(i.first, ind + " key: ");
       debug_ast(i.second, ind + " val: ");
     }
   } else if (Cast<List>(node)) {
     List* expression = Cast<List>(node);
-    std::cerr << ind << "List " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " (" << expression->length() << ") " <<
+    std::clog << ind << "List " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " (" << expression->length() << ") " <<
       (expression->separator() == SASS_COMMA ? "Comma " : expression->separator() == SASS_HASH ? "Map " : "Space ") <<
       " [delayed: " << expression->is_delayed() << "] " <<
       " [interpolant: " << expression->is_interpolant() << "] " <<
@@ -837,120 +837,120 @@ inline void debug_ast(AST_Node* node, std::string ind, Env* env)
     for(const auto& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Boolean>(node)) {
     Boolean* expression = Cast<Boolean>(node);
-    std::cerr << ind << "Boolean " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
-    std::cerr << " [" << expression->value() << "]" << std::endl;
+    std::clog << ind << "Boolean " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] ";
+    std::clog << " [" << expression->value() << "]" << std::endl;
   } else if (Cast<Color_RGBA>(node)) {
     Color_RGBA* expression = Cast<Color_RGBA>(node);
-    std::cerr << ind << "Color " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [name: " << expression->disp() << "] ";
-    std::cerr << " [delayed: " << expression->is_delayed() << "] ";
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
-    std::cerr << " rgba[" << expression->r() << ":"  << expression->g() << ":" << expression->b() << "@" << expression->a() << "]" << std::endl;
+    std::clog << ind << "Color " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [name: " << expression->disp() << "] ";
+    std::clog << " [delayed: " << expression->is_delayed() << "] ";
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] ";
+    std::clog << " rgba[" << expression->r() << ":"  << expression->g() << ":" << expression->b() << "@" << expression->a() << "]" << std::endl;
   } else if (Cast<Color_HSLA>(node)) {
     Color_HSLA* expression = Cast<Color_HSLA>(node);
-    std::cerr << ind << "Color " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [name: " << expression->disp() << "] ";
-    std::cerr << " [delayed: " << expression->is_delayed() << "] ";
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
-    std::cerr << " hsla[" << expression->h() << ":"  << expression->s() << ":" << expression->l() << "@" << expression->a() << "]" << std::endl;
+    std::clog << ind << "Color " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [name: " << expression->disp() << "] ";
+    std::clog << " [delayed: " << expression->is_delayed() << "] ";
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] ";
+    std::clog << " hsla[" << expression->h() << ":"  << expression->s() << ":" << expression->l() << "@" << expression->a() << "]" << std::endl;
   } else if (Cast<Number>(node)) {
     Number* expression = Cast<Number>(node);
-    std::cerr << ind << "Number " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [delayed: " << expression->is_delayed() << "] ";
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] ";
-    std::cerr << " [" << expression->value() << expression->unit() << "]" <<
+    std::clog << ind << "Number " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [delayed: " << expression->is_delayed() << "] ";
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] ";
+    std::clog << " [" << expression->value() << expression->unit() << "]" <<
       " [hash: " << expression->hash() << "] " <<
       std::endl;
   } else if (Cast<Null>(node)) {
     Null* expression = Cast<Null>(node);
-    std::cerr << ind << "Null " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [interpolant: " << expression->is_interpolant() << "] "
+    std::clog << ind << "Null " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [interpolant: " << expression->is_interpolant() << "] "
       // " [hash: " << expression->hash() << "] "
       << std::endl;
   } else if (Cast<String_Quoted>(node)) {
     String_Quoted* expression = Cast<String_Quoted>(node);
-    std::cerr << ind << "String_Quoted " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << prettyprint(expression->value()) << "]";
-    if (expression->is_delayed()) std::cerr << " [delayed]";
-    if (expression->is_interpolant()) std::cerr << " [interpolant]";
-    if (expression->quote_mark()) std::cerr << " [quote_mark: " << expression->quote_mark() << "]";
-    std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
+    std::clog << ind << "String_Quoted " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << prettyprint(expression->value()) << "]";
+    if (expression->is_delayed()) std::clog << " [delayed]";
+    if (expression->is_interpolant()) std::clog << " [interpolant]";
+    if (expression->quote_mark()) std::clog << " [quote_mark: " << expression->quote_mark() << "]";
+    std::clog << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
   } else if (Cast<String_Constant>(node)) {
     String_Constant* expression = Cast<String_Constant>(node);
-    std::cerr << ind << "String_Constant " << expression;
+    std::clog << ind << "String_Constant " << expression;
     if (expression->concrete_type()) {
-      std::cerr << " " << expression->concrete_type();
+      std::clog << " " << expression->concrete_type();
     }
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " [" << prettyprint(expression->value()) << "]";
-    if (expression->is_delayed()) std::cerr << " [delayed]";
-    if (expression->is_interpolant()) std::cerr << " [interpolant]";
-    std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " [" << prettyprint(expression->value()) << "]";
+    if (expression->is_delayed()) std::clog << " [delayed]";
+    if (expression->is_interpolant()) std::clog << " [interpolant]";
+    std::clog << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
   } else if (Cast<String_Schema>(node)) {
     String_Schema* expression = Cast<String_Schema>(node);
-    std::cerr << ind << "String_Schema " << expression;
-    std::cerr << " (" << pstate_source_position(expression) << ")";
-    std::cerr << " " << expression->concrete_type();
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    if (expression->css()) std::cerr << " [css]";
-    if (expression->is_delayed()) std::cerr << " [delayed]";
-    if (expression->is_interpolant()) std::cerr << " [is interpolant]";
-    if (expression->has_interpolant()) std::cerr << " [has interpolant]";
-    if (expression->is_left_interpolant()) std::cerr << " [left interpolant] ";
-    if (expression->is_right_interpolant()) std::cerr << " [right interpolant] ";
-    std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
+    std::clog << ind << "String_Schema " << expression;
+    std::clog << " (" << pstate_source_position(expression) << ")";
+    std::clog << " " << expression->concrete_type();
+    std::clog << " (" << pstate_source_position(node) << ")";
+    if (expression->css()) std::clog << " [css]";
+    if (expression->is_delayed()) std::clog << " [delayed]";
+    if (expression->is_interpolant()) std::clog << " [is interpolant]";
+    if (expression->has_interpolant()) std::clog << " [has interpolant]";
+    if (expression->is_left_interpolant()) std::clog << " [left interpolant] ";
+    if (expression->is_right_interpolant()) std::clog << " [right interpolant] ";
+    std::clog << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
     for(const auto& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<String>(node)) {
     String* expression = Cast<String>(node);
-    std::cerr << ind << "String " << expression;
-    std::cerr << " " << expression->concrete_type();
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    if (expression->is_interpolant()) std::cerr << " [interpolant]";
-    std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
+    std::clog << ind << "String " << expression;
+    std::clog << " " << expression->concrete_type();
+    std::clog << " (" << pstate_source_position(node) << ")";
+    if (expression->is_interpolant()) std::clog << " [interpolant]";
+    std::clog << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
   } else if (Cast<Expression>(node)) {
     Expression* expression = Cast<Expression>(node);
-    std::cerr << ind << "Expression " << expression;
-    std::cerr << " (" << pstate_source_position(node) << ")";
+    std::clog << ind << "Expression " << expression;
+    std::clog << " (" << pstate_source_position(node) << ")";
     switch (expression->concrete_type()) {
-      case Expression::Type::NONE: std::cerr << " [NONE]"; break;
-      case Expression::Type::BOOLEAN: std::cerr << " [BOOLEAN]"; break;
-      case Expression::Type::NUMBER: std::cerr << " [NUMBER]"; break;
-      case Expression::Type::COLOR: std::cerr << " [COLOR]"; break;
-      case Expression::Type::STRING: std::cerr << " [STRING]"; break;
-      case Expression::Type::LIST: std::cerr << " [LIST]"; break;
-      case Expression::Type::MAP: std::cerr << " [MAP]"; break;
-      case Expression::Type::SELECTOR: std::cerr << " [SELECTOR]"; break;
-      case Expression::Type::NULL_VAL: std::cerr << " [NULL_VAL]"; break;
-      case Expression::Type::C_WARNING: std::cerr << " [C_WARNING]"; break;
-      case Expression::Type::C_ERROR: std::cerr << " [C_ERROR]"; break;
-      case Expression::Type::FUNCTION: std::cerr << " [FUNCTION]"; break;
-      case Expression::Type::NUM_TYPES: std::cerr << " [NUM_TYPES]"; break;
-      case Expression::Type::VARIABLE: std::cerr << " [VARIABLE]"; break;
-      case Expression::Type::FUNCTION_VAL: std::cerr << " [FUNCTION_VAL]"; break;
-      case Expression::Type::PARENT: std::cerr << " [PARENT]"; break;
+      case Expression::Type::NONE: std::clog << " [NONE]"; break;
+      case Expression::Type::BOOLEAN: std::clog << " [BOOLEAN]"; break;
+      case Expression::Type::NUMBER: std::clog << " [NUMBER]"; break;
+      case Expression::Type::COLOR: std::clog << " [COLOR]"; break;
+      case Expression::Type::STRING: std::clog << " [STRING]"; break;
+      case Expression::Type::LIST: std::clog << " [LIST]"; break;
+      case Expression::Type::MAP: std::clog << " [MAP]"; break;
+      case Expression::Type::SELECTOR: std::clog << " [SELECTOR]"; break;
+      case Expression::Type::NULL_VAL: std::clog << " [NULL_VAL]"; break;
+      case Expression::Type::C_WARNING: std::clog << " [C_WARNING]"; break;
+      case Expression::Type::C_ERROR: std::clog << " [C_ERROR]"; break;
+      case Expression::Type::FUNCTION: std::clog << " [FUNCTION]"; break;
+      case Expression::Type::NUM_TYPES: std::clog << " [NUM_TYPES]"; break;
+      case Expression::Type::VARIABLE: std::clog << " [VARIABLE]"; break;
+      case Expression::Type::FUNCTION_VAL: std::clog << " [FUNCTION_VAL]"; break;
+      case Expression::Type::PARENT: std::clog << " [PARENT]"; break;
     }
-    std::cerr << std::endl;
+    std::clog << std::endl;
   } else if (Cast<Has_Block>(node)) {
     Has_Block* has_block = Cast<Has_Block>(node);
-    std::cerr << ind << "Has_Block " << has_block;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << has_block->tabs() << std::endl;
+    std::clog << ind << "Has_Block " << has_block;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << has_block->tabs() << std::endl;
     if (has_block->block()) for(const Statement_Obj& i : has_block->block()->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<Statement>(node)) {
     Statement* statement = Cast<Statement>(node);
-    std::cerr << ind << "Statement " << statement;
-    std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << statement->tabs() << std::endl;
+    std::clog << ind << "Statement " << statement;
+    std::clog << " (" << pstate_source_position(node) << ")";
+    std::clog << " " << statement->tabs() << std::endl;
   }
 
-  if (ind == "") std::cerr << "####################################################################\n";
+  if (ind == "") std::clog << "####################################################################" << std::endl;
 }
 
 

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -31,7 +31,7 @@ namespace Sass {
   template <typename T>
   bool Environment<T>::is_lexical() const
   {
-    return !! parent_ && parent_->parent_;
+    return parent_ && parent_->parent_;
   }
 
   // only match the real root scope
@@ -240,13 +240,13 @@ namespace Sass {
   {
     size_t indent = 0;
     if (parent_) indent = parent_->print(prefix) + 1;
-    std::cerr << prefix << std::string(indent, ' ') << "== " << this << std::endl;
+    std::clog << prefix << std::string(indent, ' ') << "== " << this << std::endl;
     for (typename environment_map<std::string, T>::iterator i = local_frame_.begin(); i != local_frame_.end(); ++i) {
       if (!ends_with(i->first, "[f]") && !ends_with(i->first, "[f]4") && !ends_with(i->first, "[f]2")) {
-        std::cerr << prefix << std::string(indent, ' ') << i->first << " " << i->second;
+        std::clog << prefix << std::string(indent, ' ') << i->first << " " << i->second;
         if (Value* val = Cast<Value>(i->second))
-        { std::cerr << " : " << val->to_string(); }
-        std::cerr << std::endl;
+        { std::clog << " : " << val->to_string(); }
+        std::clog << std::endl;
       }
     }
     return indent ;

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -158,7 +158,7 @@ namespace Sass {
 
   void warn(std::string msg, ParserState pstate)
   {
-    std::cerr << "Warning: " << msg << std::endl;
+    std::clog << "Warning: " << msg << std::endl;
   }
 
   void warning(std::string msg, ParserState pstate)
@@ -168,8 +168,8 @@ namespace Sass {
     std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
     std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
 
-    std::cerr << "WARNING on line " << pstate.line+1 << ", column " << pstate.column+1 << " of " << output_path << ":" << std::endl;
-    std::cerr << msg << std::endl << std::endl;
+    std::clog << "WARNING on line " << pstate.line+1 << ", column " << pstate.column+1 << " of " << output_path << ":" << std::endl;
+    std::clog << msg << std::endl << std::endl;
   }
 
   void warn(std::string msg, ParserState pstate, Backtrace* bt)
@@ -184,9 +184,9 @@ namespace Sass {
     std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
     std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
 
-    std::cerr << "DEPRECATION WARNING: " << msg << std::endl;
-    std::cerr << "will be an error in future versions of Sass." << std::endl;
-    std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
+    std::clog << "DEPRECATION WARNING: " << msg << std::endl;
+    std::clog << "will be an error in future versions of Sass." << std::endl;
+    std::clog << "on line " << pstate.line+1 << " of " << output_path << std::endl;
   }
 
   void deprecated(std::string msg, std::string msg2, bool with_column, ParserState pstate)
@@ -196,13 +196,13 @@ namespace Sass {
     std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
     std::string output_path(Sass::File::path_for_console(rel_path, pstate.path, pstate.path));
 
-    std::cerr << "DEPRECATION WARNING on line " << pstate.line + 1;
-    if (with_column) std::cerr << ", column " << pstate.column + pstate.offset.column + 1;
-    if (output_path.length()) std::cerr << " of " << output_path;
-    std::cerr << ":" << std::endl;
-    std::cerr << msg << std::endl;
-    if (msg2.length()) std::cerr << msg2 << std::endl;
-    std::cerr << std::endl;
+    std::clog << "DEPRECATION WARNING on line " << pstate.line + 1;
+    if (with_column) std::clog << ", column " << pstate.column + pstate.offset.column + 1;
+    if (output_path.length()) std::clog << " of " << output_path;
+    std::clog << ":" << std::endl;
+    std::clog << msg << std::endl;
+    if (msg2.length()) std::clog << msg2 << std::endl;
+    std::clog << std::endl;
   }
 
   void deprecated_bind(std::string msg, ParserState pstate)
@@ -212,9 +212,9 @@ namespace Sass {
     std::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
     std::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
 
-    std::cerr << "WARNING: " << msg << std::endl;
-    std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
-    std::cerr << "This will be an error in future versions of Sass." << std::endl;
+    std::clog << "WARNING: " << msg << std::endl;
+    std::clog << "on line " << pstate.line+1 << " of " << output_path << std::endl;
+    std::clog << "This will be an error in future versions of Sass." << std::endl;
   }
 
   // should be replaced with error with backtraces

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -370,10 +370,12 @@ namespace Sass {
     }
 
     std::string result(unquote(message->to_sass()));
-    std::cerr << "WARNING: " << result << std::endl;
+    // Can this not done in error_handling?
+    // There's a warning method there...
+    std::clog << "WARNING: " << result << std::endl;
     traces.push_back(Backtrace(w->pstate()));
-    std::cerr << traces_to_string(traces, "         ");
-    std::cerr << std::endl;
+    std::clog << traces_to_string(traces, "         ");
+    std::clog << std::endl;
     options().output_style = outstyle;
     traces.pop_back();
     return 0;
@@ -467,8 +469,8 @@ namespace Sass {
     std::string output_path(Sass::File::path_for_console(rel_path, abs_path, d->pstate().path));
     options().output_style = outstyle;
 
-    std::cerr << output_path << ":" << d->pstate().line+1 << " DEBUG: " << result;
-    std::cerr << std::endl;
+    std::clog << output_path << ":" << d->pstate().line+1 << " DEBUG: " << result;
+    std::clog << std::endl;
     return 0;
   }
 

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -681,10 +681,10 @@ namespace Sass {
 
           if (compound->length() != 1) {
 
-            std::cerr <<
-              "compound selectors may no longer be extended.\n"
-              "Consider `@extend ${compound.components.join(', ')}` instead.\n"
-              "See http://bit.ly/ExtendCompound for details.\n";
+            std::clog
+			  << "compound selectors may no longer be extended." << std::endl
+			  << "Consider `@extend ${compound.components.join(', ')}` instead." << std::endl
+			  << "See http://bit.ly/ExtendCompound for details." << std::endl;
 
             // Make this an error once deprecation is over
             for (SimpleSelectorObj simple : compound->elements()) {

--- a/src/fn_miscs.cpp
+++ b/src/fn_miscs.cpp
@@ -100,10 +100,10 @@ namespace Sass {
 
       if (ss) {
         function = Util::normalize_underscores(unquote(ss->value()));
-        std::cerr << "DEPRECATION WARNING: ";
-        std::cerr << "Passing a string to call() is deprecated and will be illegal" << std::endl;
-        std::cerr << "in Sass 4.0. Use call(get-function(" + quote(function) + ")) instead." << std::endl;
-        std::cerr << std::endl;
+		  std::string title("Passing a string to call() is deprecated and will be illegal in Sass 4.0.");
+		  std::ostringstream workAround;
+		  workAround << "Use call(get-function(" << quote(function) << ")) instead.";
+		  deprecated(title, workAround.str(), true , pstate);
       } else if (ff) {
         function = ff->name();
       }

--- a/src/memory/SharedPtr.cpp
+++ b/src/memory/SharedPtr.cpp
@@ -14,14 +14,14 @@ namespace Sass {
   #ifdef DEBUG_SHARED_PTR
   void SharedObj::dumpMemLeaks() {
     if (!all.empty()) {
-      std::cerr << "###################################\n";
-      std::cerr << "# REPORTING MISSING DEALLOCATIONS #\n";
-      std::cerr << "###################################\n";
+      std::clog << "###################################" << std::endl;
+      std::clog << "# REPORTING MISSING DEALLOCATIONS #" << std::endl;
+      std::clog << "###################################" << std::endl;
       for (SharedObj* var : all) {
         if (AST_Node* ast = dynamic_cast<AST_Node*>(var)) {
           debug_ast(ast);
         } else {
-          std::cerr << "LEAKED " << var << "\n";
+          std::clog << "LEAKED " << var << std::endl;
         }
       }
     }

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -138,7 +138,7 @@ namespace Sass {
       if (node != nullptr) node->detached = true;
       #ifdef DEBUG_SHARED_PTR
       if (node->dbg) {
-        std::cerr << "DETACHING NODE\n";
+        std::clog << "DETACHING NODE" << std::endl;
       }
       #endif 
       return node;
@@ -155,17 +155,17 @@ namespace Sass {
       if (node == nullptr) return;
       --node->refcount;
       #ifdef DEBUG_SHARED_PTR
-      if (node->dbg) std::cerr << "- " << node << " X " << node->refcount << " (" << this << ") " << "\n";
+      if (node->dbg) std::clog << "- " << node << " X " << node->refcount << " (" << this << ") " << std::endl;
       #endif
       if (node->refcount == 0 && !node->detached) {
         #ifdef DEBUG_SHARED_PTR
-        if (node->dbg) std::cerr << "DELETE NODE " << node << "\n";
+        if (node->dbg) std::clog << "DELETE NODE " << node << std::endl;
         #endif
         delete node;
       }
       else if (node->refcount == 0) {
         #ifdef DEBUG_SHARED_PTR
-        if (node->dbg) std::cerr << "NODE EVAEDED DELETE " << node << "\n";
+        if (node->dbg) std::clog << "NODE EVAEDED DELETE " << node << std::endl;
         #endif
       }
     }
@@ -174,7 +174,7 @@ namespace Sass {
       node->detached = false;
       ++node->refcount;
       #ifdef DEBUG_SHARED_PTR
-      if (node->dbg) std::cerr << "+ " << node << " X " << node->refcount << " (" << this << ") " << "\n";
+      if (node->dbg) std::clog << "+ " << node << " X " << node->refcount << " (" << this << ") " << std::endl;
       #endif
     }
   };

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -172,7 +172,7 @@ namespace Sass {
       if (it_after_token > end) return 0;
 
       // maybe we want to update the parser state anyway?
-      if (force == false) {
+      if (!force) {
         // assertion that we got a valid match
         if (it_after_token == 0) return 0;
         // assertion that we actually lexed something
@@ -360,13 +360,13 @@ namespace Sass {
     {
       if (lex < open >(false)) {
         String_Schema_Obj schema = SASS_MEMORY_NEW(String_Schema, pstate);
-        // std::cerr << "LEX [[" << std::string(lexed) << "]]\n";
+        // std::clog << "LEX [[" << std::string(lexed) << "]]" << std::endl;
         schema->append(SASS_MEMORY_NEW(String_Constant, pstate, lexed));
         if (position[0] == '#' && position[1] == '{') {
           Expression_Obj itpl = lex_interpolation();
           if (!itpl.isNull()) schema->append(itpl);
           while (lex < close >(false)) {
-            // std::cerr << "LEX [[" << std::string(lexed) << "]]\n";
+            // std::clog << "LEX [[" << std::string(lexed) << "]]" << std::endl;
             schema->append(SASS_MEMORY_NEW(String_Constant, pstate, lexed));
             if (position[0] == '#' && position[1] == '{') {
               Expression_Obj itpl = lex_interpolation();

--- a/src/permutate.hpp
+++ b/src/permutate.hpp
@@ -87,10 +87,10 @@ namespace Sass {
 
     while (true) {
       /*
-      // std::cerr << "PERM: ";
+      // std::clog << "PERM: ";
       for (size_t p = 0; p < L; p++)
-      { // std::cerr << state[p] << " "; }
-      // std::cerr << "\n";
+      { // std::clog << state[p] << " "; }
+      // std::clog << std::endl;
       */
       std::vector<T> perm;
       // Create one permutation for state

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -96,16 +96,19 @@ namespace Sass {
       else
       {
         // print debug message to stderr (should not happen)
-        std::cerr << "failed loading 'libsass_support' in <" << path << ">" << std::endl;
-        if (const char* dlsym_error = dlerror()) std::cerr << dlsym_error << std::endl;
+        std::clog << "failed loading 'libsass_support' in <" << path << ">" << std::endl;
+        if (const char* dlsym_error = dlerror()) std::clog << dlsym_error << std::endl;
         CLOSE_LIB(plugin);
       }
     }
     else
     {
       // print debug message to stderr (should not happen)
-      std::cerr << "failed loading plugin <" << path << ">" << std::endl;
-      if (const char* dlopen_error = dlerror()) std::cerr << dlopen_error << std::endl;
+      std::clog << "failed loading plugin <" << path << ">" << std::endl;
+      if (const char* dlopen_error = dlerror())
+      {
+		  std::clog << dlopen_error << std::endl;
+	  }
     }
 
     return false;
@@ -154,7 +157,7 @@ namespace Sass {
           {
             // report the error to the console (should not happen)
             // seems like we got strange data from the system call?
-            std::cerr << "filename in plugin path has invalid utf8?" << std::endl;
+            std::clog << "filename in plugin path has invalid utf8?" << std::endl;
           }
         }
       }
@@ -162,7 +165,7 @@ namespace Sass {
       {
         // report the error to the console (should not happen)
         // implementors should make sure to provide valid utf8
-        std::cerr << "plugin path contains invalid utf8" << std::endl;
+        std::clog << "plugin path contains invalid utf8" << std::endl;
       }
 
     #else

--- a/src/sass.cpp
+++ b/src/sass.cpp
@@ -37,8 +37,8 @@ extern "C" {
   void* ADDCALL sass_alloc_memory(size_t size)
   {
     void* ptr = malloc(size);
-    if (ptr == NULL) {
-      std::cerr << "Out of memory.\n";
+    if (ptr == NULL) { // This should use cerr.
+      std::cerr << "Out of memory." << std::endl;
       exit(EXIT_FAILURE);
     }
     return ptr;

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -284,7 +284,7 @@ extern "C" {
 
       // allocate a new compiler instance
       void* ctxmem = calloc(1, sizeof(struct Sass_Compiler));
-      if (ctxmem == 0) { std::cerr << "Error allocating memory for context" << std::endl; return 0; }
+      if (ctxmem == 0) { std::clog << "Error allocating memory for context" << std::endl; return 0; }
       Sass_Compiler* compiler = (struct Sass_Compiler*) ctxmem;
       compiler->state = SASS_COMPILER_CREATED;
 
@@ -335,7 +335,7 @@ extern "C" {
   Sass_Options* ADDCALL sass_make_options (void)
   {
     struct Sass_Options* options = (struct Sass_Options*) calloc(1, sizeof(struct Sass_Options));
-    if (options == 0) { std::cerr << "Error allocating memory for options" << std::endl; return 0; }
+    if (options == 0) { std::clog << "Error allocating memory for options" << std::endl; return 0; }
     init_options(options);
     return options;
   }
@@ -346,7 +346,7 @@ extern "C" {
     SharedObj::setTaint(true);
     #endif
     struct Sass_File_Context* ctx = (struct Sass_File_Context*) calloc(1, sizeof(struct Sass_File_Context));
-    if (ctx == 0) { std::cerr << "Error allocating memory for file context" << std::endl; return 0; }
+    if (ctx == 0) { std::clog << "Error allocating memory for file context" << std::endl; return 0; }
     ctx->type = SASS_CONTEXT_FILE;
     init_options(ctx);
     try {
@@ -365,7 +365,7 @@ extern "C" {
     SharedObj::setTaint(true);
     #endif
     struct Sass_Data_Context* ctx = (struct Sass_Data_Context*) calloc(1, sizeof(struct Sass_Data_Context));
-    if (ctx == 0) { std::cerr << "Error allocating memory for data context" << std::endl; return 0; }
+    if (ctx == 0) { std::clog << "Error allocating memory for data context" << std::endl; return 0; }
     ctx->type = SASS_CONTEXT_DATA;
     init_options(ctx);
     try {


### PR DESCRIPTION
std::clog is a std::ostream that represents the standard logging stream, and therefore is more suitable for most of the uses where std::cerr has been used in libsass.

While clog is not tied to another stream, it is synchronized with stderr by default, and it is more efficient, being buffered.

