### PR TITLE
revert concurrent compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ ifndef COVERAGE
   CFLAGS   += -O2
   CXXFLAGS += -O2
   LDFLAGS  += -O2
-  MAKEFLAGS += "-j 0"
 else
   CFLAGS   += -O1 -fno-omit-frame-pointer
   CXXFLAGS += -O1 -fno-omit-frame-pointer


### PR DESCRIPTION
reverts https://github.com/sass/libsass/pull/2888

it looks like -j 0 spawns unlimited number of processes that causes problems on memory constrained environments