### PR TITLE
math.h is deprecated

### DIFF
--- a/src/util.hpp
+++ b/src/util.hpp
@@ -13,7 +13,6 @@
 #include <vector>
 #include <string>
 #include <assert.h>
-#include <math.h>
 
 #define SASS_ASSERT(cond, msg) assert(cond && msg)
 


### PR DESCRIPTION
there should be no reason to include this header because `cmath` is already included

possible fix for https://github.com/sass/sassc-ruby/issues/149