### PR TITLE
Assorted typo fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ sudo: required
 # this will still catch all coding errors!
 # - AUTOTOOLS=yes COVERAGE=no BUILD=static
 
-# currenty there are various issues when
+# currently there are various issues when
 # built with coverage, clang and autotools
 # - AUTOTOOLS=yes COVERAGE=yes BUILD=shared
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ cache:
   - C:\Ruby%ruby_version%\lib\ruby\gems
   - C:\mingw64
 
-# Uncomment to debug hanging builds via RDP, password can ve found/set under Environment-Variables in appveyor settings!
+# Uncomment to debug hanging builds via RDP, password can be found/set under Environment-Variables in appveyor settings!
 #
 # init:
 #   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/docs/api-context-example.md
+++ b/docs/api-context-example.md
@@ -12,7 +12,7 @@ int main( int argc, const char* argv[] )
   char* text = sass_copy_c_string("a{b:c;}");
   // Normally you'll load data into a buffer from i.e. the disk.
   // Use `sass_alloc_memory` to get a buffer to pass to LibSass
-  // then fill it with data you load from disk or somwhere else.
+  // then fill it with data you load from disk or somewhere else.
 
   // create the data context and get all related structs
   struct Sass_Data_Context* data_ctx = sass_make_data_context(text);

--- a/docs/custom-functions-internal.md
+++ b/docs/custom-functions-internal.md
@@ -39,7 +39,7 @@ union Sass_Value* call_sass_function(
 
 ### cookie
 
-The cookie can hold any pointer you want. In the `perl-libsass` implementation it holds the structure with the reference of the actual registered callback into the perl interpreter. Before that call `perl-libsass` will convert all `Sass_Values` to corresponding perl data types (so they can be used natively inside the perl interpretor). The callback can also return a `Sass_Value`. In `perl-libsass` the actual function returns a perl value, which has to be converted before `libsass` can work with it again!
+The cookie can hold any pointer you want. In the `perl-libsass` implementation it holds the structure with the reference of the actual registered callback into the perl interpreter. Before that call `perl-libsass` will convert all `Sass_Values` to corresponding perl data types (so they can be used natively inside the perl interpreter). The callback can also return a `Sass_Value`. In `perl-libsass` the actual function returns a perl value, which has to be converted before `libsass` can work with it again!
 
 ## Sass_Values
 

--- a/src/ast_sel_unify.cpp
+++ b/src/ast_sel_unify.cpp
@@ -11,7 +11,7 @@ namespace Sass {
   // elements that are matched by both [complex1] and [complex2].
   // If no such list can be produced, returns `null`.
   // ##########################################################################
-  // ToDo: fine-tune API to avoid unecessary wrapper allocations
+  // ToDo: fine-tune API to avoid unnecessary wrapper allocations
   // ##########################################################################
   std::vector<std::vector<SelectorComponentObj>> unifyComplex(
     const std::vector<std::vector<SelectorComponentObj>>& complexes)

--- a/src/ast_selectors.hpp
+++ b/src/ast_selectors.hpp
@@ -273,7 +273,7 @@ namespace Sass {
 
     // Returns true if the first components
     // is a compound selector and fullfills
-    // a few other criterias.
+    // a few other criteria.
     bool isInvisible() const;
 
     size_t hash() const override;
@@ -410,7 +410,7 @@ namespace Sass {
     CompoundSelector(ParserState pstate, bool postLineBreak = false);
 
     // Returns true if this compound selector
-    // fullfills various criterias.
+    // fullfills various criteria.
     bool isInvisible() const;
 
     bool empty() const override {

--- a/src/ast_values.cpp
+++ b/src/ast_values.cpp
@@ -536,7 +536,7 @@ namespace Sass {
     l.normalize(); r.normalize();
     Units &lhs_unit = l, &rhs_unit = r;
     if (!(lhs_unit == rhs_unit)) {
-      /* ToDo: do we always get usefull backtraces? */
+      /* ToDo: do we always get useful backtraces? */
       throw Exception::IncompatibleUnits(rhs, *this);
     }
     if (lhs_unit == rhs_unit) {

--- a/src/bind.cpp
+++ b/src/bind.cpp
@@ -168,7 +168,7 @@ namespace Sass {
         }
         // consumed parameter
         ++ip;
-        // no more paramaters
+        // no more parameters
         break;
       }
 

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -377,7 +377,7 @@ namespace Sass {
       // if (protocol.compare("file") && true) { }
     }
 
-    // add urls (protocol other than file) and urls without procotol to `urls` member
+    // add urls (protocol other than file) and urls without protocol to `urls` member
     // ToDo: if ctx_path is already a file resource, we should not add it here?
     if (imp->import_queries() || protocol != "file" || imp_path.substr(0, 2) == "//") {
       imp->urls().push_back(SASS_MEMORY_NEW(String_Quoted, imp->pstate(), load_path));
@@ -501,7 +501,7 @@ namespace Sass {
     OutputBuffer emitted = emitter.get_buffer();
     // should we append a source map url?
     if (!c_options.omit_source_map_url) {
-      // generate an embeded source map
+      // generate an embedded source map
       if (c_options.source_map_embed) {
         emitted.buffer += linefeed;
         emitted.buffer += format_embedded_source_map();

--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -148,7 +148,7 @@ namespace Sass {
     // this can return a string schema
     // string schema is not a statement!
     // r->block() is already a string schema
-    // and that is comming from propset expand
+    // and that is coming from propset expand
     Block* bb = operator()(r->block());
     // this should protect us (at least a bit) from our mess
     // fixing this properly is harder that it should be ...

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -916,7 +916,7 @@ namespace Sass {
       return nr.detach();
     }
     else {
-      // Special cases: +/- variables which evaluate to null ouput just +/-,
+      // Special cases: +/- variables which evaluate to null output just +/-,
       // but +/- null itself outputs the string
       if (operand->concrete_type() == Expression::NULL_VAL && Cast<Variable>(u->operand())) {
         u->operand(SASS_MEMORY_NEW(String_Quoted, u->pstate(), ""));

--- a/src/extender.hpp
+++ b/src/extender.hpp
@@ -82,7 +82,7 @@ namespace Sass {
 
     // ##########################################################################
     // Shared backtraces with context and expander. Needed the throw
-    // errors when e.g. extending accross media query boundaries.
+    // errors when e.g. extending across media query boundaries.
     // ##########################################################################
     Backtraces& traces;
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -118,7 +118,7 @@ namespace Sass {
       return path[i] == '/';
     }
 
-    // helper function to find the last directory seperator
+    // helper function to find the last directory separator
     inline size_t find_last_folder_separator(const std::string& path, size_t limit = std::string::npos)
     {
       size_t pos;

--- a/src/file.hpp
+++ b/src/file.hpp
@@ -104,7 +104,7 @@ namespace Sass {
     public:
       // the file contents
       char* contents;
-      // conected sourcemap
+      // connected sourcemap
       char* srcmap;
     public:
       Resource(char* contents, char* srcmap)

--- a/src/memory/SharedPtr.hpp
+++ b/src/memory/SharedPtr.hpp
@@ -55,7 +55,7 @@ namespace Sass {
   // allocate additional control blocks and/or the need to dereference two
   // pointers on each operation. This can be optimized in `std::shared_ptr`
   // too by using `std::make_shared` (where the control block and the actual
-  // object are allocated in one continous memory block via one single call).
+  // object are allocated in one continuous memory block via one single call).
   class SharedObj {
    public:
     SharedObj() : refcount(0), detached(false) {

--- a/src/operation.hpp
+++ b/src/operation.hpp
@@ -127,7 +127,7 @@ namespace Sass {
   // example: Operation_CRTP<Expression*, Eval>
   // T is the base return type of all visitors
   // D is the class derived visitor class
-  // normaly you want to implement all operators
+  // normally you want to implement all operators
   template <typename T, typename D>
   class Operation_CRTP : public Operation<T> {
   public:

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -565,7 +565,7 @@ namespace Sass {
 
     // process until end
     while (i < end_of_selector) {
-      // try to parse mutliple interpolants
+      // try to parse multiple interpolants
       if (const char* p = find_first_in_interval< exactly<hash_lbrace>, block_comment >(i, end_of_selector)) {
         // accumulate the preceding segment if the position has advanced
         if (i < p) {
@@ -1187,7 +1187,7 @@ namespace Sass {
     Expression_Obj lhs = parse_operators();
     // if it's a singleton, return it (don't wrap it)
     if (!(peek_css< exactly<'+'> >(position) ||
-          // condition is a bit misterious, but some combinations should not be counted as operations
+          // condition is a bit mysterious, but some combinations should not be counted as operations
           (peek< no_spaces >(position) && peek< sequence< negate< unsigned_number >, exactly<'-'>, negate< space > > >(position)) ||
           (peek< sequence< negate< unsigned_number >, exactly<'-'>, negate< unsigned_number > > >(position))) ||
           peek< sequence < zero_plus < exactly <'-' > >, identifier > >(position))
@@ -2639,7 +2639,7 @@ namespace Sass {
       rv.error = q;
       rv.position = q;
       // check expected opening bracket
-      // only after successfull matching
+      // only after successful matching
       if (peek < exactly<'{'> >(q)) rv.found = q;
       // else if (peek < end_of_file >(q)) rv.found = q;
       else if (peek < exactly<'('> >(q)) rv.found = q;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -188,7 +188,7 @@ namespace Sass {
       // update after_token position for current token
       after_token.add(it_before_token, it_after_token);
 
-      // ToDo: could probably do this incremetal on original object (API wants offset?)
+      // ToDo: could probably do this incremental on original object (API wants offset?)
       pstate = ParserState(path, source, lexed, before_token, after_token - before_token);
 
       // advance internal char iterator

--- a/src/sass2scss.cpp
+++ b/src/sass2scss.cpp
@@ -467,7 +467,7 @@ namespace Sass
 		// right trim input
 		sass = rtrim(sass);
 
-		// get postion of first meaningfull character in string
+		// get position of first meaningfull character in string
 		size_t pos_left = sass.find_first_not_of(SASS2SCSS_FIND_WHITESPACE);
 
 		// special case for final run
@@ -557,7 +557,7 @@ namespace Sass
 				// default to a selector
 				// change back if property found
 				converter.selector = true;
-				// get postion of first whitespace char
+				// get position of first whitespace char
 				size_t pos_wspace = sass.find_first_of(SASS2SCSS_FIND_WHITESPACE, pos_left);
 				// assertion check for valid result
 				if (pos_wspace != std::string::npos)
@@ -580,7 +580,7 @@ namespace Sass
 							// assertion for valid result
 							if (pos_colon != std::string::npos)
 							{
-								// ... after the first word (skip begining colons)
+								// ... after the first word (skip beginning colons)
 								pos_colon = sass.find_first_of(":", pos_colon);
 								// it is a selector if there was no colon found
 								converter.selector = pos_colon == std::string::npos;
@@ -758,7 +758,7 @@ namespace Sass
 				scss += flush(sass, converter);
 			}
 
-			// get postion of last meaningfull char
+			// get position of last meaningfull char
 			size_t pos_right = sass.find_last_not_of(SASS2SCSS_FIND_WHITESPACE);
 
 			// check for invalid result

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -399,7 +399,7 @@ extern "C" {
       return data_ctx->error_status;
     try {
       if (data_ctx->source_string == 0) { throw(std::runtime_error("Data context has no source string")); }
-      // empty source string is a valid case, even if not really usefull (different than with file context)
+      // empty source string is a valid case, even if not really useful (different than with file context)
       // if (*data_ctx->source_string == 0) { throw(std::runtime_error("Data context has empty source string")); }
     }
     catch (...) { return handle_errors(data_ctx) | 1; }
@@ -481,7 +481,7 @@ extern "C" {
   static void sass_clear_options (struct Sass_Options* options)
   {
     if (options == 0) return;
-    // Deallocate custom functions, headers and importes
+    // Deallocate custom functions, headers and imports
     sass_delete_function_list(options->c_functions);
     sass_delete_importer_list(options->c_importers);
     sass_delete_importer_list(options->c_headers);
@@ -604,7 +604,7 @@ extern "C" {
   void ADDCALL sass_file_context_set_options (struct Sass_File_Context* ctx, struct Sass_Options* opt) { copy_options(ctx, opt); }
   void ADDCALL sass_data_context_set_options (struct Sass_Data_Context* ctx, struct Sass_Options* opt) { copy_options(ctx, opt); }
 
-  // Getters for Sass_Compiler options (get conected sass context)
+  // Getters for Sass_Compiler options (get connected sass context)
   enum Sass_Compiler_State ADDCALL sass_compiler_get_state(struct Sass_Compiler* compiler) { return compiler->state; }
   struct Sass_Context* ADDCALL sass_compiler_get_context(struct Sass_Compiler* compiler) { return compiler->c_ctx; }
   struct Sass_Options* ADDCALL sass_compiler_get_options(struct Sass_Compiler* compiler) { return compiler->c_ctx; }

--- a/src/sass_functions.cpp
+++ b/src/sass_functions.cpp
@@ -101,7 +101,7 @@ extern "C" {
   }
 
   // Creator for a single import entry returned by the custom importer inside the list
-  // We take ownership of the memory for source and srcmap (freed when context is destroyd)
+  // We take ownership of the memory for source and srcmap (freed when context is destroyed)
   Sass_Import_Entry ADDCALL sass_make_import(const char* imp_path, const char* abs_path, char* source, char* srcmap)
   {
     Sass_Import* v = (Sass_Import*) calloc(1, sizeof(Sass_Import));

--- a/src/units.cpp
+++ b/src/units.cpp
@@ -330,7 +330,7 @@ namespace Sass {
     // has the advantage that they will be pre-sorted
     std::map<std::string, int> exponents;
 
-    // initialize by summing up occurences in unit vectors
+    // initialize by summing up occurrences in unit vectors
     // this will already cancel out equivalent units (e.q. px/px)
     for (size_t i = 0; i < iL; i ++) exponents[numerators[i]] += 1;
     for (size_t n = 0; n < nL; n ++) exponents[denominators[n]] -= 1;
@@ -396,7 +396,7 @@ namespace Sass {
            denominators.size() == 0;
   }
 
-  // this does not cover all cases (multiple prefered units)
+  // this does not cover all cases (multiple preferred units)
   double Units::convert_factor(const Units& r) const
   {
 
@@ -467,7 +467,7 @@ namespace Sass {
       {
         // get and increment afterwards
         const std::string r_den = *(r_den_it);
-        // get possible converstion factor for units
+        // get possible conversion factor for units
         double conversion = conversion_factor(l_den, r_den);
         // skip incompatible denominator
         if (conversion == 0) {


### PR DESCRIPTION
There one case I wasn't sure about, so I didn't change it: `binominal`

```
C:\Users\xmr\Desktop\libsass>git grep binominal
src/ast_helpers.hpp:  // Pseudo-element selectors that has binominals
src/parser.cpp:  // Helper to clean binominal string
src/parser.cpp:          std::string parsed(lexed); // always compacting binominals (as dart-sass)
src/parser.hpp:    Expression* parse_binominal();
```