### PR TITLE
unrecognized psuedos with arguments parse as declaration-values

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -766,10 +766,23 @@ namespace Sass {
           if (peek_css< exactly<')'>>()  && Util::equalsLiteral("nth-", name.substr(0, 4))) {
             css_error("Invalid CSS", " after ", ": expected An+B expression, was ");
           }
-          if (SelectorListObj wrapped = parseSelectorList(true)) {
-            if (wrapped && lex_css< exactly<')'> >()) {
-              Pseudo_Selector* pseudo = SASS_MEMORY_NEW(Pseudo_Selector, p, name, element);
-              pseudo->selector(wrapped);
+
+          std::string unvendored = Util::unvendor(name);
+
+          if (unvendored == "not" || unvendored == "matches" || unvendored == "current"  || unvendored == "any" || unvendored == "has" || unvendored == "host" || unvendored == "host-context" || unvendored == "slotted") {
+             if (SelectorListObj wrapped = parseSelectorList(true)) {
+                if (wrapped && lex_css< exactly<')'> >()) {
+                  Pseudo_Selector* pseudo = SASS_MEMORY_NEW(Pseudo_Selector, p, name, element);
+                  pseudo->selector(wrapped);
+                  return pseudo;
+                }
+              }
+          } else {
+            String_Schema_Obj arg = parse_css_variable_value();
+            Pseudo_Selector* pseudo = SASS_MEMORY_NEW(Pseudo_Selector, p, name, element);
+            pseudo->argument(arg);
+
+            if (lex_css< exactly<')'> >()) {
               return pseudo;
             }
           }


### PR DESCRIPTION
See sass/sass-spec#1462

fixes #2424, fixes #2944  I think.

Not a c++ dev so please forgive me if this is bad 🙏 It seems to work, i've added a few tests and removed some existing TODO's but i guess i need to PR those to the spec repo directly. I'm not sure on the order of operations on that...

I didn't know know how to parse the unknown case, so reused the css custom variable logic since I think they should be the same, or close?