### PR TITLE
util_string cleanup: Remove const-ref arg rtrim

### DIFF
--- a/src/util_string.cpp
+++ b/src/util_string.cpp
@@ -61,19 +61,6 @@ namespace Sass {
     }
     // EO unvendor
 
-    std::string rtrim(const std::string& str) {
-
-      std::string trimmed = str;
-      size_t pos_ws = trimmed.find_last_not_of(" \t\n\v\f\r");
-      if (pos_ws != std::string::npos) {
-        trimmed.erase(pos_ws + 1);
-      }
-      else {
-        trimmed.clear();
-      }
-      return trimmed;
-    }
-
     std::string normalize_newlines(const std::string& str) {
       std::string result;
       result.reserve(str.size());

--- a/src/util_string.hpp
+++ b/src/util_string.hpp
@@ -22,7 +22,7 @@ namespace Sass {
     // ###########################################################################
     std::string unvendor(const std::string& name);
 
-    std::string rtrim(const std::string& str);
+    std::string rtrim(std::string str);
     std::string normalize_newlines(const std::string& str);
     std::string normalize_underscores(const std::string& str);
     std::string normalize_decimals(const std::string& str);


### PR DESCRIPTION
The by-value version is always better as we need to copy the argument
anyway, and now it can be a move instead.