### PR TITLE
Compressed style: Fix space removal after ancestor

### DIFF
--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -1054,14 +1054,21 @@ namespace Sass {
   }
   void Inspect::operator()(ComplexSelector* sel)
   {
-    bool many = false;
     if (sel->hasPreLineFeed()) {
       append_optional_linefeed();
     }
+    const SelectorComponent* prev = nullptr;
     for (auto& item : sel->elements()) {
-      if (many) append_optional_space();
+      if (prev != nullptr) {
+        if (typeid(*item) == typeid(SelectorCombinator) ||
+            typeid(*prev) == typeid(SelectorCombinator)) {
+          append_optional_space();
+        } else {
+          append_mandatory_space();
+        }
+      }
       item->perform(this);
-      many = true;
+      prev = item.ptr();
     }
   }
 


### PR DESCRIPTION
    echo '.foo .bar{top:0}' | sassc/bin/sassc -t compressed

Before: `.foo.bar{top:0}`
After:  `.foo .bar{top:0}`

Fixes #2988