### PR TITLE
 Handle loaded source code as shared objects 

### DIFF
--- a/Makefile.conf
+++ b/Makefile.conf
@@ -35,6 +35,7 @@ SOURCES = \
 	units.cpp \
 	values.cpp \
 	plugins.cpp \
+	source.cpp \
 	position.cpp \
 	lexer.cpp \
 	parser.cpp \

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -55,7 +55,7 @@ namespace Sass {
 
   void AST_Node::update_pstate(const SourceSpan& pstate)
   {
-    pstate_.offset += pstate - pstate_ + pstate.offset;
+    pstate_.offset += pstate.position - pstate_.position + pstate.offset;
   }
 
   sass::string AST_Node::to_string(Sass_Inspect_Options opt) const

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -84,8 +84,8 @@ namespace Sass {
     // ToDo: add specific implementions to all children
     virtual bool find ( bool (*f)(AST_Node_Obj) ) { return f(this); };
     void update_pstate(const SourceSpan& pstate);
-    Offset off() { return pstate(); }
-    Position pos() { return pstate(); }
+    Offset off() { return pstate().off(); }
+    Position pos() { return pstate().pos(); }
 
     // Some obects are not meant to be compared
     // ToDo: maybe fallback to pointer comparison?

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -81,20 +81,18 @@ namespace Sass {
     virtual sass::string to_string() const;
     virtual void cloneChildren() {};
     // generic find function (not fully implemented yet)
-    // ToDo: add specific implementions to all children
+    // ToDo: add specific implementations to all children
     virtual bool find ( bool (*f)(AST_Node_Obj) ) { return f(this); };
     void update_pstate(const SourceSpan& pstate);
-    Offset off() { return pstate().off(); }
-    Position pos() { return pstate().pos(); }
 
-    // Some obects are not meant to be compared
-    // ToDo: maybe fallback to pointer comparison?
+    // Some objects are not meant to be compared
+    // ToDo: maybe fall-back to pointer comparison?
     virtual bool operator== (const AST_Node& rhs) const {
       throw std::runtime_error("operator== not implemented");
     }
 
     // We can give some reasonable implementations by using
-    // inverst operators on the specialized implementations
+    // invert operators on the specialized implementations
     virtual bool operator!= (const AST_Node& rhs) const {
       // Unequal if not equal
       return !(*this == rhs);

--- a/src/ast_fwd_decl.hpp
+++ b/src/ast_fwd_decl.hpp
@@ -12,6 +12,11 @@
 /////////////////////////////////////////////
 namespace Sass {
 
+  class SourceData;
+  class SourceFile;
+  class SynthFile;
+  class ItplFile;
+
   class AST_Node;
 
   class ParentStatement;
@@ -126,6 +131,11 @@ namespace Sass {
   #define IMPL_MEM_OBJ(type) \
     typedef SharedImpl<type> type##Obj; \
     typedef SharedImpl<type> type##_Obj; \
+
+  IMPL_MEM_OBJ(SourceData);
+  IMPL_MEM_OBJ(SourceFile);
+  IMPL_MEM_OBJ(SynthFile);
+  IMPL_MEM_OBJ(ItplFile);
 
   IMPL_MEM_OBJ(AST_Node);
   IMPL_MEM_OBJ(Statement);

--- a/src/backtrace.cpp
+++ b/src/backtrace.cpp
@@ -15,7 +15,7 @@ namespace Sass {
       const Backtrace& trace = traces[i];
 
       // make path relative to the current directory
-      sass::string rel_path(File::abs2rel(trace.pstate.path, cwd, cwd));
+      sass::string rel_path(File::abs2rel(trace.pstate.getPath(), cwd, cwd));
 
       // skip functions on error cases (unsure why ruby sass does this)
       // if (trace.caller.substr(0, 6) == ", in f") continue;
@@ -23,9 +23,9 @@ namespace Sass {
       if (first) {
         ss << indent;
         ss << "on line ";
-        ss << trace.pstate.line + 1;
+        ss << trace.pstate.getLine();
         ss << ":";
-        ss << trace.pstate.column + 1;
+        ss << trace.pstate.getColumn();
         ss << " of " << rel_path;
         // ss << trace.caller;
         first = false;
@@ -34,9 +34,9 @@ namespace Sass {
         ss << std::endl;
         ss << indent;
         ss << "from line ";
-        ss << trace.pstate.line + 1;
+        ss << trace.pstate.getLine();
         ss << ":";
-        ss << trace.pstate.column + 1;
+        ss << trace.pstate.getColumn();
         ss << " of " << rel_path;
       }
 

--- a/src/debugger.hpp
+++ b/src/debugger.hpp
@@ -310,9 +310,10 @@ inline sass::string longToHex(long long t) {
 inline sass::string pstate_source_position(AST_Node* node)
 {
   sass::sstream str;
-  Position start(node->pstate());
-  Position end(start + node->pstate().offset);
-  str << (start.file == sass::string::npos ? 99999999 : start.file)
+  Offset start(node->pstate().position);
+  Offset end(start + node->pstate().offset);
+  size_t file = node->pstate().getSrcId();
+  str << (file == sass::string::npos ? 99999999 : file)
     << "@[" << start.line << ":" << start.column << "]"
     << "-[" << end.line << ":" << end.column << "]";
 #ifdef DEBUG_SHARED_PTR
@@ -419,7 +420,7 @@ inline void debug_ast(AST_Node* node, sass::string ind, Env* env)
     std::cerr << ind << "Parent_Reference " << selector;
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
-    std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">" << std::endl;
+    std::cerr << std::endl;
 
   } else if (Cast<PseudoSelector>(node)) {
     PseudoSelector* selector = Cast<PseudoSelector>(node);
@@ -460,7 +461,6 @@ inline void debug_ast(AST_Node* node, sass::string ind, Env* env)
     std::cerr << " (" << pstate_source_position(node) << ")";
     std::cerr << " <" << selector->hash() << ">";
     std::cerr << " <<" << selector->ns_name() << ">>";
-    std::cerr << " <" << prettyprint(selector->pstate().token.ws_before()) << ">";
     std::cerr << std::endl;
   } else if (Cast<PlaceholderSelector>(node)) {
 
@@ -600,8 +600,7 @@ inline void debug_ast(AST_Node* node, sass::string ind, Env* env)
     Comment* block = Cast<Comment>(node);
     std::cerr << ind << "Comment " << block;
     std::cerr << " (" << pstate_source_position(node) << ")";
-    std::cerr << " " << block->tabs() <<
-      " <" << prettyprint(block->pstate().token.ws_before()) << ">" << std::endl;
+    std::cerr << " " << block->tabs() << std::endl;
     debug_ast(block->text(), ind + "// ", env);
   } else if (Cast<If>(node)) {
     If* block = Cast<If>(node);
@@ -881,7 +880,7 @@ inline void debug_ast(AST_Node* node, sass::string ind, Env* env)
     if (expression->is_delayed()) std::cerr << " [delayed]";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
     if (expression->quote_mark()) std::cerr << " [quote_mark: " << expression->quote_mark() << "]";
-    std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
+    std::cerr << std::endl;
   } else if (Cast<String_Constant>(node)) {
     String_Constant* expression = Cast<String_Constant>(node);
     std::cerr << ind << "String_Constant " << expression;
@@ -892,7 +891,7 @@ inline void debug_ast(AST_Node* node, sass::string ind, Env* env)
     std::cerr << " [" << prettyprint(expression->value()) << "]";
     if (expression->is_delayed()) std::cerr << " [delayed]";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
-    std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
+    std::cerr << std::endl;
   } else if (Cast<String_Schema>(node)) {
     String_Schema* expression = Cast<String_Schema>(node);
     std::cerr << ind << "String_Schema " << expression;
@@ -905,7 +904,7 @@ inline void debug_ast(AST_Node* node, sass::string ind, Env* env)
     if (expression->has_interpolant()) std::cerr << " [has interpolant]";
     if (expression->is_left_interpolant()) std::cerr << " [left interpolant] ";
     if (expression->is_right_interpolant()) std::cerr << " [right interpolant] ";
-    std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
+    std::cerr << std::endl;
     for(const auto& i : expression->elements()) { debug_ast(i, ind + " ", env); }
   } else if (Cast<String>(node)) {
     String* expression = Cast<String>(node);
@@ -913,7 +912,7 @@ inline void debug_ast(AST_Node* node, sass::string ind, Env* env)
     std::cerr << " " << expression->concrete_type();
     std::cerr << " (" << pstate_source_position(node) << ")";
     if (expression->is_interpolant()) std::cerr << " [interpolant]";
-    std::cerr << " <" << prettyprint(expression->pstate().token.ws_before()) << ">" << std::endl;
+    std::cerr << std::endl;
   } else if (Cast<Expression>(node)) {
     Expression* expression = Cast<Expression>(node);
     std::cerr << ind << "Expression " << expression;

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -18,8 +18,8 @@ namespace Sass {
       prefix("Error"), pstate(pstate), traces(traces)
     { }
 
-    InvalidSass::InvalidSass(SourceSpan pstate, Backtraces traces, sass::string msg, char* owned_src)
-    : Base(pstate, msg, traces), owned_src(owned_src)
+    InvalidSass::InvalidSass(SourceSpan pstate, Backtraces traces, sass::string msg)
+    : Base(pstate, msg, traces)
     { }
 
 

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -164,11 +164,11 @@ namespace Sass {
   void warning(sass::string msg, SourceSpan pstate)
   {
     sass::string cwd(Sass::File::get_cwd());
-    sass::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
-    sass::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
-    sass::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
+    sass::string abs_path(Sass::File::rel2abs(pstate.getPath(), cwd, cwd));
+    sass::string rel_path(Sass::File::abs2rel(pstate.getPath(), cwd, cwd));
+    sass::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.getPath()));
 
-    std::cerr << "WARNING on line " << pstate.line+1 << ", column " << pstate.column+1 << " of " << output_path << ":" << std::endl;
+    std::cerr << "WARNING on line " << pstate.getLine() << ", column " << pstate.getColumn() << " of " << output_path << ":" << std::endl;
     std::cerr << msg << std::endl << std::endl;
   }
 
@@ -180,24 +180,24 @@ namespace Sass {
   void deprecated_function(sass::string msg, SourceSpan pstate)
   {
     sass::string cwd(Sass::File::get_cwd());
-    sass::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
-    sass::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
-    sass::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
+    sass::string abs_path(Sass::File::rel2abs(pstate.getPath(), cwd, cwd));
+    sass::string rel_path(Sass::File::abs2rel(pstate.getPath(), cwd, cwd));
+    sass::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.getPath()));
 
     std::cerr << "DEPRECATION WARNING: " << msg << std::endl;
     std::cerr << "will be an error in future versions of Sass." << std::endl;
-    std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
+    std::cerr << "        on line " << pstate.getLine() << " of " << output_path << std::endl;
   }
 
   void deprecated(sass::string msg, sass::string msg2, bool with_column, SourceSpan pstate)
   {
     sass::string cwd(Sass::File::get_cwd());
-    sass::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
-    sass::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
-    sass::string output_path(Sass::File::path_for_console(rel_path, pstate.path, pstate.path));
+    sass::string abs_path(Sass::File::rel2abs(pstate.getPath(), cwd, cwd));
+    sass::string rel_path(Sass::File::abs2rel(pstate.getPath(), cwd, cwd));
+    sass::string output_path(Sass::File::path_for_console(rel_path, pstate.getPath(), pstate.getPath()));
 
-    std::cerr << "DEPRECATION WARNING on line " << pstate.line + 1;
-    if (with_column) std::cerr << ", column " << pstate.column + pstate.offset.column + 1;
+    std::cerr << "DEPRECATION WARNING on line " << pstate.getLine();
+    // if (with_column) std::cerr << ", column " << pstate.column + pstate.offset.column + 1;
     if (output_path.length()) std::cerr << " of " << output_path;
     std::cerr << ":" << std::endl;
     std::cerr << msg << std::endl;
@@ -208,12 +208,12 @@ namespace Sass {
   void deprecated_bind(sass::string msg, SourceSpan pstate)
   {
     sass::string cwd(Sass::File::get_cwd());
-    sass::string abs_path(Sass::File::rel2abs(pstate.path, cwd, cwd));
-    sass::string rel_path(Sass::File::abs2rel(pstate.path, cwd, cwd));
-    sass::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.path));
+    sass::string abs_path(Sass::File::rel2abs(pstate.getPath(), cwd, cwd));
+    sass::string rel_path(Sass::File::abs2rel(pstate.getPath(), cwd, cwd));
+    sass::string output_path(Sass::File::path_for_console(rel_path, abs_path, pstate.getPath()));
 
     std::cerr << "WARNING: " << msg << std::endl;
-    std::cerr << "        on line " << pstate.line+1 << " of " << output_path << std::endl;
+    std::cerr << "        on line " << pstate.getLine() << " of " << output_path << std::endl;
     std::cerr << "This will be an error in future versions of Sass." << std::endl;
   }
 

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -41,20 +41,8 @@ namespace Sass {
 
     class InvalidSass : public Base {
       public:
-        InvalidSass(InvalidSass& other) : Base(other), owned_src(other.owned_src) {
-          // Assumes that `this` will outlive `other`.
-          other.owned_src = nullptr;
-        }
-
-        // Required because the copy constructor's argument is not const.
-        // Can't use `std::move` here because we build on Visual Studio 2013.
-        InvalidSass(InvalidSass &&other) : Base(other), owned_src(other.owned_src) {
-          other.owned_src = nullptr;
-        }
-
-        InvalidSass(SourceSpan pstate, Backtraces traces, sass::string msg, char* owned_src = nullptr);
-        virtual ~InvalidSass() throw() { sass_free_memory(owned_src); };
-        char *owned_src;
+        InvalidSass(SourceSpan pstate, Backtraces traces, sass::string msg);
+        virtual ~InvalidSass() throw() {};
     };
 
     class InvalidParent : public Base {

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1503,9 +1503,9 @@ namespace Sass {
     ExpressionObj sel = s->contents()->perform(this);
     sass::string result_str(sel->to_string(options()));
     result_str = unquote(Util::rtrim(result_str));
-    char* temp_cstr = sass_copy_c_string(result_str.c_str());
-    ctx.strings.push_back(temp_cstr); // attach to context
-    Parser p = Parser::from_c_str(temp_cstr, ctx, traces, s->pstate());
+    ItplFile* source = SASS_MEMORY_NEW(ItplFile,
+      result_str.c_str(), s->pstate());
+    Parser p(source, ctx, traces);
 
     // If a schema contains a reference to parent it is already
     // connected to it, so don't connect implicitly anymore

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -344,9 +344,9 @@ namespace Sass {
       // add call stack entry
       callee_stack().push_back({
         "@warn",
-        w->pstate().path,
-        w->pstate().line + 1,
-        w->pstate().column + 1,
+        w->pstate().getPath(),
+        w->pstate().getLine(),
+        w->pstate().getColumn(),
         SASS_CALLEE_FUNCTION,
         { env }
       });
@@ -392,9 +392,9 @@ namespace Sass {
       // add call stack entry
       callee_stack().push_back({
         "@error",
-        e->pstate().path,
-        e->pstate().line + 1,
-        e->pstate().column + 1,
+        e->pstate().getPath(),
+        e->pstate().getLine(),
+        e->pstate().getColumn(),
         SASS_CALLEE_FUNCTION,
         { env }
       });
@@ -436,9 +436,9 @@ namespace Sass {
       // add call stack entry
       callee_stack().push_back({
         "@debug",
-        d->pstate().path,
-        d->pstate().line + 1,
-        d->pstate().column + 1,
+        d->pstate().getPath(),
+        d->pstate().getLine(),
+        d->pstate().getColumn(),
         SASS_CALLEE_FUNCTION,
         { env }
       });
@@ -462,12 +462,12 @@ namespace Sass {
     }
 
     sass::string result(unquote(message->to_sass()));
-    sass::string abs_path(Sass::File::rel2abs(d->pstate().path, cwd(), cwd()));
-    sass::string rel_path(Sass::File::abs2rel(d->pstate().path, cwd(), cwd()));
-    sass::string output_path(Sass::File::path_for_console(rel_path, abs_path, d->pstate().path));
+    sass::string abs_path(Sass::File::rel2abs(d->pstate().getPath(), cwd(), cwd()));
+    sass::string rel_path(Sass::File::abs2rel(d->pstate().getPath(), cwd(), cwd()));
+    sass::string output_path(Sass::File::path_for_console(rel_path, abs_path, d->pstate().getPath()));
     options().output_style = outstyle;
 
-    std::cerr << output_path << ":" << d->pstate().line+1 << " DEBUG: " << result;
+    std::cerr << output_path << ":" << d->pstate().getLine() << " DEBUG: " << result;
     std::cerr << std::endl;
     return 0;
   }
@@ -1043,9 +1043,9 @@ namespace Sass {
       traces.push_back(Backtrace(c->pstate(), msg));
       callee_stack().push_back({
         c->name().c_str(),
-        c->pstate().path,
-        c->pstate().line + 1,
-        c->pstate().column + 1,
+        c->pstate().getPath(),
+        c->pstate().getLine(),
+        c->pstate().getColumn(),
         SASS_CALLEE_FUNCTION,
         { env }
       });
@@ -1083,9 +1083,9 @@ namespace Sass {
       traces.push_back(Backtrace(c->pstate(), msg));
       callee_stack().push_back({
         c->name().c_str(),
-        c->pstate().path,
-        c->pstate().line + 1,
-        c->pstate().column + 1,
+        c->pstate().getPath(),
+        c->pstate().getLine(),
+        c->pstate().getColumn(),
         SASS_CALLEE_C_FUNCTION,
         { env }
       });
@@ -1122,7 +1122,7 @@ namespace Sass {
 
     // link back to function definition
     // only do this for custom functions
-    if (result->pstate().file == sass::string::npos)
+    if (result->pstate().getSrcId() == sass::string::npos)
       result->pstate(c->pstate());
 
     result = result->perform(this);

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -786,9 +786,9 @@ namespace Sass {
     traces.push_back(Backtrace(c->pstate(), msg));
     ctx.callee_stack.push_back({
       c->name().c_str(),
-      c->pstate().path,
-      c->pstate().line + 1,
-      c->pstate().column + 1,
+      c->pstate().getPath(),
+      c->pstate().getLine(),
+      c->pstate().getColumn(),
       SASS_CALLEE_MIXIN,
       { env }
     });

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -258,9 +258,9 @@ namespace Sass {
   {
     ExpressionObj mq = eval(m->schema());
     sass::string str_mq(mq->to_css(ctx.c_options));
-    char* str = sass_copy_c_string(str_mq.c_str());
-    ctx.strings.push_back(str);
-    Parser parser(Parser::from_c_str(str, ctx, traces, mq->pstate()));
+    ItplFile* source = SASS_MEMORY_NEW(ItplFile,
+      str_mq.c_str(), m->pstate());
+    Parser parser(source, ctx, traces);
     // Create a new CSS only representation of the media rule
     CssMediaRuleObj css = SASS_MEMORY_NEW(CssMediaRule, m->pstate(), m->block());
     sass::vector<CssMediaQuery_Obj> parsed = parser.parseCssMediaQueries();

--- a/src/extender.cpp
+++ b/src/extender.cpp
@@ -388,7 +388,7 @@ namespace Sass {
       CssMediaRuleObj mediaContext;
       if (mediaContexts.hasKey(rule)) mediaContext = mediaContexts.get(rule);
       SelectorListObj ext = extendList(rule, newExtensions, mediaContext);
-      // If no extends actually happenedit (for example becaues unification
+      // If no extends actually happened (for example because unification
       // failed), we don't need to re-register the selector.
       if (ObjEqualityFn(oldValue, ext)) continue;
       rule->elements(ext->elements());
@@ -1063,7 +1063,7 @@ namespace Sass {
     // TODO(nweiz): I think there may be a way to get perfect trimming 
     // without going quadratic by building some sort of trie-like
     // data structure that can be used to look up superselectors.
-    // TODO(mgreter): Check how this perfoms in C++ (up the limit)
+    // TODO(mgreter): Check how this performs in C++ (up the limit)
     if (selectors.size() > 100) return selectors;
 
     // This is n² on the sequences, but only comparing between separate sequences

--- a/src/fn_selectors.cpp
+++ b/src/fn_selectors.cpp
@@ -36,7 +36,8 @@ namespace Sass {
           str->quote_mark(0);
         }
         sass::string exp_src = exp->to_string(ctx.c_options);
-        SelectorListObj sel = Parser::parse_selector(exp_src.c_str(), ctx, traces);
+        ItplFile* source = SASS_MEMORY_NEW(ItplFile, exp_src.c_str(), exp->pstate());
+        SelectorListObj sel = Parser::parse_selector(source, ctx, traces);
         parsedSelectors.push_back(sel);
       }
 
@@ -90,9 +91,8 @@ namespace Sass {
           str->quote_mark(0);
         }
         sass::string exp_src = exp->to_string();
-        SelectorListObj sel = Parser::parse_selector(exp_src.c_str(), ctx, traces,
-                                                     exp->pstate(), pstate.src,
-                                                     /*allow_parent=*/true);
+        ItplFile* source = SASS_MEMORY_NEW(ItplFile, exp_src.c_str(), exp->pstate());
+        SelectorListObj sel = Parser::parse_selector(source, ctx, traces, true);
 
         for (auto& complex : sel->elements()) {
           if (complex->empty()) {

--- a/src/mapping.hpp
+++ b/src/mapping.hpp
@@ -2,6 +2,7 @@
 #define SASS_MAPPING_H
 
 #include "position.hpp"
+#include "backtrace.hpp"
 
 namespace Sass {
 

--- a/src/memory/allocator.cpp
+++ b/src/memory/allocator.cpp
@@ -1,5 +1,6 @@
 #include "../sass.hpp"
-#include "../memory.hpp"
+#include "allocator.hpp"
+#include "memory_pool.hpp"
 
 #if defined (_MSC_VER) // Visual studio
 #define thread_local __declspec( thread )

--- a/src/memory/allocator.hpp
+++ b/src/memory/allocator.hpp
@@ -133,7 +133,6 @@ namespace std {
   };
 }
 
-
 #endif
 
 #endif

--- a/src/memory/memory_pool.hpp
+++ b/src/memory/memory_pool.hpp
@@ -1,9 +1,11 @@
 #ifndef SASS_MEMORY_POOL_H
 #define SASS_MEMORY_POOL_H
 
-#include "../sass.hpp"
-#include "../memory.hpp"
+#include <stdlib.h>
+#include <iostream>
+#include <algorithm>
 #include <climits>
+#include <vector>
 
 namespace Sass {
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -137,8 +137,8 @@ namespace Sass {
     if (opt.source_comments) {
       sass::ostream ss;
       append_indentation();
-      sass::string path(File::abs2rel(r->pstate().path));
-      ss << "/* line " << r->pstate().line + 1 << ", " << path << " */";
+      sass::string path(File::abs2rel(r->pstate().getPath()));
+      ss << "/* line " << r->pstate().getLine() << ", " << path << " */";
       append_string(ss.str());
       append_optional_linefeed();
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -81,7 +81,7 @@ namespace Sass {
     // check seems a bit esoteric but works
     if (ctx.resources.size() == 1) {
       // apply headers only on very first include
-      ctx.apply_custom_headers(root, path, pstate);
+      ctx.apply_custom_headers(root, getPath(), pstate);
     }
 
     // parse children nodes
@@ -346,9 +346,9 @@ namespace Sass {
         imp->urls().push_back(location.second);
       }
       // check if custom importers want to take over the handling
-      else if (!ctx.call_importers(unquote(location.first), path, pstate, imp)) {
+      else if (!ctx.call_importers(unquote(location.first), getPath(), pstate, imp)) {
         // nobody wants it, so we do our import
-        ctx.import_url(imp, location.first, path);
+        ctx.import_url(imp, location.first, getPath());
       }
     }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -40,7 +40,7 @@ namespace Sass {
    void Parser::advanceToNextToken() {
       lex < css_comments >(false);
       // advance to position
-      pstate += pstate.offset;
+      pstate.position += pstate.offset;
       pstate.offset.column = 0;
       pstate.offset.line = 0;
     }
@@ -70,7 +70,7 @@ namespace Sass {
 
     // report invalid utf8
     if (it != end) {
-      pstate += Offset::init(position, it);
+      pstate.position += Offset::init(position, it);
       traces.push_back(Backtrace(pstate));
       throw Exception::InvalidSass(pstate, traces, "Invalid UTF-8 sequence");
     }
@@ -545,7 +545,7 @@ namespace Sass {
         if (i < p) {
           sass::string parsed(i, p);
           String_Constant_Obj str = SASS_MEMORY_NEW(String_Constant, pstate, parsed);
-          pstate += Offset(parsed);
+          pstate.position += Offset(parsed);
           str->update_pstate(pstate);
           schema->append(str);
         }
@@ -567,7 +567,7 @@ namespace Sass {
         // add to the string schema
         schema->append(interpolant);
         // advance parser state
-        pstate.add(p+2, j);
+        pstate.position.add(p+2, j);
         // advance position
         i = j;
       }
@@ -578,7 +578,7 @@ namespace Sass {
         if (i < end_of_selector) {
           sass::string parsed(i, end_of_selector);
           String_Constant_Obj str = SASS_MEMORY_NEW(String_Constant, pstate, parsed);
-          pstate += Offset(parsed);
+          pstate.position += Offset(parsed);
           str->update_pstate(pstate);
           i = end_of_selector;
           schema->append(str);
@@ -595,7 +595,7 @@ namespace Sass {
     selector_schema->update_pstate(pstate);
     schema->update_pstate(pstate);
 
-    after_token = before_token = pstate;
+    after_token = before_token = pstate.position;
 
     // return parsed result
     return selector_schema.detach();
@@ -941,7 +941,7 @@ namespace Sass {
     }
 
     SourceSpan ps = map->pstate();
-    ps.offset = pstate - ps + pstate.offset;
+    ps.offset = pstate.position - ps.position + pstate.offset;
     map->pstate(ps);
 
     return map;
@@ -1081,7 +1081,7 @@ namespace Sass {
     if (operands.size() == 0) return conj;
     // fold all operands into one binary expression
     ExpressionObj ex = fold_operands(conj, operands, { Sass_OP::OR });
-    state.offset = pstate - state + pstate.offset;
+    state.offset = pstate.position - state.position + pstate.offset;
     ex->pstate(state);
     return ex;
   }
@@ -1104,7 +1104,7 @@ namespace Sass {
     if (operands.size() == 0) return rel;
     // fold all operands into one binary expression
     ExpressionObj ex = fold_operands(rel, operands, { Sass_OP::AND });
-    state.offset = pstate - state + pstate.offset;
+    state.offset = pstate.position - state.position + pstate.offset;
     ex->pstate(state);
     return ex;
   }
@@ -1153,7 +1153,7 @@ namespace Sass {
     // single nested items. So we cannot set delay on the
     // returned result here, as we have lost nestings ...
     ExpressionObj ex = fold_operands(lhs, operands, operators);
-    state.offset = pstate - state + pstate.offset;
+    state.offset = pstate.position - state.position + pstate.offset;
     ex->pstate(state);
     return ex;
   }
@@ -1202,7 +1202,7 @@ namespace Sass {
 
     if (operands.size() == 0) return lhs;
     ExpressionObj ex = fold_operands(lhs, operands, operators);
-    state.offset = pstate - state + pstate.offset;
+    state.offset = pstate.position - state.position + pstate.offset;
     ex->pstate(state);
     return ex;
   }
@@ -1232,7 +1232,7 @@ namespace Sass {
     }
     // operands and operators to binary expression
     ExpressionObj ex = fold_operands(factor, operands, operators);
-    state.offset = pstate - state + pstate.offset;
+    state.offset = pstate.position - state.position + pstate.offset;
     ex->pstate(state);
     return ex;
   }
@@ -2889,7 +2889,7 @@ namespace Sass {
 
   void Parser::error(sass::string msg)
   {
-    error(msg, pstate);
+    error(msg, pstate.position);
   }
 
   // print a css parsing error with actual context information from parsed source

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -57,7 +57,7 @@ namespace Sass {
 
     Parser(Context& ctx, const SourceSpan& pstate, Backtraces traces, bool allow_parent = true)
     : SourceSpan(pstate), ctx(ctx), block_stack(), stack(0),
-      source(0), position(0), end(0), before_token(pstate), after_token(pstate),
+      source(0), position(0), end(0), before_token(pstate.position), after_token(pstate.position),
       pstate(pstate), traces(traces), indentation(0), nestings(0), allow_parent(allow_parent)
     {
       stack.push_back(Scope::Root);

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -187,7 +187,7 @@ namespace Sass {
       after_token.add(it_before_token, it_after_token);
 
       // ToDo: could probably do this incremental on original object (API wants offset?)
-      pstate = SourceSpan(path, source, lexed, before_token, after_token - before_token);
+      pstate = SourceSpan(path, source, before_token, after_token - before_token);
 
       // advance internal char iterator
       return position = it_after_token;

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -13,6 +13,7 @@
 #include "context.hpp"
 #include "position.hpp"
 #include "prelexer.hpp"
+#include "source.hpp"
 
 #ifndef MAX_NESTING
 // Note that this limit is not an exact science
@@ -42,31 +43,23 @@ namespace Sass {
     Context& ctx;
     sass::vector<Block_Obj> block_stack;
     sass::vector<Scope> stack;
-    const char* source;
+    SourceDataObj source;
+    const char* begin;
     const char* position;
     const char* end;
-    Position before_token;
-    Position after_token;
+    Offset before_token;
+    Offset after_token;
     SourceSpan pstate;
     Backtraces traces;
     size_t indentation;
     size_t nestings;
     bool allow_parent;
-
     Token lexed;
 
-    Parser(Context& ctx, const SourceSpan& pstate, Backtraces traces, bool allow_parent = true)
-    : SourceSpan(pstate), ctx(ctx), block_stack(), stack(0),
-      source(0), position(0), end(0), before_token(pstate.position), after_token(pstate.position),
-      pstate(pstate), traces(traces), indentation(0), nestings(0), allow_parent(allow_parent)
-    {
-      stack.push_back(Scope::Root);
-    }
+    Parser(SourceData* source, Context& ctx, Backtraces, bool allow_parent = true);
 
-    // static Parser from_string(const sass::string& src, Context& ctx, SourceSpan pstate = SourceSpan("[STRING]"));
-    static Parser from_c_str(const char* src, Context& ctx, Backtraces, SourceSpan pstate = SourceSpan("[CSTRING]"), const char* source = nullptr, bool allow_parent = true);
     // special static parsers to convert strings into certain selectors
-    static SelectorListObj parse_selector(const char* src, Context& ctx, Backtraces, SourceSpan pstate = SourceSpan("[SELECTOR]"), const char* source = nullptr, bool allow_parent = true);
+    static SelectorListObj parse_selector(SourceData* source, Context& ctx, Backtraces, bool allow_parent = true);
 
 #ifdef __clang__
 
@@ -187,7 +180,7 @@ namespace Sass {
       after_token.add(it_before_token, it_after_token);
 
       // ToDo: could probably do this incremental on original object (API wants offset?)
-      pstate = SourceSpan(path, source, before_token, after_token - before_token);
+      pstate = SourceSpan(source, before_token, after_token - before_token);
 
       // advance internal char iterator
       return position = it_after_token;
@@ -204,8 +197,8 @@ namespace Sass {
       Token prev = lexed;
       // store previous pointer
       const char* oldpos = position;
-      Position bt = before_token;
-      Position at = after_token;
+      Offset bt = before_token;
+      Offset at = after_token;
       SourceSpan op = pstate;
       // throw away comments
       // update srcmap position
@@ -239,7 +232,6 @@ namespace Sass {
 #endif
 
     void error(sass::string msg);
-    void error(sass::string msg, Position pos);
     // generate message with given and expected sample
     // text before and in the middle are configurable
     void css_error(const sass::string& msg,

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -65,8 +65,6 @@ namespace Sass {
 
     // static Parser from_string(const sass::string& src, Context& ctx, SourceSpan pstate = SourceSpan("[STRING]"));
     static Parser from_c_str(const char* src, Context& ctx, Backtraces, SourceSpan pstate = SourceSpan("[CSTRING]"), const char* source = nullptr, bool allow_parent = true);
-    static Parser from_c_str(const char* beg, const char* end, Context& ctx, Backtraces, SourceSpan pstate = SourceSpan("[CSTRING]"), const char* source = nullptr, bool allow_parent = true);
-    static Parser from_token(Token t, Context& ctx, Backtraces, SourceSpan pstate = SourceSpan("[TOKEN]"), const char* source = nullptr);
     // special static parsers to convert strings into certain selectors
     static SelectorListObj parse_selector(const char* src, Context& ctx, Backtraces, SourceSpan pstate = SourceSpan("[SELECTOR]"), const char* source = nullptr, bool allow_parent = true);
 

--- a/src/parser_selectors.cpp
+++ b/src/parser_selectors.cpp
@@ -148,7 +148,7 @@ namespace Sass {
         if (!seq->empty()) { sel = seq->last()->to_string({ NESTED, 5 }); }
         // ToDo: parser should throw parser exceptions
         error("Invalid CSS after \"" + sel + "\": expected \"{\", was \"" + found + "\"\n\n"
-          "\"" + found + "\" may only be used at the beginning of a compound selector.", state.position);
+          "\"" + found + "\" may only be used at the beginning of a compound selector.");
       }
       // parse functional
       else if (match < re_functional >())

--- a/src/parser_selectors.cpp
+++ b/src/parser_selectors.cpp
@@ -148,7 +148,7 @@ namespace Sass {
         if (!seq->empty()) { sel = seq->last()->to_string({ NESTED, 5 }); }
         // ToDo: parser should throw parser exceptions
         error("Invalid CSS after \"" + sel + "\": expected \"{\", was \"" + found + "\"\n\n"
-          "\"" + found + "\" may only be used at the beginning of a compound selector.", state);
+          "\"" + found + "\" may only be used at the beginning of a compound selector.", state.position);
       }
       // parse functional
       else if (match < re_functional >())

--- a/src/permutate.hpp
+++ b/src/permutate.hpp
@@ -7,13 +7,17 @@ namespace Sass {
 
   // Returns a list of all possible paths through the given lists.
   //
-  // For example, given `[[1, 2], [3, 4], [5]]`, this returns:
+  // For example, given `[[1, 2], [3, 4], [5, 6]]`, this returns:
   //
   // ```
   // [[1, 3, 5],
   //  [2, 3, 5],
   //  [1, 4, 5],
-  //  [2, 4, 5]]
+  //  [2, 4, 5],
+  //  [1, 3, 6],
+  //  [2, 3, 6],
+  //  [1, 4, 6],
+  //  [2, 4, 6]]
   // ```
   // 
   // Note: called `paths` in dart-sass
@@ -74,7 +78,22 @@ namespace Sass {
   }
   // EO permutate
 
-  // ToDo: this variant is used in resolve_parent_refs
+  // ToDo: this variant is used in resolveParentSelectors
+  // Returns a list of all possible paths through the given lists.
+  //
+  // For example, given `[[1, 2], [3, 4], [5, 6]]`, this returns:
+  //
+  // ```
+  // [[1, 3, 5],
+  //  [1, 3, 6],
+  //  [1, 4, 5],
+  //  [1, 4, 6],
+  //  [2, 3, 5],
+  //  [2, 3, 6],
+  //  [2, 4, 5],
+  //  [2, 4, 6]]
+  // ```
+  // 
   template <class T>
   sass::vector<sass::vector<T>>
     permutateAlt(const sass::vector<sass::vector<T>>& in) {
@@ -89,7 +108,7 @@ namespace Sass {
     }
 
     size_t* state = new size_t[L];
-    sass::vector< sass::vector<T>> out;
+    sass::vector<sass::vector<T>> out;
 
     // First initialize all states for every permutation group
     for (size_t i = 0; i < L; i += 1) {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -118,10 +118,10 @@ namespace Sass {
 
 
   SourceSpan::SourceSpan(const char* path, const char* src, const size_t file)
-  : Position(file, 0, 0), path(path), src(src), offset(0, 0) { }
+  : position(file, 0, 0), offset(0, 0), path(path), src(src) { }
 
   SourceSpan::SourceSpan(const char* path, const char* src, const Position& position, Offset offset)
-  : Position(position), path(path), src(src), offset(offset) { }
+  : position(position), offset(offset), path(path), src(src) { }
 
   Position Position::add(const char* begin, const char* end)
   {

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -3,6 +3,7 @@
 #include "sass.hpp"
 
 #include "position.hpp"
+#include "source.hpp"
 
 namespace Sass {
 
@@ -56,7 +57,7 @@ namespace Sass {
         // skip over 10xxxxxx
         // is 1st bit not set
         if ((chr & 128) == 0) {
-          // regular ascii char
+          // regular ASCII char
           column += 1;
         }
         // is 2nd bit not set
@@ -117,11 +118,11 @@ namespace Sass {
   : Offset(line, column), file(file) { }
 
 
-  SourceSpan::SourceSpan(const char* path, const char* src, const size_t file)
-  : position(file, 0, 0), offset(0, 0), path(path), src(src) { }
+  SourceSpan::SourceSpan(const char* path)
+  : source(SASS_MEMORY_NEW(SynthFile, path)), position(0, 0), offset(0, 0) { }
 
-  SourceSpan::SourceSpan(const char* path, const char* src, const Position& position, Offset offset)
-  : position(position), offset(offset), path(path), src(src) { }
+  SourceSpan::SourceSpan(SourceDataObj source, const Offset& position, const Offset& offset)
+    : source(source), position(position), offset(offset) { }
 
   Position Position::add(const char* begin, const char* end)
   {
@@ -160,22 +161,5 @@ namespace Sass {
   {
     return Offset(line - off.line, off.line == line ? column - off.column : column);
   }
-
-  /* not used anymore - remove?
-  std::ostream& operator<<(std::ostream& strm, const Offset& off)
-  {
-    if (off.line == string::npos) strm << "-1:"; else strm << off.line << ":";
-    if (off.column == string::npos) strm << "-1"; else strm << off.column;
-    return strm;
-  } */
-
-  /* not used anymore - remove?
-  std::ostream& operator<<(std::ostream& strm, const Position& pos)
-  {
-    if (pos.file != string::npos) strm << pos.file << ":";
-    if (pos.line == string::npos) strm << "-1:"; else strm << pos.line << ":";
-    if (pos.column == string::npos) strm << "-1"; else strm << pos.column;
-    return strm;
-  } */
 
 }

--- a/src/position.cpp
+++ b/src/position.cpp
@@ -118,13 +118,10 @@ namespace Sass {
 
 
   SourceSpan::SourceSpan(const char* path, const char* src, const size_t file)
-  : Position(file, 0, 0), path(path), src(src), offset(0, 0), token() { }
+  : Position(file, 0, 0), path(path), src(src), offset(0, 0) { }
 
   SourceSpan::SourceSpan(const char* path, const char* src, const Position& position, Offset offset)
-  : Position(position), path(path), src(src), offset(offset), token() { }
-
-  SourceSpan::SourceSpan(const char* path, const char* src, const Token& token, const Position& position, Offset offset)
-  : Position(position), path(path), src(src), offset(offset), token(token) { }
+  : Position(position), path(path), src(src), offset(offset) { }
 
   Position Position::add(const char* begin, const char* end)
   {

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -110,6 +110,22 @@ namespace Sass {
       Position pos() { return *this; }
       SourceSpan pstate() { return *this; }
 
+      const char* getPath() const {
+        return path;
+      }
+      const char* getRawData() const {
+        return src;
+      }
+      size_t getLine() const {
+        return line + 1;
+      }
+      size_t getColumn() const {
+        return column + 1;
+      }
+      size_t getSrcId() const {
+        return file;
+      }
+
     public:
       const char* path;
       const char* src;

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -104,7 +104,6 @@ namespace Sass {
     public: // c-tor
       SourceSpan(const char* path, const char* src = 0, const size_t file = sass::string::npos);
       SourceSpan(const char* path, const char* src, const Position& position, Offset offset = Offset(0, 0));
-      SourceSpan(const char* path, const char* src, const Token& token, const Position& position, Offset offset = Offset(0, 0));
 
     public: // down casts
       Offset off() { return *this; }
@@ -115,7 +114,6 @@ namespace Sass {
       const char* path;
       const char* src;
       Offset offset;
-      Token token;
 
   };
 

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -3,7 +3,8 @@
 
 #include <string>
 #include <cstring>
-// #include <iostream>
+#include "source_data.hpp"
+#include "ast_fwd_decl.hpp"
 
 namespace Sass {
 
@@ -101,36 +102,43 @@ namespace Sass {
 
   class SourceSpan {
 
-    public: // c-tor
-      SourceSpan(const char* path, const char* src = 0, const size_t file = sass::string::npos);
-      SourceSpan(const char* path, const char* src, const Position& position, Offset offset = Offset(0, 0));
+    public:
 
-    public: // down casts
-      Offset off() { return position; }
-      Position pos() { return position; }
-      SourceSpan pstate() { return *this; }
+      SourceSpan(const char* path);
+
+      SourceSpan(SourceDataObj source,
+        const Offset& position = Offset(0, 0),
+        const Offset& offset = Offset(0, 0));
 
       const char* getPath() const {
-        return path;
+        return source->getPath();
       }
+
       const char* getRawData() const {
-        return src;
+        return source->getRawData();
       }
+
+      Offset getPosition() const {
+        return position;
+      }
+
       size_t getLine() const {
         return position.line + 1;
       }
+
       size_t getColumn() const {
         return position.column + 1;
       }
+
       size_t getSrcId() const {
-        return position.file;
+        return source == nullptr
+          ? std::string::npos
+          : source->getSrcId();
       }
 
-    public:
-      Position position;
+      SourceDataObj source;
+      Offset position;
       Offset offset;
-      const char* path;
-      const char* src;
 
   };
 

--- a/src/position.hpp
+++ b/src/position.hpp
@@ -99,15 +99,15 @@ namespace Sass {
     bool operator==(Token t)  { return to_string() == t.to_string(); }
   };
 
-  class SourceSpan : public Position {
+  class SourceSpan {
 
     public: // c-tor
       SourceSpan(const char* path, const char* src = 0, const size_t file = sass::string::npos);
       SourceSpan(const char* path, const char* src, const Position& position, Offset offset = Offset(0, 0));
 
     public: // down casts
-      Offset off() { return *this; }
-      Position pos() { return *this; }
+      Offset off() { return position; }
+      Position pos() { return position; }
       SourceSpan pstate() { return *this; }
 
       const char* getPath() const {
@@ -117,19 +117,20 @@ namespace Sass {
         return src;
       }
       size_t getLine() const {
-        return line + 1;
+        return position.line + 1;
       }
       size_t getColumn() const {
-        return column + 1;
+        return position.column + 1;
       }
       size_t getSrcId() const {
-        return file;
+        return position.file;
       }
 
     public:
+      Position position;
+      Offset offset;
       const char* path;
       const char* src;
-      Offset offset;
 
   };
 

--- a/src/sass.cpp
+++ b/src/sass.cpp
@@ -46,6 +46,7 @@ extern "C" {
 
   char* ADDCALL sass_copy_c_string(const char* str)
   {
+    if (str == nullptr) return nullptr;
     size_t len = strlen(str) + 1;
     char* cpy = (char*) sass_alloc_memory(len);
     std::memcpy(cpy, str, len);

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -77,12 +77,13 @@ namespace Sass {
       // now create the code trace (ToDo: maybe have util functions?)
       if (e.pstate.position.line != sass::string::npos &&
           e.pstate.position.column != sass::string::npos &&
-          e.pstate.src != nullptr) {
-        size_t lines = e.pstate.position.line;
+          e.pstate.source != nullptr) {
+        Offset offset(e.pstate.position);
+        size_t lines = offset.line;
         // scan through src until target line
         // move line_beg pointer to line start
         const char* line_beg;
-        for (line_beg = e.pstate.src; *line_beg != '\0'; ++line_beg) {
+        for (line_beg = e.pstate.getRawData(); *line_beg != '\0'; ++line_beg) {
           if (lines == 0) break;
           if (*line_beg == '\n') --lines;
         }
@@ -96,12 +97,12 @@ namespace Sass {
         size_t move_in = 0; size_t shorten = 0;
         size_t left_chars = 42; size_t max_chars = 76;
         // reported excerpt should not exceed `max_chars` chars
-        if (e.pstate.position.column > line_len) left_chars = e.pstate.position.column;
-        if (e.pstate.position.column > left_chars) move_in = e.pstate.position.column - left_chars;
+        if (offset.column > line_len) left_chars = offset.column;
+        if (offset.column > left_chars) move_in = offset.column - left_chars;
         if (line_len > max_chars + move_in) shorten = line_len - move_in - max_chars;
         utf8::advance(line_beg, move_in, line_end);
         utf8::retreat(line_end, shorten, line_beg);
-        sass::string sanitized; sass::string marker(e.pstate.position.column - move_in, '-');
+        sass::string sanitized; sass::string marker(offset.column - move_in, '-');
         utf8::replace_invalid(line_beg, line_end, std::back_inserter(sanitized));
         msg_stream << ">> " << sanitized << "\n";
         msg_stream << "   " << marker << "^\n";

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -75,10 +75,10 @@ namespace Sass {
       }
 
       // now create the code trace (ToDo: maybe have util functions?)
-      if (e.pstate.line != sass::string::npos &&
-          e.pstate.column != sass::string::npos &&
+      if (e.pstate.position.line != sass::string::npos &&
+          e.pstate.position.column != sass::string::npos &&
           e.pstate.src != nullptr) {
-        size_t lines = e.pstate.line;
+        size_t lines = e.pstate.position.line;
         // scan through src until target line
         // move line_beg pointer to line start
         const char* line_beg;
@@ -96,12 +96,12 @@ namespace Sass {
         size_t move_in = 0; size_t shorten = 0;
         size_t left_chars = 42; size_t max_chars = 76;
         // reported excerpt should not exceed `max_chars` chars
-        if (e.pstate.column > line_len) left_chars = e.pstate.column;
-        if (e.pstate.column > left_chars) move_in = e.pstate.column - left_chars;
+        if (e.pstate.position.column > line_len) left_chars = e.pstate.position.column;
+        if (e.pstate.position.column > left_chars) move_in = e.pstate.position.column - left_chars;
         if (line_len > max_chars + move_in) shorten = line_len - move_in - max_chars;
         utf8::advance(line_beg, move_in, line_end);
         utf8::retreat(line_end, shorten, line_beg);
-        sass::string sanitized; sass::string marker(e.pstate.column - move_in, '-');
+        sass::string sanitized; sass::string marker(e.pstate.position.column - move_in, '-');
         utf8::replace_invalid(line_beg, line_end, std::back_inserter(sanitized));
         msg_stream << ">> " << sanitized << "\n";
         msg_stream << "   " << marker << "^\n";

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -65,12 +65,12 @@ namespace Sass {
 
       if (e.traces.empty()) {
         // we normally should have some traces, still here as a fallback
-        sass::string rel_path(Sass::File::abs2rel(e.pstate.path, cwd, cwd));
+        sass::string rel_path(Sass::File::abs2rel(e.pstate.getPath(), cwd, cwd));
         msg_stream << sass::string(msg_prefix.size() + 2, ' ');
-        msg_stream << " on line " << e.pstate.line + 1 << " of " << rel_path << "\n";
+        msg_stream << " on line " << e.pstate.getLine() << " of " << rel_path << "\n";
       }
       else {
-        sass::string rel_path(Sass::File::abs2rel(e.pstate.path, cwd, cwd));
+        sass::string rel_path(Sass::File::abs2rel(e.pstate.getPath(), cwd, cwd));
         msg_stream << traces_to_string(e.traces, "        ");
       }
 
@@ -109,9 +109,9 @@ namespace Sass {
 
       JsonNode* json_err = json_mkobject();
       json_append_member(json_err, "status", json_mknumber(1));
-      json_append_member(json_err, "file", json_mkstring(e.pstate.path));
-      json_append_member(json_err, "line", json_mknumber((double)(e.pstate.line + 1)));
-      json_append_member(json_err, "column", json_mknumber((double)(e.pstate.column + 1)));
+      json_append_member(json_err, "file", json_mkstring(e.pstate.getPath()));
+      json_append_member(json_err, "line", json_mknumber((double)(e.pstate.getLine())));
+      json_append_member(json_err, "column", json_mknumber((double)(e.pstate.getColumn())));
       json_append_member(json_err, "message", json_mkstring(e.what()));
       json_append_member(json_err, "formatted", json_mkstream(msg_stream));
       try { c_ctx->error_json = json_stringify(json_err, "  "); }
@@ -119,10 +119,10 @@ namespace Sass {
       c_ctx->error_message = sass_copy_string(msg_stream.str());
       c_ctx->error_text = sass_copy_c_string(e.what());
       c_ctx->error_status = 1;
-      c_ctx->error_file = sass_copy_c_string(e.pstate.path);
-      c_ctx->error_line = e.pstate.line + 1;
-      c_ctx->error_column = e.pstate.column + 1;
-      c_ctx->error_src = sass_copy_c_string(e.pstate.src);
+      c_ctx->error_file = sass_copy_c_string(e.pstate.getPath());
+      c_ctx->error_line = e.pstate.getLine();
+      c_ctx->error_column = e.pstate.getColumn();
+      c_ctx->error_src = sass_copy_c_string(e.pstate.getRawData());
       c_ctx->output_string = 0;
       c_ctx->source_map_string = 0;
       json_delete(json_err);

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -343,7 +343,7 @@ extern "C" {
         rv = Operators::op_strings(op, *lhs, *rhs, options, lhs->pstate());
       }
 
-      // ToDo: maybe we should should return null value?
+      // ToDo: maybe we should return null value?
       if (!rv) return sass_make_error("invalid return value");
 
       // convert result back to ast node

--- a/src/sass_values.cpp
+++ b/src/sass_values.cpp
@@ -340,9 +340,7 @@ extern "C" {
         rv = Operators::op_colors(op, *l_c, *r_c, options, l_c->pstate());
       }
       else /* convert other stuff to string and apply operation */ {
-        Value* l_v = Cast<Value>(lhs);
-        Value* r_v = Cast<Value>(rhs);
-        rv = Operators::op_strings(op, *l_v, *r_v, options, l_v->pstate());
+        rv = Operators::op_strings(op, *lhs, *rhs, options, lhs->pstate());
       }
 
       // ToDo: maybe we should should return null value?

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <string.h>
+#include "source.hpp"
+#include "utf8/checked.h"
+#include "position.hpp"
+
+namespace Sass {
+
+  SourceData::SourceData()
+    : SharedObj()
+  {
+  }
+
+  SourceFile::SourceFile(
+    const char* path,
+    const char* data,
+    size_t srcid) :
+    SourceData(),
+    path(sass_copy_c_string(path)),
+    data(sass_copy_c_string(data)),
+    length(0),
+    srcid(srcid)
+  {
+    length = strlen(data);
+  }
+
+  SourceFile::~SourceFile() {
+    sass_free_memory(path);
+    sass_free_memory(data);
+  }
+
+  const char* SourceFile::end() const
+  {
+    return data + length;
+  }
+
+  const char* SourceFile::begin() const
+  {
+    return data;
+  }
+
+  const char* SourceFile::getRawData() const
+  {
+    return data;
+  }
+
+  SourceSpan SourceFile::getSourceSpan()
+  {
+    return SourceSpan(this);
+  }
+
+  ItplFile::ItplFile(const char* data, const SourceSpan& pstate) :
+    SourceFile(pstate.getPath(),
+      data, pstate.getSrcId()),
+    pstate(pstate)
+  {}
+
+  const char* ItplFile::getRawData() const
+  {
+    return pstate.getRawData();
+  }
+
+  SourceSpan ItplFile::getSourceSpan()
+  {
+    return SourceSpan(pstate);
+  }
+
+}
+

--- a/src/source.hpp
+++ b/src/source.hpp
@@ -1,0 +1,95 @@
+#ifndef SASS_SOURCE_H
+#define SASS_SOURCE_H
+
+#include "sass.hpp"
+#include "memory.hpp"
+#include "position.hpp"
+#include "source_data.hpp"
+
+namespace Sass {
+
+  class SourceFile :
+    public SourceData {
+  protected:
+    char* path;
+    char* data;
+    size_t length;
+    size_t srcid;
+  public:
+
+    SourceFile(
+      const char* path,
+      const char* data,
+      size_t srcid);
+
+    ~SourceFile();
+
+    const char* end() const override final;
+    const char* begin() const override final;
+    virtual const char* getRawData() const override;
+    virtual SourceSpan getSourceSpan() override;
+
+    size_t size() const override final {
+      return length;
+    }
+
+    virtual const char* getPath() const override {
+      return path;
+    }
+
+    virtual size_t getSrcId() const override {
+      return srcid;
+    }
+
+  };
+
+  class SynthFile :
+    public SourceData {
+  protected:
+    const char* path;
+  public:
+
+    SynthFile(
+      const char* path) :
+      path(path)
+    {}
+
+    ~SynthFile() {}
+
+    const char* end() const override final { return nullptr; }
+    const char* begin() const override final { return nullptr; };
+    virtual const char* getRawData() const override { return nullptr; };
+    virtual SourceSpan getSourceSpan() override { return SourceSpan(path); };
+
+    size_t size() const override final {
+      return 0;
+    }
+
+    virtual const char* getPath() const override {
+      return path;
+    }
+
+    virtual size_t getSrcId() const override {
+      return std::string::npos;
+    }
+
+  };
+  
+
+  class ItplFile :
+    public SourceFile {
+  private:
+    SourceSpan pstate;
+  public:
+
+    ItplFile(const char* data,
+      const SourceSpan& pstate);
+
+    // Offset getPosition() const override final;
+    const char* getRawData() const override final;
+    SourceSpan getSourceSpan() override final;
+  };
+
+}
+
+#endif

--- a/src/source_data.hpp
+++ b/src/source_data.hpp
@@ -1,0 +1,32 @@
+#ifndef SASS_SOURCE_DATA_H
+#define SASS_SOURCE_DATA_H
+
+#include "sass.hpp"
+#include "memory.hpp"
+
+namespace Sass {
+
+  class SourceSpan;
+
+  class SourceData :
+    public SharedObj {
+  public:
+    SourceData();
+    virtual size_t size() const = 0;
+    virtual size_t getSrcId() const = 0;
+    virtual const char* end() const = 0;
+    virtual const char* begin() const = 0;
+    virtual const char* getPath() const = 0;
+    // virtual Offset getPosition() const = 0;
+    virtual const char* getRawData() const = 0;
+    virtual SourceSpan getSourceSpan() = 0;
+
+    sass::string to_string() const override {
+      return sass::string{ begin(), end() };
+    }
+    ~SourceData() {}
+  };
+
+}
+
+#endif

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -175,23 +175,27 @@ namespace Sass {
 
   void SourceMap::add_open_mapping(const AST_Node* node)
   {
-    mappings.push_back(Mapping(node->pstate().position, current_position));
+    const SourceSpan& span(node->pstate());
+    Position from(span.getSrcId(), span.position);
+    mappings.push_back(Mapping(from, current_position));
   }
 
   void SourceMap::add_close_mapping(const AST_Node* node)
   {
-    mappings.push_back(Mapping(node->pstate().position + node->pstate().offset, current_position));
+    const SourceSpan& span(node->pstate());
+    Position to(span.getSrcId(), span.position + span.offset);
+    mappings.push_back(Mapping(to, current_position));
   }
 
   SourceSpan SourceMap::remap(const SourceSpan& pstate) {
     for (size_t i = 0; i < mappings.size(); ++i) {
       if (
-        mappings[i].generated_position.file == pstate.position.file &&
+        mappings[i].generated_position.file == pstate.getSrcId() &&
         mappings[i].generated_position.line == pstate.position.line &&
         mappings[i].generated_position.column == pstate.position.column
-      ) return SourceSpan(pstate.path, pstate.src, mappings[i].original_position, pstate.offset);
+      ) return SourceSpan(pstate.source, mappings[i].original_position, pstate.offset);
     }
-    return SourceSpan(pstate.path, pstate.src, Position(-1, -1, -1), Offset(0, 0));
+    return SourceSpan(pstate.source, Position(-1, -1, -1), Offset(0, 0));
 
   }
 

--- a/src/source_map.cpp
+++ b/src/source_map.cpp
@@ -175,20 +175,20 @@ namespace Sass {
 
   void SourceMap::add_open_mapping(const AST_Node* node)
   {
-    mappings.push_back(Mapping(node->pstate(), current_position));
+    mappings.push_back(Mapping(node->pstate().position, current_position));
   }
 
   void SourceMap::add_close_mapping(const AST_Node* node)
   {
-    mappings.push_back(Mapping(node->pstate() + node->pstate().offset, current_position));
+    mappings.push_back(Mapping(node->pstate().position + node->pstate().offset, current_position));
   }
 
   SourceSpan SourceMap::remap(const SourceSpan& pstate) {
     for (size_t i = 0; i < mappings.size(); ++i) {
       if (
-        mappings[i].generated_position.file == pstate.file &&
-        mappings[i].generated_position.line == pstate.line &&
-        mappings[i].generated_position.column == pstate.column
+        mappings[i].generated_position.file == pstate.position.file &&
+        mappings[i].generated_position.line == pstate.position.line &&
+        mappings[i].generated_position.column == pstate.position.column
       ) return SourceSpan(pstate.path, pstate.src, mappings[i].original_position, pstate.offset);
     }
     return SourceSpan(pstate.path, pstate.src, Position(-1, -1, -1), Offset(0, 0));

--- a/src/source_map.hpp
+++ b/src/source_map.hpp
@@ -9,6 +9,9 @@
 #include "position.hpp"
 #include "mapping.hpp"
 
+#include "backtrace.hpp"
+#include "memory.hpp"
+
 #define VECTOR_PUSH(vec, ins) vec.insert(vec.end(), ins.begin(), ins.end())
 #define VECTOR_UNSHIFT(vec, ins) vec.insert(vec.begin(), ins.begin(), ins.end())
 
@@ -49,7 +52,7 @@ private:
   class OutputBuffer {
     public:
       OutputBuffer(void)
-      : buffer(""),
+      : buffer(),
         smap()
       { }
     public:

--- a/src/utf8_string.cpp
+++ b/src/utf8_string.cpp
@@ -11,7 +11,6 @@
 
 namespace Sass {
   namespace UTF_8 {
-    using sass::string;
 
     // naming conventions:
     // offset: raw byte offset (0 based)
@@ -19,25 +18,25 @@ namespace Sass {
     // index: code point offset (1 based or negative)
 
     // function that will count the number of code points (utf-8 characters) from the given beginning to the given end
-    size_t code_point_count(const string& str, size_t start, size_t end) {
+    size_t code_point_count(const sass::string& str, size_t start, size_t end) {
       return utf8::distance(str.begin() + start, str.begin() + end);
     }
 
-    size_t code_point_count(const string& str) {
+    size_t code_point_count(const sass::string& str) {
       return utf8::distance(str.begin(), str.end());
     }
 
     // function that will return the byte offset at a code point position
-    size_t offset_at_position(const string& str, size_t position) {
-      string::const_iterator it = str.begin();
+    size_t offset_at_position(const sass::string& str, size_t position) {
+      sass::string::const_iterator it = str.begin();
       utf8::advance(it, position, str.end());
       return std::distance(str.begin(), it);
     }
 
     // function that returns number of bytes in a character at offset
-    size_t code_point_size_at_offset(const string& str, size_t offset) {
+    size_t code_point_size_at_offset(const sass::string& str, size_t offset) {
       // get iterator from string and forward by offset
-      string::const_iterator stop = str.begin() + offset;
+      sass::string::const_iterator stop = str.begin() + offset;
       // check if beyond boundary
       if (stop == str.end()) return 0;
       // advance by one code point
@@ -78,9 +77,9 @@ namespace Sass {
     using std::wstring;
 
     // convert from utf16/wide string to utf8 string
-    string convert_from_utf16(const wstring& utf16)
+    sass::string convert_from_utf16(const wstring& utf16)
     {
-      string utf8;
+      sass::string utf8;
       // pre-allocate expected memory
       utf8.reserve(sizeof(utf16)/2);
       utf8::utf16to8(utf16.begin(), utf16.end(),
@@ -89,7 +88,7 @@ namespace Sass {
     }
 
     // convert from utf8 string to utf16/wide string
-    wstring convert_to_utf16(const string& utf8)
+    wstring convert_to_utf16(const sass::string& utf8)
     {
       wstring utf16;
       // pre-allocate expected memory

--- a/src/utf8_string.hpp
+++ b/src/utf8_string.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include "utf8.h"
+#include "memory.hpp"
 
 namespace Sass {
   namespace UTF_8 {

--- a/win/libsass.targets
+++ b/win/libsass.targets
@@ -60,6 +60,7 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\parser.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\paths.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\plugins.hpp" />
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\source.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\position.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\prelexer.hpp" />
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\remove_placeholders.hpp" />
@@ -128,6 +129,7 @@
     <ClCompile Include="$(LIBSASS_SRC_DIR)\parser.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\parser_selectors.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\plugins.cpp" />
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\source.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\position.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\prelexer.cpp" />
     <ClCompile Include="$(LIBSASS_SRC_DIR)\backtrace.cpp" />

--- a/win/libsass.vcxproj.filters
+++ b/win/libsass.vcxproj.filters
@@ -195,6 +195,9 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\plugins.hpp">
       <Filter>Headers</Filter>
     </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\source.hpp">
+      <Filter>Headers</Filter>
+    </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\position.hpp">
       <Filter>Headers</Filter>
     </ClInclude>
@@ -375,6 +378,9 @@
       <Filter>Sources</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\plugins.cpp">
+      <Filter>Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\source.cpp">
       <Filter>Sources</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\position.cpp">


### PR DESCRIPTION
Makes them survive our context more easily. This enables
use to safe and cheaply pass them to error handlers.