### PR TITLE
Fix parent resolving for selector schema and real parents

### DIFF
--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -188,9 +188,9 @@ namespace Sass {
     if (r->schema()) {
       SelectorListObj sel = eval(r->schema());
       r->selector(sel);
-      bool chroot = sel->has_real_parent_ref();
       for (auto complex : sel->elements()) {
-        complex->chroots(chroot);
+        // ToDo: maybe we can get rid of chroots?
+        complex->chroots(complex->has_real_parent_ref());
       }
 
     }


### PR DESCRIPTION
When only one complex selector had a real parent reference
we wrongly marked the whole selector list as chrooted.

Fixes https://github.com/sass/libsass/issues/3046