### PR TITLE
Fix segfault on directive ruleset

### DIFF
--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -1033,6 +1033,7 @@ namespace Sass {
 
       if (!in_wrapped && i == 0) append_indentation();
       if ((*g)[i] == nullptr) continue;
+      if (g->at(i)->length() == 0) continue;
       schedule_mapping(g->at(i)->last());
       // add_open_mapping((*g)[i]->last());
       (*g)[i]->perform(this);


### PR DESCRIPTION
Reported in https://oss-fuzz.com/testcase-detail/5739632306421760

```scss
@keyframes{#{&}v,{}}
```
```shell
[1]    85013 segmentation fault  /Users/xzyfer/Projects/Sass/sassc/bin/sassc test.scss
```