### PR TITLE
Fix stack-overflow in Binary_Expression

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2849,6 +2849,13 @@ namespace Sass {
       }
     }
 
+    if (operands.size() > Constants::MaxCallStack) {
+        // XXX: this is never hit via spec tests
+        sass::ostream stm;
+        stm << "Stack depth exceeded max of " << Constants::MaxCallStack;
+        error(stm.str());
+    }
+
     for (size_t S = operands.size(); i < S; ++i) {
       if (String_Schema* schema = Cast<String_Schema>(operands[i])) {
         if (schema->has_interpolants()) {


### PR DESCRIPTION
```

  | ==1==ERROR: AddressSanitizer: stack-overflow on address 0x7ffd4469eff8 (pc 0x000000b87f3e bp 0x7ffd4469f030 sp 0x7ffd4469f000 T0)
-- | --
  | #0 0xb87f3e in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:256:14
  | #1 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #2 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #3 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #4 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #5 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #6 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #7 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #8 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #9 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #10 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #11 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #12 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #13 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #14 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #15 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #16 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
  | #17 0xb880ac in Sass::Binary_Expression::set_delayed(bool) libsass/src/ast_values.cpp:257:13
```