### PR TITLE
Fix memory leak in Parser::parse_media_query

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2242,7 +2242,7 @@ namespace Sass {
 
     while (lex_css < kwd_and >()) media_query->append(parse_media_expression());
     if (lex < identifier_schema >()) {
-      String_Schema* schema = SASS_MEMORY_NEW(String_Schema, pstate);
+      String_Schema_Obj schema = SASS_MEMORY_NEW(String_Schema, pstate);
       if (media_query->media_type()) {
         schema->append(media_query->media_type());
         schema->append(SASS_MEMORY_NEW(String_Constant, pstate, " "));


### PR DESCRIPTION
```css
e{@media_ #{}
```
```
Direct leak of 128 byte(s) in 1 object(s) allocated from:
--
  | #0 0x595afd in operator new(unsigned long) /src/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:99:3
  | #1 0x87960a in Sass::Parser::parse_media_query() libsass/src/parser.cpp:2245:31
  | #2 0x7a6914 in Sass::Parser::parse_media_queries() libsass/src/parser.cpp:2225:56
  | #3 0x782dd4 in Sass::Parser::parseMediaRule() libsass/src/parser.cpp:2214:18
  | #4 0x74dcac in Sass::Parser::parse_block_node(bool) libsass/src/parser.cpp:264:55
  | #5 0x74290d in Sass::Parser::parse_block_nodes(bool) libsass/src/parser.cpp:171:11
  | #6 0x746b9a in Sass::Parser::parse_css_block(bool) libsass/src/parser.cpp:128:10
  | #7 0x7802e8 in parse_block libsass/src/parser.cpp:152:12
  | #8 0x7802e8 in Sass::Parser::parse_ruleset(Lookahead) libsass/src/parser.cpp:522:20
  | #9 0x74d26a in Sass::Parser::parse_block_node(bool) libsass/src/parser.cpp:260:21
  | #10 0x74290d in Sass::Parser::parse_block_nodes(bool) libsass/src/parser.cpp:171:11
```