### PR TITLE
Fix memory leak in Sass::Eval::operator()(Sass::String_Schema*)

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -1286,7 +1286,8 @@ namespace Sass {
     }
     if (!s->is_interpolant()) {
       if (s->length() > 1 && res == "") return SASS_MEMORY_NEW(Null, s->pstate());
-      return SASS_MEMORY_NEW(String_Constant, s->pstate(), res, s->css());
+      String_Constant_Obj str = SASS_MEMORY_NEW(String_Constant, s->pstate(), res, s->css());
+      return str.detach();
     }
     // string schema seems to have a special unquoting behavior (also handles "nested" quotes)
     String_Quoted_Obj str = SASS_MEMORY_NEW(String_Quoted, s->pstate(), res, 0, false, false, false, s->css());


### PR DESCRIPTION
```css
@i&{&{}}
```

```
Direct leak of 112 byte(s) in 1 object(s) allocated from:
--
  | #0 0x595afd in operator new(unsigned long) /src/llvm-project/compiler-rt/lib/asan/asan_new_delete.cpp:99:3
  | #1 0x93d666 in Sass::Eval::operator()(Sass::String_Schema*) libsass/src/eval.cpp:1289:14
  | #2 0x968e12 in Sass::Expand::operator()(Sass::AtRule*) libsass/src/expand.cpp:309:22
  | #3 0x95ba4e in Sass::Expand::append_block(Sass::Block*) libsass/src/expand.cpp:863:32
  | #4 0x95ad4e in Sass::Expand::operator()(Sass::Block*) libsass/src/expand.cpp:157:11
  | #5 0x5d3624 in Sass::Context::compile() libsass/src/context.cpp:653:12
  | #6 0x5d1f91 in Sass::Data_Context::parse() libsass/src/context.cpp:624:12
  | #7 0x59b3d5 in sass_parse_block libsass/src/sass_context.cpp:181:31
  | #8 0x59b3d5 in sass_compiler_parse libsass/src/sass_context.cpp:435:22
  | #9 0x59a8a8 in sass_compile_context(Sass_Context*, Sass::Context*) libsass/src/sass_context.cpp:318:7
```