### PR TITLE
Ensure correct output order of compound selectors

### DIFF
--- a/src/ast_selectors.cpp
+++ b/src/ast_selectors.cpp
@@ -940,6 +940,16 @@ namespace Sass {
 
   }
 
+  bool cmpSimpleSelectors(SimpleSelector* a, SimpleSelector* b)
+  {
+    return (a->getSortOrder() < b->getSortOrder());
+  }
+
+  void CompoundSelector::sortChildren()
+  {
+    std::sort(begin(), end(), cmpSimpleSelectors);
+  }
+
   /* better return sass::vector? only - is empty container anyway? */
   SelectorList* ComplexSelector::resolve_parent_refs(SelectorStack pstack, Backtraces& traces, bool implicit_parent)
   {

--- a/src/ast_selectors.hpp
+++ b/src/ast_selectors.hpp
@@ -99,6 +99,8 @@ namespace Sass {
     HASH_PROPERTY(bool, has_ns)
   public:
     SimpleSelector(SourceSpan pstate, sass::string n = "");
+    // ordering within parent (peudos go last)
+    virtual int getSortOrder() const = 0;
     virtual sass::string ns_name() const;
     size_t hash() const override;
     virtual bool empty() const;
@@ -147,6 +149,7 @@ namespace Sass {
   class PlaceholderSelector final : public SimpleSelector {
   public:
     PlaceholderSelector(SourceSpan pstate, sass::string n);
+    int getSortOrder() const override final { return 0; }
     bool isInvisible() const override { return true; }
     virtual unsigned long specificity() const override;
     virtual bool has_placeholder() override;
@@ -162,6 +165,7 @@ namespace Sass {
   class TypeSelector final : public SimpleSelector {
   public:
     TypeSelector(SourceSpan pstate, sass::string n);
+    int getSortOrder() const override final { return 1; }
     virtual unsigned long specificity() const override;
     SimpleSelector* unifyWith(const SimpleSelector*);
     CompoundSelector* unifyWith(CompoundSelector*) override;
@@ -178,6 +182,7 @@ namespace Sass {
   class ClassSelector final : public SimpleSelector {
   public:
     ClassSelector(SourceSpan pstate, sass::string n);
+    int getSortOrder() const override final { return 3; }
     virtual unsigned long specificity() const override;
     bool operator==(const SimpleSelector& rhs) const final override;
     ATTACH_CMP_OPERATIONS(ClassSelector)
@@ -191,6 +196,7 @@ namespace Sass {
   class IDSelector final : public SimpleSelector {
   public:
     IDSelector(SourceSpan pstate, sass::string n);
+    int getSortOrder() const override final { return 2; }
     virtual unsigned long specificity() const override;
     CompoundSelector* unifyWith(CompoundSelector*) override;
     IDSelector* getIdSelector() final override { return this; }
@@ -210,6 +216,7 @@ namespace Sass {
     ADD_PROPERTY(char, modifier);
   public:
     AttributeSelector(SourceSpan pstate, sass::string n, sass::string m, String_Obj v, char o = 0);
+    int getSortOrder() const override final { return 4; }
     size_t hash() const override;
     virtual unsigned long specificity() const override;
     bool operator==(const SimpleSelector& rhs) const final override;
@@ -230,6 +237,7 @@ namespace Sass {
     ADD_PROPERTY(bool, isClass)
   public:
     PseudoSelector(SourceSpan pstate, sass::string n, bool element = false);
+    int getSortOrder() const override final { return 5; }
     virtual bool is_pseudo_element() const override;
     size_t hash() const override;
 
@@ -444,6 +452,8 @@ namespace Sass {
     bool operator==(const SelectorList& rhs) const;
     bool operator==(const ComplexSelector& rhs) const;
     bool operator==(const SimpleSelector& rhs) const;
+
+    void sortChildren();
 
     ATTACH_CMP_OPERATIONS(CompoundSelector)
     ATTACH_AST_OPERATIONS(CompoundSelector)

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -1091,6 +1091,7 @@ namespace Sass {
     if (sel->hasRealParent()) {
       append_string("&");
     }
+    sel->sortChildren();
     for (auto& item : sel->elements()) {
       item->perform(this);
     }

--- a/src/memory/memory_pool.hpp
+++ b/src/memory/memory_pool.hpp
@@ -55,7 +55,8 @@ namespace Sass {
     std::vector<void*> arenas;
 
     // One pointer for every bucket (zero init)
-    void* freeList[SassAllocatorBuckets] = {};
+    #pragma warning (suppress:4351)
+    void* freeList[SassAllocatorBuckets]{};
 
     // Increase the address until it sits on a
     // memory aligned address (maybe use `aligned`).


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/3084, Needs https://github.com/sass/sass-spec/pull/1529

~I believe this will fail quite a few spec tests, since it seems we have
some of these as expected outputs!? Lets check what CI returns.~

Opened PR to address this in sass-spec.