### PR TITLE
Add back C-API getters for plugin paths

### DIFF
--- a/include/sass/context.h
+++ b/include/sass/context.h
@@ -125,6 +125,9 @@ ADDAPI char** ADDCALL sass_context_get_included_files (struct Sass_Context* ctx)
 // Getters for options include path array
 ADDAPI size_t ADDCALL sass_option_get_include_path_size(struct Sass_Options* options);
 ADDAPI const char* ADDCALL sass_option_get_include_path(struct Sass_Options* options, size_t i);
+// Plugin paths to load dynamic libraries work the same
+ADDAPI size_t ADDCALL sass_option_get_plugin_path_size(struct Sass_Options* options);
+ADDAPI const char* ADDCALL sass_option_get_plugin_path(struct Sass_Options* options, size_t i);
 
 // Calculate the size of the stored null terminated array
 ADDAPI size_t ADDCALL sass_context_get_included_files_size (struct Sass_Context* ctx);

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -704,6 +704,23 @@ extern "C" {
   }
 
   // Push function for plugin paths (no manipulation support for now)
+  size_t ADDCALL sass_option_get_plugin_path_size(struct Sass_Options* options)
+  {
+    size_t len = 0;
+    struct string_list* cur = options->plugin_paths;
+    while (cur) { len++; cur = cur->next; }
+    return len;
+  }
+
+  // Push function for plugin paths (no manipulation support for now)
+  const char* ADDCALL sass_option_get_plugin_path(struct Sass_Options* options, size_t i)
+  {
+    struct string_list* cur = options->plugin_paths;
+    while (i) { i--; cur = cur->next; }
+    return cur->string;
+  }
+
+  // Push function for plugin paths (no manipulation support for now)
   void ADDCALL sass_option_push_plugin_path(struct Sass_Options* options, const char* path)
   {
 


### PR DESCRIPTION
They are probably not really useful, but we already
have them documented in the context API documentation.

Fixes https://github.com/sass/libsass/issues/3082