### PR TITLE
Fix an interesting memory handling edge case

### DIFF
--- a/src/cssize.cpp
+++ b/src/cssize.cpp
@@ -86,7 +86,7 @@ namespace Sass {
 
     if (parent()->statement_type() == Statement::RULESET)
     {
-      return (r->is_keyframes()) ? SASS_MEMORY_NEW(Bubble, r->pstate(), r) : bubble(r);
+      return r->is_keyframes() ? SASS_MEMORY_NEW(Bubble, r->pstate(), r) : bubble(r);
     }
 
     p_stack.push_back(r);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -288,12 +288,10 @@ namespace Sass {
             Expression* var = scalars;
             env.set_local(variables[0], var);
           } else {
-            // XXX: this is never hit via spec tests
+            // https://github.com/sass/libsass/issues/3078
             for (size_t j = 0, K = variables.size(); j < K; ++j) {
-              Expression* res = j >= scalars->length()
-                ? SASS_MEMORY_NEW(Null, expr->pstate())
-                : scalars->at(j);
-              env.set_local(variables[j], res);
+              env.set_local(variables[j], j >= scalars->length()
+                ? SASS_MEMORY_NEW(Null, expr->pstate()) : scalars->at(j));
             }
           }
         } else {

--- a/src/expand.cpp
+++ b/src/expand.cpp
@@ -636,10 +636,9 @@ namespace Sass {
             env.set_local(variables[0], var);
           } else {
             for (size_t j = 0, K = variables.size(); j < K; ++j) {
-              ExpressionObj res = j >= scalars->length()
+              env.set_local(variables[j], j >= scalars->length()
                 ? SASS_MEMORY_NEW(Null, expr->pstate())
-                : (*scalars)[j]->perform(&eval);
-              env.set_local(variables[j], res);
+                : (*scalars)[j]->perform(&eval));
             }
           }
         } else {


### PR DESCRIPTION
Fixes https://github.com/sass/libsass/issues/3078

It seems the ternary is returning the type of the second argument.
This means that the first one was first upgraded to a shared object,
and once assigned to a normal pointer, it got prematurely collected.