### PR TITLE
Fix issue with some std::unordered_map implementations

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -358,7 +358,7 @@ namespace Sass {
   class Hashed {
   private:
     std::unordered_map<
-      K, T, ObjHash, ObjEquality
+      K, T, ObjHash, ObjHashEquality
     > elements_;
 
     sass::vector<K> _keys;
@@ -396,7 +396,7 @@ namespace Sass {
     bool has_duplicate_key() const         { return duplicate_key_ != nullptr; }
     K get_duplicate_key() const  { return duplicate_key_; }
     const std::unordered_map<
-      K, T, ObjHash, ObjEquality
+      K, T, ObjHash, ObjHashEquality
     >& elements() { return elements_; }
     Hashed& operator<<(std::pair<K, T> p)
     {
@@ -432,7 +432,7 @@ namespace Sass {
       return *this;
     }
     const std::unordered_map<
-      K, T, ObjHash, ObjEquality
+      K, T, ObjHash, ObjHashEquality
     >& pairs() const { return elements_; }
 
     const sass::vector<K>& keys() const { return _keys; }

--- a/src/ast_helpers.hpp
+++ b/src/ast_helpers.hpp
@@ -150,6 +150,30 @@ namespace Sass {
   };
 
   // ###########################################################################
+  // Special compare function only for hashes.
+  // We need to make sure to not have objects equal that 
+  // have different hashes. This is currently an issue,
+  // since `1px` is equal to `1` but have different hashes.
+  // This goes away once we remove unitless equality.
+  // ###########################################################################
+
+  template <class T>
+  // Compare the objects and its hashes
+  bool ObjHashEqualityFn(const T& lhs, const T& rhs) {
+    if (lhs == nullptr) return rhs == nullptr;
+    else if (rhs == nullptr) return false;
+    else return lhs->hash() == rhs->hash();
+  }
+  struct ObjHashEquality {
+    template <class T>
+    // Compare the objects and its contents and hashes
+    bool operator() (const T& lhs, const T& rhs) const {
+      return ObjEqualityFn<T>(lhs, rhs) &&
+        ObjHashEqualityFn(lhs, rhs);
+    }
+  };
+
+  // ###########################################################################
   // Implement ordering operations for AST Nodes
   // ###########################################################################
 


### PR DESCRIPTION
Needs https://github.com/sass/sass-spec/pull/1529 to pass CI.

We currently don't adhere to the restriction that if two
items are equal to each other, their hashes must be the
same too. This comes from the issue that unitless numbers
compare equal to the same number even if they have units.

Fixes https://github.com/sass/libsass/issues/3094