### PR TITLE
Revert compound re-ordering for non extended selectors

### DIFF
--- a/src/ast_selectors.hpp
+++ b/src/ast_selectors.hpp
@@ -182,7 +182,7 @@ namespace Sass {
   class ClassSelector final : public SimpleSelector {
   public:
     ClassSelector(SourceSpan pstate, sass::string n);
-    int getSortOrder() const override final { return 3; }
+    int getSortOrder() const override final { return 2; }
     virtual unsigned long specificity() const override;
     bool operator==(const SimpleSelector& rhs) const final override;
     ATTACH_CMP_OPERATIONS(ClassSelector)
@@ -216,7 +216,7 @@ namespace Sass {
     ADD_PROPERTY(char, modifier);
   public:
     AttributeSelector(SourceSpan pstate, sass::string n, sass::string m, String_Obj v, char o = 0);
-    int getSortOrder() const override final { return 4; }
+    int getSortOrder() const override final { return 2; }
     size_t hash() const override;
     virtual unsigned long specificity() const override;
     bool operator==(const SimpleSelector& rhs) const final override;
@@ -237,7 +237,7 @@ namespace Sass {
     ADD_PROPERTY(bool, isClass)
   public:
     PseudoSelector(SourceSpan pstate, sass::string n, bool element = false);
-    int getSortOrder() const override final { return 5; }
+    int getSortOrder() const override final { return 3; }
     virtual bool is_pseudo_element() const override;
     size_t hash() const override;
 
@@ -273,16 +273,17 @@ namespace Sass {
   // Between each item there is an implicit ancestor of combinator
   ////////////////////////////////////////////////////////////////////////////
   class ComplexSelector final : public Selector, public Vectorized<SelectorComponentObj> {
-    ADD_PROPERTY(bool, chroots)
+    ADD_PROPERTY(bool, chroots);
     // line break before list separator
-    ADD_PROPERTY(bool, hasPreLineFeed)
+    ADD_PROPERTY(bool, hasPreLineFeed);
   public:
     ComplexSelector(SourceSpan pstate);
 
     // Returns true if the first components
-    // is a compound selector and fullfills
+    // is a compound selector and fulfills
     // a few other criteria.
     bool isInvisible() const;
+    bool isInvalidCss() const;
 
     size_t hash() const override;
     void cloneChildren() override;
@@ -413,12 +414,11 @@ namespace Sass {
   ////////////////////////////////////////////////////////////////////////////
   class CompoundSelector final : public SelectorComponent, public Vectorized<SimpleSelectorObj> {
     ADD_PROPERTY(bool, hasRealParent)
-    ADD_PROPERTY(bool, extended)
   public:
     CompoundSelector(SourceSpan pstate, bool postLineBreak = false);
 
     // Returns true if this compound selector
-    // fullfills various criteria.
+    // fulfills various criteria.
     bool isInvisible() const;
 
     bool empty() const override {
@@ -454,6 +454,7 @@ namespace Sass {
     bool operator==(const SimpleSelector& rhs) const;
 
     void sortChildren();
+    bool isInvalidCss() const;
 
     ATTACH_CMP_OPERATIONS(CompoundSelector)
     ATTACH_AST_OPERATIONS(CompoundSelector)

--- a/src/inspect.cpp
+++ b/src/inspect.cpp
@@ -439,7 +439,7 @@ namespace Sass {
     if (list->is_bracketed()) {
       append_string(lbracket(list));
     }
-    // probably ruby sass eqivalent of element_needs_parens
+    // probably ruby sass equivalent of element_needs_parens
     else if (output_style() == TO_SASS &&
         list->length() == 1 &&
         !list->from_selector() &&
@@ -489,7 +489,7 @@ namespace Sass {
       }
       append_string(rbracket(list));
     }
-    // probably ruby sass eqivalent of element_needs_parens
+    // probably ruby sass equivalent of element_needs_parens
     else if (output_style() == TO_SASS &&
         list->length() == 1 &&
         !list->from_selector() &&
@@ -1017,7 +1017,7 @@ namespace Sass {
 
 
     bool was_comma_array = in_comma_array;
-    // probably ruby sass eqivalent of element_needs_parens
+    // probably ruby sass equivalent of element_needs_parens
     if (output_style() == TO_SASS && g->length() == 1 &&
       (!Cast<List>((*g)[0]) &&
         !Cast<SelectorList>((*g)[0]))) {
@@ -1045,7 +1045,7 @@ namespace Sass {
     }
 
     in_comma_array = was_comma_array;
-    // probably ruby sass eqivalent of element_needs_parens
+    // probably ruby sass equivalent of element_needs_parens
     if (output_style() == TO_SASS && g->length() == 1 &&
       (!Cast<List>((*g)[0]) &&
         !Cast<SelectorList>((*g)[0]))) {
@@ -1081,7 +1081,7 @@ namespace Sass {
   void Inspect::operator()(SelectorComponent* sel)
   {
     // You should probably never call this method directly
-    // But in case anyone does, we will do the upcasting
+    // But in case anyone does, we will do the up-casting
     if (auto comp = Cast<CompoundSelector>(sel)) operator()(comp);
     if (auto comb = Cast<SelectorCombinator>(sel)) operator()(comb);
   }
@@ -1091,7 +1091,6 @@ namespace Sass {
     if (sel->hasRealParent()) {
       append_string("&");
     }
-    sel->sortChildren();
     for (auto& item : sel->elements()) {
       item->perform(this);
     }


### PR DESCRIPTION
Tested against ruby sass 3.7.4 since this is still the compatibility goal for current libsass branch.

```test.scss
.red-icon {
    color: red;
}

a:before.nested {
    &.error {
      @extend .red-icon;
      qwe: asd;
    }
}

.red-icon {
    color: blue;
}

:before {
    &.red-icon2 {
        foo: bar;
    }
}

:before {
    &.red-icon {
        foo: baz;
    }
}

.asd#asd {
    &qwe {
        asd: qwe;
    }
}

:before {
    &.qwe#{&} {
        asd: qwe;
    }
}

a :before.baz {a: b}
:foo {@extend .baz}

```

Expected output as from ruby sass and previous libsass:
```css
.red-icon, a.nested.error:before {
  color: red; }

a:before.nested.error {
  qwe: asd; }

.red-icon, a.nested.error:before {
  color: blue; }

:before.red-icon2 {
  foo: bar; }

:before.red-icon, a.nested.error:before {
  foo: baz; }

.asd#asdqwe {
  asd: qwe; }

:before.qwe:before {
  asd: qwe; }

a :before.baz, a :foo:before {
  a: b; }
```

Output by dart sass which differs from ruby sass and previous libsass:
```css
.red-icon, a:before.nested.error {
  color: red;
}

a:before.nested.error {
  qwe: asd;
}

.red-icon, a:before.nested.error {
  color: blue;
}

:before.red-icon2 {
  foo: bar;
}

:before.red-icon, a.nested.error:before {
  foo: baz;
}

.asd#asdqwe {
  asd: qwe;
}

:before.qwe:before {
  asd: qwe;
}

a :before.baz, a :foo:before {
  a: b;
}
```
