### PR TITLE
Prevent compiler warning about unnecessary copy

### DIFF
--- a/src/ast_values.cpp
+++ b/src/ast_values.cpp
@@ -481,9 +481,9 @@ namespace Sass {
   {
     if (hash_ == 0) {
       hash_ = std::hash<double>()(value_);
-      for (const auto numerator : numerators)
+      for (const auto& numerator : numerators)
         hash_combine(hash_, std::hash<sass::string>()(numerator));
-      for (const auto denominator : denominators)
+      for (const auto& denominator : denominators)
         hash_combine(hash_, std::hash<sass::string>()(denominator));
     }
     return hash_;


### PR DESCRIPTION
This compiler warning comes up a lot, and is due to the unnecessary copy introduced by accidentally using const value instead of const ref here.