### PR TITLE
fix: url() contains exclamation marks cause parsing error (#2880)

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -39,7 +39,7 @@ namespace Sass {
     {
       unsigned int cmp = unsigned(chr);
       return (cmp > 41 && cmp < 127) ||
-             cmp == ':' || cmp == '/';
+             cmp == ':' || cmp == '/' || cmp == '!';
     }
 
     // check if char is within a reduced ascii range


### PR DESCRIPTION
url() contains exclamation marks show be ok:
```scss
body {
background-image: url(https://example/imgextra/i1/UI1kx5YpZyVz7_!!6000000004749-55-tps-42-43.svg);
}
```