### PR TITLE
fix: url() contains exclamation marks cause parsing error (#2880)

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -39,7 +39,7 @@ namespace Sass {
     {
       unsigned int cmp = unsigned(chr);
       return (cmp > 41 && cmp < 127) ||
-             cmp == ':' || cmp == '/';
+             cmp == ':' || cmp == '/' || cmp == '|';
     }
 
     // check if char is within a reduced ascii range


### PR DESCRIPTION
it should work:
```scss
.a {
  background-image: url(https://example.com/abc!!def.png);
}
```

Refs [sass/libsass#2880](https://github.com/sass/libsass/issues/2880)