### PR TITLE
Use pseudo-random rand() instead of cryptographically secure random numbers

### DIFF
--- a/src/fn_numbers.cpp
+++ b/src/fn_numbers.cpp
@@ -41,8 +41,7 @@ namespace Sass {
     #else
       uint64_t GetSeed()
       {
-        std::random_device rd;
-        return rd();
+        return rand();
       }
     #endif
 


### PR DESCRIPTION
Some AMD CPUs seems to return a non-random number, but still claim success. This makes `random_device` throw an exception, which is passed to the host application, which then crashes.

To work around this, simply use pseudo-random numbers.

Fixes #3151 and probably sass/node-sass#3047

This is a simplistic fix, but is tested to work and fix the problem on a CPU where it was broken before. I can surely imagine more elaborate fixes, e.g. to use `random_device` first, catch the exception, and use `rand()` only as fallback.

However, I do wonder why libsass is using cryptographically secure random numbers in the first place, and what for. I don't see why CSS would need that. I would think that pseudo-random is sufficient. So, maybe this is even the right fix, as-is.

I am contributing the fix that I found. If you would like to improve this, please go ahead. My involvement stops here. My objectively was merely to continue to use the host application, which suddenly failed on the new computer. I hope to help others who run into the same problem.