### PR TITLE
Fix extend edge case going endlessly

### DIFF
--- a/src/ast_helpers.hpp
+++ b/src/ast_helpers.hpp
@@ -61,7 +61,7 @@ namespace Sass {
   // Implement compare and hashing operations for AST Nodes
   // ###########################################################################
 
-  // TODO: get rid of funtions and use ObjEquality<T>
+  // TODO: get rid of functions and use ObjEquality<T>
 
   template <class T>
   // Hash the raw pointer instead of object

--- a/src/ast_sel_unify.cpp
+++ b/src/ast_sel_unify.cpp
@@ -20,7 +20,7 @@ namespace Sass {
     SASS_ASSERT(!complexes.empty(), "Can't unify empty list");
     if (complexes.size() == 1) return complexes;
 
-    CompoundSelectorObj unifiedBase = SASS_MEMORY_NEW(CompoundSelector, SourceSpan("[phony]"));
+    CompoundSelectorObj unifiedBase = SASS_MEMORY_NEW(CompoundSelector, SourceSpan("[unify]"));
     for (auto complex : complexes) {
       SelectorComponentObj base = complex.back();
       if (CompoundSelector * comp = base->getCompound()) {

--- a/src/error_handling.cpp
+++ b/src/error_handling.cpp
@@ -84,6 +84,12 @@ namespace Sass {
       msg = "stack level too deep";
     }
 
+    EndlessExtendError::EndlessExtendError(Backtraces traces, const AST_Node& node)
+      : Base(node.pstate(), def_msg, traces), node(node)
+    {
+      msg = "Extend is creating an absurdly big selector, aborting!";
+    }
+
     IncompatibleUnits::IncompatibleUnits(const Units& lhs, const Units& rhs)
     {
       msg = "Incompatible units: '" + rhs.unit() + "' and '" + lhs.unit() + "'.";

--- a/src/error_handling.hpp
+++ b/src/error_handling.hpp
@@ -134,6 +134,15 @@ namespace Sass {
         virtual ~StackError() throw() {};
     };
 
+    class EndlessExtendError : public Base {
+    protected:
+      const AST_Node& node;
+    public:
+      EndlessExtendError(Backtraces traces, const AST_Node& node);
+      virtual const char* errtype() const { return "EndlessExtendError"; }
+      virtual ~EndlessExtendError() throw() {};
+    };
+
     /* common virtual base class (has no pstate or trace) */
     class OperationError : public std::runtime_error {
       protected:

--- a/src/extender.cpp
+++ b/src/extender.cpp
@@ -626,7 +626,7 @@ namespace Sass {
 
       for (sass::vector<SelectorComponentObj>& components : weaved) {
 
-        ComplexSelectorObj cplx = SASS_MEMORY_NEW(ComplexSelector, "[phony]");
+        ComplexSelectorObj cplx = SASS_MEMORY_NEW(ComplexSelector, complex->pstate());
         cplx->hasPreLineFeed(complex->hasPreLineFeed());
         for (auto& pp : path) {
           if (pp->hasPreLineFeed()) {
@@ -643,7 +643,18 @@ namespace Sass {
         }
         first = false;
 
-        result.push_back(cplx);
+        auto it = result.begin();
+        while (it != result.end()) {
+          if (ObjEqualityFn(*it, cplx)) break;
+          it += 1;
+        }
+        if (it == result.end()) {
+          result.push_back(cplx);
+        }
+
+        if (result.size() > 500) {
+          throw Exception::EndlessExtendError(traces, complex);
+        }
 
       }
 
@@ -838,7 +849,7 @@ namespace Sass {
         }
         if (!originals.empty()) {
           CompoundSelectorObj merged =
-            SASS_MEMORY_NEW(CompoundSelector, "[phony]");
+            SASS_MEMORY_NEW(CompoundSelector, "[compound]");
           merged->concat(originals);
           toUnify.insert(toUnify.begin(), { merged });
         }
@@ -1050,7 +1061,7 @@ namespace Sass {
       }
     }
 
-    SelectorListObj list = SASS_MEMORY_NEW(SelectorList, "[phony]");
+    SelectorListObj list = SASS_MEMORY_NEW(SelectorList, "[pseudo]");
     list->concat(expanded);
     return { pseudo->withSelector(list) };
 

--- a/src/fn_selectors.cpp
+++ b/src/fn_selectors.cpp
@@ -96,7 +96,7 @@ namespace Sass {
 
         for (auto& complex : sel->elements()) {
           if (complex->empty()) {
-            complex->append(SASS_MEMORY_NEW(CompoundSelector, "[phony]"));
+            complex->append(SASS_MEMORY_NEW(CompoundSelector, "[append]"));
           }
           if (CompoundSelector* comp = Cast<CompoundSelector>(complex->first())) {
             comp->hasRealParent(true);

--- a/src/sass_context.cpp
+++ b/src/sass_context.cpp
@@ -77,6 +77,7 @@ namespace Sass {
       // now create the code trace (ToDo: maybe have util functions?)
       if (e.pstate.position.line != sass::string::npos &&
           e.pstate.position.column != sass::string::npos &&
+          e.pstate.getRawData() != nullptr &&
           e.pstate.source != nullptr) {
         Offset offset(e.pstate.position);
         size_t lines = offset.line;


### PR DESCRIPTION
Properly avoiding to add duplicate selectors already seems
to improve the situation heavily. Also added a hard-limit of
500 selectors to create at maximum. Hoping nobody needs more.

To bad I didn't see/find this fix one year ago when the issue was introduced.
The change should IMHO be sane and I hope it doesn't break anything.

Addresses https://github.com/sass/libsass/issues/3081