### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/dev-ast-memory.md
+++ b/docs/dev-ast-memory.md
@@ -200,7 +200,7 @@ define DEBUG_SHARED_PTR
 ```
 
 This will print lost memory on exit to stderr. You can also use
-`setDbg(true)` on sepecific variables to emit reference counter
+`setDbg(true)` on specific variables to emit reference counter
 increase, decrease and other events.
 
 

--- a/src/prelexer.cpp
+++ b/src/prelexer.cpp
@@ -305,7 +305,7 @@ namespace Sass {
     const char* css_whitespace(const char* src) {
       return one_plus< alternatives<spaces, line_comment> >(src);
     }
-    // Match optional_css_whitepace plus block_comments
+    // Match optional_css_whitespace plus block_comments
     const char* optional_css_comments(const char* src) {
       return zero_plus< alternatives<spaces, line_comment, block_comment> >(src);
     }

--- a/src/prelexer.hpp
+++ b/src/prelexer.hpp
@@ -189,7 +189,7 @@ namespace Sass {
     // Match zero plus white-space or line_comments
     const char* optional_css_whitespace(const char* src);
     const char* css_whitespace(const char* src);
-    // Match optional_css_whitepace plus block_comments
+    // Match optional_css_whitespace plus block_comments
     const char* optional_css_comments(const char* src);
     const char* css_comments(const char* src);
 

--- a/src/sass2scss.cpp
+++ b/src/sass2scss.cpp
@@ -179,10 +179,10 @@ namespace Sass
 		while (true)
 		{
 
-			// try to find some meaningfull char
+			// try to find some meaningful char
 			col_pos = sass.find_first_not_of(" \t\n\v\f\r", col_pos);
 
-			// there was no meaningfull char found
+			// there was no meaningful char found
 			if (col_pos == std::string::npos) return false;
 
 			// found a multiline comment opener
@@ -467,7 +467,7 @@ namespace Sass
 		// right trim input
 		sass = rtrim(sass);
 
-		// get position of first meaningfull character in string
+		// get position of first meaningful character in string
 		size_t pos_left = sass.find_first_not_of(SASS2SCSS_FIND_WHITESPACE);
 
 		// special case for final run
@@ -479,7 +479,7 @@ namespace Sass
 			// just add complete whitespace
 			converter.whitespace += sass + "\n";
 		}
-		// have meaningfull first char
+		// have meaningful first char
 		else
 		{
 
@@ -683,7 +683,7 @@ namespace Sass
 				// not in comment mode
 				if (IS_PARSING(converter))
 				{
-					// has meaningfull chars
+					// has meaningful chars
 					if (hasCharData(sass))
 					{
 						// is probably a property
@@ -698,7 +698,7 @@ namespace Sass
 				// not in comment mode
 				if (IS_PARSING(converter))
 				{
-					// had meaningfull chars
+					// had meaningful chars
 					if (converter.property)
 					{
 						// print block opener
@@ -758,14 +758,14 @@ namespace Sass
 				scss += flush(sass, converter);
 			}
 
-			// get position of last meaningfull char
+			// get position of last meaningful char
 			size_t pos_right = sass.find_last_not_of(SASS2SCSS_FIND_WHITESPACE);
 
 			// check for invalid result
 			if (pos_right != std::string::npos)
 			{
 
-				// get the last meaningfull char
+				// get the last meaningful char
 				std::string close = sass.substr(pos_right, 1);
 
 				// check if next line should be concatenated (list mode)
@@ -773,7 +773,7 @@ namespace Sass
 				converter.semicolon = IS_PARSING(converter) && close == ";";
 
 				// check if we have more than
-				// one meaningfull char
+				// one meaningful char
 				if (pos_right > 0)
 				{
 
@@ -785,10 +785,10 @@ namespace Sass
 				}
 
 			}
-			// EO have meaningfull chars from end
+			// EO have meaningful chars from end
 
 		}
-		// EO have meaningfull chars from start
+		// EO have meaningful chars from start
 
 		// return scss
 		return scss;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -306,7 +306,7 @@ namespace Sass {
           // if (cp == '\n') cp = 32;
 
           // use a very simple approach to convert via utf8 lib
-          // maybe there is a more elegant way; maybe we shoud
+          // maybe there is a more elegant way; maybe we should
           // convert the whole output from string to a stream!?
           // allocate memory for utf8 char and convert to utf8
           unsigned char u[5] = {0,0,0,0,0}; utf8::append(cp, u);
@@ -395,7 +395,7 @@ namespace Sass {
           // if (cp == '\n') cp = 32;
 
           // use a very simple approach to convert via utf8 lib
-          // maybe there is a more elegant way; maybe we shoud
+          // maybe there is a more elegant way; maybe we should
           // convert the whole output from string to a stream!?
           // allocate memory for utf8 char and convert to utf8
           unsigned char u[5] = {0,0,0,0,0}; utf8::append(cp, u);


### PR DESCRIPTION
There are small typos in:
- docs/dev-ast-memory.md
- src/prelexer.cpp
- src/prelexer.hpp
- src/sass2scss.cpp
- src/util.cpp

Fixes:
- Should read `meaningful` rather than `meaningfull`.
- Should read `whitespace` rather than `whitepace`.
- Should read `should` rather than `shoud`.
- Should read `specific` rather than `sepecific`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md