### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -33,6 +33,20 @@ Since `libsass` is a library, it makes sense to install it as a shared library o
 
 - [Building shared system library][4]
 
+### Building from vcpkg
+
+The libsass port in [vcpkg][12] is kept up to date by Microsoft team members and community contributors. You can download and install libsass using the vcpkg dependency manager:
+
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+./vcpkg integrate install
+./vcpkg install libsass
+```
+
+If the version is out of date, please [create an issue or pull request][12] on the vcpkg repository.
+
 Compiling with clang instead of gcc
 --
 
@@ -95,3 +109,4 @@ Miscellaneous
 [9]: implementations.md
 [10]: build-on-darwin.md
 [11]: build-with-visual-studio.md
+[12]: https://github.com/Microsoft/vcpkg


### PR DESCRIPTION
LibSass is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for libsass and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libsass, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here](https://github.com/microsoft/vcpkg/blob/master/ports/libsass/portfile.cmake) is what the port script looks like. We try to keep the library maintained as close as possible to the original library.