### PR TITLE
ci: Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 99


### PR DESCRIPTION
Allow Dependabot to create PRs to update things like `actions/checkout@v2` to the latest versions as they come out