### PR TITLE
Delete allocated memory before throwing an exception

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -291,6 +291,8 @@ namespace Sass {
           stack += "\n    " + sass::string(File::abs2rel(import_stack[n]->abs_path, cwd, cwd)) +
             " imports " + sass::string(File::abs2rel(import_stack[n+1]->abs_path, cwd, cwd));
         }
+        sass_delete_import(import_stack.back());
+        delete source;
         // implement error throw directly until we
         // decided how to handle full stack traces
         throw Exception::InvalidSyntax(pstate, traces, stack);


### PR DESCRIPTION
I added two `delete`s for the import entry and the `source` file entry before an exception is thrown.

If the client code captures and tries to recover from the exception, the previous version without delete may cause memory leak.